### PR TITLE
cluster v1: ignore redacted secrets in drift detection

### DIFF
--- a/src/go/k8s/internal/controller/redpanda/cluster_controller_configuration_drift_test.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller_configuration_drift_test.go
@@ -1,0 +1,92 @@
+package redpanda
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasDrift(t *testing.T) {
+	assert := require.New(t)
+
+	schema := map[string]rpadmin.ConfigPropertyMetadata{
+		"write_caching_default": {
+			Type:         "integer",
+			Description:  "wait_for_leader_timeout_ms",
+			Nullable:     false,
+			NeedsRestart: false,
+			IsSecret:     false,
+			Visibility:   "tunable",
+			Units:        "ms",
+		},
+		"cloud_storage_secret_key": {
+			Type:         "string",
+			Description:  "AWS secret key",
+			Nullable:     true,
+			NeedsRestart: true,
+			IsSecret:     true,
+			Visibility:   "user",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		desired       map[string]any
+		actual        map[string]any
+		driftExpected bool
+	}{
+		{
+			name: "cloud_storage_secret_key is omitted",
+			desired: map[string]any{
+				"cloud_storage_secret_key": "my-key",
+				"write_caching_default":    10,
+			},
+			actual: map[string]any{
+				"cloud_storage_secret_key": "[secret]", // Redpanda replaces secret values with [secret]
+				"write_caching_default":    10,
+			},
+			driftExpected: false,
+		},
+		{
+			name: "diff is detected",
+			desired: map[string]any{
+				"cloud_storage_background_jobs_quota": 1337,
+			},
+			actual: map[string]any{
+				"cloud_storage_background_jobs_quota": 123,
+			},
+			driftExpected: true,
+		},
+		{
+			name: "diff is detected along other diffs",
+			desired: map[string]any{
+				"cloud_storage_secret_key":            "my-key",
+				"cloud_storage_background_jobs_quota": 1337,
+			},
+			actual: map[string]any{
+				"cloud_storage_secret_key":            "[secret]",
+				"cloud_storage_background_jobs_quota": 123,
+			},
+			driftExpected: true,
+		},
+		{
+			name: "no diff is detected if all is equal",
+			desired: map[string]any{
+				"cloud_storage_background_jobs_quota": 1337,
+			},
+			actual: map[string]any{
+				"cloud_storage_background_jobs_quota": 1337,
+			},
+			driftExpected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := hasDrift(logr.Discard(), tt.desired, tt.actual, schema)
+			assert.Equal(tt.driftExpected, ok)
+		})
+	}
+}


### PR DESCRIPTION
Redpanda redacts some secrets by replacing their values with `[secret]` in the admin API response. We must ignore these in the 3-way-merge-patch, or we will constantly flag config as "drifted", even if the secret may be configured correctly.

seen this live on multiple clusters, config being reported as drifted all the time, causing (almost) infinite reconcile loops.