### PR TITLE
k8s: fix console schema regisitry refreshInterval name

### DIFF
--- a/src/go/k8s/api/vectorized/v1alpha1/console_types.go
+++ b/src/go/k8s/api/vectorized/v1alpha1/console_types.go
@@ -150,7 +150,7 @@ type Schema struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
 	// +kubebuilder:default="1m"
-	RefreshInterval *metav1.Duration `json:"targetRefreshInterval,omitempty"`
+	RefreshInterval *metav1.Duration `json:"refreshInterval,omitempty"`
 }
 
 // Deployment defines configurable fields for the Console Deployment resource

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
@@ -597,7 +597,7 @@ spec:
                 properties:
                   enabled:
                     type: boolean
-                  targetRefreshInterval:
+                  refreshInterval:
                     default: 1m
                     format: duration
                     type: string


### PR DESCRIPTION
Sigh, the property introduced in https://github.com/redpanda-data/redpanda-operator/pull/68 is not appropriately named. ideally this property should be named `refreshInterval`, rather than `targetRefreshInterval`.