### PR TITLE
configure logging from root command

### DIFF
--- a/src/go/k8s/cmd/main.go
+++ b/src/go/k8s/cmd/main.go
@@ -13,16 +13,28 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/configurator"
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/envsubst"
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/run"
 	"github.com/redpanda-data/redpanda-operator/src/go/k8s/cmd/syncclusterconfig"
 	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var rootCmd = cobra.Command{
-	Use: "redpanda-operator",
-}
+var (
+	rootCmd = cobra.Command{
+		Use: "redpanda-operator",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Configure logging consistently for all sub-commands.
+			// NB: If a subcommand relies on outputting to stdout, logging may
+			// cause issues as it's default output it stdout.
+			ctrl.SetLogger(logger.NewLogger(logOptions))
+		},
+	}
+
+	logOptions logger.Options
+)
 
 func init() {
 	rootCmd.AddCommand(
@@ -31,6 +43,8 @@ func init() {
 		run.Command(),
 		syncclusterconfig.Command(),
 	)
+
+	logOptions.BindFlags(rootCmd.PersistentFlags())
 }
 
 func main() {

--- a/src/go/k8s/cmd/run/run.go
+++ b/src/go/k8s/cmd/run/run.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/client"
 	helper "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
-	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/fluxcd/pkg/runtime/metrics"
 	sourceControllerAPIv1 "github.com/fluxcd/source-controller/api/v1"
 	sourceControllerAPIv1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -103,7 +102,6 @@ var (
 
 	clientOptions  client.Options
 	kubeConfigOpts client.KubeConfigOptions
-	logOptions     logger.Options
 
 	storageAdvAddr string
 
@@ -215,7 +213,6 @@ func Command() *cobra.Command {
 	cmd.Flags().DurationVar(&unbindPVCsAfter, "unbind-pvcs-after", 0, "if not zero, runs the PVCUnbinder controller which attempts to 'unbind' the PVCs' of Pods that are Pending for longer than the given duration")
 	cmd.Flags().BoolVar(&autoDeletePVCs, "auto-delete-pvcs", false, "Use StatefulSet PersistentVolumeClaimRetentionPolicy to auto delete PVCs on scale down and Cluster resource delete.")
 
-	logOptions.BindFlags(cmd.Flags())
 	clientOptions.BindFlags(cmd.Flags())
 	kubeConfigOpts.BindFlags(cmd.Flags())
 
@@ -246,8 +243,6 @@ func Run(
 	unbindPVCsAfter time.Duration,
 	autoDeletePVCs bool,
 ) {
-	ctrl.SetLogger(logger.NewLogger(logOptions))
-
 	// set the managedFields owner for resources reconciled from Helm charts
 	kube.ManagedFieldsManager = controllerName
 


### PR DESCRIPTION
Prior to this commit logging was only being configured from the `run` command which resulted in no output from commands such as `sync-cluster-config`.

This commit moves logging configuration into the root command to ensure a consistent logging output experience from all commands.