### PR TITLE
vectorized/v1alpha1: make redpanda connect properties optional

### DIFF
--- a/src/go/k8s/api/vectorized/v1alpha1/console_enterprise_types.go
+++ b/src/go/k8s/api/vectorized/v1alpha1/console_enterprise_types.go
@@ -85,6 +85,7 @@ type EnterpriseLoginGoogleDirectory struct {
 type CloudConfig struct {
 	PrometheusEndpoint *PrometheusEndpointConfig `json:"prometheusEndpoint"`
 
+	// +optional
 	// RedpandaConnect is the configuration for Redpanda Connect in Redpanda Cloud.
 	RedpandaConnect CloudRedpandaConnect `json:"redpandaConnect"`
 }
@@ -139,8 +140,10 @@ type PrometheusScraperJobConfig struct {
 
 // CloudRedpandaConnect represents configuration for Cloud Redpanda Connect.
 type CloudRedpandaConnect struct {
+	// +optional
 	Enabled bool `json:"enabled"`
 
+	// +optional
 	// Address to Redpanda Connect Cloud API service endpoint
 	// (e.g. "redpanda-connect-api.redpanda-connect.svc.cluster.local:8080")
 	Address string `json:"address"`

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_consoles.yaml
@@ -150,13 +150,9 @@ spec:
                         type: string
                       enabled:
                         type: boolean
-                    required:
-                    - address
-                    - enabled
                     type: object
                 required:
                 - prometheusEndpoint
-                - redpandaConnect
                 type: object
               clusterRef:
                 description: The referenced Redpanda Cluster


### PR DESCRIPTION
While Redpanda Connect is in development, and not available in all environments, having these properties required is causing some inconvenience and issues.

Console itself handles defaults and validation, so we do not need strict requirement on these.

Lets set them as optional.