### PR TITLE
Calculate Redpanda CRD status conditions based on StatefulSet/Deployment status and unblock HelmReleases on job completion

### DIFF
--- a/src/go/k8s/api/redpanda/v1alpha2/redpanda_types.go
+++ b/src/go/k8s/api/redpanda/v1alpha2/redpanda_types.go
@@ -18,6 +18,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/api/vectorized/v1alpha1"
 )
@@ -238,6 +239,7 @@ func (in *Redpanda) OwnerShipRefObj() metav1.OwnerReference {
 		Kind:       in.Kind,
 		Name:       in.Name,
 		UID:        in.UID,
+		Controller: ptr.To(true),
 	}
 }
 

--- a/src/go/k8s/cmd/run/run.go
+++ b/src/go/k8s/cmd/run/run.go
@@ -524,11 +524,10 @@ func Run(
 		}
 
 		if err = (&redpandacontrollers.RedpandaReconciler{
-			Client:          mgr.GetClient(),
-			Scheme:          mgr.GetScheme(),
-			EventRecorder:   redpandaEventRecorder,
-			RequeueHelmDeps: 10 * time.Second,
-		}).SetupWithManager(mgr); err != nil {
+			Client:        mgr.GetClient(),
+			Scheme:        mgr.GetScheme(),
+			EventRecorder: redpandaEventRecorder,
+		}).SetupWithManager(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Redpanda")
 			os.Exit(1)
 		}

--- a/src/go/k8s/internal/controller/redpanda/index.go
+++ b/src/go/k8s/internal/controller/redpanda/index.go
@@ -85,6 +85,10 @@ func clusterForPod(o client.Object) (types.NamespacedName, bool) {
 		return types.NamespacedName{}, false
 	}
 
+	if _, ok := pod.Labels["batch.kubernetes.io/job-name"]; ok {
+		return types.NamespacedName{}, false
+	}
+
 	return types.NamespacedName{
 		Namespace: o.GetNamespace(),
 		Name:      clusterName,

--- a/src/go/k8s/internal/controller/redpanda/redpanda_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/redpanda_controller.go
@@ -951,10 +951,10 @@ func disableConsoleReconciliation(console *vectorzied_v1alpha1.Console) {
 
 func checkClusterPodStatus(pods []corev1.Pod) (string, bool) {
 	notReady := []string{}
-	for _, p := range pods {
+	for _, p := range pods { //nolint:gocritic // gocritic is mad that a copy of slice value is being made here
 		_, ready := pod.GetPodConditionFromList(p.Status.Conditions, corev1.PodReady)
 		if ready == nil || ready.Status == corev1.ConditionFalse {
-			notReady = append(notReady, client.ObjectKeyFromObject(&p).String())
+			notReady = append(notReady, client.ObjectKeyFromObject(&p).String()) //nolint:gosec // this memory addressing is fine since its usage doesn't exceed this loop iteration
 		}
 	}
 	if len(notReady) > 0 {

--- a/src/go/k8s/internal/controller/redpanda/redpanda_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/redpanda_controller.go
@@ -972,7 +972,7 @@ func checkReplicasForList[T client.Object](fn replicasExtractor[T], list []T, re
 	if len(notReady) > 0 {
 		notReady.Sort()
 
-		return fmt.Sprintf("Not all replicas updated, available, and ready for %s(s) [%s].", resource, strings.Join(notReady, "; ")), false
+		return fmt.Sprintf("Not all %s replicas updated, available, and ready for [%s]", resource, strings.Join(notReady, "; ")), false
 	}
 	return "", true
 }

--- a/src/go/k8s/internal/controller/redpanda/redpanda_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/redpanda_controller.go
@@ -958,7 +958,7 @@ func checkStatefulSetStatus(ss []*appsv1.StatefulSet) (string, bool) {
 
 type replicasExtractor[T client.Object] func(o T) (updated, available, ready, total int32)
 
-func checkReplicasForList[T client.Object](fn replicasExtractor[T], list []T, name string) (string, bool) {
+func checkReplicasForList[T client.Object](fn replicasExtractor[T], list []T, resource string) (string, bool) {
 	var notReady sort.StringSlice
 	for _, item := range list {
 		updated, available, ready, total := fn(item)
@@ -972,8 +972,7 @@ func checkReplicasForList[T client.Object](fn replicasExtractor[T], list []T, na
 	if len(notReady) > 0 {
 		notReady.Sort()
 
-		return fmt.Sprintf("Not all replicas updated, available, and ready for %s(s) [%s].", name, strings.Join(notReady, "; ")), false
+		return fmt.Sprintf("Not all replicas updated, available, and ready for %s(s) [%s].", resource, strings.Join(notReady, "; ")), false
 	}
 	return "", true
-
 }

--- a/src/go/k8s/internal/controller/test/suite_test.go
+++ b/src/go/k8s/internal/controller/test/suite_test.go
@@ -283,11 +283,10 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 
 	// Redpanda Reconciler
 	err = (&redpanda.RedpandaReconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		EventRecorder:   k8sManager.GetEventRecorderFor("RedpandaReconciler"),
-		RequeueHelmDeps: 10 * time.Second,
-	}).SetupWithManager(k8sManager)
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		EventRecorder: k8sManager.GetEventRecorderFor("RedpandaReconciler"),
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&redpanda.DecommissionReconciler{

--- a/src/go/k8s/tests/e2e-v2/upgrade-rollback/00-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/upgrade-rollback/00-create-redpanda.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   chartRef:
     chartVersion: "5.3.2"
+    upgrade:
+      remediation:
+        retries: 1
+        strategy: "rollback"
   clusterSpec:
     image:
       tag: v23.2.3

--- a/src/go/k8s/tests/e2e-v2/upgrade-rollback/01-upgrade-bad-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/upgrade-rollback/01-upgrade-bad-redpanda.yaml
@@ -7,6 +7,10 @@ spec:
   chartRef:
     timeout: 1m
     chartVersion: "5.3.2"
+    upgrade:
+      remediation:
+        retries: 1
+        strategy: "rollback"
   clusterSpec:
     image:
       tag: v23.99.99

--- a/src/go/k8s/tests/e2e-v2/upgrade-rollback/02-upgrade-good-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/upgrade-rollback/02-upgrade-good-redpanda.yaml
@@ -7,6 +7,10 @@ spec:
   chartRef:
     timeout: 3m
     chartVersion: "5.3.2"
+    upgrade:
+      remediation:
+        retries: 1
+        strategy: "rollback"
   clusterSpec:
     image:
       tag: v23.2.10


### PR DESCRIPTION
This commit does a few things:
1. It calculates the Ready status condition of Redpanda objects based on statefulset and deployment status.
2. It removes the wait during helm applies **NOTE that this means we don't know if after upgrade hooks have run when the HelmRelease says it's done**
3. It removes most of the superfluous RetryAfter/Retry usage in the reconciler since the For/Owns watch setups will retrigger a reconciliation on a change in any dependent resource.

Number 3 is a bit of hygiene, but 1 and 2 are necessary due to the way that we currently block on any sort of helm operation. After reviewing the internal flux controller code, it looks like once a helm operation is kicked off the *only* way to cancel it before it succeeds is for 1. the operation to timeout (after 15 minutes in our case), or 2. to forcibly restart the operator pod.

We currently have two issues that are caused by this behavior:

1. If an upgrade takes longer than 15 minutes due to slowness in our job containers (typically when a cluster is under load?) we won't ever succeed.
2. If someone makes a bad cluster configuration change that kills one of the pods (say by setting the resource allocations to 40TB of RAM) by making it either unscheduleable or in a restart loop, then any additional changes to the CRD are blocked by the helm upgrade waiting for an operation that will never complete -- so, subsequent changes are blocked for the full 15 minute timeout.

By removing the wait operations in the HelmRelease, we just fire and forget the upgrades, which is actually a lot more inline with what we will eventually want to do when we remove flux altogether -- just apply resources and check statuses to back-propagate a status onto the Redpanda CRD. As a result, both 1 and 2 are solved, but we now need to have a better gauge as to when an installation is actually complete, namely, we should make sure that the pods its creating are actually marked as "Ready".

Fixes both [K8S-324](https://redpandadata.atlassian.net/browse/K8S-324)/[K8S-323](https://redpandadata.atlassian.net/browse/K8S-323)/https://github.com/redpanda-data/redpanda-operator/issues/196 and [K8S-341](https://redpandadata.atlassian.net/browse/K8S-341)/https://github.com/redpanda-data/redpanda-operator/issues/217

[K8S-341]: https://redpandadata.atlassian.net/browse/K8S-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[K8S-324]: https://redpandadata.atlassian.net/browse/K8S-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ