### PR TITLE
Move topic reconciler from only v2 mode to both modes

### DIFF
--- a/src/go/k8s/cmd/main.go
+++ b/src/go/k8s/cmd/main.go
@@ -303,6 +303,21 @@ func main() {
 			os.Exit(1)
 		}
 
+		var topicEventRecorder *events.Recorder
+		if topicEventRecorder, err = events.NewRecorder(mgr, ctrl.Log, eventsAddr, "TopicReconciler"); err != nil {
+			setupLog.Error(err, "unable to create event recorder for: TopicReconciler")
+			os.Exit(1)
+		}
+
+		if err = (&clusterredpandacomcontrollers.TopicReconciler{
+			Client:        mgr.GetClient(),
+			Scheme:        mgr.GetScheme(),
+			EventRecorder: topicEventRecorder,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Topic")
+			os.Exit(1)
+		}
+
 		// Setup webhooks
 		if webhookEnabled {
 			setupLog.Info("Setup webhook")


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/commit/f44fe76ae10edb8ecd30a03386d61f2d2db46897#diff-8074ab08efa0940c749c32af395271faf34280c16da67864c5334d6c0f7f1596R396-R402 commit the logic of running Topic controller in any operator mode was moved to only run in v2 mode. With this change topic controller would be available in v1 and v2 modes.