### PR TITLE
preStop hook: give up if receiving 404

### DIFF
--- a/src/go/k8s/pkg/resources/secret.go
+++ b/src/go/k8s/pkg/resources/secret.go
@@ -194,6 +194,11 @@ preStopHook () {
 	echo "Setting maintenance mode on node ${NODE_ID}"
 	until [ "${status:-}" = "200" ]; do
 		status=$(%s)
+		if [ "${status:-}" = "404" ]; then
+			echo "Got 404 when enabling maintenance mode, giving up because node does not exist anymore."
+			return 0
+		fi
+		echo "Got ${status} for enabling maint. mode"
 		sleep 0.5
 	done
 	until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do


### PR DESCRIPTION
404 means, node does not exist anymore, aka it's decommissioned. In this case, we can give up, instead of retrying for a very long time. This solves the problem of redpanda pods being stuck for long in Terminating, after decommission.