### PR TITLE
operator v1: create internal kafka api port

### DIFF
--- a/src/go/k8s/internal/controller/redpanda/cluster_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller.go
@@ -1070,6 +1070,11 @@ func collectClusterPorts(
 		port := redpandaCluster.Spec.Configuration.SchemaRegistry.Port
 		clusterPorts = append(clusterPorts, resources.NamedServicePort{Name: resources.SchemaRegistryPortName, Port: port})
 	}
+	if redpandaPorts.KafkaAPI.Internal != nil {
+		port := redpandaPorts.KafkaAPI.Internal.Port
+		clusterPorts = append(clusterPorts, resources.NamedServicePort{Name: resources.InternalListenerName, Port: port})
+	}
+
 	return clusterPorts
 }
 

--- a/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/00-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: kafka-api-cluster-service-internal
+status:
+  replicas: 1
+  restarting: false
+  conditions:
+    - type: ClusterConfigured
+      status: "True"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-api-cluster-service-internal
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-api-cluster-service-internal-cluster
+spec:
+  ports:
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: ClusterIP
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/00-create.yaml
+++ b/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/00-create.yaml
@@ -1,0 +1,28 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: kafka-api-cluster-service-internal
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 1Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+      - port: 9092
+        tls:
+          enabled: false
+    adminApi:
+      - port: 9644
+    developerMode: true
+    additionalCommandlineArguments:
+      dump-memory-diagnostics-on-alloc-failure-kind: all
+      abort-on-seastar-bad-alloc: ''

--- a/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/01-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/01-clean.yaml
+++ b/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/01-clean.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: redpanda.vectorized.io/v1alpha1
+    kind: Cluster
+    name: kafka-api-cluster-service-internal
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: datadir-kafka-api-cluster-service-internal-0
+    namespace: redpanda-system


### PR DESCRIPTION
currently in cloud, we use the full list of brokers and pass it around to various service making use of it, e.g. kafka connect.

however, this is completely ignoring the service discovery feature of the kafka api: bootstrap servers.

there is already a ClusterIP service for this purpose. However, it does not include kafka API. this patch adds kafka API to the ClusterIP service.

internal usage can now be done via the $name-cluster service on port 9092, if configured. tested on a cloud cluster.

the new usage internally is:
- Use $name-cluster ClusterIP service for Service Discovery. This improves stability a lot, because k8s networking will quickly remove "gone" pods from this service's endpoints slice.
- After discovering brokers via seed ClusterIP service, connections to brokers are performed directly as usual, via headless service => pod.

(From debug pod in same namespace):
```
root@ubuntu:/# export REDPANDA_BROKERS="rp-cr81n8j008pdnihh1ohg-cluster:9092"
root@ubuntu:/#   
export REDPANDA_SASL_MECHANISM="SCRAM-SHA-256"
export REDPANDA_SASL_USERNAME="abcdef"
export REDPANDA_SASL_PASSWORD="abcdef"
root@ubuntu:/# rpk topic list
NAME                          PARTITIONS  REPLICAS
__redpanda.connect.logs       1           3
__redpanda.connect.status     1           3
__redpanda.connectors_logs    1           3
_internal_connectors_configs  1           3
_internal_connectors_offsets  25          3
_internal_connectors_status   5           3
_redpanda.audit_log           12          3
_redpanda_e2e_probe           3           3
_schemas                      1           3
root@ubuntu:/# rpk cluster metadata
CLUSTER
=======
redpanda.rp-cr81n8j008pdnihh1ohg

BROKERS
=======
ID    HOST                                                                           PORT  RACK
0*    rp-cr81n8j008pdnihh1ohg-0.rp-cr81n8j008pdnihh1ohg.redpanda.svc.cluster.local.  9092  europe-west1-b
1     rp-cr81n8j008pdnihh1ohg-1.rp-cr81n8j008pdnihh1ohg.redpanda.svc.cluster.local.  9092  europe-west1-b
2     rp-cr81n8j008pdnihh1ohg-2.rp-cr81n8j008pdnihh1ohg.redpanda.svc.cluster.local.  9092  europe-west1-b
```