### PR TITLE
Add reusable set implementation

### DIFF
--- a/src/go/k8s/pkg/client/acls/rules.go
+++ b/src/go/k8s/pkg/client/acls/rules.go
@@ -42,7 +42,7 @@ func rulesFromV1Alpha2ACL(principal string, r redpandav1alpha2.ACLRule) ([]rule,
 	return rules, nil
 }
 
-func (r rule) toV1Alpha2Rule() redpandav1alpha2.ACLRule {
+func ruleToV1Alpha2Rule(r rule) redpandav1alpha2.ACLRule {
 	return redpandav1alpha2.ACLRule{
 		Type: redpandav1alpha2.ACLTypeFromKafka(r.PermissionType),
 		Resource: redpandav1alpha2.ACLResourceSpec{
@@ -57,7 +57,7 @@ func (r rule) toV1Alpha2Rule() redpandav1alpha2.ACLRule {
 	}
 }
 
-func (r rule) toDeletionFilter() kmsg.DeleteACLsRequestFilter {
+func ruleToDeletionFilter(r rule) kmsg.DeleteACLsRequestFilter {
 	return kmsg.DeleteACLsRequestFilter{
 		ResourceType:        r.ResourceType,
 		ResourceName:        &r.ResourceName,
@@ -69,7 +69,7 @@ func (r rule) toDeletionFilter() kmsg.DeleteACLsRequestFilter {
 	}
 }
 
-func (r rule) toCreationRequest() kmsg.CreateACLsRequestCreation {
+func ruleToCreationRequest(r rule) kmsg.CreateACLsRequestCreation {
 	return kmsg.CreateACLsRequestCreation{
 		ResourceType:        r.ResourceType,
 		ResourceName:        r.ResourceName,

--- a/src/go/k8s/pkg/client/acls/syncer.go
+++ b/src/go/k8s/pkg/client/acls/syncer.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/src/go/k8s/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/src/go/k8s/pkg/collections"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -96,7 +97,9 @@ func (s *Syncer) ListACLs(ctx context.Context, principal string) ([]redpandav1al
 		return nil, fmt.Errorf("listing ACLs: %w", err)
 	}
 
-	return rulesetFromDescribeResponse(describeResponse).asV1Alpha2Rules(), nil
+	rules := collections.MapSet(rulesetFromDescribeResponse(describeResponse), ruleToV1Alpha2Rule)
+
+	return rules, nil
 }
 
 func (s *Syncer) listACLs(ctx context.Context, principal string) ([]kmsg.DescribeACLsResponseResource, error) {

--- a/src/go/k8s/pkg/collections/doc.go
+++ b/src/go/k8s/pkg/collections/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package collections contains structures for manipulating
+// collections of data, such as sets, trees, etc.
+package collections

--- a/src/go/k8s/pkg/collections/map.go
+++ b/src/go/k8s/pkg/collections/map.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package collections
+
+// MapSet returns a slice of the values of the given set with a transformation
+// function applied to them.
+func MapSet[T comparable, U any](set Set[T], fn func(T) U) []U {
+	var values []U
+	for _, value := range set.Values() {
+		values = append(values, fn(value))
+	}
+	return values
+}

--- a/src/go/k8s/pkg/collections/set.go
+++ b/src/go/k8s/pkg/collections/set.go
@@ -1,0 +1,270 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package collections
+
+import "sync"
+
+// Set is a generic interface for set implementations.
+type Set[T comparable] interface {
+	// Add adds the given values to a set.
+	Add(values ...T)
+	// HasAll checks if all of the given values exist in the set.
+	HasAll(values ...T) bool
+	// HasAny checks if any of the given values exist in the set.
+	HasAny(values ...T) bool
+	// Delete removes all of the given values from the set.
+	Delete(values ...T)
+	// Clear removes all values from the set.
+	Clear()
+	// Size returns the cardinality of the set.
+	Size() int
+	// Values returns a list of values found in the given set. The
+	// order of the returned values is not guaranteed.
+	Values() []T
+	// Merge merges all of the values from a given set into this set.
+	Merge(other Set[T])
+	// Clone makes a copy of the current set. All set implementations should
+	// clone to the same set implementation as the current set.
+	Clone() Set[T]
+	// RightDisjoint returns a new set of the same type as the current set with
+	// items only found in the given set, any overlapping elements, or elements
+	// only found in the current set are removed.
+	RightDisjoint(other Set[T]) Set[T]
+	// LeftDisjoint returns a new set of the same type as the current set with
+	// items only found in the current set, any overlapping elements, or elements
+	// only found in the given set are removed.
+	LeftDisjoint(other Set[T]) Set[T]
+	// Intersection returns a new set of the same type as the current set with
+	// items only found in both the current and the given set, any non-overlapping
+	// elements are removed.
+	Intersection(other Set[T]) Set[T]
+	// Union returns a new set of the same type as the current set with all
+	// items found in either the current and the given set.
+	Union(other Set[T]) Set[T]
+}
+
+type singleThreadedSet[T comparable] struct {
+	data map[T]struct{}
+}
+
+var _ Set[string] = (*singleThreadedSet[string])(nil)
+
+func NewSet[T comparable]() Set[T] {
+	return &singleThreadedSet[T]{
+		data: make(map[T]struct{}),
+	}
+}
+
+func (s *singleThreadedSet[T]) Add(values ...T) {
+	for _, value := range values {
+		s.data[value] = struct{}{}
+	}
+}
+
+func (s *singleThreadedSet[T]) HasAll(values ...T) bool {
+	for _, value := range values {
+		_, ok := s.data[value]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *singleThreadedSet[T]) HasAny(values ...T) bool {
+	for _, value := range values {
+		_, ok := s.data[value]
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *singleThreadedSet[T]) Delete(values ...T) {
+	for _, value := range values {
+		delete(s.data, value)
+	}
+}
+
+func (s *singleThreadedSet[T]) Clear() {
+	s.data = make(map[T]struct{})
+}
+
+func (s *singleThreadedSet[T]) Size() int {
+	return len(s.data)
+}
+
+func (s *singleThreadedSet[T]) Values() []T {
+	var values []T
+	for value := range s.data {
+		values = append(values, value)
+	}
+	return values
+}
+
+func (s *singleThreadedSet[T]) Merge(other Set[T]) {
+	for _, value := range other.Values() {
+		s.Add(value)
+	}
+}
+
+func (s *singleThreadedSet[T]) Clone() Set[T] {
+	set := &singleThreadedSet[T]{
+		data: make(map[T]struct{}),
+	}
+	set.Add(s.Values()...)
+	return set
+}
+
+func (s *singleThreadedSet[T]) RightDisjoint(other Set[T]) Set[T] {
+	set := &singleThreadedSet[T]{
+		data: make(map[T]struct{}),
+	}
+	set.Add(other.Values()...)
+	set.Delete(s.Values()...)
+	return set
+}
+
+func (s *singleThreadedSet[T]) LeftDisjoint(other Set[T]) Set[T] {
+	set := s.Clone()
+	set.Delete(other.Values()...)
+	return set
+}
+
+func (s *singleThreadedSet[T]) Intersection(other Set[T]) Set[T] {
+	set := &singleThreadedSet[T]{
+		data: make(map[T]struct{}),
+	}
+	for _, value := range other.Values() {
+		if _, ok := s.data[value]; ok {
+			set.Add(value)
+		}
+	}
+	return set
+}
+
+func (s *singleThreadedSet[T]) Union(other Set[T]) Set[T] {
+	set := s.Clone()
+	set.Add(other.Values()...)
+	return set
+}
+
+type concurrentSet[T comparable] struct {
+	set   *singleThreadedSet[T]
+	mutex sync.RWMutex
+}
+
+var _ Set[string] = (*concurrentSet[string])(nil)
+
+func NewConcurrentSet[T comparable]() Set[T] {
+	return &concurrentSet[T]{
+		set: &singleThreadedSet[T]{
+			data: make(map[T]struct{}),
+		},
+	}
+}
+
+func (s *concurrentSet[T]) Add(values ...T) {
+	s.mutex.Lock()
+	s.set.Add(values...)
+	s.mutex.Unlock()
+}
+
+func (s *concurrentSet[T]) HasAll(values ...T) bool {
+	s.mutex.RLock()
+	hasAll := s.set.HasAll(values...)
+	s.mutex.RUnlock()
+	return hasAll
+}
+
+func (s *concurrentSet[T]) HasAny(values ...T) bool {
+	s.mutex.RLock()
+	hasAny := s.set.HasAny(values...)
+	s.mutex.RUnlock()
+	return hasAny
+}
+
+func (s *concurrentSet[T]) Delete(values ...T) {
+	s.mutex.Lock()
+	s.set.Delete(values...)
+	s.mutex.Unlock()
+}
+
+func (s *concurrentSet[T]) Clear() {
+	s.mutex.Lock()
+	s.set.Clear()
+	s.mutex.Unlock()
+}
+
+func (s *concurrentSet[T]) Size() int {
+	s.mutex.RLock()
+	size := s.set.Size()
+	s.mutex.RUnlock()
+	return size
+}
+
+func (s *concurrentSet[T]) Values() []T {
+	s.mutex.RLock()
+	values := s.set.Values()
+	s.mutex.RUnlock()
+	return values
+}
+
+func (s *concurrentSet[T]) Merge(other Set[T]) {
+	s.mutex.Lock()
+	s.set.Merge(other)
+	s.mutex.Unlock()
+}
+
+func (s *concurrentSet[T]) Clone() Set[T] {
+	s.mutex.RLock()
+	set := &concurrentSet[T]{
+		set: s.set.Clone().(*singleThreadedSet[T]),
+	}
+	s.mutex.RUnlock()
+	return set
+}
+
+func (s *concurrentSet[T]) RightDisjoint(other Set[T]) Set[T] {
+	s.mutex.RLock()
+	set := &concurrentSet[T]{
+		set: s.set.RightDisjoint(other).(*singleThreadedSet[T]),
+	}
+	s.mutex.RUnlock()
+	return set
+}
+
+func (s *concurrentSet[T]) LeftDisjoint(other Set[T]) Set[T] {
+	s.mutex.RLock()
+	set := &concurrentSet[T]{
+		set: s.set.LeftDisjoint(other).(*singleThreadedSet[T]),
+	}
+	s.mutex.RUnlock()
+	return set
+}
+
+func (s *concurrentSet[T]) Intersection(other Set[T]) Set[T] {
+	s.mutex.RLock()
+	set := &concurrentSet[T]{
+		set: s.set.Intersection(other).(*singleThreadedSet[T]),
+	}
+	s.mutex.RUnlock()
+	return set
+}
+
+func (s *concurrentSet[T]) Union(other Set[T]) Set[T] {
+	s.mutex.RLock()
+	set := &concurrentSet[T]{
+		set: s.set.Union(other).(*singleThreadedSet[T]),
+	}
+	s.mutex.RUnlock()
+	return set
+}

--- a/src/go/k8s/pkg/collections/set_test.go
+++ b/src/go/k8s/pkg/collections/set_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package collections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testSetImplementation(t *testing.T, set Set[string]) {
+	// Test Add, HasAny, HasAll, Size
+	require.Equal(t, 0, set.Size())
+
+	set.Add("1", "2", "3")
+
+	require.Equal(t, 3, set.Size())
+	require.True(t, set.HasAll("1", "2", "3"))
+	require.False(t, set.HasAll("1", "2", "3", "4"))
+	require.True(t, set.HasAny("1", "2", "3", "4"))
+	require.False(t, set.HasAny("4"))
+
+	// Test Delete
+	set.Delete("3")
+
+	require.Equal(t, 2, set.Size())
+	require.False(t, set.HasAny("3"))
+
+	// Test Clone and Values
+	other := set.Clone()
+
+	require.Equal(t, other.Size(), set.Size())
+	require.True(t, other.HasAll(set.Values()...))
+	require.True(t, set.HasAll(other.Values()...))
+
+	// Test Clear
+	set.Clear()
+
+	require.Equal(t, 0, set.Size())
+	require.False(t, set.HasAny("1"))
+
+	// Test Merging
+	other.Clear()
+	set.Add("1")
+	other.Add("2")
+	set.Merge(other)
+
+	require.Equal(t, 2, set.Size())
+	require.True(t, set.HasAll("1", "2"))
+
+	// Test *Disjoint, Union, and Insersection
+	other.Clear()
+	set.Clear()
+
+	set.Add("1", "2", "3")
+	other.Add("3", "4", "5")
+
+	left := set.LeftDisjoint(other)
+	right := set.RightDisjoint(other)
+	intersect := set.Intersection(other)
+	union := set.Union(other)
+
+	require.Equal(t, 2, left.Size())
+	require.True(t, left.HasAll("1", "2"), "Set did not contain 1, 2 as expected %+v", left.Values())
+
+	require.Equal(t, 2, right.Size())
+	require.True(t, right.HasAll("4", "5"), "Set did not contain 4, 5 as expected %+v", right.Values())
+
+	require.Equal(t, 1, intersect.Size())
+	require.True(t, intersect.HasAll("3"), "Set did not contain 3 as expected %+v", intersect.Values())
+
+	require.Equal(t, 5, union.Size())
+	require.True(t, union.HasAll("1", "2", "3", "4", "5"), "Set did not contain 1, 2, 3, 4, 5 as expected %+v", union.Values())
+}
+
+func TestSets(t *testing.T) {
+	for name, set := range map[string]Set[string]{
+		"SingleThreaded": NewSet[string](),
+		"Concurrent":     NewConcurrentSet[string](),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testSetImplementation(t, set)
+		})
+	}
+}


### PR DESCRIPTION
This adds a reusable set implementation and changes the acls package to use it rather than implement its own set for tracking rules. I already have a few other places where I want to use this, but wanted to keep this a fairly lean PR.