### PR TITLE
Change almost all kubernetes client Update call to Patch

### DIFF
--- a/src/go/k8s/internal/controller/test/cluster_controller_common_test.go
+++ b/src/go/k8s/internal/controller/test/cluster_controller_common_test.go
@@ -84,8 +84,9 @@ func clusterUpdater(
 		if err := k8sClient.Get(context.Background(), clusterNamespacedName, cl); err != nil {
 			return err
 		}
+		latest := cl.DeepCopy()
 		upd(cl)
-		return k8sClient.Update(context.Background(), cl)
+		return k8sClient.Patch(context.Background(), cl, client.MergeFrom(latest))
 	}
 }
 
@@ -97,8 +98,9 @@ func consoleUpdater(
 		if err := k8sClient.Get(context.Background(), consoleNamespacedName, con); err != nil {
 			return err
 		}
+		latest := con.DeepCopy()
 		upd(con)
-		return k8sClient.Update(context.Background(), con)
+		return k8sClient.Patch(context.Background(), con, client.MergeFrom(latest))
 	}
 }
 
@@ -111,6 +113,7 @@ func statefulSetReplicasReconciler(
 		if err != nil {
 			return err
 		}
+		latest := sts.DeepCopy()
 
 		// Aligning Pods first
 		var podList corev1.PodList
@@ -165,7 +168,7 @@ func statefulSetReplicasReconciler(
 		sts.Status.Replicas = *sts.Spec.Replicas
 		sts.Status.ReadyReplicas = sts.Status.Replicas
 		log.Info("update sts", "sts", sts)
-		return k8sClient.Status().Update(context.Background(), &sts)
+		return k8sClient.Status().Patch(context.Background(), &sts, client.MergeFrom(latest))
 	}
 }
 

--- a/src/go/k8s/internal/controller/test/cluster_controller_test.go
+++ b/src/go/k8s/internal/controller/test/cluster_controller_test.go
@@ -770,10 +770,10 @@ var _ = Describe("RedPandaCluster controller", func() {
 			configMapHash := sts.Annotations[res.ConfigMapHashAnnotationKey]
 			var existingCluster v1alpha1.Cluster
 			Expect(k8sClient.Get(context.Background(), key, &existingCluster)).Should(Succeed())
-
+			latest := existingCluster.DeepCopy()
 			var newReplicas int32 = replicas + 2
 			existingCluster.Spec.Replicas = &newReplicas
-			Expect(k8sClient.Update(context.Background(), &existingCluster)).Should(Succeed())
+			Expect(k8sClient.Patch(context.Background(), &existingCluster, client.MergeFrom(latest))).Should(Succeed())
 
 			// verify scale-out completed and the configmap hash did not change
 			var newSts appsv1.StatefulSet


### PR DESCRIPTION
The strategic merge patch should help in integration tests flakiness as many nighlty tests are failing with the following log:
```
Operation cannot be fulfilled on clusters.redpanda.vectorized.io \"central-removal\": the object has been modified; please apply your changes to the latest version and try again
```

That problem could happen due to addition of `Quiescent` condition in https://github.com/redpanda-data/redpanda-operator/pull/201