### PR TITLE
cmd: implement `envsubst`

### DIFF
--- a/src/go/k8s/cmd/envsubst/envsubst.go
+++ b/src/go/k8s/cmd/envsubst/envsubst.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package envsubst implements a go version of the `envsubst` command.
+package envsubst
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "envsubst file [--output file]",
+		Short: "envsubst injects environment variables into the provided file and prints it to stdout",
+		Long: `envsubst is a minimal re-implementation of envsubst[1] for usage in environments where it is not available.
+It utilizes and therefore follows the semantics of os.ExpandEnv:
+
+It replaces ${var} or $var in the string according to the values of the current
+environment variables. References to undefined variables are replaced by the
+empty string.
+
+[1]: https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := nopCloser(cmd.OutOrStdout())
+
+			if output != "" && output != "-" {
+				var err error
+				out, err = os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o775)
+				if err != nil {
+					return err
+				}
+			}
+
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+
+			expanded := os.ExpandEnv(string(data))
+
+			if _, err := out.Write([]byte(expanded)); err != nil {
+				return err
+			}
+			return out.Close()
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "p", "-", "The file to write the results to or - for stdout")
+
+	return cmd
+}
+
+type nopWriterCloser struct {
+	io.Writer
+}
+
+func (nopWriterCloser) Close() error {
+	return nil
+}
+
+func nopCloser(w io.Writer) io.WriteCloser {
+	return nopWriterCloser{w}
+}

--- a/src/go/k8s/cmd/envsubst/envsubst_test.go
+++ b/src/go/k8s/cmd/envsubst/envsubst_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package envsubst_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/envsubst"
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/pkg/utils/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommand(t *testing.T) {
+	t.Setenv("KEY_1", "value 1")
+	t.Setenv("KEY_2", "value 2")
+
+	cases := []struct {
+		In  string
+		Out string
+	}{
+		{In: "", Out: ""},
+		{In: "$KEY_1", Out: "value 1"},
+		{In: "Foo: bar\nBar: ${KEY_2}", Out: "Foo: bar\nBar: value 2"},
+	}
+
+	for _, tc := range cases {
+		path := testutils.WriteFile(t, "*", []byte(tc.In))
+
+		// To stdout
+		{
+			var out bytes.Buffer
+			cmd := envsubst.Command()
+			cmd.SetArgs([]string{path})
+			cmd.SetOut(&out)
+			require.NoError(t, cmd.Execute())
+			require.Equal(t, tc.Out, out.String())
+		}
+
+		// To a file
+		{
+			outfile := t.TempDir() + "/output.txt"
+
+			cmd := envsubst.Command()
+			cmd.SetArgs([]string{path, "--output", outfile})
+			require.NoError(t, cmd.Execute())
+
+			data, err := os.ReadFile(outfile)
+			require.NoError(t, err)
+			require.Equal(t, tc.Out, string(data))
+		}
+	}
+}

--- a/src/go/k8s/cmd/main.go
+++ b/src/go/k8s/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/configurator"
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/envsubst"
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/run"
 	"github.com/spf13/cobra"
 )
@@ -24,8 +25,9 @@ var rootCmd = cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(
-		run.Command(),
 		configurator.Command(),
+		envsubst.Command(),
+		run.Command(),
 	)
 }
 

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -1565,6 +1565,7 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v5 v5.7.0 h1:dGKGylPlZ/jus2g1YqhhyzfH0gPy2R8/MYUpW/OslTY=
+gopkg.in/evanphx/json-patch.v5 v5.7.0/go.mod h1:/kvTRh1TVm5wuM6OkHxqXtE/1nUZZpihg29RtuIyfvk=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-jose/go-jose.v2 v2.6.2 h1:Rl5+9rA0kG3vsO1qhncMPRT5eHICihAMQYJkD7u/i4M=
 gopkg.in/go-jose/go-jose.v2 v2.6.2/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=

--- a/src/go/k8s/pkg/utils/testutils/testutil.go
+++ b/src/go/k8s/pkg/utils/testutils/testutil.go
@@ -1,0 +1,38 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package testutils is a collection of generic test-centric utilities.
+//
+// Functions that accept a [testing.T] and return no error may call
+// [testing.T.Fatal].
+package testutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WriteFile writes data to a temporary file following the semantics of
+// [os.CreateTemp] and returns the full path to the written file.
+// Usage:
+//
+//	WriteFile(t, "*.json", []byte("{}"))
+func WriteFile(t *testing.T, pattern string, data []byte) string {
+	tmpFile, err := os.CreateTemp(t.TempDir(), pattern)
+	require.NoError(t, err)
+
+	_, err = tmpFile.Write(data)
+	require.NoError(t, err)
+
+	require.NoError(t, tmpFile.Close())
+
+	return tmpFile.Name()
+}


### PR DESCRIPTION
This commit implements a golang variant of the `envsubst` linux command for usage in environments (containers) that do not contain the `envsubst` binary. For example the redpanda or redpanda-operator containers.

It will be used to inject secret values into `.bootstrap.yaml`.