### PR TITLE
Support setting priority class name in broker pods

### DIFF
--- a/src/go/k8s/api/vectorized/v1alpha1/cluster_types.go
+++ b/src/go/k8s/api/vectorized/v1alpha1/cluster_types.go
@@ -104,6 +104,8 @@ type ClusterSpec struct {
 	// Replicas determine how big the cluster will be.
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
+	// PriorityClassName is the name of PriortyClass.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// PodDisruptionBudget specifies whether PDB resource should be created for
 	// the cluster and how should it be configured. By default this is enabled
 	// and defaults to MaxUnavailable=1

--- a/src/go/k8s/api/vectorized/v1alpha1/cluster_types.go
+++ b/src/go/k8s/api/vectorized/v1alpha1/cluster_types.go
@@ -104,7 +104,7 @@ type ClusterSpec struct {
 	// Replicas determine how big the cluster will be.
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
-	// PriorityClassName is the name of PriortyClass.
+	// PriorityClassName is used to set the PodSpec.PriorityClassName of the redpanda Statefulset.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// PodDisruptionBudget specifies whether PDB resource should be created for
 	// the cluster and how should it be configured. By default this is enabled

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -1072,7 +1072,8 @@ spec:
                     x-kubernetes-int-or-string: true
                 type: object
               priorityClassName:
-                description: PriorityClassName is the name of PriortyClass.
+                description: PriorityClassName is used to set the PodSpec.PriorityClassName
+                  of the redpanda Statefulset.
                 type: string
               replicas:
                 description: Replicas determine how big the cluster will be.

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -1071,6 +1071,9 @@ spec:
                       you can read more in https://kubernetes.io/docs/tasks/run-application/configure-pdb/
                     x-kubernetes-int-or-string: true
                 type: object
+              priorityClassName:
+                description: PriorityClassName is the name of PriortyClass.
+                type: string
               replicas:
                 description: Replicas determine how big the cluster will be.
                 format: int32

--- a/src/go/k8s/config/rbac/role.yaml
+++ b/src/go/k8s/config/rbac/role.yaml
@@ -274,6 +274,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - list
+  - get
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -670,3 +677,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - list
+  - get
+

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -340,7 +340,6 @@ func (r *StatefulSetResource) obj(
 
 	// We set statefulset replicas via status.currentReplicas in order to control it from the handleScaling function
 	replicas := r.pandaCluster.GetCurrentReplicas()
-
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.Key().Namespace,
@@ -371,6 +370,7 @@ func (r *StatefulSetResource) obj(
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: ptr.To(int64(fsGroup)),
 					},
+					PriorityClassName: r.pandaCluster.Spec.PriorityClassName,
 					Volumes: append([]corev1.Volume{
 						{
 							Name: "configmap-dir",


### PR DESCRIPTION
Add `priorityClassName` to `cluster` CRD for setting priority class in Redpanda broker pods.