### PR TITLE
Notify slack channel when operator nightly test fails

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,15 @@ steps:
     artifact_paths:
       - src/go/k8s/*.tar.gz
       - src/go/k8s/tests/_e2e_artifacts/kuttl-report.xml
+    plugins:
+      - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
+          message: ":cloud: K8s Operator v1 Jobs failed"
+          channel_name: "kubernetes-tests"
+          slack_token_env_var_name: "SLACK_VBOT_TOKEN"
+          conditions:
+            failed: true
+            branches:
+              - main
 
   - group: K8s Operator v2 Jobs
     if: |
@@ -39,6 +48,15 @@ steps:
         artifact_paths:
           - src/go/k8s/*.tar.gz
           - src/go/k8s/tests/_e2e_artifacts_v2/kuttl-report.xml
+        plugins:
+          - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
+              message: ":cloud: K8s Operator v2 Jobs failed"
+              channel_name: "kubernetes-tests"
+              slack_token_env_var_name: "SLACK_VBOT_TOKEN"
+              conditions:
+                failed: true
+                branches:
+                  - main
 
       - key: annotate-v2-testresults
         label: Parse Operator v2 Test Results
@@ -75,6 +93,15 @@ steps:
         artifact_paths:
           - src/go/k8s/*.tar.gz
           - src/go/k8s/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
+        plugins:
+          - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
+              message: ":cloud: K8s Operator v2 Helm Jobs failed"
+              channel_name: "kubernetes-tests"
+              slack_token_env_var_name: "SLACK_VBOT_TOKEN"
+              conditions:
+                failed: true
+                branches:
+                  - main
 
       - key: annotate-v2-helm-testresults
         label: Parse Operator v2 Helm Test Results

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,6 +87,8 @@ steps:
            # suffix. Those would not be taken by chart testing (`ct`) program, but
            # `hack/v2-helm-setup.sh` takes all files currently and disables only handful of them.
 #          - ./ci/scripts/run-in-nix-docker.sh ./task ci:k8s-v2-helm
+          - mkdir -p src/go/k8s/tests/_e2e_helm_artifacts_v2
+          - touch src/go/k8s/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
           - echo Noop
         agents:
           queue: amd64-builders


### PR DESCRIPTION
Over the last 3 days, nightly test failures went unnoticed.

https://buildkite.com/redpanda/redpanda-operator/builds?branch=main

From 1295 till 1310 nightly build failed at the operator v2 helm test jobs.