### PR TITLE
Fix decommission process with Redpanda status

### DIFF
--- a/src/go/k8s/internal/controller/redpanda/redpanda_decommission_controller.go
+++ b/src/go/k8s/internal/controller/redpanda/redpanda_decommission_controller.go
@@ -746,11 +746,10 @@ func needsDecommission(ctx context.Context, sts *appsv1.StatefulSet, log logr.Lo
 		return false, fmt.Errorf("error creating adminAPI: %w", err)
 	}
 
-	health, err := watchClusterHealth(ctx, adminAPI)
+	health, err := adminAPI.GetHealthOverview(ctx)
 	if err != nil {
 		return false, fmt.Errorf("could not make request to admin-api: %w", err)
 	}
-
 	if requestedReplicas == 0 || len(health.AllNodes) == 0 {
 		return false, nil
 	}


### PR DESCRIPTION
So, my previous changes to unblock the Helm chart installation process broke our e2e decommissioning test by introducing a race condition into our test assertions. Basically, with the decommission controller there was a small window in which decommissioning had not yet happened and hence the nodes were technically unhealthy, and yet they were not marked yet as "unhealthy" within the statefulset.

What that meant is that the `Redpanda` CRD we were creating in our test was getting marked as "ready" for a split second, when it really wasn't and we were prematurely triggering a second scale down operation.

This fixes the test by setting a status condition if the controller detects that the statefulset for our Redpanda cluster needs to be "decommission" dead nodes. As a result, the CRD is never marked as "ready" until decommissioning is fully finished.