### PR TITLE
CIAINFRA-282: Cluster V1 CR: add observedGeneration and OperatorQuiescent

### DIFF
--- a/src/go/k8s/api/vectorized/v1alpha1/cluster_types.go
+++ b/src/go/k8s/api/vectorized/v1alpha1/cluster_types.go
@@ -388,6 +388,9 @@ type ClusterStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// If set, this represents the .metadata.generation that was observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Replicas show how many nodes have been created for the cluster
 	// +optional
 	Replicas int32 `json:"replicas"`
@@ -436,13 +439,15 @@ type ClusterCondition struct {
 }
 
 // ClusterConditionType is a valid value for ClusterCondition.Type
-// +kubebuilder:validation:Enum=ClusterConfigured
+// +kubebuilder:validation:Enum=ClusterConfigured;OperatorQuiescent
 type ClusterConditionType string
 
 // These are valid conditions of the cluster.
 const (
 	// ClusterConfiguredConditionType indicates whether the Redpanda cluster configuration is in sync with the desired one
 	ClusterConfiguredConditionType ClusterConditionType = "ClusterConfigured"
+	// OperatorQuiescentConditionType indicates that the operator has no outstanding work to do, based on the observedGeneration.
+	OperatorQuiescentConditionType ClusterConditionType = "OperatorQuiescent"
 )
 
 // GetCondition return the condition of the given type

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -1361,6 +1361,7 @@ spec:
                       description: Type is the type of the condition
                       enum:
                       - ClusterConfigured
+                      - OperatorQuiescent
                       type: string
                   required:
                   - status
@@ -1496,6 +1497,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              observedGeneration:
+                description: If set, this represents the .metadata.generation that
+                  was observed by the controller.
+                format: int64
+                type: integer
               readyReplicas:
                 description: ReadyReplicas is the number of Pods belonging to the
                   cluster that have a Ready Condition.

--- a/src/go/k8s/tests/e2e-unstable/decommission-on-delete/00-assert.yaml
+++ b/src/go/k8s/tests/e2e-unstable/decommission-on-delete/00-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decomm-on-delete --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e-unstable/decommission-on-delete/01-assert.yaml
+++ b/src/go/k8s/tests/e2e-unstable/decommission-on-delete/01-assert.yaml
@@ -8,9 +8,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decomm-on-delete --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-unstable/decommission-on-delete/03-assert.yaml
+++ b/src/go/k8s/tests/e2e-unstable/decommission-on-delete/03-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decomm-on-delete --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e-unstable/decommission-on-delete/04-assert.yaml
+++ b/src/go/k8s/tests/e2e-unstable/decommission-on-delete/04-assert.yaml
@@ -8,9 +8,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decomm-on-delete --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-unstable/decommission-on-delete/05-assert.yaml
+++ b/src/go/k8s/tests/e2e-unstable/decommission-on-delete/05-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decomm-on-delete --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e/additional-cmdline-arguments/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/additional-cmdline-arguments/00-assert.yaml
@@ -8,9 +8,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-additional-cmdline-arguments --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "False"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=False cluster/centralized-configuration-bootstrap --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/01-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-bootstrap --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-drift/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-drift/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-drift --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-drift/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-drift/02-assert.yaml
@@ -18,9 +18,13 @@ metadata:
   name: centralized-configuration-drift
 status:
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-drift --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-drift/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-drift/03-assert.yaml
@@ -18,9 +18,13 @@ metadata:
   name: centralized-configuration-drift
 status:
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-drift --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-tls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/01-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-tls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/03-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-tls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/04-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-tls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/02-assert.yaml
@@ -4,9 +4,13 @@ metadata:
   name: centralized-configuration-upgrade
 status:
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration-upgrade --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/01-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/centralized-configuration/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/04-assert.yaml
@@ -18,9 +18,13 @@ metadata:
   name: centralized-configuration
 status:
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/centralized-configuration --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/console-admin-api/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-admin-api/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-for-console-with-admin --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/console-finalizers/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-finalizers/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 1
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-finalizers --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/01-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-kafka-mtls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e/console/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/console/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-for-console --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-assert.yaml
@@ -7,9 +7,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/create-topic-with-client-auth --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/src/go/k8s/tests/e2e/decommission/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/decommission/00-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decommission --timeout 300s -n redpanda --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/decommission/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/decommission/01-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 2
   currentReplicas: 2
   readyReplicas: 2
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/decommission/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/decommission/04-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/decommission/05-assert.yaml
+++ b/src/go/k8s/tests/e2e/decommission/05-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 2
   currentReplicas: 2
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/endpoint-template/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/endpoint-template/00-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   readyReplicas: 3
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/endpoint-template --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/endpoint-template/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/endpoint-template/01-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   readyReplicas: 3
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/endpoint-template --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 1
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/external-connectivity --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/src/go/k8s/tests/e2e/kafkaapi-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/kafkaapi-client-auth/00-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 1
   readyReplicas: 1
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/kafkaapi-client-auth --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/src/go/k8s/tests/e2e/lost-redpanda-decommission/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/lost-redpanda-decommission/00-assert.yaml
@@ -9,9 +9,13 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/lost-rp-decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/managed-decommission/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/00-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/managed-decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e/managed-decommission/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/01-assert.yaml
@@ -6,9 +6,13 @@ status:
   replicas: 3
   currentReplicas: 3
   readyReplicas: 3
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/managed-decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client-external-ca/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client-external-ca/01-assert.yaml
@@ -7,9 +7,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-proxy --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Secret

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry-sasl/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry-sasl/00-assert.yaml
@@ -7,9 +7,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/schema-registry-sasl --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/regressions/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/regressions/00-assert.yaml
@@ -7,9 +7,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-sasl-no-calls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/schema-registry-tls-client-external-ca/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/schema-registry-tls-client-external-ca/01-assert.yaml
@@ -7,9 +7,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/sr-external-ca-mtls --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Secret

--- a/src/go/k8s/tests/e2e/superusers-prefix/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/superusers-prefix/00-assert.yaml
@@ -7,9 +7,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/cluster-superusers-prefix --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Secret

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
@@ -39,6 +39,10 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-image-cluster-and-node-port --timeout 300s --namespace $NAMESPACE

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -72,6 +72,10 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-image-cluster-and-node-port --timeout 300s --namespace $NAMESPACE

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/03-assert.yaml
@@ -53,6 +53,11 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-image-cluster-and-node-port --timeout 300s --namespace $NAMESPACE
+

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-external-ca/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-external-ca/01-assert.yaml
@@ -85,9 +85,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-img-external-client-ca --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-external-ca/06-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-external-ca/06-assert.yaml
@@ -97,9 +97,13 @@ status:
   version: "dev"
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-img-external-client-ca --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/00-assert.yaml
@@ -70,6 +70,11 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-mtls --timeout 300s --namespace $NAMESPACE
+

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/02-assert.yaml
@@ -53,6 +53,10 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-mtls --timeout 300s --namespace $NAMESPACE

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/03-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-mtls --timeout 300s --namespace $NAMESPACE
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -53,6 +60,3 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"

--- a/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/00-assert.yaml
@@ -60,6 +60,9 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE

--- a/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/02-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE
+    kubectl wait --for=condition=OperatorQuiescent=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -53,6 +60,3 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"

--- a/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/03-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE
+    kubectl wait --for=condition=OperatorQuiescent=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -53,6 +60,3 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"

--- a/src/go/k8s/tests/e2e/update/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/00-assert.yaml
@@ -8,9 +8,13 @@ status:
   replicas: 1
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-cluster --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/src/go/k8s/tests/e2e/update/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/01-assert.yaml
@@ -8,9 +8,13 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-cluster --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: Pod

--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -22,9 +22,13 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-cluster --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/update/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/03-assert.yaml
@@ -34,9 +34,13 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-cluster --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/update/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/04-assert.yaml
@@ -25,9 +25,13 @@ status:
   replicas: 3
   upgrading: false
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/update-cluster --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/user-specified-serviceaccount-name/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/user-specified-serviceaccount-name/00-assert.yaml
@@ -5,9 +5,13 @@ metadata:
 status:
   replicas: 1
   restarting: false
-  conditions:
-    - type: ClusterConfigured
-      status: "True"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/user-specified-servicename --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: v1
 kind: serviceaccount


### PR DESCRIPTION
It is currently challenging to determine if a resource has been reconciled, and it is "ready":

- No observedGeneration is exported in status. This makes it hard to determine, if the controller has already reconciled the cluster. Having observedGeneration in status, clients can just store the returned metadata.generation from the Update call, and wait until status.observedGeneration >= that value.
- No field represents the controller having "done its work". The ClusterQuiescent condition represents this. If no outstanding work is known (business logic), and no errors are thrown, True is reported. Otherwise, false is reported.