### PR TITLE
cluster: delete PVCs after decom if flag is set

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,6 +69,70 @@ steps:
             failed: true
             branches:
               - main
+  - key: k8s-operator-with-flags
+    label: K8s Operator tests with flags
+    timeout_in_minutes: 180
+    notify:
+      - github_commit_status:
+          context: k8s-operator
+    commands:
+      - |
+        TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh ./task ci:run-k8s-tests-with-flags
+    agents:
+      queue: amd64-builders
+    artifact_paths:
+      - src/go/k8s/*.tar.gz
+      - src/go/k8s/tests/_e2e_artifacts/kuttl-report.xml
+    plugins:
+      - seek-oss/aws-sm#v2.3.2: &aws-sm-plugin
+          json-to-env:
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/active_directory
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/buildkite_analytics_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/buildkite_api_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/cdt_gcp
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/cdt_runner_aws
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/ci_db
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/cloudsmith
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/dockerhub
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/gh_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/github_api_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/goreleaser_key
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/grafana_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/redpanda_sample_license
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/rpk_test_client
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/seceng_audit_aws
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/slack_vbot_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/teleport_bot_token
+            - json-key: .
+              secret-id: sdlc/prod/buildkite/test_result_dsn
+      - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
+          message: ":cloud: K8s Operator v1 Jobs failed"
+          channel_name: "kubernetes-tests"
+          slack_token_env_var_name: "SLACK_VBOT_TOKEN"
+          conditions:
+            failed: true
+            branches:
+              - main
+
 
   - group: K8s Operator v2 Jobs
     if: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /dbuild
 bin
 _e2e_artifacts/
+_e2e_with_flags_artifacts/
 _e2e_unstable_artifacts/
 _helm_e2e_artifacts/
 src/go/k8s/testbin/*

--- a/src/go/k8s/cmd/main.go
+++ b/src/go/k8s/cmd/main.go
@@ -151,6 +151,7 @@ func main() {
 		debug                       bool
 		ghostbuster                 bool
 		unbindPVCsAfter             time.Duration
+		autoDeletePVCs              bool
 	)
 
 	flag.StringVar(&eventsAddr, "events-addr", "", "The address of the events receiver.")
@@ -180,6 +181,7 @@ func main() {
 	flag.BoolVar(&operatorMode, "operator-mode", true, "enables to run as an operator, setting this to false will disable cluster (deprecated), redpanda resources reconciliation.")
 	flag.BoolVar(&enableHelmControllers, "enable-helm-controllers", true, "if a namespace is defined and operator mode is true, this enables the use of helm controllers to manage fluxcd helm resources.")
 	flag.DurationVar(&unbindPVCsAfter, "unbind-pvcs-after", 0, "if not zero, runs the PVCUnbinder controller which attempts to 'unbind' the PVCs' of Pods that are Pending for longer than the given duration")
+	flag.BoolVar(&autoDeletePVCs, "auto-delete-pvcs", false, "Use StatefulSet PersistentVolumeClaimRetentionPolicy to auto delete PVCs on scale down and Cluster resource delete.")
 
 	logOptions.BindFlags(flag.CommandLine)
 	clientOptions.BindFlags(flag.CommandLine)
@@ -265,6 +267,7 @@ func main() {
 			MetricsTimeout:            metricsTimeout,
 			RestrictToRedpandaVersion: restrictToRedpandaVersion,
 			GhostDecommissioning:      ghostbuster,
+			AutoDeletePVCs:            autoDeletePVCs,
 		}).WithClusterDomain(clusterDomain).WithConfiguratorSettings(configurator).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "Cluster")
 			os.Exit(1)

--- a/src/go/k8s/config/e2e-tests-with-flags/kustomization.yaml
+++ b/src/go/k8s/config/e2e-tests-with-flags/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../e2e-tests
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --auto-delete-pvcs
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: controller-manager

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -45,6 +45,7 @@ require (
 	k8s.io/apimachinery v0.29.5
 	k8s.io/client-go v0.29.5
 	k8s.io/component-helpers v0.29.0
+	k8s.io/kubectl v0.29.0
 	k8s.io/utils v0.0.0-20240310230437-4693a0247e57
 	pgregory.net/rapid v1.1.0
 	sigs.k8s.io/controller-runtime v0.17.2
@@ -407,7 +408,6 @@ require (
 	k8s.io/component-base v0.29.5 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240103051144-eec4567ac022 // indirect
-	k8s.io/kubectl v0.29.0 // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/gateway-api v1.0.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/src/go/k8s/internal/controller/redpanda/cluster_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller.go
@@ -75,6 +75,7 @@ type ClusterReconciler struct {
 	MetricsTimeout            time.Duration
 	RestrictToRedpandaVersion string
 	GhostDecommissioning      bool
+	AutoDeletePVCs            bool
 }
 
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete

--- a/src/go/k8s/internal/controller/redpanda/cluster_controller_attached_resources.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller_attached_resources.go
@@ -15,12 +15,13 @@ import (
 )
 
 type attachedResources struct {
-	ctx        context.Context
-	reconciler *ClusterReconciler
-	log        logr.Logger
-	cluster    *vectorizedv1alpha1.Cluster
-	items      map[string]resources.Resource
-	order      []string
+	ctx            context.Context
+	reconciler     *ClusterReconciler
+	log            logr.Logger
+	cluster        *vectorizedv1alpha1.Cluster
+	items          map[string]resources.Resource
+	order          []string
+	autoDeletePVCs bool
 }
 
 const (
@@ -43,11 +44,12 @@ const (
 
 func newAttachedResources(ctx context.Context, r *ClusterReconciler, log logr.Logger, cluster *vectorizedv1alpha1.Cluster) *attachedResources {
 	return &attachedResources{
-		ctx:        ctx,
-		reconciler: r,
-		log:        log,
-		cluster:    cluster,
-		items:      map[string]resources.Resource{},
+		ctx:            ctx,
+		reconciler:     r,
+		log:            log,
+		cluster:        cluster,
+		items:          map[string]resources.Resource{},
+		autoDeletePVCs: r.AutoDeletePVCs,
 	}
 }
 
@@ -393,7 +395,8 @@ func (a *attachedResources) statefulSet() error {
 		a.reconciler.AdminAPIClientFactory,
 		a.reconciler.DecommissionWaitInterval,
 		a.log,
-		a.reconciler.MetricsTimeout)
+		a.reconciler.MetricsTimeout,
+		a.autoDeletePVCs)
 	a.order = append(a.order, statefulSet)
 	return nil
 }

--- a/src/go/k8s/kind-for-cloud.yaml
+++ b/src/go/k8s/kind-for-cloud.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  # Need to run KIND 0.19 based image; >0.19 does not support cgroupsv1/missing cgroupns - and this is required for CI at the moment.
+  image: kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213
+- role: worker
+  image: kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213
+- role: worker
+  image: kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213
+- role: worker
+  image: kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213

--- a/src/go/k8s/kuttl-test-with-flags.yaml
+++ b/src/go/k8s/kuttl-test-with-flags.yaml
@@ -1,0 +1,30 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+startKIND: true
+kindContainers:
+  - localhost/redpanda-operator:dev
+  - localhost/configurator:dev
+  - localhost/redpanda:dev
+testDirs:
+  - ./tests/e2e-with-flags
+kindConfig: ./kind-for-cloud.yaml
+kindNodeCache: false
+commands:
+  - command: kubectl taint node kind-control-plane  node-role.kubernetes.io/control-plane-
+  - command: "mkdir -p tests/_e2e_with_flags_artifacts"
+  - command: "./hack/install-cert-manager.sh tests/_e2e_with_flags_artifacts"
+    background: true
+    ignoreFailure: true
+  - command: "kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/e23ff77fceba6a5d9f190f5d1a123c87701dc964/bundle.yaml"
+    background: true
+    ignoreFailure: true
+  - command: "sh -c 'until kustomize build config/e2e-tests-with-flags 2>> tests/_e2e_with_flags_artifacts/kustomize-output.txt | kubectl apply --server-side -f - 1>> tests/_e2e_with_flags_artifacts/kubectl-output.txt 2>> tests/_e2e_with_flags_artifacts/kubectl-error-output.txt; do sleep 0.5; done'"
+    background: true
+  - command: "./hack/wait-for-webhook-ready.sh"
+artifactsDir: tests/_e2e_with_flags_artifacts
+timeout: 330
+reportFormat: xml
+parallel: 2
+namespace: redpanda-system
+suppress:
+  - events

--- a/src/go/k8s/pkg/patch/patch.go
+++ b/src/go/k8s/pkg/patch/patch.go
@@ -1,0 +1,25 @@
+// Package patch is a utility package that provides utils around patching a resource.
+// It has its own package, because of a dependency conflict; pkg/utils may not
+// import types/v1alpha1, types/v1alpha1 imports pkg/utils (cycle).
+package patch
+
+import (
+	"context"
+	"fmt"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/src/go/k8s/api/vectorized/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PatchStatus persforms a mutation as done by mutator, calls k8s-api with PATCH, and then returns the
+// new status.
+func PatchStatus(ctx context.Context, c client.Client, observedCluster *vectorizedv1alpha1.Cluster, mutator func(cluster *vectorizedv1alpha1.Cluster)) (vectorizedv1alpha1.ClusterStatus, error) {
+	clusterPatch := client.MergeFrom(observedCluster.DeepCopy())
+	mutator(observedCluster)
+
+	if err := c.Status().Patch(ctx, observedCluster, clusterPatch); err != nil {
+		return vectorizedv1alpha1.ClusterStatus{}, fmt.Errorf("failed to update cluster status: %w", err)
+	}
+
+	return observedCluster.Status, nil
+}

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -101,7 +101,9 @@ func TestEnsure_StatefulSet(t *testing.T) {
 		adminutils.NewInternalAdminAPI,
 		time.Second,
 		ctrl.Log.WithName("test"),
-		0)
+		0,
+		true,
+	)
 
 	err = sts.Ensure(context.Background())
 	assert.NoError(t, err)

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -66,6 +66,7 @@ const (
 	defaultDatadirCapacity       = "100Gi"
 	trueString                   = "true"
 
+	// PodAnnotationNodeIDKey is identical to its label counterpart.
 	PodAnnotationNodeIDKey = "operator.redpanda.com/node-id"
 )
 
@@ -115,6 +116,8 @@ type StatefulSetResource struct {
 	metricsTimeout           time.Duration
 
 	LastObservedState *appsv1.StatefulSet
+
+	autoDeletePVCs bool
 }
 
 // NewStatefulSet creates StatefulSetResource
@@ -134,6 +137,7 @@ func NewStatefulSet(
 	decommissionWaitInterval time.Duration,
 	logger logr.Logger,
 	metricsTimeout time.Duration,
+	autoDeletePVCs bool,
 ) *StatefulSetResource {
 	ssr := &StatefulSetResource{
 		client,
@@ -153,6 +157,7 @@ func NewStatefulSet(
 		logger.WithName("StatefulSetResource"),
 		defaultAdminAPITimeout,
 		nil,
+		autoDeletePVCs,
 	}
 	if metricsTimeout != 0 {
 		ssr.metricsTimeout = metricsTimeout
@@ -338,6 +343,18 @@ func (r *StatefulSetResource) obj(
 			fmt.Sprintf("--admin-api-tls-key %q", path.Join(resourcetypes.GetTLSMountPoints().AdminAPI.ClientCAMountDir, "tls.key")))
 	}
 
+	// In any case, configure PersistentVolumeClaimRetentionPolicy
+	// Default to old behavior: Retain PVC
+	// If auto-remove-pvcs flag is set, active new behavior: switch to Delete for both WhenScaled and WhenDeleted.
+	var pvcReclaimRetentionPolicy appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy
+	if r.autoDeletePVCs {
+		pvcReclaimRetentionPolicy.WhenScaled = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
+		pvcReclaimRetentionPolicy.WhenDeleted = appsv1.DeletePersistentVolumeClaimRetentionPolicyType
+	} else {
+		pvcReclaimRetentionPolicy.WhenScaled = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
+		pvcReclaimRetentionPolicy.WhenDeleted = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+
 	// We set statefulset replicas via status.currentReplicas in order to control it from the handleScaling function
 	replicas := r.pandaCluster.GetCurrentReplicas()
 	ss := &appsv1.StatefulSet{
@@ -351,9 +368,10 @@ func (r *StatefulSetResource) obj(
 			APIVersion: "apps/v1",
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas:            &replicas,
-			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector:            clusterLabels.AsAPISelector(),
+			PersistentVolumeClaimRetentionPolicy: &pvcReclaimRetentionPolicy,
+			Replicas:                             &replicas,
+			PodManagementPolicy:                  appsv1.ParallelPodManagement,
+			Selector:                             clusterLabels.AsAPISelector(),
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -151,7 +151,8 @@ func TestEnsure(t *testing.T) {
 				},
 				time.Second,
 				ctrl.Log.WithName("test"),
-				0)
+				0,
+				true)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 
@@ -502,7 +503,9 @@ func TestCurrentVersion(t *testing.T) {
 			},
 			time.Second,
 			ctrl.Log.WithName("test"),
-			0)
+			0,
+			true,
+		)
 		sts.LastObservedState = &v1.StatefulSet{
 			Spec: v1.StatefulSetSpec{
 				Replicas: &tests[i].expectedReplicas,
@@ -754,7 +757,7 @@ func TestStatefulSetResource_IsManagedDecommission(t *testing.T) {
 				tt.fields.pandaCluster,
 				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, time.Hour,
 				tt.fields.logger,
-				time.Hour)
+				time.Hour, true)
 			got, err := r.IsManagedDecommission()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StatefulSetResource.IsManagedDecommission() error = %v, wantErr %v", err, tt.wantErr)
@@ -848,7 +851,7 @@ func TestStatefulSetPorts_AdditionalListeners(t *testing.T) {
 				tt.pandaCluster,
 				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, time.Hour,
 				logger,
-				time.Hour)
+				time.Hour, true)
 			containerPorts := r.GetPortsForListenersInAdditionalConfig()
 			assert.Equal(t, len(tt.expectedContainerPorts), len(containerPorts))
 			for _, cp := range containerPorts {
@@ -922,7 +925,8 @@ func TestStatefulSetEnv_AdditionalListeners(t *testing.T) {
 				tt.pandaCluster,
 				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, time.Hour,
 				logger,
-				time.Hour)
+				time.Hour,
+				true)
 			envs := r.AdditionalListenersEnvVars()
 
 			if tt.expectedEnvValue == "" {

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -435,7 +435,7 @@ func (r *StatefulSetResource) podEviction(ctx context.Context, pod, artificialPo
 		}
 
 		if err = utils.DeletePodPVCs(ctx, r.Client, pod, log); err != nil {
-			return fmt.Errorf(`unable to remove VPCs for pod "%s/%s: %w"`, pod.GetNamespace(), pod.GetName(), err)
+			return fmt.Errorf(`unable to remove PVCs for pod "%s/%s: %w"`, pod.GetNamespace(), pod.GetName(), err)
 		}
 
 		log.Info("deleting pod")

--- a/src/go/k8s/tests/e2e-with-flags/decommission/00-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/00-assert.yaml
@@ -5,32 +5,30 @@ commands:
     kubectl wait --for=condition=ClusterConfigured=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE
     kubectl wait --for=condition=OperatorQuiescent=True cluster/up-img-admin-tls --timeout 300s --namespace $NAMESPACE
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: decommission-0
+status:
+  phase: Running
+---
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: kafka-api-cluster-service-internal
+  name: decommission
 status:
-  replicas: 1
-  restarting: false
+  replicas: 3
+  currentReplicas: 3
+  readyReplicas: 3
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kafka-api-cluster-service-internal
-status:
-  readyReplicas: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kafka-api-cluster-service-internal-cluster
+  name: decommission
 spec:
-  ports:
-    - name: kafka
-      port: 9092
-      protocol: TCP
-      targetPort: 9092
-  type: ClusterIP
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-with-flags/decommission/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/00-redpanda-cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: decommission
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 3
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 1Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+      - port: 9092
+    adminApi:
+      - port: 9644
+    pandaproxyApi:
+      - port: 8082
+    developerMode: true
+    additionalCommandlineArguments:
+      dump-memory-diagnostics-on-alloc-failure-kind: all
+      abort-on-seastar-bad-alloc: ''

--- a/src/go/k8s/tests/e2e-with-flags/decommission/01-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/01-assert.yaml
@@ -8,29 +8,11 @@ commands:
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: kafka-api-cluster-service-internal
+  name: decommission
 status:
-  replicas: 1
-  restarting: false
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: kafka-api-cluster-service-internal
-status:
-  readyReplicas: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kafka-api-cluster-service-internal-cluster
-spec:
-  ports:
-    - name: kafka
-      port: 9092
-      protocol: TCP
-      targetPort: 9092
-  type: ClusterIP
+  replicas: 2
+  currentReplicas: 2
+  readyReplicas: 2
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-with-flags/decommission/01-redpanda-downscale.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/01-redpanda-downscale.yaml
@@ -1,0 +1,6 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: decommission
+spec:
+  replicas: 2

--- a/src/go/k8s/tests/e2e-with-flags/decommission/02-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/02-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    job-name: get-broker-count
+status:
+  containerStatuses:
+    - name: curl
+      state:
+        terminated:
+          exitCode: 0
+          reason: Completed
+  phase: Succeeded
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e-with-flags/decommission/02-probe.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/02-probe.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: get-broker-count
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      activeDeadlineSeconds: 90
+      containers:
+        - name: curl
+          image: apteno/alpine-jq:latest
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/sh
+            - -c
+            - -ex
+          args:
+            - |
+              url=http://decommission-0.decommission.$NAMESPACE.svc.cluster.local:9644/v1/brokers
+              res=$(curl --silent -L $url | jq '. | length')
+
+              if [[ "$res" != "2" ]]; then
+                exit 1;
+              fi
+      restartPolicy: Never

--- a/src/go/k8s/tests/e2e-with-flags/decommission/03-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/03-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=delete pvc/datadir-decommission-2 --timeout 0s -n redpanda --namespace $NAMESPACE

--- a/src/go/k8s/tests/e2e-with-flags/decommission/04-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/04-assert.yaml
@@ -8,29 +8,11 @@ commands:
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: kafka-api-cluster-service-internal
+  name: decommission
 status:
-  replicas: 1
-  restarting: false
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: kafka-api-cluster-service-internal
-status:
-  readyReplicas: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kafka-api-cluster-service-internal-cluster
-spec:
-  ports:
-    - name: kafka
-      port: 9092
-      protocol: TCP
-      targetPort: 9092
-  type: ClusterIP
+  replicas: 3
+  currentReplicas: 3
+  readyReplicas: 3
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-with-flags/decommission/04-redpanda-upscale.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/04-redpanda-upscale.yaml
@@ -1,0 +1,6 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: decommission
+spec:
+  replicas: 3

--- a/src/go/k8s/tests/e2e-with-flags/decommission/05-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/05-assert.yaml
@@ -8,29 +8,10 @@ commands:
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: kafka-api-cluster-service-internal
+  name: decommission
 status:
-  replicas: 1
-  restarting: false
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: kafka-api-cluster-service-internal
-status:
-  readyReplicas: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kafka-api-cluster-service-internal-cluster
-spec:
-  ports:
-    - name: kafka
-      port: 9092
-      protocol: TCP
-      targetPort: 9092
-  type: ClusterIP
+  replicas: 2
+  currentReplicas: 2
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e-with-flags/decommission/05-redpanda-downscale.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/05-redpanda-downscale.yaml
@@ -1,0 +1,6 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: decommission
+spec:
+  replicas: 2

--- a/src/go/k8s/tests/e2e-with-flags/decommission/06-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/06-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    job-name: get-broker-count-again
+status:
+  containerStatuses:
+    - name: curl
+      state:
+        terminated:
+          exitCode: 0
+          reason: Completed
+  phase: Succeeded
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e-with-flags/decommission/06-probe.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/06-probe.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: get-broker-count-again
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      activeDeadlineSeconds: 90
+      containers:
+        - name: curl
+          image: apteno/alpine-jq:latest
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/sh
+            - -c
+            - -ex
+          args:
+            - |
+              url=http://decommission-0.decommission.$NAMESPACE.svc.cluster.local:9644/v1/brokers
+              res=$(curl --silent -L $url | jq '. | length')
+
+              if [[ "$res" != "2" ]]; then
+                exit 1;
+              fi
+      restartPolicy: Never

--- a/src/go/k8s/tests/e2e-with-flags/decommission/07-assert.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/07-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=delete pvc/datadir-decommission-0 --timeout 0s -n redpanda --namespace $NAMESPACE
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=delete pvc/datadir-decommission-1 --timeout 0s -n redpanda --namespace $NAMESPACE
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=delete pvc/datadir-decommission-2 --timeout 0s -n redpanda --namespace $NAMESPACE

--- a/src/go/k8s/tests/e2e-with-flags/decommission/07-clean.yaml
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/07-clean.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: redpanda.vectorized.io/v1alpha1
+    kind: Cluster
+    name: decommission
+    namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: get-broker-count
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-broker-count
+    namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: get-broker-count-again
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-broker-count-again
+    namespace: redpanda-system
+

--- a/src/go/k8s/tests/e2e-with-flags/decommission/README.txt
+++ b/src/go/k8s/tests/e2e-with-flags/decommission/README.txt
@@ -1,0 +1,5 @@
+This test
+
+0. creates a 3 node Redpanda cluster
+1. changes the cluster spec.replicas to 2
+2. check that there are only 2 brokers registered with redpanda

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -71,6 +71,22 @@ tasks:
     status:
       - test -n '{{.TAG_NAME}}' # skip on tagged commit builds
 
+  run-k8s-tests-with-flags:
+    cmds:
+      - task: configure-git-private-repo
+      - task: :k8s:generate
+      - task: assert-no-diffs
+      - 'echo "~~~ Running operator e2e tests :k8s:"'
+      - task: :k8s:run-kuttl-tests
+        vars:
+          KUTTL_CONFIG_FILE: kuttl-test-with-flags.yaml
+      - cp "{{.SRC_DIR}}/src/go/k8s/kuttl-exit-code" ./k8s-stable-test-exit-code
+      # fail explicitly if stable operator tests failed
+      - "grep -q '0' ./k8s-stable-test-exit-code"
+    status:
+      - test -n '{{.TAG_NAME}}' # skip on tagged commit builds
+
+
   publish-k8s-operator-images:
     cmds:
       - 'echo "~~~ Tagging and uploading images to Dockerhub :docker:"'

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -122,15 +122,6 @@ tasks:
       - :dev:install-kustomize
       - :dev:install-kuttl
       - :dev:install-yq
-      - task: set-aio-max
-        vars:
-          USE_SUDO: "false"
-      - task: set-inotify-watches
-        vars:
-          USE_SUDO: "false"
-      - task: set-inotify-instances
-        vars:
-          USE_SUDO: "false"
       - task: fetch-latest-redpanda
       - task: build-operator-images
     cmds:


### PR DESCRIPTION
To scale down and up again, we need to delete PVCs after a broker/pod
has been removed.

if auto-delete-pvcs is set, use PersistentVolumeClaimRetentionPolicy to
auto delete PVCs at scale down and delete.

this allows us to scale down and up; PVCs are worthless after scaling
down because we decomission before scaling down. A decomissioned broker
can not rejoin the cluster.