### PR TITLE
Always reconcile decommission

### DIFF
--- a/src/go/k8s/cmd/main.go
+++ b/src/go/k8s/cmd/main.go
@@ -440,8 +440,9 @@ func main() {
 
 		if runThisController(DecommissionController, additionalControllers) {
 			if err = (&redpandacontrollers.DecommissionReconciler{
-				Client:       mgr.GetClient(),
-				OperatorMode: operatorMode,
+				Client:                   mgr.GetClient(),
+				OperatorMode:             operatorMode,
+				DecommissionWaitInterval: decommissionWaitInterval,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "DecommissionReconciler")
 				os.Exit(1)
@@ -466,8 +467,9 @@ func main() {
 
 		if runThisController(DecommissionController, additionalControllers) {
 			if err = (&redpandacontrollers.DecommissionReconciler{
-				Client:       mgr.GetClient(),
-				OperatorMode: operatorMode,
+				Client:                   mgr.GetClient(),
+				OperatorMode:             operatorMode,
+				DecommissionWaitInterval: decommissionWaitInterval,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "DecommissionReconciler")
 				os.Exit(1)


### PR DESCRIPTION
In GKE case when VM was deleted Statefulset was reconciled only once. The number of replicas matches the number of registered nodes. Unfortunately when VM is recreated and Pod starts, then the Statefulset is not changed/updated. The decommission reconciler is not trigger never again. This functionality changes that to always reconcile in some interval.

Another change is done to change unstructured logging to structured one (at least in `verifyIfNeedDecommission` function).


```
  {
    "level": "debug",
    "ts": "2023-11-30T06:53:59.513Z",
    "logger": "DecommissionReconciler.verifyIfNeedDecommission",
    "msg": "health is found to be &{IsHealthy:false ControllerID:0 AllNodes:[0 1 2] NodesDown:[1] LeaderlessPartitions:[] UnderReplicatedPartitions:[kafka/__consumer_offsets/8 kafka/__consumer_offsets/5 kafka/_internal_connectors_offsets/8 kafka/__consumer_offsets/15 kafka/_internal_connectors_offsets/11 kafka/_internal_connectors_offsets/7 kafka/_internal_connectors_offsets/22 kafka/__consumer_offsets/7 kafka/__consumer_offsets/0 kafka/_redpanda_e2e_probe/0 kafka/_redpanda_e2e_probe/1 kafka/_internal_connectors_offsets/10 kafka/_internal_connectors_status/2 kafka/__consumer_offsets/2 kafka/__consumer_offsets/3 kafka/__consumer_offsets/9 kafka/_internal_connectors_offsets/21 kafka/_internal_connectors_offsets/24 kafka/__consumer_offsets/14 kafka_internal/id_allocator/0 kafka/_internal_connectors_offsets/16 kafka/_internal_connectors_offsets/5 kafka/_internal_connectors_configs/0 kafka/_redpanda_e2e_probe/2 kafka/_schemas/0 kafka/_internal_connectors_offsets/20]}",
    "controller": "statefulset",
    "controllerGroup": "apps",
    "controllerKind": "StatefulSet",
    "StatefulSet": {
      "name": "rp",
      "namespace": "redpanda"
    },
    "namespace": "redpanda",
    "name": "rp",
    "reconcileID": "f17916f2-e48a-4c03-a850-47ab4b2fb4b3"
  },
  {
    "level": "info",
    "ts": "2023-11-30T06:53:59.513Z",
    "logger": "DecommissionReconciler.verifyIfNeedDecommission",
    "msg": "all-nodes/requestedReps: 3/3",
    "controller": "statefulset",
    "controllerGroup": "apps",
    "controllerKind": "StatefulSet",
    "StatefulSet": {
      "name": "rp",
      "namespace": "redpanda"
    },
    "namespace": "redpanda",
    "name": "rp",
    "reconcileID": "f17916f2-e48a-4c03-a850-47ab4b2fb4b3"
  }
```