### PR TITLE
cache AdminAPIClients

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,3 +57,17 @@ tasks:
   generate:
     cmds:
       - task: k8s:generate
+
+  build:
+    cmds:
+      - task: build:binaries
+
+  build:binaries:
+    cmds:
+      # TODO(chrisseto): Ditch goreleaser in favor of just go build in task
+      # files. We're not using it for anything other than an arch build matrix.
+      - task: goreleaser:build-operator-binaries
+
+  build:images:
+    cmds:
+      - task: k8s:build-operator-images

--- a/src/go/k8s/cmd/run/run.go
+++ b/src/go/k8s/cmd/run/run.go
@@ -315,11 +315,13 @@ func Run(
 	case OperatorV1Mode:
 		ctrl.Log.Info("running in v1", "mode", OperatorV1Mode)
 
+		adminAPIClientFactory := adminutils.CachedAdminAPIClientFactory(adminutils.NewInternalAdminAPI)
+
 		if err = (&redpandacontrollers.ClusterReconciler{
 			Client:                    mgr.GetClient(),
 			Log:                       ctrl.Log.WithName("controllers").WithName("redpanda").WithName("Cluster"),
 			Scheme:                    mgr.GetScheme(),
-			AdminAPIClientFactory:     adminutils.NewInternalAdminAPI,
+			AdminAPIClientFactory:     adminAPIClientFactory,
 			DecommissionWaitInterval:  decommissionWaitInterval,
 			MetricsTimeout:            metricsTimeout,
 			RestrictToRedpandaVersion: restrictToRedpandaVersion,
@@ -334,7 +336,7 @@ func Run(
 			Client:                    mgr.GetClient(),
 			Log:                       ctrl.Log.WithName("controllers").WithName("redpanda").WithName("ClusterConfigurationDrift"),
 			Scheme:                    mgr.GetScheme(),
-			AdminAPIClientFactory:     adminutils.NewInternalAdminAPI,
+			AdminAPIClientFactory:     adminAPIClientFactory,
 			RestrictToRedpandaVersion: restrictToRedpandaVersion,
 		}).WithClusterDomain(clusterDomain).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "ClusterConfigurationDrift")
@@ -351,7 +353,7 @@ func Run(
 			Client:                  mgr.GetClient(),
 			Scheme:                  mgr.GetScheme(),
 			Log:                     ctrl.Log.WithName("controllers").WithName("redpanda").WithName("Console"),
-			AdminAPIClientFactory:   adminutils.NewInternalAdminAPI,
+			AdminAPIClientFactory:   adminAPIClientFactory,
 			Store:                   consolepkg.NewStore(mgr.GetClient(), mgr.GetScheme()),
 			EventRecorder:           mgr.GetEventRecorderFor("Console"),
 			KafkaAdminClientFactory: consolepkg.NewKafkaAdmin,

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
 	github.com/redpanda-data/helm-charts v0.0.0-20240916201426-9ca3b128bb8e
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
+	github.com/scalalang2/golang-fifo v1.0.2
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -38,6 +38,8 @@ emperror.dev/errors v0.8.1 h1:UavXZ5cSX/4u9iyvH6aDcuGkVjeexUGJ7Ij7G4VfQT0=
 emperror.dev/errors v0.8.1/go.mod h1:YcRvLPh626Ubn2xqtoprejnA5nFha+TJ+2vew48kWuE=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+fortio.org/assert v1.2.1 h1:48I39urpeDj65RP1KguF7akCjILNeu6vICiYMEysR7Q=
+fortio.org/assert v1.2.1/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230618160516-e936619f9f18 h1:rd389Q26LMy03gG4anandGFC2LW/xvjga5GezeeaxQk=
@@ -1125,6 +1127,8 @@ github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGq
 github.com/sassoftware/relic v7.2.1+incompatible/go.mod h1:CWfAxv73/iLZ17rbyhIEq3K9hs5w6FpNMdUT//qR+zk=
 github.com/sassoftware/relic/v7 v7.6.1 h1:O5s8ewCgq5QYNpv45dK4u6IpBmDM9RIcsbf/G1uXepQ=
 github.com/sassoftware/relic/v7 v7.6.1/go.mod h1:NxwtWxWxlUa9as2qZi635Ye6bBT/tGnMALLq7dSfOOU=
+github.com/scalalang2/golang-fifo v1.0.2 h1:sfOJBB86iXuqB5WoLtVI7+wxn8UOEOr9SnJaTakinBA=
+github.com/scalalang2/golang-fifo v1.0.2/go.mod h1:TsyVkLbka5m8tmfqsWBXwJ7Om1jV/uuOuvoPulZbMmA=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/secure-systems-lab/go-securesystemslib v0.7.0 h1:OwvJ5jQf9LnIAS83waAjPbcMsODrTQUpJ02eNLUoxBg=
 github.com/secure-systems-lab/go-securesystemslib v0.7.0/go.mod h1:/2gYnlnHVQ6xeGtfIqFy7Do03K4cdCY0A/GlJLDKLHI=


### PR DESCRIPTION
This commit wraps the default AdminAPIClientFactory in a cache to mitigate a suspected leak of memory / goroutines from the http.Clients within the returned AdminAPIClients as they can't be manually cleaned up.

A handful of other interactions seem to cause reconciliation of `Cluster`s to "storm" which greatly exacerbates the leak, especially on larger clusters.