### PR TITLE
v1: fix Cluster CRD PriorityClassName description

### DIFF
--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -1072,7 +1072,8 @@ spec:
                     x-kubernetes-int-or-string: true
                 type: object
               priorityClassName:
-                description: PriorityClassName is used to set the PodSpec.PriorityClassName
+                description: |-
+                  PriorityClassName is used to set the PodSpec.PriorityClassName
                   of the redpanda Statefulset.
                 type: string
               replicas:


### PR DESCRIPTION
Fix `v1` Cluster CRD `PriorityClassName` description field that's not properly formatted 

Ref: https://github.com/redpanda-data/redpanda-operator/pull/154