### PR TITLE
chore: update decommission test for latest changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,7 @@ steps:
     steps:
       - key: k8s-operator-v2
         label: K8s Operator v2
-        timeout: 37
+        timeout: 45
         notify:
           - github_commit_status:
               context: k8s-operator-v2

--- a/src/go/k8s/tests/e2e-v2/decommission/00-assert-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/decommission/00-assert-create-redpanda.yaml
@@ -45,8 +45,8 @@ status:
       status: "True"
       type: Released
   helmChart: redpanda/redpanda-decommission
-  lastAppliedRevision: 5.3.2
-  lastAttemptedRevision: 5.3.2
+  lastAppliedRevision: 5.6.48
+  lastAttemptedRevision: 5.6.48
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-v2/decommission/00-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/decommission/00-create-redpanda.yaml
@@ -5,7 +5,7 @@ metadata:
   name: decommission
 spec:
   chartRef:
-    chartVersion: "5.3.2"
+    chartVersion: "5.6.48"
   clusterSpec:
     statefulset:
       replicas: 5

--- a/src/go/k8s/tests/e2e-v2/decommission/01-assert-scale-down-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/decommission/01-assert-scale-down-redpanda.yaml
@@ -45,8 +45,8 @@ status:
       status: "True"
       type: Released
   helmChart: redpanda/redpanda-decommission
-  lastAppliedRevision: 5.3.2
-  lastAttemptedRevision: 5.3.2
+  lastAppliedRevision: 5.6.48
+  lastAttemptedRevision: 5.6.48
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-v2/decommission/01-scale-down-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/decommission/01-scale-down-redpanda.yaml
@@ -5,7 +5,7 @@ metadata:
   name: decommission
 spec:
   chartRef:
-    chartVersion: "5.3.2"
+    chartVersion: "5.6.48"
   clusterSpec:
     statefulset:
       replicas: 4

--- a/src/go/k8s/tests/e2e-v2/decommission/02-assert-scale-down-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/decommission/02-assert-scale-down-redpanda.yaml
@@ -45,8 +45,8 @@ status:
       status: "True"
       type: Released
   helmChart: redpanda/redpanda-decommission
-  lastAppliedRevision: 5.3.2
-  lastAttemptedRevision: 5.3.2
+  lastAppliedRevision: 5.6.48
+  lastAttemptedRevision: 5.6.48
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-v2/decommission/02-scale-down-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/decommission/02-scale-down-redpanda.yaml
@@ -5,7 +5,7 @@ metadata:
   name: decommission
 spec:
   chartRef:
-    chartVersion: "5.3.2"
+    chartVersion: "5.6.48"
   clusterSpec:
     statefulset:
       replicas: 3


### PR DESCRIPTION
Latest changes to the helm chart currently roll pods in an unexpected manner. I would like to ensure that current helm changes are still passing today.