### PR TITLE
Remove wrong assertion

### DIFF
--- a/src/go/k8s/internal/controller/test/suite_test.go
+++ b/src/go/k8s/internal/controller/test/suite_test.go
@@ -100,11 +100,10 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f, err := os.Open("testdata/metrics.golden.txt")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cfg).NotTo(BeNil())
+		defer f.Close()
 
 		_, err = io.Copy(w, f)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cfg).NotTo(BeNil())
 	}))
 
 	resources.UnderReplicatedPartitionsHostOverwrite = ts.Listener.Addr().String()


### PR DESCRIPTION
The cfg assertion was copied from other places within `suite_test.go`. cfg is not used in this http handler those it should not be asserted.

The missing file descriptor close function call is added.

Reference:
https://github.com/redpanda-data/redpanda/commit/c8bd1650300db0c789204b4ea9aa74e3ee6aa6bb#diff-8dc5beefd6b5f6302ad354811063b60d63ef4062149258baa3f5e3284502a963R95 https://buildkite.com/redpanda/redpanda-operator/builds/2654#019208b1-28fa-48bf-a4c6-796d48a828e9/1106-1125