### PR TITLE
Fix syncing prefix-based ACL rules

### DIFF
--- a/operator/pkg/client/acls/syncer.go
+++ b/operator/pkg/client/acls/syncer.go
@@ -110,6 +110,7 @@ func (s *Syncer) listACLs(ctx context.Context, principal string) ([]kmsg.Describ
 	req.ResourceType = kmsg.ACLResourceTypeAny
 	req.Principal = ptrUsername
 	req.Operation = kmsg.ACLOperationAny
+	req.ResourcePatternType = kmsg.ACLResourcePatternTypeAny
 
 	response, err := req.RequestWith(ctx, s.client)
 	if err != nil {

--- a/operator/pkg/client/acls/syncer_test.go
+++ b/operator/pkg/client/acls/syncer_test.go
@@ -121,10 +121,26 @@ func TestSyncer(t *testing.T) {
 		Type: v1alpha2.ACLTypeAllow,
 		Host: ptr.To("*"),
 		Resource: v1alpha2.ACLResourceSpec{
-			Type: v1alpha2.ResourceTypeCluster,
+			Type:        v1alpha2.ResourceTypeTopic,
+			Name:        "mytopic",
+			PatternType: ptr.To(v1alpha2.PatternTypePrefixed),
 		},
 		Operations: []v1alpha2.ACLOperation{
-			v1alpha2.ACLOperationClusterAction,
+			v1alpha2.ACLOperationRead,
+		},
+	}}, 1, 1)
+
+	// update acl again
+	expectACLUpdate(t, principalOne, []v1alpha2.ACLRule{{
+		Type: v1alpha2.ACLTypeAllow,
+		Host: ptr.To("*"),
+		Resource: v1alpha2.ACLResourceSpec{
+			Type:        v1alpha2.ResourceTypeTopic,
+			Name:        "mytopic2",
+			PatternType: ptr.To(v1alpha2.PatternTypePrefixed),
+		},
+		Operations: []v1alpha2.ACLOperation{
+			v1alpha2.ACLOperationRead,
 		},
 	}}, 1, 1)
 


### PR DESCRIPTION
When pulling ACLs in our User/ACL synchronization code, the filter for `ACLResourcePatternTypeAny` wasn't being set, so it was only returning exact-match ACLs by default. What this meant is that rules with a prefix type weren't being seen by our listing code, and, accordingly were never getting deleted if an end-user was updating the prefixed rule.