### PR TITLE
Enable webhook conversion patch in kustomization

### DIFF
--- a/src/go/k8s/api/redpanda/v1alpha1/redpanda_conversion_test.go
+++ b/src/go/k8s/api/redpanda/v1alpha1/redpanda_conversion_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -218,6 +220,13 @@ func CRDFuzzer() *fuzz.Fuzzer {
 		// is... Scary.
 		func(q *resource.Quantity, c fuzz.Continue) { // nolint:ineffassign,staticcheck // Fuzzing is weird, we're assigning to a pointer to pass the value out.
 			q = resource.NewQuantity(c.Int63(), resource.DecimalSI)
+		},
+		// TypeMeta is special case where ApiVersion needs to be empty. In the real webhook handler the apiVersion will be set
+		// by controller runtime.
+		func(typeMeta *metav1.TypeMeta, c fuzz.Continue) { // nolint:staticcheck // Fuzzing is weird, we're assigning to a pointer to pass the value out.
+			typeMeta = &metav1.TypeMeta{ // nolint:ineffassign,staticcheck // Fuzzing is weird, we're assigning to a pointer to pass the value out.
+				Kind: c.RandString(),
+			}
 		},
 	).SkipFieldsWithPattern(regexp.MustCompile("Console|Config|Connectors|FieldsV1"))
 }

--- a/src/go/k8s/config/crd/kustomization.yaml
+++ b/src/go/k8s/config/crd/kustomization.yaml
@@ -19,6 +19,7 @@ patches:
 - path: patches/webhook_in_clusters.yaml
 - path: patches/webhook_in_redpanda_consoles.yaml
 - path: patches/webhook_in_cluster.redpanda.com_topics.yaml
+- path: patches/webhook_in_redpanda_redpanda.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
@@ -26,6 +27,7 @@ patches:
 - path: patches/cainjection_in_clusters.yaml
 - path: patches/cainjection_in_redpanda_consoles.yaml
 - path: patches/cainjection_in_cluster.redpanda.com_topics.yaml
+- path: patches/cainjection_in_redpanda_redpanda.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # patches CRD to re-add removed fields from beta CRDs

--- a/src/go/k8s/config/crd/patches/cainjection_in_redpanda_redpanda.yaml
+++ b/src/go/k8s/config/crd/patches/cainjection_in_redpanda_redpanda.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: redpanda.redpanda.vectorized.io
+  name: redpandas.cluster.redpanda.com

--- a/src/go/k8s/config/crd/patches/webhook_in_redpanda_redpanda.yaml
+++ b/src/go/k8s/config/crd/patches/webhook_in_redpanda_redpanda.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: redpanda.redpanda.vectorized.io
+  name: redpandas.cluster.redpanda.com
 spec:
   conversion:
     strategy: Webhook

--- a/src/go/k8s/internal/controller/redpanda/redpanda_decommission_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/redpanda_decommission_controller.go
@@ -30,7 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/src/go/k8s/api/redpanda/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/api/redpanda/v1alpha2"
 )
 
 // +kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=redpandas,verbs=get;list;watch;
@@ -176,7 +176,7 @@ func (r *DecommissionReconciler) verifyIfNeedDecommission(ctx context.Context, s
 	redpandaNameList := make([]string, 0)
 	if r.OperatorMode {
 		opts := &client.ListOptions{Namespace: namespace}
-		redpandaList := &v1alpha1.RedpandaList{}
+		redpandaList := &v1alpha2.RedpandaList{}
 		if errGET := r.Client.List(ctx, redpandaList, opts); errGET != nil {
 			return ctrl.Result{}, fmt.Errorf("could not GET list of Redpandas in namespace: %w", errGET)
 		}

--- a/src/go/k8s/internal/controller/redpanda/redpanda_node_pvc_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/redpanda_node_pvc_controller.go
@@ -22,7 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/src/go/k8s/api/redpanda/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/api/redpanda/v1alpha2"
 )
 
 // +kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=redpandas,verbs=get;list;watch;
@@ -71,7 +71,7 @@ func (r *RedpandaNodePVCReconciler) reconcile(ctx context.Context, req ctrl.Requ
 	redpandaNameList := make([]string, 0)
 	if r.OperatorMode {
 		opts := &client.ListOptions{Namespace: req.Namespace}
-		redpandaList := &v1alpha1.RedpandaList{}
+		redpandaList := &v1alpha2.RedpandaList{}
 		if errList := r.Client.List(ctx, redpandaList, opts); errList != nil {
 			return ctrl.Result{}, fmt.Errorf("could not GET list of Redpandas in namespace: %w", errList)
 		}


### PR DESCRIPTION
https://github.com/redpanda-data/redpanda-operator/pull/143/commits/b4809a1be725d3910f5b805e6aaf5dbc3890567a

### Enable webhook conversion patch in kustomization

Kustomization is not recommented in our official documentation, but those
kustomization patch are neccessery for Redpanda conversion

https://github.com/redpanda-data/redpanda-operator/pull/143/commits/605ec3a016980c20d3109026007ee42c78ffb43e

### Fix ApiVersion overwrite during conversion

During conversion webhook handler controller-runtime sets desire meta api version of the
destination resource from the Kubernetes API server request. Round trip marshall and unmarshall
is overwriting metadata.

#### Reference

https://github.com/kubernetes-sigs/controller-runtime/blob/f4ca78ebc00a4717ecd1c2daea1874d69ddd0137/pkg/webhook/conversion/conversion.go#L101