### PR TITLE
console: increase protobuf schema registry refresh interval to 1m

### DIFF
--- a/src/go/k8s/pkg/console/configmap.go
+++ b/src/go/k8s/pkg/console/configmap.go
@@ -535,7 +535,7 @@ func (cm *ConfigMap) genKafka(username string) config.Kafka {
 			Enabled: y,
 			SchemaRegistry: config.ProtoSchemaRegistry{
 				Enabled:         y,
-				RefreshInterval: time.Second * 10,
+				RefreshInterval: time.Minute * 1,
 			},
 		}
 	}


### PR DESCRIPTION
The Console schema registry protobuf refresh can be costly (in terms of CPU and memory) operation depending on the amount of schemas registered within the schema registry and actual schema content. We are working to further optimize this.

Typically users do not update schemas that often, and some lag between an introduction of a new protobuf schema within registry, and the availability of that schema within Console itself to be able to deserialize messages for example is acceptable. 

The current default of `10s` can be overly aggressive or frequent depending on context.
This PR sets the default console proto schema registry refresh interval config to `1m`. 
The default within Console itself is [`5m`](https://github.com/redpanda-data/console/blob/master/backend/pkg/config/proto_schema_registry.go#L22-L25).
