### PR TITLE
buildkite: chown directory after docker run

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,8 +14,12 @@ steps:
       - github_commit_status:
           context: k8s-operator
     commands:
-      - |
-        TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh ./task ci:k8s
+      - TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh ./task ci:k8s
+      # Docker runs as the root user which will prevent buildkite from
+      # picking up artifacts. The nix docker image doesn't play nicely with
+      # --user, so as a final step, chown everything back to the buildkite
+      # user.
+      - sudo chown -R $(id -u):$(id -g) .
     agents:
       queue: v6-amd64-builders
     artifact_paths:
@@ -146,6 +150,11 @@ steps:
               context: k8s-operator-v2
         commands:
           - ./ci/scripts/run-in-nix-docker.sh ./task ci:k8s-v2
+          # Docker runs as the root user which will prevent buildkite from
+          # picking up artifacts. The nix docker image doesn't play nicely with
+          # --user, so as a final step, chown everything back to the buildkite
+          # user.
+          - sudo chown -R $(id -u):$(id -g) .
         agents:
           queue: v6-amd64-builders
         artifact_paths:

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -101,9 +101,6 @@ tasks:
   assert-no-diffs:
     desc: "Fail on any unexpected diffs to generated files (CI only)"
     cmds:
-    - ls -lah # Debugging
-    - ls -lah .git # Debugging
-    - git status # Debugging
     - git diff --exit-code
     status:
       - test "$CI" != "true" # run only in CI as local runs may have unstaged changes.


### PR DESCRIPTION
Prior to this commit buildkite artifact uploads were failing due to permissions issues. This stems from a `chown` command having been removed in 302f9886b8c75146b910f1366e3af0a092a10dff due to a lack of context.

This commit re-adds the chown but only within the buildkite pipeline specification and includes an explanation as to why the chown is required.