### PR TITLE
gha: only run add_jira_comment on issues

### DIFF
--- a/.github/workflows/comment_added.yml
+++ b/.github/workflows/comment_added.yml
@@ -6,6 +6,7 @@ on:
       - created
 jobs:
   add_jira_comment:
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: configure aws credentials
@@ -26,14 +27,12 @@ jobs:
           python-version: '3.9'
           cache: 'pip'
       - name: install dependencies
-        if: ${{ !github.event.issue.pull_request }}
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
         run: pip install -r ${SCRIPT_DIR}/requirements.txt
       - name: install pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Add comment to JIRA Issue
-        if: ${{ !github.event.issue.pull_request }}
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
           JIRA_TOKEN: ${{ env.JIRA_TOKEN  }}


### PR DESCRIPTION
jira: https://redpandadata.atlassian.net/browse/PESDLC-2028

instead of skipping pip install on PR comments, just skip entire step if a PR comment. so, this step should only run on issue comments which is what we want.