### PR TITLE
V1: Prevent configs from becoming outdated when scaling down

### DIFF
--- a/ci/setup-envtest.nix
+++ b/ci/setup-envtest.nix
@@ -1,0 +1,31 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "setup-envtest";
+  version = "0.18.2";
+
+  # Don't run tests.
+  doCheck = false;
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "controller-runtime";
+    rev = "v${version}";
+    hash = "sha256-fQgWwndxzBIi3zsNMYvFDXjetnaQF0NNK+qW8j4Wn/M=";
+  };
+
+  sourceRoot = "source/tools/setup-envtest";
+
+  vendorHash = "sha256-Xr5b/CRz/DMmoc4bvrEyAZcNufLIZOY5OGQ6yw4/W9k=";
+
+  meta = with lib; {
+    description = "A small tool that manages binaries for envtest";
+    homepage = "https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest";
+    license = licenses.asl20;
+    mainProgram = "setup-envtest";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,15 @@
 
       perSystem = { self', system, ... }:
         let
-          pkgs = import nixpkgs { inherit system; };
           lib = pkgs.lib;
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              (final: prev: {
+                setup-envtest = pkgs.callPackage ./ci/setup-envtest.nix { };
+              })
+            ];
+          };
         in
         {
           formatter = pkgs.nixpkgs-fmt;
@@ -41,6 +48,7 @@
               pkgs.go-task
               pkgs.go_1_21
               pkgs.openssl
+              pkgs.setup-envtest # Kubernetes provided test utilities
               # TODO(chrisseto): Migrate taskfile to using dependencies from
               # this flake.
               # pkgs.goreleaser

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -42,8 +42,8 @@ endif
 all: build
 
 # Run tests
-test: manifests generate fmt vet envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile cover.out
+test: manifests generate fmt vet
+	cd ../../.. && nix develop -c ./task k8s:run-unit-tests
 
 # Build manager binary
 .PHONY: manager
@@ -167,7 +167,6 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
-ENVTEST ?= $(LOCALBIN)/setup-envtest
 KUTTL ?= $(LOCALBIN)/kubectl-kuttl
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
@@ -182,11 +181,6 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: kuttl
 kuttl: $(KUTTL)

--- a/src/go/k8s/pkg/resources/configuration/configuration.go
+++ b/src/go/k8s/pkg/resources/configuration/configuration.go
@@ -153,16 +153,9 @@ func (c *GlobalConfiguration) GetFullConfigurationHash() (string, error) {
 }
 
 // Ignore seeds in the hash computation such that any seed changes do not
-// trigger a rolling restart across the nodes. Similarly for pandaproxy and
-// schema registry clients.
+// trigger a rolling restart across the nodes.
 func removeFieldsThatShouldNotTriggerRestart(c *GlobalConfiguration) {
 	c.NodeConfiguration.Redpanda.SeedServers = []config.SeedServer{}
-	if c.NodeConfiguration.PandaproxyClient != nil {
-		c.NodeConfiguration.PandaproxyClient.Brokers = []config.SocketAddress{}
-	}
-	if c.NodeConfiguration.SchemaRegistryClient != nil {
-		c.NodeConfiguration.SchemaRegistryClient.Brokers = []config.SocketAddress{}
-	}
 }
 
 // GetAdditionalRedpandaProperty retrieves a configuration option

--- a/src/go/k8s/pkg/resources/configuration/configuration_test.go
+++ b/src/go/k8s/pkg/resources/configuration/configuration_test.go
@@ -132,16 +132,12 @@ func TestStringSliceProperties(t *testing.T) {
 func TestHash_FieldsWithNoHashChange(t *testing.T) {
 	cfg := configuration.For("v22.1.1-test")
 	cfg.NodeConfiguration.Redpanda.SeedServers = []rpkcfg.SeedServer{}
-	cfg.NodeConfiguration.PandaproxyClient = &rpkcfg.KafkaClient{Brokers: []rpkcfg.SocketAddress{}}
-	cfg.NodeConfiguration.SchemaRegistryClient = &rpkcfg.KafkaClient{Brokers: []rpkcfg.SocketAddress{}}
 	nodeConfHash, err := cfg.GetNodeConfigurationHash()
 	require.NoError(t, err)
 	allConfHash, err := cfg.GetFullConfigurationHash()
 	require.NoError(t, err)
 
 	cfg.NodeConfiguration.Redpanda.SeedServers = []rpkcfg.SeedServer{{Host: rpkcfg.SocketAddress{Address: "redpanda.com", Port: 9090}}}
-	cfg.NodeConfiguration.PandaproxyClient = &rpkcfg.KafkaClient{Brokers: []rpkcfg.SocketAddress{{Address: "redpanda.com", Port: 9091}}}
-	cfg.NodeConfiguration.SchemaRegistryClient = &rpkcfg.KafkaClient{Brokers: []rpkcfg.SocketAddress{{Address: "redpanda.com", Port: 9092}}}
 	nodeConfHashNew, err := cfg.GetNodeConfigurationHash()
 	require.NoError(t, err)
 	allConfHashNew, err := cfg.GetFullConfigurationHash()

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config-v22.1.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config-v22.1.sh
@@ -14,7 +14,7 @@ pandaproxy:
     port: 8082
 pandaproxy_client:
   brokers:
-  - address: additional-configuration-0.additional-configuration.${NAMESPACE}.svc.cluster.local.
+  - address: additional-configuration.${NAMESPACE}.svc.cluster.local.
     port: 9092
   retries: ${PANDAPROXY_RETRIES}
 redpanda:

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config-v22.2.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config-v22.2.sh
@@ -14,7 +14,7 @@ pandaproxy:
     port: 8082
 pandaproxy_client:
   brokers:
-  - address: additional-configuration-0.additional-configuration.${NAMESPACE}.svc.cluster.local.
+  - address: additional-configuration.${NAMESPACE}.svc.cluster.local.
     port: 9092
   retries: ${PANDAPROXY_RETRIES}
 redpanda:

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config-v22.3.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config-v22.3.sh
@@ -14,7 +14,7 @@ pandaproxy:
     port: 8082
 pandaproxy_client:
   brokers:
-  - address: additional-configuration-0.additional-configuration.${NAMESPACE}.svc.cluster.local.
+  - address: additional-configuration.${NAMESPACE}.svc.cluster.local.
     port: 9092
   retries: ${PANDAPROXY_RETRIES}
 redpanda:

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config-v23.1.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config-v23.1.sh
@@ -66,7 +66,7 @@ pandaproxy:
           name: proxy
 pandaproxy_client:
     brokers:
-        - address: additional-configuration-0.additional-configuration.${NAMESPACE}.svc.cluster.local.
+        - address: additional-configuration.${NAMESPACE}.svc.cluster.local.
           port: 9092
     retries: ${PANDAPROXY_RETRIES}
 schema_registry:

--- a/src/go/k8s/webhooks/redpanda/validate_enterprise_test.go
+++ b/src/go/k8s/webhooks/redpanda/validate_enterprise_test.go
@@ -71,9 +71,10 @@ func TestDoNotValidateWhenDeleted(t *testing.T) {
 	testEnv := &testutils.RedpandaTestEnv{}
 
 	cfg, err := testEnv.StartRedpandaTestEnv(true)
-	defer testEnv.Stop() //nolint:errcheck // in test test env error is not relevant
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
+
+	defer testEnv.Stop() //nolint:errcheck // in test test env error is not relevant
 
 	testAdminAPI := &adminutils.MockAdminAPI{Log: ctrl.Log.WithName("testAdminAPI").WithName("mockAdminAPI")}
 	testAdminAPIFactory := func(

--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -15,8 +15,6 @@ vars:
   GOFUMPT_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/gofumpt/{{.GOFUMPT_VERSION}}'
   K8S_CONTROLLER_GEN_VERSION: 'v0.13.0'
   K8S_CONTROLLER_GEN_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/k8s-controller-gen/{{.K8S_CONTROLLER_GEN_VERSION}}'
-  K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_VERSION: 'v0.7.0'
-  K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/k8s-controller-runtime-setup-envtest/{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_VERSION}}'
   KUSTOMIZE_VERSION: 'v5.1.1'
   KUSTOMIZE_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/kustomize/{{.KUSTOMIZE_VERSION}}'
   YQ_VERSION: '4.35.2'
@@ -212,16 +210,6 @@ tasks:
     cmds:
       - docker buildx create --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=-1 --driver-opt env.BUILDKIT_STEP_LOG_MAX_SPEED=-1 --platform linux/amd64,linux/arm64 --name v-builder --use
       - '{{if eq ARCH "amd64"}} docker run --rm --privileged linuxkit/binfmt:v0.8 {{else}} echo "" {{end}}'
-
-  install-k8s-controller-runtime-setup-envtest:
-    vars:
-      SETUP_ENVTEST_URL: 'https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_VERSION}}/hack/setup-envtest.sh'
-    cmds:
-      - mkdir -p '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}'
-      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.SETUP_ENVTEST_URL}}' -o '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh'
-      - chmod +x '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh'
-    status:
-      - test -f '{{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh'
 
   install-goreleaser:
     desc: install goreleaser

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -53,15 +53,9 @@ tasks:
       - run-go-vet
       - generate-controller-code
       - generate-manifests
-      - :dev:install-k8s-controller-runtime-setup-envtest
-    vars:
-      ENVTEST_ASSETS_DIR_DEFAULT: '{{.BUILD_ROOT}}/k8s-operator/envtest/'
-      ENVTEST_ASSETS_DIR: '{{.ENVTEST_ASSETS_DIR | default .ENVTEST_ASSETS_DIR_DEFAULT}}'
     cmds:
       - |
-        source {{.K8S_CONTROLLER_RUNTIME_SETUP_ENVTEST_INSTALL_DIR}}/setup-envtest.sh
-        fetch_envtest_tools {{.ENVTEST_ASSETS_DIR}}
-        setup_envtest_env {{.ENVTEST_ASSETS_DIR}}
+        source <(cd {{ .SRC_DIR }} && nix develop -c setup-envtest use -p env 1.29.x)
         go test -v ./... -coverprofile cover.out
 
   build-operator-images:
@@ -172,6 +166,7 @@ tasks:
         vars:
           USE_SUDO: "false"
       - task: fetch-latest-redpanda
+      - task: build-operator-images
     cmds:
       - mkdir -p {{.KUTTL_ARTIFACTS_DIR}}
       - docker image list


### PR DESCRIPTION
#### 0dd40b5a1825f9fee71f7a1b658fa9ede40c72cb move setup-envtest to nix

This commit moves the `setup-envtest` shell scripts downloaded by
taskfile to the go binary equivalent and instead utilizes nix to install
it.


#### c84a283f41633ebba55c60b2f9618e27ea87bb9d V1: Prevent configs from becoming outdated when scaling down

Previously a collection of configurations (Seed Brokers, PandaProxy
Client, and SchemaRegistry Client) could become out of date when scaling
a cluster down. For example 5 replicas to 3. A special case of the
config hasher would ignore these fields to prevent needless restarts in
the case of scaling up which left stale values when scaling down. These
stale configurations would prevent various components of redpanda from
working correctly.

To mitigate these issues, this commit:
- Changes the PandaProxy and SchemaRegistry clients configurations to
instead always point at redpanda's headless service.
- Caps the list of seed brokers to a maximum of 3.

While these changes will prevent needless restarts in the future, the
upgrade to this new configuration WILL result in a single rolling
restart.

Fixes #125