### PR TITLE
buildkite: upgrade to v6 aws stack

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
       - |
         TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh ./task ci:k8s
     agents:
-      queue: amd64-builders
+      queue: v6-amd64-builders
     artifact_paths:
       - src/go/k8s/*.tar.gz
       - src/go/k8s/tests/_e2e_artifacts/kuttl-report.xml
@@ -80,7 +80,7 @@ steps:
       - |
         TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh ./task ci:run-k8s-tests-with-flags
     agents:
-      queue: amd64-builders
+      queue: v6-amd64-builders
     artifact_paths:
       - src/go/k8s/*.tar.gz
       - src/go/k8s/tests/_e2e_with_flags_artifacts/kuttl-report.xml
@@ -147,7 +147,7 @@ steps:
         commands:
           - ./ci/scripts/run-in-nix-docker.sh ./task ci:k8s-v2
         agents:
-          queue: amd64-builders
+          queue: v6-amd64-builders
         artifact_paths:
           - src/go/k8s/*.tar.gz
           - src/go/k8s/tests/_e2e_artifacts_v2/kuttl-report.xml
@@ -196,7 +196,7 @@ steps:
           - touch src/go/k8s/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
           - echo Noop
         agents:
-          queue: amd64-builders
+          queue: v6-amd64-builders
         artifact_paths:
           - src/go/k8s/*.tar.gz
           - src/go/k8s/tests/_e2e_helm_artifacts_v2/kuttl-report.xml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -171,7 +171,7 @@ steps:
               report-slowest: 5
         timeout_in_minutes: 0
         agents:
-          queue: k8s-builders
+          queue: v6-k8s-builders
         depends_on: k8s-operator-v2
         allow_dependency_failure: true
 
@@ -220,7 +220,7 @@ steps:
               report-slowest: 5
         timeout_in_minutes: 0
         agents:
-          queue: k8s-builders
+          queue: v6-k8s-builders
         depends_on: k8s-operator-v2-helm
         allow_dependency_failure: true
 


### PR DESCRIPTION
jira: https://redpandadata.atlassian.net/browse/PESDLC-2012

Use the buildkite agents launched from amazon linux 2023 with cgroupsv2