### PR TITLE
flake: upgrade to go 1.22.7

### DIFF
--- a/ci/overlay.nix
+++ b/ci/overlay.nix
@@ -1,0 +1,25 @@
+{ pkgs
+}: (final: prev: {
+  # Custom package for Kubernetes' setup-envtest.
+  setup-envtest = pkgs.callPackage ./setup-envtest.nix { };
+
+  # Pin to 1.22.7 (latest at time of writing) to support go.work files with
+  # gopls.
+  # Notably, we DO NOT override the go or go_1_22 packages. This is done for
+  # two reasons:
+  # 1. Doing so would break our ability to use nix's binary cache (3rd party
+  # hosted) and require us rebuild all go packages within CI as there's no
+  # local cache due to docker usage.
+  # 2. It makes it very easy to see the exact version of go we use in flake.nix
+  go_1_22_7 = prev.go_1_22.overrideAttrs (final: prev:
+    let
+      version = "1.22.7";
+    in
+    {
+      inherit version;
+      src = pkgs.fetchurl {
+        url = "https://go.dev/dl/go${version}.src.tar.gz";
+        hash = "sha256-ZkMth9heDPrD7f/mN9WTD8Td9XkzE/4R5KDzMwI8h58=";
+      };
+    });
+})

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,8 @@
           pkgs = import nixpkgs {
             inherit system;
             overlays = [
-              (final: prev: {
-                setup-envtest = pkgs.callPackage ./ci/setup-envtest.nix { };
-              })
+              # Load in various overrides for custom packages and version pinning.
+              (import ./ci/overlay.nix { pkgs = pkgs; })
             ];
           };
         in
@@ -46,7 +45,7 @@
               pkgs.gawk # GNU awk, used by some build scripts.
               pkgs.gnused # Stream Editor, used by some build scripts.
               pkgs.go-task
-              pkgs.go_1_22
+              pkgs.go_1_22_7
               pkgs.gofumpt
               pkgs.golangci-lint
               pkgs.k3d # Kind alternative that allows adding/removing Nodes.
@@ -54,7 +53,6 @@
               pkgs.setup-envtest # Kubernetes provided test utilities
               # TODO(chrisseto): Migrate taskfile to using dependencies from
               # this flake.
-              # pkgs.goreleaser
               # pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               # pkgs.goreleaser
               # pkgs.gotools


### PR DESCRIPTION
Developers that utilize the nix go binary for development, specifically for running `gopls`, would encounter errors from `packages.Load` stemming from `go mod list` calls due to the introduction of a `go.work` file.

This commit upgrades the go version in `flake.nix` to 1.22.7 to ensure proper support of go.work files.