### PR TITLE
k8s: fix connectors assertion

### DIFF
--- a/src/go/k8s/tests/e2e-v2/connectors/00-assert-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/connectors/00-assert-create-redpanda.yaml
@@ -37,13 +37,13 @@ status:
   replicas: 1
   updatedReplicas: 1
 ---
-apiVersion: apps/v1
-kind: pod
+apiVersion: v1
+kind: Pod
 metadata:
-  name: redpanda
   labels:
     app.kubernetes.io/component: connectors
     app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: connectors
 status:
   phase: Running
 ---


### PR DESCRIPTION
First PR to address current failures in kuttl testing. Local testing shows this is passing. 

```
    harness.go:576: tearing down kind cluster
--- PASS: kuttl (254.68s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/connectors (162.56s)
PASS
```