### PR TITLE
k8s: increase the default console prometheus scrape interval to 1m

### DIFF
--- a/src/go/k8s/api/vectorized/v1alpha1/console_enterprise_types.go
+++ b/src/go/k8s/api/vectorized/v1alpha1/console_enterprise_types.go
@@ -116,7 +116,7 @@ type PrometheusConfig struct {
 	Jobs []PrometheusScraperJobConfig `json:"jobs"`
 
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:default="10s"
+	// +kubebuilder:default="1m"
 	TargetRefreshInterval *metav1.Duration `json:"targetRefreshInterval,omitempty"`
 }
 

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
@@ -109,7 +109,7 @@ spec:
                               type: object
                             type: array
                           targetRefreshInterval:
-                            default: 10s
+                            default: 1m
                             type: string
                         required:
                         - address

--- a/src/go/k8s/webhooks/redpanda/console_webhook.go
+++ b/src/go/k8s/webhooks/redpanda/console_webhook.go
@@ -149,7 +149,7 @@ func (m *ConsoleDefaulter) Default(
 		console.Spec.Cloud.PrometheusEndpoint != nil &&
 		console.Spec.Cloud.PrometheusEndpoint.Prometheus != nil &&
 		console.Spec.Cloud.PrometheusEndpoint.Prometheus.TargetRefreshInterval == nil {
-		console.Spec.Cloud.PrometheusEndpoint.Prometheus.TargetRefreshInterval = &metav1.Duration{Duration: 10 * time.Second}
+		console.Spec.Cloud.PrometheusEndpoint.Prometheus.TargetRefreshInterval = &metav1.Duration{Duration: 1 * time.Minute}
 	}
 
 	current, err := json.Marshal(console)


### PR DESCRIPTION
The default for Console prometheus scrape interval being `10s` is overly aggressive. `1m` seems like a saner default.