### PR TITLE
Flag to turn off helm-controller added.

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -172,7 +172,7 @@ KUTTL ?= $(LOCALBIN)/kubectl-kuttl
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.7
+KUSTOMIZE_VERSION ?= v5.1.1
 CONTROLLER_TOOLS_VERSION ?= v0.13.0
 KUTTL_VERSION ?= v0.15.0
 
@@ -243,3 +243,7 @@ lint: golangci-lint
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
+
+.PHONY: install-prometheus
+install-prometheus:
+	kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/e23ff77fceba6a5d9f190f5d1a123c87701dc964/bundle.yaml || true

--- a/src/go/k8s/kuttl-v2-test.yaml
+++ b/src/go/k8s/kuttl-v2-test.yaml
@@ -18,7 +18,7 @@ commands:
   - command: helm install --set logLevel=trace --set image.tag=dev
       --set image.repository=localhost/redpanda-operator --namespace redpanda --create-namespace redpanda-operator
        redpanda/operator --set rbac.createAdditionalControllerCRs=true --set additionalCmdFlags="{--additional-controllers=all}"
-      --set rbac.createRPKBundleCRs=true
+      --set rbac.createRPKBundleCRs=true --wait
 artifactsDir: tests/_e2e_artifacts_v2
 timeout: 720
 reportFormat: xml

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/00-assert-disable-helm-controllers.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/00-assert-disable-helm-controllers.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-operator
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  conditions:
+    - message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - message: ReplicaSet "redpanda-operator-bb6bc9dc8" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+# TestAssert cannot be used, since TestStep is used and this assertion is used there

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/00-disable-helm-controllers.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/00-disable-helm-controllers.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: helm upgrade --install --set logLevel=trace --set image.tag=dev
+        --set image.repository=localhost/redpanda-operator --namespace redpanda --create-namespace redpanda-operator
+        redpanda/operator --set rbac.createAdditionalControllerCRs=true --set additionalCmdFlags="{--additional-controllers=all,--enable-helm-controllers=false}"
+        --set rbac.createRPKBundleCRs=true --wait
+assert:
+  - 00-assert-disable-helm-controllers.yaml

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/01-assert-install-flux.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/01-assert-install-flux.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  namespace: flux-system
+status:
+  availableReplicas: 1
+  conditions:
+    - message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - message: ReplicaSet "helm-controller-b69f59f87" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/01-install-flux.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/01-install-flux.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl apply -f https://github.com/fluxcd/flux2/releases/download/v2.1.2/install.yaml
+assert:
+  - 01-assert-install-flux.yaml

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/02-assert-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/02-assert-create-redpanda.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  finalizers:
+    - operator.redpanda.com/finalizer
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec: {}
+status:
+  conditions:
+    - message: Redpanda reconciliation succeeded
+      reason: RedpandaClusterDeployed
+      status: "True"
+      type: Ready
+  helmRelease: redpanda
+  helmReleaseReady: true
+  helmRepository: redpanda-repository
+  helmRepositoryReady: true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+spec:
+  replicas: 3
+status:
+  availableReplicas: 3
+  currentReplicas: 3
+  readyReplicas: 3
+  replicas: 3
+  updatedReplicas: 3
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh redpanda ../../_e2e_artifacts_v2

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/02-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/02-create-redpanda.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec: {}

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/03-assert.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/03-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- command: ../../../hack/get-redpanda-info.sh redpanda ../../_e2e_artifacts_v2

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/03-delete-redpandas.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/03-delete-redpandas.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+delete:
+  - apiVersion: cluster.redpanda.com/v1alpha1
+    kind: Redpanda
+  - apiVersion: batch/v1
+    kind: Job
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      app.kubernetes.io/name: redpanda
+  - apiVersion: v1
+    kind: Service
+    labels:
+      app.kubernetes.io/name: redpanda

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/04-assert-enable-helm-controllers.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/04-assert-enable-helm-controllers.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-operator
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  conditions:
+    - message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - message: ReplicaSet "redpanda-operator-5cdf66789" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+# TestAssert cannot be used, since TestStep is used and this assertion is used there

--- a/src/go/k8s/tests/e2e-v2/disable-helm-controllers/04-enable-helm-controllers.yaml
+++ b/src/go/k8s/tests/e2e-v2/disable-helm-controllers/04-enable-helm-controllers.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
+  - command: helm upgrade --install --set logLevel=trace --set image.tag=dev
+      --set image.repository=localhost/redpanda-operator --namespace redpanda --create-namespace redpanda-operator
+      redpanda/operator --set rbac.createAdditionalControllerCRs=true --set additionalCmdFlags="{--additional-controllers=all,--enable-helm-controllers=true}"
+      --set rbac.createRPKBundleCRs=true
+assert:
+  - 04-assert-enable-helm-controllers.yaml


### PR DESCRIPTION
Allows a flag that will disable the running of internal helm-controllers. Should allow for users to use flux-cd that they have deployed. This was tested and a cluster can be created cleanly and deleted with nothing for a customer to do. 

