### PR TITLE
Better test failure handling for acceptance test framework

### DIFF
--- a/harpoon/features/stub.feature
+++ b/harpoon/features/stub.feature
@@ -14,6 +14,7 @@ Feature: stub
     And there is a stub
     When a user updates the stub key "foo" to "bar"
     Then the stub should have "foo" equal "bar"
+    And there is no error
 
   @skip:stub
   Scenario: skipped stub

--- a/harpoon/internal/testing/panic.go
+++ b/harpoon/internal/testing/panic.go
@@ -1,0 +1,103 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+const godogFailMessage = "FailNow or SkipNow called"
+
+type stringer interface {
+	String() string
+}
+
+func WrapWithPanicHandler[U any](needsLog bool, exitBehavior ExitBehavior, fn U) U {
+	fnValue := reflect.ValueOf(fn)
+	return reflect.MakeFunc(fnValue.Type(), func(args []reflect.Value) (results []reflect.Value) {
+		runTestingFunc := func(fn func(t *TestingT)) {
+			if len(args) > 0 {
+				if ctx, ok := args[0].Interface().(context.Context); ok {
+					t, ok := ctx.Value(testingContextKey).(*TestingT)
+					if ok && t != nil {
+						fn(t)
+					}
+				}
+			}
+		}
+
+		defer func() {
+			if err := recover(); err != nil {
+				// swallow any panics from godog
+				message, ok := isGodogLogPanic(err)
+				if !ok {
+					// otherwise re-panic
+					panic(err)
+				}
+				runTestingFunc(func(t *TestingT) {
+					if priorError := t.PriorError(); priorError != "" {
+						message = priorError
+					}
+				})
+				switch exitBehavior {
+				case ExitBehaviorNone:
+				case ExitBehaviorLog:
+					fmt.Print(message)
+				case ExitBehaviorTerminateProgram:
+					fmt.Print(message)
+					os.Exit(1)
+				case ExitBehaviorTestFail:
+					select {
+					case TerminationChan <- TerminationError{
+						Message:  message,
+						NeedsLog: needsLog,
+					}:
+					default:
+					}
+				}
+			}
+			returnSize := fnValue.Type().NumOut()
+			results = make([]reflect.Value, returnSize)
+			for i := 0; i < returnSize; i++ {
+				outType := fnValue.Type().Out(i)
+				path := outType.PkgPath()
+				name := outType.Name()
+				if len(args) > 0 && i == 0 && path == "context" && name == "Context" {
+					if ctx, ok := args[0].Interface().(context.Context); ok {
+						results[i] = reflect.ValueOf(ctx)
+						continue
+					}
+				}
+				results[i] = reflect.New(outType).Elem()
+			}
+		}()
+		results = fnValue.Call(args)
+		return
+	}).Interface().(U)
+}
+
+func isGodogLogPanic(s interface{}) (string, bool) {
+	if errString, ok := s.(string); ok {
+		if strings.HasPrefix(errString, godogFailMessage) {
+			return errString, true
+		}
+	}
+
+	if errStringer, ok := s.(stringer); ok {
+		message := errStringer.String()
+		if strings.HasPrefix(message, godogFailMessage) {
+			return message, true
+		}
+	}
+
+	if err, ok := s.(error); ok {
+		message := err.Error()
+		if strings.HasPrefix(message, godogFailMessage) {
+			return message, true
+		}
+	}
+
+	return "", false
+}

--- a/harpoon/internal/testing/panic.go
+++ b/harpoon/internal/testing/panic.go
@@ -23,6 +23,33 @@ type stringer interface {
 	String() string
 }
 
+// WrapWithPanicHandler wraps an arbitrary function with panic handling that attempts
+// to gracefully handle godog's wonky usage of panic when calls to godog.TestingT FailNow
+// or SkipNow occur. This predominantly happens when you try and use standard go testing
+// idioms like checking some condition and then calling t.Fatal, or t.FailNow. Internally
+// testify's ubiquitous require library also leverages these functions. What this means is
+// that if you have some code that needs to get run during cleanup time or want tests to
+// continue running in the case of a requirement failure, stock godog cannot call either of
+// these functions.
+//
+// This function attempts to mitigate this in a couple of ways:
+// 1. Constructs a function wrapper via reflection that installs a panic/recover handler that
+// looks for panics with the godog panic message
+// 2. If "exitBehavior" is set to nothing, then just rescue and continue. This is primarily used
+// when we know that godog is going to do an internal check on the failure status of a test
+// immediately after us recovering, such as when a test step or before hook fails.
+// 3. If "exitBehavior" is set to log, then just log the error that last occurred in our TestingT
+// prior to the panic, because that is likely what is to have caused the panic.
+// 4. If "exitBehavior" is set to exit, then call os.Exit after logging the last error.
+// 5. If "exitBehavior" is set to fail, then propagate the last error up via a global channel
+// that the top-level test runner receives, at the end of the test run, even if all of the tests pass
+// then the overall test will fail.
+//
+// The first of the above behaviors, as mentioned, are used before or after an individual step function
+// as we know godog will subsequently check the error status of the test. The last 3 need to be used in
+// any after test hooks or calls to t.Cleanup due to the error check already having happened in godog, instead
+// we need to bypass the godog stack and either fail the test directly or, in some other way, signal that
+// something bad/unexpected happened.
 func WrapWithPanicHandler[U any](needsLog bool, exitBehavior ExitBehavior, fn U) U {
 	fnValue := reflect.ValueOf(fn)
 	return reflect.MakeFunc(fnValue.Type(), func(args []reflect.Value) (results []reflect.Value) {
@@ -67,13 +94,20 @@ func WrapWithPanicHandler[U any](needsLog bool, exitBehavior ExitBehavior, fn U)
 					}
 				}
 			}
+			// We need to construct results here because if we rescue from a panic
+			// but wind up returning nothing, then go freaks out saying we returned
+			// the wrong number of return values from a function constructed with
+			// reflection.
+			//
+			// Generally we can just construct an array of zero-values by type, but
+			// we special-case having to return context.Context since you can't initialize
+			// it directly, instead just passing back any unomdified context we found
+			// as a first argument to the function handed to us.
 			returnSize := fnValue.Type().NumOut()
 			results = make([]reflect.Value, returnSize)
 			for i := 0; i < returnSize; i++ {
 				outType := fnValue.Type().Out(i)
-				path := outType.PkgPath()
-				name := outType.Name()
-				if len(args) > 0 && i == 0 && path == "context" && name == "Context" {
+				if len(args) > 0 && i == 0 && reflect.TypeFor[context.Context]() == outType {
 					if ctx, ok := args[0].Interface().(context.Context); ok {
 						results[i] = reflect.ValueOf(ctx)
 						continue

--- a/harpoon/internal/testing/panic.go
+++ b/harpoon/internal/testing/panic.go
@@ -1,3 +1,12 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package testing
 
 import (

--- a/harpoon/internal/testing/tags.go
+++ b/harpoon/internal/testing/tags.go
@@ -18,18 +18,15 @@ import (
 // CleanupFunc is a function run during a cleanup execution.
 type CleanupFunc func(context.Context)
 
-// TagHandler is a function that processes a tag and returns a cleanup function.
-type TagHandler func(context.Context, *TestingT, ...string) context.Context
-
 type ParsedTagHandler struct {
 	Priority  int
 	Arguments []string
-	Handler   TagHandler
+	Handler   func(context.Context, *TestingT, []string) context.Context
 }
 
 type PriorityTagHandler struct {
 	Priority int
-	Handler  TagHandler
+	Handler  func(context.Context, *TestingT, []string) context.Context
 }
 
 type TagRegistry struct {
@@ -42,7 +39,7 @@ func NewTagRegistry() *TagRegistry {
 	}
 }
 
-func (r *TagRegistry) Register(tag string, priority int, handler TagHandler) {
+func (r *TagRegistry) Register(tag string, priority int, handler func(context.Context, *TestingT, []string) context.Context) {
 	r.tags[tag] = PriorityTagHandler{
 		Handler:  handler,
 		Priority: priority,

--- a/harpoon/internal/tracking/features.go
+++ b/harpoon/internal/tracking/features.go
@@ -11,6 +11,7 @@ package tracking
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -23,7 +24,9 @@ import (
 type feature struct {
 	*internaltesting.Cleaner
 
+	name           string
 	opts           *internaltesting.TestingOptions
+	t              *internaltesting.TestingT
 	scenariosToRun int
 	isRunning      bool
 	hasStepFailure bool
@@ -47,7 +50,6 @@ type FeatureHookTracker struct {
 	registry    *internaltesting.TagRegistry
 	opts        *internaltesting.TestingOptions
 
-	schemas    []func()
 	onFeatures []func(context.Context, *internaltesting.TestingT)
 	features   map[string]*feature
 	mutex      sync.RWMutex
@@ -69,31 +71,34 @@ func (f *FeatureHookTracker) Scenario(ctx context.Context, scenario *godog.Scena
 
 	features := f.features[scenario.Uri]
 
-	if !features.isRunning {
+	isFirst := !features.isRunning
+	if isFirst {
 		opts := f.opts.Clone()
 
 		cleaner := internaltesting.NewCleaner(godog.T(ctx), opts)
+		t := internaltesting.NewTesting(ctx, opts, cleaner)
 
 		features.isRunning = true
 		features.opts = opts
 		features.Cleaner = cleaner
-
-		t := internaltesting.NewTesting(ctx, opts, cleaner)
+		features.t = t
 
 		// we process the configured hooks first and then tags
 		for _, fn := range f.onFeatures {
-			fn(ctx, t)
+			t.SetMessagePrefix("Feature Hook Failure: ")
+			internaltesting.WrapWithPanicHandler(false, internaltesting.ExitBehaviorNone, fn)(ctx, t)
 		}
 
 		for _, fn := range f.registry.Handlers(features.tags.flatten()) {
 			// iteratively inject tag handler context
-			ctx = fn.Handler(ctx, t, fn.Arguments...)
+			t.SetMessagePrefix("Feature Tag Failure: ")
+			ctx = internaltesting.WrapWithPanicHandler(false, internaltesting.ExitBehaviorNone, fn.Handler)(ctx, t, fn.Arguments)
 		}
 
 		f.features[scenario.Uri] = features
 	}
 
-	return f.scenarios.start(ctx, scenario, features, func() {
+	return f.scenarios.start(ctx, isFirst, scenario, features, func() {
 		f.scenarioFailed(scenario)
 	})
 }
@@ -110,7 +115,9 @@ func (f *FeatureHookTracker) ScenarioFinished(ctx context.Context, scenario *god
 	f.scenarios.finish(ctx, scenario)
 	if features.scenariosToRun <= 0 {
 		delete(f.features, scenario.Uri)
-		features.DoCleanup(ctx, features.hasStepFailure)
+
+		features.t.SetMessagePrefix(fmt.Sprintf("Feature (%s) Cleanup Failure: ", features.name))
+		internaltesting.WrapWithPanicHandler(false, f.opts.ExitBehavior, features.DoCleanup)(ctx, features.hasStepFailure)
 	}
 }
 
@@ -140,6 +147,7 @@ func (f *FeatureHookTracker) Feature(doc *messages.GherkinDocument, uri string, 
 	children := FilterChildren(f.opts.Provider, doc.Feature.Children)
 
 	f.features[uri] = &feature{
+		name:           doc.Feature.Name,
 		scenariosToRun: len(children),
 		tags:           tagsForFeature(doc.Feature.Tags),
 	}

--- a/harpoon/internal/tracking/scenarios.go
+++ b/harpoon/internal/tracking/scenarios.go
@@ -11,6 +11,7 @@ package tracking
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/cucumber/godog"
@@ -42,7 +43,7 @@ func newScenarioHookTracker(registry *internaltesting.TagRegistry, opts *interna
 	}
 }
 
-func (s *scenarioHookTracker) start(ctx context.Context, sc *godog.Scenario, feature *feature, onFailure func()) (context.Context, error) {
+func (s *scenarioHookTracker) start(ctx context.Context, isFirst bool, sc *godog.Scenario, feature *feature, onFailure func()) (context.Context, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -53,14 +54,18 @@ func (s *scenarioHookTracker) start(ctx context.Context, sc *godog.Scenario, fea
 	cleaner := internaltesting.NewCleaner(godog.T(ctx), opts)
 	t := internaltesting.NewTesting(ctx, opts, cleaner)
 
+	feature.t.PropagateError(isFirst, t)
+
 	// we process the configured hooks first and then tags
 	for _, fn := range s.onScenarios {
-		fn(ctx, t)
+		t.SetMessagePrefix("Scenario Hook Failure: ")
+		internaltesting.WrapWithPanicHandler(true, internaltesting.ExitBehaviorNone, fn)(ctx, t)
 	}
 
 	for _, fn := range s.registry.Handlers(tags.flatten()) {
 		// iteratively inject tag handler context
-		ctx = fn.Handler(ctx, t, fn.Arguments...)
+		t.SetMessagePrefix("Scenario Tag Failure: ")
+		ctx = internaltesting.WrapWithPanicHandler(true, internaltesting.ExitBehaviorNone, fn.Handler)(ctx, t, fn.Arguments)
 	}
 
 	s.scenarios[sc.Id] = &scenario{
@@ -86,7 +91,9 @@ func (s *scenarioHookTracker) finish(ctx context.Context, scenario *godog.Scenar
 	failure := scene.t.IsFailure()
 
 	// and then clean up the scenario hooks themselves
-	scene.DoCleanup(ctx, failure)
+	scene.t.SetMessagePrefix(fmt.Sprintf("Scenario (%s) Cleanup Failure: ", scenario.Name))
+	internaltesting.WrapWithPanicHandler(true, s.opts.ExitBehavior, scene.DoCleanup)(ctx, failure)
+	scene.t.SetMessagePrefix("")
 	if failure {
 		scene.onFail()
 	}

--- a/harpoon/steps.go
+++ b/harpoon/steps.go
@@ -9,7 +9,13 @@
 
 package framework
 
-import "github.com/cucumber/godog"
+import (
+	"context"
+	"reflect"
+
+	"github.com/cucumber/godog"
+	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
+)
 
 type stepDefinition struct {
 	expression string
@@ -24,6 +30,56 @@ func RegisterStep(expression string, step interface{}) {
 
 func getSteps(ctx *godog.ScenarioContext) {
 	for _, step := range registeredSteps {
-		ctx.Step(step.expression, step.step)
+		ctx.Step(step.expression, injectTestingT(internaltesting.WrapWithPanicHandler(false, internaltesting.ExitBehaviorNone, step.step)))
 	}
+}
+
+type empty struct{}
+
+func injectTestingT(fn interface{}) interface{} {
+	fnValue := reflect.ValueOf(fn)
+	fnType := fnValue.Type()
+	inTypes := []reflect.Type{}
+	for i := 0; i < fnType.NumIn(); i++ {
+		inTypes = append(inTypes, fnType.In(i))
+	}
+	outTypes := []reflect.Type{}
+	for i := 0; i < fnType.NumOut(); i++ {
+		outTypes = append(outTypes, fnType.Out(i))
+	}
+
+	path := reflect.TypeOf(empty{}).PkgPath()
+
+	// handle the case of ctx.Context, TestingT...
+	if len(inTypes) > 1 && isType("context", "Context", inTypes[0]) && isType(path, "TestingT", inTypes[1]) {
+		inTypes = append([]reflect.Type{inTypes[0]}, inTypes[2:]...)
+		fnType := reflect.FuncOf(inTypes, outTypes, false)
+		newFn := reflect.MakeFunc(fnType, func(args []reflect.Value) (results []reflect.Value) {
+			ctx := args[0].Interface().(context.Context)
+			t := T(ctx)
+			newArgs := append([]reflect.Value{args[0], reflect.ValueOf(t)}, args[1:]...)
+			return fnValue.Call(newArgs)
+		}).Interface()
+		return newFn
+	}
+
+	// handle the case of TestingT
+	if len(inTypes) > 0 && isType(path, "TestingT", inTypes[0]) {
+		// inject a ctx.Context, pull TestingT out, and then drop the context
+		inTypes = append([]reflect.Type{reflect.TypeFor[context.Context]()}, inTypes[1:]...)
+		fnType := reflect.FuncOf(inTypes, outTypes, false)
+		newFn := reflect.MakeFunc(fnType, func(args []reflect.Value) (results []reflect.Value) {
+			ctx := args[0].Interface().(context.Context)
+			t := T(ctx)
+			newArgs := append([]reflect.Value{reflect.ValueOf(t)}, args[1:]...)
+			return fnValue.Call(newArgs)
+		}).Interface()
+		return newFn
+	}
+
+	return fn
+}
+
+func isType(pkg, name string, typ reflect.Type) bool {
+	return typ.PkgPath() == pkg && name == typ.Name()
 }

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -15,6 +15,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,17 +41,18 @@ type helmChart struct {
 }
 
 type SuiteBuilder struct {
-	testingOpts     *internaltesting.TestingOptions
-	output          string
-	opts            godog.Options
-	registry        *internaltesting.TagRegistry
-	providers       map[string]Provider
-	defaultProvider string
-	injectors       []func(context.Context) context.Context
-	crdDirectories  []string
-	helmCharts      []helmChart
-	onFeatures      []func(context.Context, *internaltesting.TestingT)
-	onScenarios     []func(context.Context, *internaltesting.TestingT)
+	testingOpts           *internaltesting.TestingOptions
+	output                string
+	opts                  godog.Options
+	registry              *internaltesting.TagRegistry
+	providers             map[string]Provider
+	defaultProvider       string
+	injectors             []func(context.Context) context.Context
+	crdDirectories        []string
+	helmCharts            []helmChart
+	onFeatures            []func(context.Context, *internaltesting.TestingT)
+	onScenarios           []func(context.Context, *internaltesting.TestingT)
+	exitOnCleanupFailures bool
 }
 
 func SuiteBuilderFromFlags() *SuiteBuilder {
@@ -58,7 +60,7 @@ func SuiteBuilderFromFlags() *SuiteBuilder {
 
 	var config string
 	var output string
-	options := &internaltesting.TestingOptions{}
+	options := &internaltesting.TestingOptions{ExitBehavior: internaltesting.ExitBehaviorLog}
 
 	// TODO: Consider adding an -always-retain flag that doesn't actually delete anything. If
 	// we add something like that we'll still have to do some "stateful" cleanup in the lifecycle,
@@ -102,7 +104,7 @@ func (b *SuiteBuilder) WithDefaultProvider(name string) *SuiteBuilder {
 }
 
 func (b *SuiteBuilder) RegisterTag(tag string, priority int, handler TagHandler) *SuiteBuilder {
-	b.registry.Register(tag, priority, func(ctx context.Context, tt *internaltesting.TestingT, s ...string) context.Context {
+	b.registry.Register(tag, priority, func(ctx context.Context, tt *internaltesting.TestingT, s []string) context.Context {
 		// wrap since we move into the internal implementation of the interface
 		handler(ctx, tt, s...)
 		return ctx
@@ -148,6 +150,11 @@ func (b *SuiteBuilder) WithHelmChart(url, repo, chart string, options helm.Insta
 		chart:   chart,
 		options: options,
 	})
+	return b
+}
+
+func (b *SuiteBuilder) ExitOnCleanupFailures() *SuiteBuilder {
+	b.exitOnCleanupFailures = true
 	return b
 }
 
@@ -279,14 +286,16 @@ func (b *SuiteBuilder) Build() (*Suite, error) {
 			},
 			Options: &opts,
 		},
-		options: b.testingOpts,
+		options:               b.testingOpts,
+		exitOnCleanupFailures: b.exitOnCleanupFailures,
 	}, nil
 }
 
 type Suite struct {
-	output  string
-	suite   *godog.TestSuite
-	options *internaltesting.TestingOptions
+	output                string
+	suite                 *godog.TestSuite
+	options               *internaltesting.TestingOptions
+	exitOnCleanupFailures bool
 }
 
 func (s *Suite) RunM(m *testing.M) {
@@ -294,6 +303,10 @@ func (s *Suite) RunM(m *testing.M) {
 	if s.output != "" {
 		s.suite.Options.Output = &testLog
 		s.suite.Options.NoColors = true
+	}
+
+	if s.exitOnCleanupFailures {
+		s.options.ExitBehavior = internaltesting.ExitBehaviorTerminateProgram
 	}
 
 	status := s.suite.Run()
@@ -310,17 +323,45 @@ func (s *Suite) RunM(m *testing.M) {
 }
 
 func (s *Suite) RunT(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var testLog bytes.Buffer
 	if s.output != "" {
 		s.suite.Options.Output = &testLog
 		s.suite.Options.NoColors = true
 	}
 
+	var errMessage internaltesting.TerminationError
+	var wg sync.WaitGroup
+	if s.exitOnCleanupFailures {
+		s.options.ExitBehavior = internaltesting.ExitBehaviorTestFail
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				return
+			case errMessage = <-internaltesting.TerminationChan:
+			}
+		}()
+	}
+
 	s.suite.Options.TestingT = t
+
 	s.suite.Run()
+	cancel()
+	wg.Wait()
 
 	if s.output != "" {
 		writeTestLog(testLog, s.output)
+	}
+
+	if errMessage.Message != "" {
+		if errMessage.NeedsLog {
+			fmt.Print(errMessage.Message)
+		}
+		t.Fail()
 	}
 }
 

--- a/harpoon/suite_test.go
+++ b/harpoon/suite_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 	suite, err = SuiteBuilderFromFlags().
 		RegisterProvider("stub", NoopProvider).
 		WithDefaultProvider("stub").
+		ExitOnCleanupFailures().
 		Build()
 
 	if err != nil {
@@ -42,38 +43,33 @@ func TestSuite(t *testing.T) {
 	suite.RunT(t)
 }
 
-func stubGiven(ctx context.Context) error {
-	T(ctx).ApplyFixture(ctx, "stub")
-
-	return nil
+func stubGiven(ctx context.Context, t TestingT) {
+	t.ApplyFixture(ctx, "stub")
 }
 
-func stubWhen(ctx context.Context, key, value string) error {
-	t := T(ctx)
-
+func stubWhen(ctx context.Context, t TestingT, key, value string) {
 	var configMap corev1.ConfigMap
 	require.NoError(t, t.Get(ctx, t.ResourceKey("stub-config-map"), &configMap))
 
 	configMap.Data = map[string]string{key: value}
 
 	require.NoError(t, t.Update(ctx, &configMap))
-
-	return nil
 }
 
-func stubThen(ctx context.Context, key, value string) error {
-	t := T(ctx)
-
+func stubThen(ctx context.Context, t TestingT, key, value string) {
 	var configMap corev1.ConfigMap
 	require.NoError(t, t.Get(ctx, t.ResourceKey("stub-config-map"), &configMap))
 
 	require.Equal(t, value, configMap.Data[key])
+}
 
-	return nil
+func stubAnd(t TestingT) {
+	require.Equal(t, 1, 1)
 }
 
 func init() {
 	RegisterStep(`^there is a stub$`, stubGiven)
 	RegisterStep(`^a user updates the stub key "([^"]*)" to "([^"]*)"$`, stubWhen)
 	RegisterStep(`^the stub should have "([^"]*)" equal "([^"]*)"$`, stubThen)
+	RegisterStep(`^there is no error$`, stubAnd)
 }


### PR DESCRIPTION
This PR does a couple of things:

1. It does a bunch of panic handling due to the way that godog panics when FailNow or SkipNow are called so that we can properly use things like testify's require or t.Fatal/t.Fail
2. It extends the way we can register step functions to include a couple of new function prototypes where we can make steps *much* more similar to a typical go test and not have to either return nil errors everywhere or pull something that looks like a testing.T out of a context.

Most of this is more fleshed out/documented in the additions to the README and I tried it by passing in panicking (via `require` failures) hooks, tag handlers, callbacks, and step definitions pretty much everywhere and watching the test runs not actually panic but instead just fail a test or the overall suite.

Eventually I want to see about doing some "meta" tests for this framework so I can just define some features, process them and make sure that we get no panics anywhere in the run unless we _actually_ panic due to something like a nil pointer deref, etc.

**NOTE** that the panic handlers, especially due to the way that the step definitions are defined, heavily leverage reflection, which, while not ideal, pretty much is the only thing we can do given the various method signatures we're wrapping.