### PR TITLE
Add missing task go dependnecies goals for private repositories

### DIFF
--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -120,7 +120,7 @@ tasks:
       - task: :docker:task
         vars:
           DOCKER_IMAGE: '{{.GOLANG_TOOLCHAIN_IMAGE}}'
-          TASK_ARGS: k8s:build-tag-and-push-images
+          TASK_ARGS: ci:configure-git-private-repo k8s:download-k8s-go-dependencies k8s:build-tag-and-push-images k8s:cleanup-k8s-go-dependencies
     status:
       - test -z '{{.TAG_NAME}}' # only run for tagged commits
 


### PR DESCRIPTION
Currently container release is not working.

```
#21 [linux/amd64 manager 2/3] COPY --from=builder /workspace/k8s/manager .
--
  | #21 CANCELED
  | ------
  | > [linux/amd64 builder 5/8] COPY k8s/mod/pkg/mod /go/pkg/mod:
  | ------
  | Dockerfile:13
  | --------------------
  | 11 \|     # cache deps before building and copying source so that we don't need to re-download as much
  | 12 \|     # and so that source changes don't invalidate our downloaded layer
  | 13 \| >>> COPY k8s/mod/pkg/mod /go/pkg/mod
  | 14 \|     RUN go mod download
  | 15 \|
  | --------------------
  | ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref kzkgdzhclexv9eirj6zukdwrx::vtot5sau2vnahnbawvjkntr99: "/k8s/mod/pkg/mod": not found
```