### PR TITLE
*: dedup and cleanup {Make,Task}file(s)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ src/go/k8s/tests/e2e-v2-helm/
 .*.sw?
 
 # direnv files
-.envrc
 .direnv/
 
 # task cache directory

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,3 +45,15 @@ tasks:
   lint:
     cmds:
       - task: k8s:run-golangci-lint
+
+  lint-fix:
+    cmds:
+      - task: k8s:run-golangci-lint-fix
+
+  fmt:
+    cmds:
+      - nix develop -c gofumpt -w ./
+
+  generate:
+    cmds:
+      - task: k8s:generate

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
               pkgs.gnused # Stream Editor, used by some build scripts.
               pkgs.go-task
               pkgs.go_1_22
+              pkgs.gofumpt
               pkgs.golangci-lint
               pkgs.k3d # Kind alternative that allows adding/removing Nodes.
               pkgs.openssl
@@ -55,7 +56,6 @@
               # this flake.
               # pkgs.goreleaser
               # pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
-              # pkgs.gofumpt
               # pkgs.goreleaser
               # pkgs.gotools
               # pkgs.kind

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -1,8 +1,6 @@
 # Image URL to use all building/pushing image targets
 OPERATOR_IMG_LATEST ?= "localhost/redpanda-operator:dev"
 CONFIGURATOR_IMG_LATEST ?= "localhost/configurator:dev"
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd"
 
 HELM_CONTROLLER_VERSION ?= v0.37.2
 SOURCE_CONTROLLER_VERSION ?= v1.2.3
@@ -42,17 +40,17 @@ endif
 all: build
 
 # Run tests
-test: manifests generate fmt vet
+test: manifests generate fmt
 	cd ../../.. && nix develop -c ./task k8s:run-unit-tests
 
 # Build manager binary
 .PHONY: manager
-manager: manifests generate fmt vet
+manager: manifests generate fmt
 	go build -o bin/manager cmd/main.go
 
 # Build manager binary
 .PHONY: configurator
-configurator: manifests generate fmt vet
+configurator: manifests generate fmt
 	go build -o bin/configurator cmd/configurator/main.go
 
 .PHONY: build
@@ -60,7 +58,7 @@ build: manager configurator
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
-	go fmt ./...
+	cd ../../.. && nix develop -c ./task fmt
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate vet manifests fmt
@@ -96,11 +94,6 @@ undeploy:
 manifests:
 	cd ../../.. && nix develop -c ./task k8s:generate-manifests
 
-# Run go vet against code
-.PHONY: vet
-vet:
-	go vet ./...
-
 # Generate code
 .PHONY: generate
 generate:
@@ -120,7 +113,7 @@ docker-build:
 	cd ../../.. && ./task k8s:build-operator-images
 
 # Build the docker image
-docker-build-configurator: prepare-dockerfile
+docker-build-configurator:
 	echo "~~~ Building configurator image :docker:"
 	cd ../../.. && ./task k8s:build-operator-images
 
@@ -130,33 +123,21 @@ push-to-kind: kind-create certmanager-install
 	kind load docker-image ${CONFIGURATOR_IMG_LATEST}
 
 # Execute end to end tests
-e2e-tests: kuttl test docker-build docker-build-configurator
-	echo "~~~ Running kuttl tests :k8s:"
-	$(KUTTL) test $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
+e2e-tests:
+	cd ../../.. && nix develop -c ./task k8s:run-k8s-tests
 
 # Execute end to end tests v2
 e2e-tests-v2: kuttl
-	echo "~~~ Running kuttl tests :k8s:redpanda"
-	$(KUTTL) test $(TEST_ONLY_FLAG) --config kuttl-v2-test.yaml $(KUTTL_TEST_FLAGS)
+	cd ../../.. && nix develop -c ./task k8s:run-k8s-v2-tests
 
 # Create resources for the e2e-tests-v2-ci
 create-e2e-tests-v2-helm:
 	./hack/v2-helm-setup.sh
 
 # Execute end to end tests v2
-e2e-tests-v2-helm: kuttl create-e2e-tests-v2-helm
+e2e-tests-v2-helm:
 	echo "~~~ Running kuttl tests :k8s:redpanda"
-	$(KUTTL) test $(TEST_ONLY_FLAG) --config kuttl-v2-helm-test.yaml $(KUTTL_TEST_FLAGS)
-
-# Execute end to end unstable tests
-e2e-unstable-tests: kuttl test docker-build docker-build-configurator
-	echo "~~~ Running kuttl unstable tests :k8s:"
-	$(KUTTL) test --config kuttl-unstable-test.yaml --kind-context=${PR_NR:-kind} $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
-
-# Execute end to end tests using helm as an installation
-helm-e2e-tests: kuttl test docker-build docker-build-configurator
-	echo "~~~ Running kuttl tests :k8s:"
-	$(KUTTL) test --config kuttl-helm-test.yaml $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
+	cd ../../.. && nix develop -c ./task k8s:run-k8s-v2-helm-tests
 
 ##@ Build Dependencies
 
@@ -167,14 +148,9 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
-KUTTL ?= $(LOCALBIN)/kubectl-kuttl
-GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.1.1
-KUTTL_VERSION ?= v0.15.0
-
-GOLANGCI_LINT_VERSION ?= v1.54.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -182,55 +158,13 @@ kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
-.PHONY: kuttl
-kuttl: $(KUTTL)
-$(KUTTL): $(LOCALBIN)
-	test -s $(LOCALBIN)/kubectl-kuttl || GOBIN=$(LOCALBIN) go install github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@$(KUTTL_VERSION)
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
-
-.PHONY: gofumpt-install
-gofumpt-install:
-	go install mvdan.cc/gofumpt@latest
-
-.PHONY: goimports-install
-goimports-install:
-	go install golang.org/x/tools/cmd/goimports@latest
-
-.PHONY: gofumpt-lint
-gofumpt-lint: gofumpt-install
-	find . -type f -name '*.go' | xargs -n1 gofumpt -w -lang=1.21
-
-.PHONY: goimports
-goimports: goimports-install
-	goimports -w .
-
-GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
-golangci-lint:
-	@[ -f $(GOLANGCI_LINT) ] || { \
-	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(  GOLANGCI_LINT_VERSION) ;\
-	}
-
 .PHONY: lint
-lint: golangci-lint
-	$(GOLANGCI_LINT) run
+lint: 
+	cd ../../.. && nix develop -c ./task lint
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+lint-fix:
+	cd ../../.. && nix develop -c ./task lint-fix
 
 .PHONY: install-prometheus
 install-prometheus:

--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -8,8 +8,6 @@ vars:
   HELM_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/helm/{{.HELM_VERSION}}'
   KIND_VERSION: '0.20.0'
   KIND_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/kind/{{.KIND_VERSION}}'
-  GOFUMPT_VERSION: 'v0.5.0'
-  GOFUMPT_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/gofumpt/{{.GOFUMPT_VERSION}}'
   K8S_CONTROLLER_GEN_VERSION: 'v0.15.0'
   K8S_CONTROLLER_GEN_INSTALL_DIR: '{{.BUILD_ROOT}}/tools/k8s-controller-gen/{{.K8S_CONTROLLER_GEN_VERSION}}'
   KUSTOMIZE_VERSION: 'v5.1.1'
@@ -32,24 +30,6 @@ tasks:
     status:
       - test -f {{.BIN_DIR}}/task
       - "[[ $({{.BIN_DIR}}/task --version | grep -o {{.TASK_VERSION}}) == {{.TASK_VERSION}} ]]"
-
-  install-gofumpt:
-    desc: install gofumpt go formater
-    summary: |
-      Install gofumpt go formater tool in the build directory ($BUILD_ROOT/bin/go),
-      only if it does not exist on the host already. Checking whether is
-      available on the host is done so that this task can also run in
-      containerized environments.
-    cmds:
-      - |
-        PATH={{.GOLANG_INSTALL_DIR}}/bin:$PATH
-        TMP_DIR=$(mktemp -d)
-        cd $TMP_DIR
-        go mod init tmp
-        GOBIN={{.GOFUMPT_INSTALL_DIR}}/bin/ go install mvdan.cc/gofumpt@{{.GOFUMPT_VERSION}}
-        rm -rf $TMP_DIR
-    status:
-      - test -f '{{.GOFUMPT_INSTALL_DIR}}/bin/gofumpt'
 
   install-kustomize:
     vars:

--- a/taskfiles/goreleaser.yml
+++ b/taskfiles/goreleaser.yml
@@ -47,7 +47,6 @@ tasks:
   build-operator-binaries:
     deps:
       - task: :dev:install-goreleaser
-      - task: :k8s:generate-controller-code
-      - task: :k8s:generate-manifests
+      - task: :k8s:generate
     cmds:
       - '{{.GORELEASER_INSTALL_DIR}}/goreleaser build --snapshot --clean --id configurator --id redpanda-operator'

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -10,49 +10,29 @@ env:
   GOPRIVATE: github.com/redpanda-data/flux-controller-shim
 
 tasks:
-  generate-controller-code:
+
+  generate:
     dir: 'src/go/k8s'
+    aliases:
+    - generate-controller-code
+    - generate-manifests
     deps:
       - :dev:install-k8s-controller-gen
-    sources:
-      - './**/*.go'
     cmds:
       - |
         {{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/bin/controller-gen \
           object:headerFile="../../../licenses/boilerplate.go.txt" \
-          paths='./...'
-
-  run-go-vet:
-    dir: 'src/go/k8s'
-    cmds:
-      - |
-        go vet ./...
-
-  generate-manifests:
-    dir: 'src/go/k8s'
-    deps:
-      - :dev:install-k8s-controller-gen
-    vars:
-      CRD_OPTIONS_DEFAULT: 'crd'
-      CRD_OPTIONS: '{{default .CRD_OPTIONS_DEFAULT .CRD_OPTIONS}}'
-    sources:
-      - './**/*.go'
-    cmds:
-      - |
-        {{.K8S_CONTROLLER_GEN_INSTALL_DIR}}/bin/controller-gen \
-          {{.CRD_OPTIONS}} \
-          rbac:roleName=manager-role \
-          webhook \
           paths='./...' \
+          crd \
+          webhook \
+          rbac:roleName=manager-role \
           output:crd:artifacts:config=config/crd/bases \
           output:rbac:artifacts:config=config/rbac/bases/operator
 
   run-unit-tests:
     dir: 'src/go/k8s'
     deps:
-      - run-go-vet
-      - generate-controller-code
-      - generate-manifests
+      - generate
     cmds:
       - |
         source <(cd {{ .SRC_DIR }} && nix develop -c setup-envtest use -p env 1.29.x)
@@ -214,6 +194,13 @@ tasks:
     cmds:
       - |
         golangci-lint run --timeout 8m -v
+
+  run-golangci-lint-fix:
+    desc: run golangci-lint
+    dir: 'src/go/k8s'
+    cmds:
+      - |
+        golangci-lint run --timeout 8m -v --fix
 
   build-tag-and-push-images:
     desc: builds, tags and pushes images to dockerhub


### PR DESCRIPTION
Prior to this commit the Makefile duplicated much of the functionality within our taskfiles albeit with minor divergences.

This commit reduplicates some of the Makefile by redirecting it to the Taskfile, removes some cruft, and adds an `.envrc` to allow [direnv](https://direnv.net/) to automatically activate `nix develop`.