### PR TITLE
Fix release process by removing task script invocation

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -3,7 +3,7 @@ version: '3'
 tasks:
   retry-task:
     vars:
-      TASK_EXEC: '{{default "./task" .TASK_EXEC}}'
+      TASK_EXEC: '{{default "task" .TASK_EXEC}}'
       RETRY_COUNT: '{{default 3 .RETRY_COUNT}}'
       SLEEP_INTERVAL: '{{default 3 .SLEEP_INTERVAL}}'
     cmds:


### PR DESCRIPTION
Prviously task was wrapped with bash script. As it is no longer in the repository `retry-task` will now call task directly.

Reference
https://github.com/redpanda-data/redpanda-operator/pull/244