### PR TITLE
Standardize binary dependency installations

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -1,34 +1,35 @@
 version: '3'
 
+# dev.yml contains all tasks that install binary dependencies (and other odds and ends).
+# To install a dependency:
+# - Add {{BINARY_NAME}}_VERSION to the vars list
+# - Create a install-{{BINARY_NAME}} task
+# - If you need a working directory, add a task local var set to `mktemp -d`.
+#   Make sure to clean it up afterwards! For safety, prefer to delete files by
+#   name and then clean up the directory with rmdir to avoid `rm -rf` disasters.
+# - Install/copy the resulting binary to {{.BIN_DIR}}. Doing so ensures that
+#   binary will be available in $PATH.
+# - Make sure to support amd64, aarch64, linux, and darwin targets.
+# - Cache dependencies with `status`. If any installation is acceptable, use
+#   command -v BINARY_NAME and grep/sed to verify version. Otherwise, test -x
+#   {{.BIN_DIR}}/BINARY_NAME and grep/sed to verify the version.
+
 vars:
   TASK_VERSION: '3.19.1'
   GOLANG_VERSION: '1.21.3'
   GOLANG_INSTALL_DIR: '{{.BUILD_ROOT}}/go/{{.GOLANG_VERSION}}'
   KUBECTL_VERSION: '1.28.2'
-  KUBECTL_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/kubectl/{{.KUBECTL_VERSION}}'
   GOLANGCI_LINT_VERSION: '1.55.2'
-  GOLANGCI_LINT_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/golangci-lint/{{.GOLANGCI_LINT_VERSION}}'
   HELM_VERSION: '3.6.3'
-  HELM_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/helm/{{.HELM_VERSION}}'
   KIND_VERSION: '0.20.0'
-  KIND_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/kind/{{.KIND_VERSION}}'
   GOFUMPT_VERSION: 'v0.5.0'
-  GOFUMPT_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/gofumpt/{{.GOFUMPT_VERSION}}'
   K8S_CONTROLLER_GEN_VERSION: 'v0.13.0'
-  K8S_CONTROLLER_GEN_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/k8s-controller-gen/{{.K8S_CONTROLLER_GEN_VERSION}}'
   K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_VERSION: 'v0.7.0'
-  K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/k8s-controller-runtime-setup-envtest/{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_VERSION}}'
   KUSTOMIZE_VERSION: 'v5.1.1'
-  KUSTOMIZE_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/kustomize/{{.KUSTOMIZE_VERSION}}'
   YQ_VERSION: '4.35.2'
-  YQ_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/yq/{{.YQ_VERSION}}'
   KUTTL_VERSION: '0.15.0'
-  KUTTL_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/kuttl/{{.KUTTL_VERSION}}'
-  GORELEASER_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/goreleaser'
   GORELEASER_VERSION: '1.20.0'
-  QUILL_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/quill'
   QUILL_VERSION: '0.4.1'
-
 
 tasks:
   install-task:
@@ -39,16 +40,27 @@ tasks:
       - "[[ $({{.BIN_DIR}}/task --version | grep -o {{.TASK_VERSION}}) == {{.TASK_VERSION}} ]]"
 
   install-go:
-    desc: install golang compiler
+    desc: Install the golang toolchain
     vars:
       GOLANG_URL: 'https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/go{{.GOLANG_VERSION}}.{{OS}}-{{ARCH}}.tar.gz'
     cmds:
+      # Go's installation is a bit special compared to everything else here. Go
+      # comes with 2 binaries and the entire standard library. Therefore we
+      # can't just dump it into BIN_DIR. It get's extracted into it's own
+      # installation directory and symlinked into BIN_DIR as task doesn't allow
+      # any form of $PATH manipulation.
       - mkdir -p '{{.GOLANG_INSTALL_DIR}}'
       - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors -o '{{.GOLANG_INSTALL_DIR}}/go{{.GOLANG_VERSION}}.{{OS}}-{{ARCH}}.tar.gz' '{{.GOLANG_URL}}'
       - tar -xz -C '{{.GOLANG_INSTALL_DIR}}' -f '{{.GOLANG_INSTALL_DIR}}/go{{.GOLANG_VERSION}}.{{OS}}-{{ARCH}}.tar.gz' --strip 1
       - rm '{{.GOLANG_INSTALL_DIR}}/go{{.GOLANG_VERSION}}.{{OS}}-{{ARCH}}.tar.gz'
+      - ln -sf '{{.GOLANG_INSTALL_DIR}}/bin/go' '{{.BIN_DIR}}/go'
+      - ln -sf '{{.GOLANG_INSTALL_DIR}}/bin/gofmt' '{{.BIN_DIR}}/gofmt'
     status:
-      - test -f '{{.GOLANG_INSTALL_DIR}}/bin/go'
+      # Don't install go if it's already present in the environment and if it's
+      # at least in line with the patch version (IE 1.21.x). This lets
+      # developers and CI agents manage their own go installation.
+      - command -v go
+      - "[[ 'go{{.GOLANG_VERSION}}' == $(go version | grep -E -o 'go[0-9]+\\.[0-9]+')* ]]"
 
   install-gofumpt:
     desc: install gofumpt go formater
@@ -60,24 +72,21 @@ tasks:
     deps:
       - task: :dev:install-go
     cmds:
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin:$PATH
-        TMP_DIR=$(mktemp -d)
-        cd $TMP_DIR
-        go mod init tmp
-        GOBIN={{.GOFUMPT_INSTALL_DIR}}/bin/ go install mvdan.cc/gofumpt@{{.GOFUMPT_VERSION}}
-        rm -rf $TMP_DIR
+      - GOBIN={{.BIN_DIR}} go install mvdan.cc/gofumpt@{{.GOFUMPT_VERSION}}
     status:
-      - test -f '{{.GOFUMPT_INSTALL_DIR}}/bin/gofumpt'
+      # Don't install gofumpt if it's already present in the environment.
+      - command -v gofumpt
+      # And if it's the same version as the one we want.
+      - "[[ $(gofumpt -version | grep -Eo 'v[^ ]+') == '{{.GOFUMPT_VERSION}}' ]]"
 
   install-kustomize:
     vars:
       KUSTOMIZE_URL: 'https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/{{.KUSTOMIZE_VERSION}}/kustomize_{{.KUSTOMIZE_VERSION}}_{{OS}}_{{ARCH}}.tar.gz'
     cmds:
-      - mkdir -p '{{.KUSTOMIZE_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors '{{.KUSTOMIZE_URL}}' | tar -xz -C '{{.KUSTOMIZE_INSTALL_DIR}}/bin'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors '{{.KUSTOMIZE_URL}}' | tar -xz -C '{{.BIN_DIR}}'
     status:
-      - test -f '{{.KUSTOMIZE_INSTALL_DIR}}/bin/kustomize'
+      - command -v kustomize
+      - "[[ $(kustomize version) == '{{.KUSTOMIZE_VERSION}}' ]]"
 
   install-kubectl:
     desc: install kubectl
@@ -85,11 +94,12 @@ tasks:
       KUBECTL_URL_DEFAULT: 'https://storage.googleapis.com/kubernetes-release/release/v{{.KUBECTL_VERSION}}/bin/{{OS}}/{{ARCH}}/kubectl'
       KUBECTL_URL: '{{default .KUBECTL_URL_DEFAULT .KUBECTL_URL}}'
     cmds:
-      - mkdir -p '{{.KUBECTL_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.KUBECTL_URL}}' --retry-all-errors -o '{{.KUBECTL_INSTALL_DIR}}/bin/kubectl'
-      - chmod +x '{{.KUBECTL_INSTALL_DIR}}/bin/kubectl'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.KUBECTL_URL}}' --retry-all-errors -o '{{.BIN_DIR}}/kubectl'
+      - chmod +x '{{.BIN_DIR}}/kubectl'
     status:
-      - test -f '{{.KUBECTL_INSTALL_DIR}}/bin/kubectl'
+      # Don't install kubectl if it's already present and matches the major and minor version of KUBECTL_VERSION.
+      - command -v kubectl
+      - "[[ '{{.KUBECTL_VERSION}}' == $(kubectl version | sed -nr 's/Client Version: v([0-9]\\.[0-9]+).*/\\1/p')*]]"
 
   install-kind:
     desc: install kind
@@ -97,50 +107,44 @@ tasks:
       KIND_URL_DEFAULT: 'https://kind.sigs.k8s.io/dl/v{{.KIND_VERSION}}/kind-{{OS}}-{{ARCH}}'
       KIND_URL: '{{default .KIND_URL_DEFAULT .KIND_URL}}'
     cmds:
-      - mkdir -p '{{.KIND_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.KIND_URL}}' --retry-all-errors -o '{{.KIND_INSTALL_DIR}}/bin/kind'
-      - chmod +x '{{.KIND_INSTALL_DIR}}/bin/kind'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.KIND_URL}}' --retry-all-errors -o '{{.BIN_DIR}}/kind'
+      - chmod +x '{{.BIN_DIR}}/kind'
     status:
-      - test -f '{{.KIND_INSTALL_DIR}}/bin/kind'
+      - test -f '{{.BIN_DIR}}/kind'
 
   install-golangci-lint:
     desc: install golangci-lint
     vars:
       GOLANGCI_LINT_URL_DEFAULT: 'https://github.com/golangci/golangci-lint/releases/download/v{{.GOLANGCI_LINT_VERSION}}/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz'
       GOLANGCI_LINT_URL: '{{default .GOLANGCI_LINT_URL_DEFAULT .GOLANGCI_LINT_URL}}'
+      TMPDIR:
+        sh: mktemp -d
     cmds:
-      - mkdir -p '{{.GOLANGCI_LINT_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors -o '{{.GOLANGCI_LINT_INSTALL_DIR}}/bin/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz' '{{.GOLANGCI_LINT_URL}}'
-      - tar -xz -C '{{.GOLANGCI_LINT_INSTALL_DIR}}/bin' -f '{{.GOLANGCI_LINT_INSTALL_DIR}}/bin/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz' --strip 1 --wildcards '*/golangci-lint'
-      - rm '{{.GOLANGCI_LINT_INSTALL_DIR}}/bin/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors -o '{{.TMPDIR}}/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz' '{{.GOLANGCI_LINT_URL}}'
+      - tar -xz -C '{{.BIN_DIR}}' -f '{{.TMPDIR}}/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz' --strip 1 --wildcards '*/golangci-lint'
+      - rm '{{.TMPDIR}}/golangci-lint-{{.GOLANGCI_LINT_VERSION}}-{{OS}}-{{ARCH}}.tar.gz'
+      - rmdir {{.TMPDIR}}
     status:
-      - test -f '{{.GOLANGCI_LINT_INSTALL_DIR}}/bin/golangci-lint'
+      - test -f '{{.BIN_DIR}}/golangci-lint'
 
   install-docker-tag-list:
     desc: install docker-tag-list
     deps:
       - install-go
     cmds:
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin/:$PATH
-        export GOBIN='{{.DOCKER_TAG_LIST_INSTALL_DIR}}/'
-        go install github.com/joejulian/docker-tag-list@latest
+      - GOBIN='{{.BIN_DIR}}' go install github.com/joejulian/docker-tag-list@latest
     status:
-      - test -f '{{.DOCKER_TAG_LIST_INSTALL_DIR}}/docker-tag-list'
+      - test -f '{{.BIN_DIR}}/docker-tag-list'
 
   install-goreleaser:
     desc: install goreleaser
     deps:
       - install-go
     cmds:
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin/:$PATH
-        GOBIN='{{.GORELEASER_INSTALL_DIR}}' \
-        go install "github.com/goreleaser/goreleaser@v{{.GORELEASER_VERSION}}"
+      - GOBIN='{{.BIN_DIR}}' go install "github.com/goreleaser/goreleaser@v{{.GORELEASER_VERSION}}"
     status:
-      - test -f {{.GORELEASER_INSTALL_DIR}}/goreleaser
+      - test -f {{.BIN_DIR}}/goreleaser
       - |
-        PATH={{.GORELEASER_INSTALL_DIR}}:$PATH
         [[ $(goreleaser --version | grep -o {{.GORELEASER_VERSION}}) == {{.GORELEASER_VERSION}} ]]
 
   install-k8s-controller-gen:
@@ -148,17 +152,9 @@ tasks:
     deps:
       - install-go
     cmds:
-      - mkdir -p '{{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/bin'
-      - mkdir -p '{{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/src'
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin/:$PATH
-        export GOBIN={{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/bin
-        cd '{{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/src'
-        go mod init tmp
-        go install sigs.k8s.io/controller-tools/cmd/controller-gen@{{.K8S_CONTROLLER_GEN_VERSION}}
-      - rm -rf '{{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/src'
+      - GOBIN='{{.BIN_DIR}}' go install sigs.k8s.io/controller-tools/cmd/controller-gen@{{.K8S_CONTROLLER_GEN_VERSION}}
     status:
-      - test -f '{{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/bin/controller-gen'
+      - test -f '{{.BIN_DIR}}/controller-gen'
 
   start-podman-socket-service:
     desc: start podman.socket service
@@ -175,35 +171,40 @@ tasks:
     vars:
       HELM_URL_DEFAULT: 'https://get.helm.sh/helm-v{{.HELM_VERSION}}-{{OS}}-{{ARCH}}.tar.gz'
       HELM_URL: '{{default .HELM_URL_DEFAULT .HELM_URL}}'
+      TMPDIR:
+        sh: mktemp -d
     cmds:
-      - mkdir -p '{{.HELM_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors '{{.HELM_URL}}' -o '{{.HELM_INSTALL_DIR}}/bin/helm.tgz'
-      - tar -xz -C '{{.HELM_INSTALL_DIR}}/bin' --strip 1 -f '{{.HELM_INSTALL_DIR}}/bin/helm.tgz' '{{OS}}-{{ARCH}}/helm'
-      - rm '{{.HELM_INSTALL_DIR}}/bin/helm.tgz'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors '{{.HELM_URL}}' -o '{{.TMPDIR}}/helm.tgz'
+      - tar -xz -C '{{.BIN_DIR}}' --strip 1 -f '{{.TMPDIR}}/helm.tgz' '{{OS}}-{{ARCH}}/helm'
+      - rm '{{.TMPDIR}}/helm.tgz'
+      - rmdir '{{.TMPDIR}}'
     status:
-      - test -f '{{.HELM_INSTALL_DIR}}/bin/helm'
+      - test -f '{{.BIN_DIR}}/helm'
 
   install-yq:
     desc: install yq (YAML processor)
+    vars:
+      TMPDIR:
+        sh: mktemp -d
+      YQ_URL: 'https://github.com/mikefarah/yq/releases/download/v{{.YQ_VERSION}}/yq_{{OS}}_{{ARCH}}.tar.gz'
     cmds:
-      - mkdir -p '{{.YQ_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors https://github.com/mikefarah/yq/releases/download/v{{.YQ_VERSION}}/yq_{{OS}}_{{ARCH}}.tar.gz -o '{{.YQ_INSTALL_DIR}}/bin/yq.tar.gz'
-      - tar -xz -C '{{.YQ_INSTALL_DIR}}/bin' --strip 1 -f '{{.YQ_INSTALL_DIR}}/bin/yq.tar.gz' './yq_{{OS}}_{{ARCH}}'
-      - rm '{{.YQ_INSTALL_DIR}}/bin/yq.tar.gz'
-      - mv {{.YQ_INSTALL_DIR}}/bin/yq_{{OS}}_{{ARCH}} {{.YQ_INSTALL_DIR}}/bin/yq
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --retry-all-errors {{ .YQ_URL }} -o '{{.TMPDIR}}/yq.tar.gz'
+      - tar -xz -C {{.TMPDIR}} --strip 1 -f '{{.TMPDIR}}/yq.tar.gz' './yq_{{OS}}_{{ARCH}}'
+      - mv {{.TMPDIR}}/yq_{{OS}}_{{ARCH}} {{.BIN_DIR}}/yq
+      - rm {{.TMPDIR}}/yq.tar.gz
+      - rmdir {{.TMPDIR}}
     status:
-      - test -f '{{.YQ_INSTALL_DIR}}/bin/yq'
+      - test -f '{{.BIN_DIR}}/yq'
 
   install-kuttl:
     desc: install kuttl
     vars:
       KUTTL_URL: 'https://github.com/kudobuilder/kuttl/releases/download/v{{.KUTTL_VERSION}}/kubectl-kuttl_{{.KUTTL_VERSION}}_{{OS}}_{{if eq ARCH "amd64"}}x86_64{{else}}arm64{{end}}'
     cmds:
-      - mkdir -p '{{.KUTTL_INSTALL_DIR}}/bin'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.KUTTL_URL}}' -o '{{.KUTTL_INSTALL_DIR}}/bin/kuttl'
-      - chmod +x '{{.KUTTL_INSTALL_DIR}}/bin/kuttl'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.KUTTL_URL}}' -o '{{.BIN_DIR}}/kuttl'
+      - chmod +x '{{.BIN_DIR}}/kuttl'
     status:
-      - test -f '{{.KUTTL_INSTALL_DIR}}/bin/kuttl'
+      - test -x '{{.BIN_DIR}}/kuttl'
 
   retry-task:
     vars:
@@ -251,35 +252,29 @@ tasks:
     vars:
       SETUP_ENVTEST_URL: 'https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_VERSION}}/hack/setup-envtest.sh'
     cmds:
-      - mkdir -p '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.SETUP_ENVTEST_URL}}' -o '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh'
-      - chmod +x '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.SETUP_ENVTEST_URL}}' -o '{{.BIN_DIR}}/setup-envtest.sh'
+      - chmod +x '{{.BIN_DIR}}/setup-envtest.sh'
     status:
-      - test -f '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh'
+      - test -f '{{.BIN_DIR}}/setup-envtest.sh'
 
   install-goreleaser:
     desc: install goreleaser
     deps:
       - install-go
     cmds:
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin/:$PATH
-        GOBIN='{{.GORELEASER_INSTALL_DIR}}' \
-        go install "github.com/goreleaser/goreleaser@v{{.GORELEASER_VERSION}}"
+      - GOBIN={{.BIN_DIR}} go install "github.com/goreleaser/goreleaser@v{{.GORELEASER_VERSION}}"
     status:
-      - test -f {{.GORELEASER_INSTALL_DIR}}/goreleaser
+      - test -f {{.BIN_DIR}}/goreleaser
       - |
-        PATH={{.GORELEASER_INSTALL_DIR}}:$PATH
         [[ $(goreleaser --version | grep -o {{.GORELEASER_VERSION}}) == {{.GORELEASER_VERSION}} ]]
 
   install-quill:
     desc: install quill
     cmds:
-      - mkdir -p '{{.QUILL_INSTALL_DIR}}'
       - |
         curl -sSfL \
           https://raw.githubusercontent.com/anchore/quill/main/install.sh \
-          | sh -s -- -b "{{.QUILL_INSTALL_DIR}}" "v{{.QUILL_VERSION}}"
+          | sh -s -- -b "{{.BIN_DIR}}" "v{{.QUILL_VERSION}}"
     status:
-      - test -f {{.QUILL_INSTALL_DIR}}/quill
-      - "[[ $({{.QUILL_INSTALL_DIR}}/quill --version | grep -o {{.QUILL_VERSION}}) == {{.QUILL_VERSION}} ]]"
+      - test -f {{.BIN_DIR}}/quill
+      - "[[ $(quill --version | grep -o {{.QUILL_VERSION}}) == {{.QUILL_VERSION}} ]]"

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -17,7 +17,6 @@ tasks:
     dir: 'src/go/k8s'
     cmds:
       - |
-        PATH="{{.GOLANGCI_LINT_INSTALL_DIR}}/bin:{{.GOLANG_INSTALL_DIR}}/bin:$PATH"
         mkdir mod || (rm -rf mod && mkdir mod)
         GOPATH=$(realpath ./mod/) go mod download
 
@@ -35,8 +34,6 @@ tasks:
       - './**/*.go'
     cmds:
       - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin:$PATH
-        PATH={{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/bin:$PATH
         controller-gen \
           object:headerFile="../../../licenses/boilerplate.go.txt" \
           paths='./...'
@@ -46,9 +43,7 @@ tasks:
     deps:
       - :dev:install-go
     cmds:
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin:$PATH
-        go vet ./...
+      - go vet ./...
 
   generate-manifests:
     dir: 'src/go/k8s'
@@ -86,8 +81,7 @@ tasks:
       ENVTEST_ASSETS_DIR: '{{.ENVTEST_ASSETS_DIR | default .ENVTEST_ASSETS_DIR_DEFAULT}}'
     cmds:
       - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin:$PATH
-        source {{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh
+        source {{.BIN_DIR}}/setup-envtest.sh
         fetch_envtest_tools {{.ENVTEST_ASSETS_DIR}}
         setup_envtest_env {{.ENVTEST_ASSETS_DIR}}
         go test -v ./... -coverprofile cover.out
@@ -138,7 +132,7 @@ tasks:
       - :dev:install-docker-tag-list
     cmds:
       - |
-        TAG=$("{{.DOCKER_TAG_LIST_INSTALL_DIR}}/docker-tag-list" -c "{{.CONSTRAINT}}" --latest -r "{{.REPO}}" | sed 's/-a..64$//')
+        TAG=$(docker-tag-list -c "{{.CONSTRAINT}}" --latest -r "{{.REPO}}" | sed 's/-a..64$//')
         docker pull "{{.REPO}}":"${TAG}"
         docker tag "{{.REPO}}":"${TAG}" localhost/redpanda:dev
 
@@ -201,7 +195,6 @@ tasks:
       - mkdir -p {{.KUTTL_ARTIFACTS_DIR}}
       - docker image list
       - |
-        PATH="{{.GOLANG_INSTALL_DIR}}"/bin:"{{.HELM_INSTALL_DIR}}"/bin:"{{.KIND_INSTALL_DIR}}"/bin:"{{.KUBECTL_INSTALL_DIR}}"/bin:"{{.KUTTL_INSTALL_DIR}}"/bin:"{{.KUSTOMIZE_INSTALL_DIR}}"/bin:"{{.YQ_INSTALL_DIR}}"/bin:$PATH
         KUTTL_EXIT_CODE=0
         kuttl test --config "{{.KUTTL_CONFIG_FILE}}" {{.CLI_ARGS}} || KUTTL_EXIT_CODE=$?
         echo "$KUTTL_EXIT_CODE" > kuttl-exit-code


### PR DESCRIPTION
### This PR is stacked on top of others!

Please consider reviewing those PRs first. This message will be removed once prerequisite PRs are merged and this one is rebased.

* fe6750fa67ad91d03bcff1a0c771b83eb2f917dc is from #71
* 1ad66b47bdcd45100c34dbaadd0987c1fd77da87 is from #72

---

#### 4ce24dc7a71dc2d8c2503011024430bd323a8327 Standardize binary dependency installations

Prior to this change, taskfiles/dev.yml was quite verbose and installed
binary tools to individual directories. Doing so required a large number
of similar variables, repeated commands, and required consumers thereof
to manage $PATH carefully.

This commit standardizes installation patterns and locations as well as
documenting best practices within taskfiles/dev.yml. Future commits will
utilize this standardization to leverage `task` more heavily in the
development process and github actions.