### PR TITLE
operator v1: does not return quiescent if replicas not synced

### DIFF
--- a/src/go/k8s/internal/controller/redpanda/cluster_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller.go
@@ -537,7 +537,7 @@ func (r *ClusterReconciler) reportStatus(
 			err = r.Status().Update(ctx, cluster)
 			if err == nil {
 				// sync original cluster variable to avoid conflicts on subsequent operations
-				redpandaCluster.Status = cluster.Status
+				*redpandaCluster = *cluster
 			}
 			return err
 		})

--- a/src/go/k8s/internal/controller/redpanda/cluster_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller.go
@@ -537,7 +537,7 @@ func (r *ClusterReconciler) reportStatus(
 			err = r.Status().Update(ctx, cluster)
 			if err == nil {
 				// sync original cluster variable to avoid conflicts on subsequent operations
-				*redpandaCluster = *cluster
+				redpandaCluster.Status = cluster.Status
 			}
 			return err
 		})

--- a/src/go/k8s/internal/controller/redpanda/cluster_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller.go
@@ -1158,10 +1158,10 @@ func getQuiescentCondition(redpandaCluster *vectorizedv1alpha1.Cluster) vectoriz
 		return condition
 	}
 
-	if redpandaCluster.Status.CurrentReplicas != redpandaCluster.Status.Replicas || redpandaCluster.Status.Replicas != redpandaCluster.Status.ReadyReplicas {
+	if redpandaCluster.Status.CurrentReplicas != redpandaCluster.Status.Replicas || redpandaCluster.Status.Replicas != redpandaCluster.Status.ReadyReplicas || (redpandaCluster.Spec.Replicas != nil && *redpandaCluster.Spec.Replicas != redpandaCluster.Status.Replicas) {
 		condition.Status = corev1.ConditionFalse
 		condition.Reason = "ReplicasNotSynced"
-		condition.Message = fmt.Sprintf("Replicas are not synced. currentReplicas=%d,replicas=%d,readyReplicas=%d. All must be equal.", redpandaCluster.Status.CurrentReplicas, redpandaCluster.Status.Replicas, redpandaCluster.Status.ReadyReplicas)
+		condition.Message = fmt.Sprintf("Replicas are not synced. spec.replicas=%d status.currentReplicas=%d,status.replicas=%d,status.readyReplicas=%d. All must be equal.", ptr.Deref(redpandaCluster.Spec.Replicas, 0), redpandaCluster.Status.CurrentReplicas, redpandaCluster.Status.Replicas, redpandaCluster.Status.ReadyReplicas)
 		return condition
 	}
 

--- a/src/go/k8s/internal/controller/redpanda/cluster_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/cluster_controller.go
@@ -1158,6 +1158,13 @@ func getQuiescentCondition(redpandaCluster *vectorizedv1alpha1.Cluster) vectoriz
 		return condition
 	}
 
+	if redpandaCluster.Status.CurrentReplicas != redpandaCluster.Status.Replicas || redpandaCluster.Status.Replicas != redpandaCluster.Status.ReadyReplicas {
+		condition.Status = corev1.ConditionFalse
+		condition.Reason = "ReplicasNotSynced"
+		condition.Message = fmt.Sprintf("Replicas are not synced. currentReplicas=%d,replicas=%d,readyReplicas=%d. All must be equal.", redpandaCluster.Status.CurrentReplicas, redpandaCluster.Status.Replicas, redpandaCluster.Status.ReadyReplicas)
+		return condition
+	}
+
 	// No reason found (no early return), so claim the controller is quiescent.
 	condition.Status = corev1.ConditionTrue
 	return condition

--- a/src/go/k8s/tests/e2e/endpoint-template/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/endpoint-template/00-assert.yaml
@@ -6,6 +6,8 @@ status:
   replicas: 3
   readyReplicas: 3
   restarting: false
+  currentReplicas: 3
+  restarting: false
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert

--- a/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/kafka-api-cluster-service-internal/00-assert.yaml
@@ -11,6 +11,8 @@ metadata:
   name: kafka-api-cluster-service-internal
 status:
   replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
   restarting: false
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
we had cases, where quiescent condition is given, even if replicas were not synced. this caused our "wait" job to not wait anymore, even if replicas are not yet up.

See https://redpandadata.slack.com/archives/C077JRCJ807/p1725902281802229