### PR TITLE
v1 operator: support configuring additional listeners with different ports

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -186,13 +186,13 @@ func main() {
 		populateRack(cfg, zone, zoneID)
 	}
 
+	if err = setAdditionalListeners(c.additionalListeners, c.hostIP, int(hostIndex), cfg); err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to set additional listeners: %w", err))
+	}
+
 	cfgBytes, err := yaml.Marshal(cfg)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to marshal the configuration: %w", err))
-	}
-
-	if err := setAdditionalListeners(c.additionalListeners, c.hostIP, int(hostIndex), cfg); err != nil {
-		log.Fatalf("%s", fmt.Errorf("unable to set additional listeners: %w", err))
 	}
 
 	if err := os.WriteFile(c.configDestination, cfgBytes, 0o600); err != nil {
@@ -561,7 +561,7 @@ func hostIndex(hostName string) (brokerID, error) {
 // sample additional listeners config string:
 // {"pandaproxy.advertised_pandaproxy_api":"[{'name': 'private-link-proxy', 'address': '{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 }}.redpanda.com', 'port': {{39282 | add .Index}}}]","pandaproxy.pandaproxy_api":"[{'name': 'private-link-proxy', 'address': '0.0.0.0','port': 'port': {{39282 | add .Index}}}]","redpanda.advertised_kafka_api":"[{'name': 'private-link-kafka', 'address': '{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 }}.redpanda.com', 'port': {{30092 | add .Index}}}]","redpanda.kafka_api":"[{'name': 'private-link-kakfa', 'address': '0.0.0.0', 'port': {{30092 | add .Index}}}]"}
 func setAdditionalListeners(additionalListenersCfg, hostIP string, hostIndex int, cfg *config.Config) error {
-	if additionalListenersCfg == "" {
+	if additionalListenersCfg == "" || additionalListenersCfg == "{}" {
 		return nil
 	}
 
@@ -588,33 +588,12 @@ func setAdditionalListeners(additionalListenersCfg, hostIP string, hostIndex int
 
 	// Merge additional listeners to the input config
 	if len(nodeConfig.Redpanda.KafkaAPI) > 0 {
-		cfg.Redpanda.KafkaAPI = append(cfg.Redpanda.KafkaAPI, nodeConfig.Redpanda.KafkaAPI...)
+		setAuthnAdditionalListeners(resources.ExternalListenerName, &cfg.Redpanda.KafkaAPI, nodeConfig.Redpanda.KafkaAPI)
 	}
 
 	if len(nodeConfig.Redpanda.AdvertisedKafkaAPI) > 0 {
-		cfg.Redpanda.AdvertisedKafkaAPI = append(cfg.Redpanda.AdvertisedKafkaAPI, nodeConfig.Redpanda.AdvertisedKafkaAPI...)
-		// Assume that the advertised kafka api use the same TLS configuration as the default external one.
-		var serverTLSCfg *config.ServerTLS
-		for i := 0; i < len(cfg.Redpanda.KafkaAPITLS); i++ {
-			tlsCfg := &cfg.Redpanda.KafkaAPITLS[i]
-			if tlsCfg.Name == resources.ExternalListenerName {
-				serverTLSCfg = tlsCfg
-				break
-			}
-		}
-		if serverTLSCfg != nil {
-			for i := 0; i < len(nodeConfig.Redpanda.AdvertisedKafkaAPI); i++ {
-				cfg.Redpanda.KafkaAPITLS = append(cfg.Redpanda.KafkaAPITLS, config.ServerTLS{
-					Name:              nodeConfig.Redpanda.AdvertisedKafkaAPI[i].Name,
-					Enabled:           serverTLSCfg.Enabled,
-					CertFile:          serverTLSCfg.CertFile,
-					KeyFile:           serverTLSCfg.KeyFile,
-					TruststoreFile:    serverTLSCfg.TruststoreFile,
-					RequireClientAuth: serverTLSCfg.RequireClientAuth,
-					Other:             serverTLSCfg.Other,
-				})
-			}
-		}
+		setAdditionalAdvertisedListeners(resources.ExternalListenerName, &cfg.Redpanda.AdvertisedKafkaAPI, &cfg.Redpanda.KafkaAPITLS,
+			nodeConfig.Redpanda.AdvertisedKafkaAPI)
 	}
 
 	if nodeConfig.Pandaproxy == nil {
@@ -625,37 +604,88 @@ func setAdditionalListeners(additionalListenersCfg, hostIP string, hostIndex int
 		if cfg.Pandaproxy == nil {
 			cfg.Pandaproxy = &config.Pandaproxy{}
 		}
-		cfg.Pandaproxy.PandaproxyAPI = append(cfg.Pandaproxy.PandaproxyAPI, nodeConfig.Pandaproxy.PandaproxyAPI...)
+		setAuthnAdditionalListeners(resources.PandaproxyPortExternalName, &cfg.Pandaproxy.PandaproxyAPI, nodeConfig.Pandaproxy.PandaproxyAPI)
 	}
 	if len(nodeConfig.Pandaproxy.AdvertisedPandaproxyAPI) > 0 {
 		if cfg.Pandaproxy == nil {
 			cfg.Pandaproxy = &config.Pandaproxy{}
 		}
-		cfg.Pandaproxy.AdvertisedPandaproxyAPI = append(cfg.Pandaproxy.AdvertisedPandaproxyAPI, nodeConfig.Pandaproxy.AdvertisedPandaproxyAPI...)
 
-		// Assume that the advertised panda proxies use the same TLS configuration as the default external one.
-		var serverTLSCfg *config.ServerTLS
-		for i := 0; i < len(cfg.Pandaproxy.PandaproxyAPITLS); i++ {
-			tlsCfg := &cfg.Pandaproxy.PandaproxyAPITLS[i]
-			if tlsCfg.Name == resources.PandaproxyPortExternalName {
-				serverTLSCfg = tlsCfg
-				break
-			}
+		setAdditionalAdvertisedListeners(resources.PandaproxyPortExternalName, &cfg.Pandaproxy.AdvertisedPandaproxyAPI, &cfg.Pandaproxy.PandaproxyAPITLS,
+			nodeConfig.Pandaproxy.AdvertisedPandaproxyAPI)
+	}
+
+	return nil
+}
+
+// setAuthnAdditionalListeners populates the authentication config in the addtiional listeners with the config from the external listener,
+// and append the additional listeners to the input listeners.
+func setAuthnAdditionalListeners(externalListenerName string, listeners *[]config.NamedAuthNSocketAddress, additionalListeners []config.NamedAuthNSocketAddress) {
+	var externalListenerCfg *config.NamedAuthNSocketAddress
+	for i := 0; i < len(*listeners); i++ {
+		cfg := &(*listeners)[i]
+		if cfg.Name == externalListenerName {
+			externalListenerCfg = cfg
+			break
 		}
-		if serverTLSCfg != nil {
-			for i := 0; i < len(nodeConfig.Pandaproxy.AdvertisedPandaproxyAPI); i++ {
-				cfg.Pandaproxy.PandaproxyAPITLS = append(cfg.Pandaproxy.PandaproxyAPITLS, config.ServerTLS{
-					Name:              nodeConfig.Pandaproxy.AdvertisedPandaproxyAPI[i].Name,
-					Enabled:           serverTLSCfg.Enabled,
-					CertFile:          serverTLSCfg.CertFile,
-					KeyFile:           serverTLSCfg.KeyFile,
-					TruststoreFile:    serverTLSCfg.TruststoreFile,
-					RequireClientAuth: serverTLSCfg.RequireClientAuth,
-					Other:             serverTLSCfg.Other,
-				})
+	}
+	if externalListenerCfg == nil {
+		*listeners = append(*listeners, additionalListeners...)
+		return
+	}
+	// Use the authn methold of the default external listener if authn method is not set in additional listener.
+	for i := 0; i < len(additionalListeners); i++ {
+		cfg := &additionalListeners[i]
+		if cfg.AuthN == nil || *cfg.AuthN == "" {
+			cfg.AuthN = externalListenerCfg.AuthN
+		}
+	}
+	*listeners = append(*listeners, additionalListeners...)
+}
+
+// setAdditionalAdvertisedListeners populates the TLS config and address in the addtiional listeners with the config from the external listener,
+// and append the additional listeners to the input advertised listeners and TLS configs.
+func setAdditionalAdvertisedListeners(externalListenerName string, advListeners *[]config.NamedSocketAddress, tlsCfgs *[]config.ServerTLS, additionalAdvListeners []config.NamedSocketAddress) {
+	var externalAPICfg *config.NamedSocketAddress
+	for i := 0; i < len(*advListeners); i++ {
+		cfg := &(*advListeners)[i]
+		if cfg.Name == externalListenerName {
+			externalAPICfg = cfg
+			break
+		}
+	}
+	if externalAPICfg != nil {
+		// Use the address of the default external listener if address is not set in additional listener.
+		for i := 0; i < len(additionalAdvListeners); i++ {
+			cfg := &additionalAdvListeners[i]
+			if cfg.Address == "" {
+				cfg.Address = externalAPICfg.Address
 			}
 		}
 	}
 
-	return nil
+	*advListeners = append(*advListeners, additionalAdvListeners...)
+
+	// Assume that the advertised panda proxies use the same TLS configuration as the default external one.
+	var serverTLSCfg *config.ServerTLS
+	for i := 0; i < len(*tlsCfgs); i++ {
+		tlsCfg := &(*tlsCfgs)[i]
+		if tlsCfg.Name == resources.PandaproxyPortExternalName {
+			serverTLSCfg = tlsCfg
+			break
+		}
+	}
+	if serverTLSCfg != nil {
+		for i := 0; i < len(additionalAdvListeners); i++ {
+			*tlsCfgs = append(*tlsCfgs, config.ServerTLS{
+				Name:              additionalAdvListeners[i].Name,
+				Enabled:           serverTLSCfg.Enabled,
+				CertFile:          serverTLSCfg.CertFile,
+				KeyFile:           serverTLSCfg.KeyFile,
+				TruststoreFile:    serverTLSCfg.TruststoreFile,
+				RequireClientAuth: serverTLSCfg.RequireClientAuth,
+				Other:             serverTLSCfg.Other,
+			})
+		}
+	}
 }

--- a/src/go/k8s/cmd/configurator/main_test.go
+++ b/src/go/k8s/cmd/configurator/main_test.go
@@ -12,6 +12,7 @@ package main
 import (
 	"testing"
 
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/pkg/resources"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,5 +32,254 @@ func TestPopulateRack(t *testing.T) {
 	for _, tt := range tests {
 		populateRack(cfg, tt.Zone, tt.ZoneID)
 		assert.Equal(t, tt.ExpectedRack, cfg.Redpanda.Rack)
+	}
+}
+
+func TestAdditionalListeners(t *testing.T) { //nolint
+	sasl := "sasl"
+	tests := []struct {
+		name                            string
+		addtionalListenersCfg           string
+		hostIndex                       int
+		hostIP                          string
+		nodeCfg                         config.Config
+		expectedKafkaAPI                []config.NamedAuthNSocketAddress
+		expectedAdvertisedKafkaAPI      []config.NamedSocketAddress
+		expectedKafkaAPITLS             []config.ServerTLS
+		expectedPandaProxyAPI           []config.NamedAuthNSocketAddress
+		expectedadvertisedPandaProxyAPI []config.NamedSocketAddress
+		expectedPandaProxyTLS           []config.ServerTLS
+		expectedError                   bool
+	}{
+		{
+			name:                  "invalid listener configuration",
+			addtionalListenersCfg: `{"redpanda.advertised_kafka_api":"[{'invalid format'`,
+			hostIndex:             1,
+			hostIP:                "192.168.0.1",
+			nodeCfg: config.Config{
+				Redpanda: config.RedpandaNodeConfig{},
+			},
+			expectedError: true,
+		},
+		{
+			name:                  "no additional listener",
+			addtionalListenersCfg: "",
+			hostIndex:             1,
+			hostIP:                "192.168.0.1",
+			nodeCfg: config.Config{
+				Redpanda: config.RedpandaNodeConfig{
+					KafkaAPI: []config.NamedAuthNSocketAddress{{
+						Name:    "internal",
+						Address: "0.0.0.0",
+						Port:    9092,
+						AuthN:   &sasl,
+					}},
+					AdvertisedKafkaAPI: []config.NamedSocketAddress{{
+						Name:    "internal",
+						Address: "cluster1.redpanda.svc.cluster.local",
+						Port:    9092,
+					}},
+				},
+			},
+			expectedKafkaAPI: []config.NamedAuthNSocketAddress{
+				{
+					Name:    "internal",
+					Address: "0.0.0.0",
+					Port:    9092,
+					AuthN:   &sasl,
+				},
+			},
+			expectedAdvertisedKafkaAPI: []config.NamedSocketAddress{
+				{
+					Name:    "internal",
+					Address: "cluster1.redpanda.svc.cluster.local",
+					Port:    9092,
+				},
+			},
+		},
+		{
+			name: "additional kafka listener",
+			addtionalListenersCfg: `{"redpanda.advertised_kafka_api":"[{'name': 'private-link-kafka', 'address': '{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 7 }}.redpanda.com', 'port': {{30092 | add .Index}}}]",` +
+				`"redpanda.kafka_api":"[{'name': 'private-link-kafka', 'address': '0.0.0.0', 'port': {{30092 | add .Index}}, 'authentication_method': 'sasl'}]"}`,
+			hostIndex: 1,
+			hostIP:    "192.168.0.1",
+			nodeCfg: config.Config{
+				Redpanda: config.RedpandaNodeConfig{},
+			},
+			expectedKafkaAPI: []config.NamedAuthNSocketAddress{
+				{
+					Address: "0.0.0.0",
+					Name:    "private-link-kafka",
+					Port:    30092 + 1,
+					AuthN:   &sasl,
+				},
+			},
+			expectedAdvertisedKafkaAPI: []config.NamedSocketAddress{
+				{
+					Address: "1-f415bda0-37d7a80.redpanda.com",
+					Name:    "private-link-kafka",
+					Port:    30092 + 1,
+				},
+			},
+		},
+		{
+			name: "additional kafka and proxy listeners with mTLS",
+			addtionalListenersCfg: `{"redpanda.advertised_kafka_api":"[{'name': 'private-link-kafka', 'address': '{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 7 }}.redpanda.com', 'port': {{39002 | add .Index}}}]",` +
+				`"redpanda.kafka_api":"[{'name': 'private-link-kafka', 'address': '0.0.0.0', 'port': {{39002 | add .Index}}, 'authentication_method': 'sasl'}]",` +
+				`"pandaproxy.advertised_pandaproxy_api":"[{'name': 'private-link-proxy', 'address': '{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 7 }}.redpanda.com', 'port': {{30282 | add .Index}}}]",` +
+				`"pandaproxy.pandaproxy_api":"[{'name': 'private-link-proxy', 'address': '0.0.0.0', 'port': {{30282 | add .Index}}, 'authentication_method': 'sasl'}]"}`,
+			hostIndex: 1,
+			hostIP:    "192.168.0.1",
+			nodeCfg: config.Config{
+				Redpanda: config.RedpandaNodeConfig{
+					KafkaAPI: []config.NamedAuthNSocketAddress{{
+						Name:    "kafka-internal",
+						Address: "0.0.0.0",
+						Port:    9092,
+						AuthN:   &sasl,
+					}},
+					AdvertisedKafkaAPI: []config.NamedSocketAddress{{
+						Name:    "kafka-internal",
+						Address: "cluster1.redpanda.svc.cluster.local",
+						Port:    9092,
+					}},
+					KafkaAPITLS: []config.ServerTLS{{
+						Name:     resources.ExternalListenerName,
+						CertFile: "crt1.pem",
+						KeyFile:  "key1.pem",
+					}},
+				},
+				Pandaproxy: &config.Pandaproxy{
+					PandaproxyAPI: []config.NamedAuthNSocketAddress{{
+						Name:    "proxy-internal",
+						Address: "0.0.0.0",
+						Port:    30082,
+						AuthN:   &sasl,
+					}},
+					AdvertisedPandaproxyAPI: []config.NamedSocketAddress{{
+						Name:    "proxy-internal",
+						Address: "cluster1.redpanda.svc.cluster.local",
+						Port:    30082,
+					}},
+					PandaproxyAPITLS: []config.ServerTLS{{
+						Name:     resources.PandaproxyPortExternalName,
+						CertFile: "crt2.pem",
+						KeyFile:  "key2.pem",
+					}},
+				},
+			},
+			expectedKafkaAPI: []config.NamedAuthNSocketAddress{
+				{
+					Name:    "kafka-internal",
+					Address: "0.0.0.0",
+					Port:    9092,
+					AuthN:   &sasl,
+				},
+				{
+					Address: "0.0.0.0",
+					Name:    "private-link-kafka",
+					Port:    39002 + 1,
+					AuthN:   &sasl,
+				},
+			},
+			expectedAdvertisedKafkaAPI: []config.NamedSocketAddress{
+				{
+					Name:    "kafka-internal",
+					Address: "cluster1.redpanda.svc.cluster.local",
+					Port:    9092,
+				},
+				{
+					Address: "1-f415bda0-37d7a80.redpanda.com",
+					Name:    "private-link-kafka",
+					Port:    39002 + 1,
+				},
+			},
+			expectedKafkaAPITLS: []config.ServerTLS{
+				{
+					Name:     resources.ExternalListenerName,
+					CertFile: "crt1.pem",
+					KeyFile:  "key1.pem",
+				},
+				{
+					Name:     "private-link-kafka",
+					CertFile: "crt1.pem",
+					KeyFile:  "key1.pem",
+				},
+			},
+			expectedPandaProxyAPI: []config.NamedAuthNSocketAddress{
+				{
+					Name:    "proxy-internal",
+					Address: "0.0.0.0",
+					Port:    30082,
+					AuthN:   &sasl,
+				},
+				{
+					Address: "0.0.0.0",
+					Name:    "private-link-proxy",
+					Port:    30282 + 1,
+					AuthN:   &sasl,
+				},
+			},
+			expectedadvertisedPandaProxyAPI: []config.NamedSocketAddress{
+				{
+					Name:    "proxy-internal",
+					Address: "cluster1.redpanda.svc.cluster.local",
+					Port:    30082,
+				},
+				{
+					Address: "1-f415bda0-37d7a80.redpanda.com",
+					Name:    "private-link-proxy",
+					Port:    30282 + 1,
+				},
+			},
+			expectedPandaProxyTLS: []config.ServerTLS{
+				{
+					Name:     resources.PandaproxyPortExternalName,
+					CertFile: "crt2.pem",
+					KeyFile:  "key2.pem",
+				},
+				{
+					Name:     "private-link-proxy",
+					CertFile: "crt2.pem",
+					KeyFile:  "key2.pem",
+				},
+			},
+		},
+	}
+	for i := 0; i < len(tests); i++ {
+		tt := &tests[i]
+		err := setAdditionalListeners(tt.addtionalListenersCfg, tt.hostIP, tt.hostIndex, &tt.nodeCfg)
+		if tt.expectedError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			validateListenerConfig(t, tt.expectedKafkaAPI, tt.nodeCfg.Redpanda.KafkaAPI, func(c config.NamedAuthNSocketAddress) string { return c.Name })
+			validateListenerConfig(t, tt.expectedAdvertisedKafkaAPI, tt.nodeCfg.Redpanda.AdvertisedKafkaAPI, func(c config.NamedSocketAddress) string { return c.Name })
+			if len(tt.expectedPandaProxyAPI) > 0 {
+				validateListenerConfig(t, tt.expectedPandaProxyAPI, tt.nodeCfg.Pandaproxy.PandaproxyAPI, func(c config.NamedAuthNSocketAddress) string { return c.Name })
+			}
+			if len(tt.expectedadvertisedPandaProxyAPI) > 0 {
+				validateListenerConfig(t, tt.expectedadvertisedPandaProxyAPI, tt.nodeCfg.Pandaproxy.AdvertisedPandaproxyAPI, func(c config.NamedSocketAddress) string { return c.Name })
+			}
+			if len(tt.expectedPandaProxyTLS) > 0 {
+				validateListenerConfig(t, tt.expectedPandaProxyTLS, tt.nodeCfg.Pandaproxy.PandaproxyAPITLS, func(c config.ServerTLS) string { return c.Name })
+			}
+		}
+	}
+}
+
+// validateListenerConfig checks whether cfg1 contains cfg2.
+func validateListenerConfig[V any](t *testing.T, cfg1, cfg2 []V, getName func(V) string) {
+	assert.Equal(t, len(cfg1), len(cfg2))
+
+	m := map[string]*V{}
+	for i := 0; i < len(cfg1); i++ {
+		m[getName(cfg1[i])] = &cfg1[i]
+	}
+
+	for _, c := range cfg2 {
+		v, found := m[getName(c)]
+		assert.True(t, found, "name", getName(c))
+		assert.Equal(t, *v, c)
 	}
 }

--- a/src/go/k8s/pkg/resources/configuration/configuration_modes.go
+++ b/src/go/k8s/pkg/resources/configuration/configuration_modes.go
@@ -69,7 +69,7 @@ func (r globalConfigurationModeClassic) SetAdditionalFlatProperties(
 			if err != nil {
 				return fmt.Errorf("setting built-in type: %w", err)
 			}
-		} else {
+		} else if !skipNodeSpecificConfiguration(v) {
 			err := targetConfig.NodeConfiguration.Set(k, v, "")
 			if err != nil {
 				return fmt.Errorf("setting complex type: %w", err)
@@ -77,6 +77,13 @@ func (r globalConfigurationModeClassic) SetAdditionalFlatProperties(
 		}
 	}
 	return nil
+}
+
+// It returns whether to skip node specific configuration in handling additional configuration.
+// Node specific configuration contains variable like {{ .Index }}
+// e.g. "[{'name':'private-link','address':'{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 }}.redpanda.com','port': 'port': {{30092 | add .Index}}}]"
+func skipNodeSpecificConfiguration(cfg string) bool {
+	return strings.Contains(cfg, ".Index")
 }
 
 // globalConfigurationModeCentralized provides centralized configuration rules

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -919,7 +919,7 @@ func (r *StatefulSetResource) AdditionalListenersEnvVars() []corev1.EnvVar {
 // - pandaproxy.pandaproxy_api
 // - pandaproxy.advertised_pandaproxy_api
 // example: redpanda.kafka_api: "[{'name':'private-link','address':'0.0.0.0','port':39002}]"
-// example: redpanda.advertised_kafka_api: "[{'name':'private-link','address':'{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 7 }}.clb2jkpb06k16j807u20.byoc.ign.cloud.redpanda.com','port': 'port': {{30092 | add .Index}}}]"
+// example: redpanda.advertised_kafka_api: "[{'name':'private-link','address':'{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 7 }}.cluster123.fmc.prd.cloud.redpanda.com','port': 'port': {{30092 | add .Index}}}]"
 func (r *StatefulSetResource) GetPortsForListenersInAdditionalConfig() []corev1.ContainerPort {
 	ports := []corev1.ContainerPort{}
 
@@ -943,7 +943,6 @@ func (r *StatefulSetResource) GetPortsForListenersInAdditionalConfig() []corev1.
 		}
 	}
 
-	// We will reply on the webhook to validate and reject invalid configurations, e.g. port conflict.
 	for i := 0; i < int(*r.pandaCluster.Spec.Replicas); i++ {
 		for _, n := range additionalNode0Config.Redpanda.AdvertisedKafkaAPI {
 			ports = append(ports, corev1.ContainerPort{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -11,6 +11,7 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -38,6 +39,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/pkg/resources/featuregates"
 	resourcetypes "github.com/redpanda-data/redpanda-operator/src/go/k8s/pkg/resources/types"
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/pkg/utils"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 )
 
 var _ Resource = &StatefulSetResource{}
@@ -75,6 +77,9 @@ var (
 
 	// terminationGracePeriodSeconds should account for additional delay introduced by hooks
 	terminationGracePeriodSeconds int64 = 120
+
+	// additionalListenerCfgNames contains the list of the listener names supported in additionalConfiguration.
+	additionalListenerCfgNames = []string{"redpanda.kafka_api", "redpanda.advertised_kafka_api", "pandaproxy.pandaproxy_api", "pandaproxy.advertised_pandaproxy_api"}
 )
 
 // ConfiguratorSettings holds settings related to configurator container and deployment
@@ -466,7 +471,7 @@ func (r *StatefulSetResource) obj(
 									Name:  "VALIDATE_MOUNTED_VOLUME",
 									Value: strconv.FormatBool(r.pandaCluster.Spec.InitialValidationForVolume != nil && *r.pandaCluster.Spec.InitialValidationForVolume),
 								},
-							}, r.pandaproxyEnvVars()...),
+							}, append(r.pandaproxyEnvVars(), r.AdditionalListenersEnvVars()...)...),
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(userID)),
 								RunAsGroup: ptr.To(int64(groupID)),
@@ -878,6 +883,83 @@ func (r *StatefulSetResource) getPorts() []corev1.ContainerPort {
 		return ports
 	}
 
+	ports = append(ports, r.GetPortsForListenersInAdditionalConfig()...)
+
+	return ports
+}
+
+// AdditionalListenersEnvVars returns the env var containing the additioanl listeners specified in additionalConfiguration.
+func (r *StatefulSetResource) AdditionalListenersEnvVars() []corev1.EnvVar {
+	if len(r.pandaCluster.Spec.AdditionalConfiguration) == 0 {
+		return nil
+	}
+
+	cfg := map[string]string{}
+	for _, k := range additionalListenerCfgNames {
+		if v, found := r.pandaCluster.Spec.AdditionalConfiguration[k]; found {
+			cfg[k] = v
+		}
+	}
+	if len(cfg) == 0 {
+		return nil
+	}
+	jsonStr, err := json.Marshal(cfg)
+	if err != nil {
+		return nil
+	}
+	return []corev1.EnvVar{{
+		Name:  "ADDITIONAL_LISTENERS",
+		Value: string(jsonStr),
+	}}
+}
+
+// GetPortsForListenersInAdditionalConfig gets the ports for the additional listeners and advertised APIs set in addtionalConfiguration.
+// - redpanda.kafka_api
+// - redpanda.advertised_kafka_api
+// - pandaproxy.pandaproxy_api
+// - pandaproxy.advertised_pandaproxy_api
+// example: redpanda.kafka_api: "[{'name':'private-link','address':'0.0.0.0','port':39002}]"
+// example: redpanda.advertised_kafka_api: "[{'name':'private-link','address':'{{ .Index }}-f415bda0-{{ .HostIP | sha256sum | substr 0 7 }}.clb2jkpb06k16j807u20.byoc.ign.cloud.redpanda.com','port': 'port': {{30092 | add .Index}}}]"
+func (r *StatefulSetResource) GetPortsForListenersInAdditionalConfig() []corev1.ContainerPort {
+	ports := []corev1.ContainerPort{}
+
+	if len(r.pandaCluster.Spec.AdditionalConfiguration) == 0 {
+		return ports
+	}
+
+	additionalNode0Config := &config.Config{}
+	for _, k := range additionalListenerCfgNames {
+		if v, found := r.pandaCluster.Spec.AdditionalConfiguration[k]; found {
+			res, err := utils.Compute(v, utils.NewEndpointTemplateData(0, "dummy"), false)
+			if err != nil {
+				r.logger.Error(err, "failed to evaluate template", "template", v)
+				continue
+			}
+			err = additionalNode0Config.Set(k, res, "")
+			if err != nil {
+				r.logger.Error(err, "failed to set node config", k, v)
+				continue
+			}
+		}
+	}
+
+	// We will reply on the webhook to validate and reject invalid configurations, e.g. port conflict.
+	for i := 0; i < int(*r.pandaCluster.Spec.Replicas); i++ {
+		for _, n := range additionalNode0Config.Redpanda.AdvertisedKafkaAPI {
+			ports = append(ports, corev1.ContainerPort{
+				Name:          n.Name,
+				ContainerPort: int32(n.Port + i),
+			})
+		}
+		if additionalNode0Config.Pandaproxy != nil {
+			for _, n := range additionalNode0Config.Pandaproxy.AdvertisedPandaproxyAPI {
+				ports = append(ports, corev1.ContainerPort{
+					Name:          n.Name,
+					ContainerPort: int32(n.Port + i),
+				})
+			}
+		}
+	}
 	return ports
 }
 

--- a/src/go/k8s/pkg/utils/template.go
+++ b/src/go/k8s/pkg/utils/template.go
@@ -40,11 +40,16 @@ func NewEndpointTemplateData(index int, hostIP string) EndpointTemplateData {
 	}
 }
 
-// ComputeEndpoint constructs the expected endpoint name using the given
+// ComputeEndpoint is the wrapper around Compute for evaluating an endpoint.
+func ComputeEndpoint(tmpl string, data EndpointTemplateData) (string, error) {
+	return Compute(tmpl, data, true)
+}
+
+// Compute constructs the expected endpoint name and port using the given
 // template.
 // In case the template is empty, the legacy method for computing the endpoint
 // name is used, which consists in using the plain index.
-func ComputeEndpoint(tmpl string, data EndpointTemplateData) (string, error) {
+func Compute(tmpl string, data EndpointTemplateData, isEndpoint bool) (string, error) {
 	if tmpl == "" {
 		return strconv.Itoa(data.Index), nil
 	}
@@ -59,7 +64,7 @@ func ComputeEndpoint(tmpl string, data EndpointTemplateData) (string, error) {
 	}
 
 	ep := b.String()
-	if !validEndpointRegexp.MatchString(ep) {
+	if isEndpoint && !validEndpointRegexp.MatchString(ep) {
 		return "", &InvalidEndpointSegmentError{endpoint: ep}
 	}
 

--- a/src/go/k8s/pkg/utils/template_test.go
+++ b/src/go/k8s/pkg/utils/template_test.go
@@ -62,6 +62,11 @@ func TestTemplateGen(t *testing.T) {
 			expected:             "'address': '2-f1412386.redpanda.com', 'port': 39004",
 			endpointContainsPort: true,
 		},
+		{
+			tmpl:                 "'address': '{{.Index}}-{{.HostIP | sha256sum | substr 0 8}}.redpanda.com', 'port': {{30092 | add (.Index | sub .Index )}}",
+			expected:             "'address': '2-f1412386.redpanda.com', 'port': 30092",
+			endpointContainsPort: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/src/go/k8s/pkg/utils/template_test.go
+++ b/src/go/k8s/pkg/utils/template_test.go
@@ -20,9 +20,10 @@ import (
 func TestTemplateGen(t *testing.T) {
 	data := utils.NewEndpointTemplateData(2, "1.1.1.1")
 	tests := []struct {
-		tmpl     string
-		expected string
-		error    bool
+		tmpl                 string
+		endpointContainsPort bool
+		expected             string
+		error                bool
 	}{
 		{
 			tmpl:     "",
@@ -56,11 +57,16 @@ func TestTemplateGen(t *testing.T) {
 			tmpl:  "{{.Index}}-",
 			error: true, // invalid end character
 		},
+		{
+			tmpl:                 "'address': '{{.Index}}-{{.HostIP | sha256sum | substr 0 8}}.redpanda.com', 'port': {{39002 | add .Index}}",
+			expected:             "'address': '2-f1412386.redpanda.com', 'port': 39004",
+			endpointContainsPort: true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.tmpl, func(t *testing.T) {
-			res, err := utils.ComputeEndpoint(tc.tmpl, data)
+			res, err := utils.Compute(tc.tmpl, data, !tc.endpointContainsPort)
 			assert.Equal(t, tc.expected, res)
 			if tc.error {
 				assert.Error(t, err)


### PR DESCRIPTION
Support the additional listeners that can be configured with different ports. 

- Support the following additional listener configurations,
   - redpanda.kafka_api
   - redpanda.advertised_kafka_api
   - pandaproxy.pandaproxy_api
   - pandaproxy.advertised_pandaproxy_api

- Additional listeners are passed to Configurator through the new env variable named `ADDITIONAL_LISTENERS`.
- The env var can take string template containing `.Index` and `HostIP` variables, e.g. `"'address': '{{.Index}}-{{.HostIP | sha256sum | substr 0 8}}.redpanda.com', 'port': {{39002 | add .Index}}"`.
- If `address` is not set in `redpanda.advertised_kafka_api` or `pandaproxy.advertised_pandaproxy_api`, it will be set to the address in the advertised listeners named `kafka-external` or `proxy-external` correspondingly. 
- If  `authentication_methold` is not set in `redpanda.kafka_api` or `pandaproxy.pandaproxy_api`, it will be set to `authentication_methold`  in the listeners named `kafka-external` or `proxy-external` correspondingly. 
- Change RP statefulset set to expose the container ports for additional listeners.
- Change RP statefulset set to set the env `ADDITIONAL_LISTENERS` for the init container Configurator if the additional listeners are set through `additionalConfiguration`.