### PR TITLE
Bump helm-chart version

### DIFF
--- a/src/go/k8s/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
+++ b/src/go/k8s/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
@@ -565,7 +565,7 @@ type PersistentVolume struct {
 	// Applies labels to the PersistentVolumeClaims to facilitate identification and selection based on custom criteria.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Specifies the storage capacity required.
-	Size *string `json:"size,omitempty"`
+	Size *resource.Quantity `json:"size,omitempty"`
 	// Specifies the StorageClass for the PersistentVolumeClaims to determine how PersistentVolumes are provisioned and managed.
 	StorageClass *string `json:"storageClass,omitempty"`
 	// Option to change volume claim template name for tiered storage persistent volume if tiered.mountType is set to `persistentVolume`

--- a/src/go/k8s/api/redpanda/v1alpha2/zz_generated.deepcopy.go
+++ b/src/go/k8s/api/redpanda/v1alpha2/zz_generated.deepcopy.go
@@ -1170,8 +1170,8 @@ func (in *PersistentVolume) DeepCopyInto(out *PersistentVolume) {
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(string)
-		**out = **in
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.StorageClass != nil {
 		in, out := &in.StorageClass, &out.StorageClass

--- a/src/go/k8s/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/src/go/k8s/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -4057,8 +4057,12 @@ spec:
                               is set to `persistentVolume`
                             type: string
                           size:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: Specifies the storage capacity required.
-                            type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           storageClass:
                             description: Specifies the StorageClass for the PersistentVolumeClaims
                               to determine how PersistentVolumes are provisioned and
@@ -8653,8 +8657,12 @@ spec:
                               is set to `persistentVolume`
                             type: string
                           size:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: Specifies the storage capacity required.
-                            type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           storageClass:
                             description: Specifies the StorageClass for the PersistentVolumeClaims
                               to determine how PersistentVolumes are provisioned and

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fluxcd/source-controller/api v1.2.3
 	github.com/fluxcd/source-controller/shim v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.4.1
+	github.com/google/gofuzz v1.2.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/json-iterator/go v1.1.12
 	github.com/moby/moby v24.0.7+incompatible
@@ -25,7 +26,7 @@ require (
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.45.0
 	github.com/redpanda-data/console/backend v0.0.0-20230222172326-354751cc7524
-	github.com/redpanda-data/helm-charts v0.0.0-20240624182334-f539d8f02f09
+	github.com/redpanda-data/helm-charts v0.0.0-20240626223457-7d1ab26b4f41
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20230511045643-19a90983809d
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
@@ -206,7 +207,6 @@ require (
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20231202142526-55ffb0092afd // indirect
 	github.com/google/go-github/v55 v55.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20231023181126-ff6d637d2a7b // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -1027,8 +1027,8 @@ github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a4
 github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240/go.mod h1:5KLXArOMFOrwb3BihpFaRNiPCyo9AXsXhvMdUmrCdUg=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19 h1:sJjDhnIbTMOuP4Rnhm1N3GNfgv6BJlocCnGliNvhgbw=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19/go.mod h1:T39OECA7eOlhpHZPBSGg+bpuwtt/G4m03fjBkJ821CM=
-github.com/redpanda-data/helm-charts v0.0.0-20240624182334-f539d8f02f09 h1:g8CH48cen6/EMGvJDSvy7iYsN+eP192ZkLC7kySdel4=
-github.com/redpanda-data/helm-charts v0.0.0-20240624182334-f539d8f02f09/go.mod h1:NhZIMNN9wnzpwRAJaj6PbWHPix5MzBdouGitxefhrgs=
+github.com/redpanda-data/helm-charts v0.0.0-20240626223457-7d1ab26b4f41 h1:mJ4OT6Bh3bnj769Gl2e9qY3cAQ1Dw+X/3JbUNkf/AaY=
+github.com/redpanda-data/helm-charts v0.0.0-20240626223457-7d1ab26b4f41/go.mod h1:ddpepNHdINZS8j+ycJVQSvkH7yh3E+q85s9tUHNPLxU=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e h1:8HB05vSCY+0MwjT2DIVq6gJV5iw7nQNIDfMqcc1NEC8=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e/go.mod h1:jF5kbQy3qT/zufL27DE3lecfYTRWeAzSiVmrbDDQwUw=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20230511045643-19a90983809d h1:EVnzgfKf/8YkXzprbiKb9YyvODIvFps/RRsKyoTaBW8=


### PR DESCRIPTION
This commit updates the helm-charts dependency to the latest commit (https://github.com/redpanda-data/helm-charts/commit/7d1ab26b4f412a578fa1d4f95e43e3143ade4b4f) which includes fixes to the generated `PartialValues` type.

It also re-enables a hand full of fields on the `TestHelmvaluesCompat` that we're failing due to the incorrectly generated type.

The now re-enabled tests found a mild mistyping in `PersistentVolume.Size` which has been "upgraded" to a `resource.Quantity` type.