### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,14 @@ src/go/k8s/tests/e2e-v2-helm/
 
 # vim
 .*.sw?
+
+# direnv files
+.envrc
+.direnv/
+
+# task cache directory
+.task/
+
+# Nix files (for now)
+flake.lock
+flake.nix


### PR DESCRIPTION
This commit updates .gitignore to include a handful of tools utilized by the author of this commit. Namely, nix and direnv.