### PR TITLE
Do not create and run e2e tests during release (new git tag)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,6 +74,9 @@ steps:
             branches:
               - main
   - key: k8s-operator-tests-with-flags
+    if: |
+      build.tag == null ||
+      build.env("K8S_NIGHTLY") == "1"
     label: K8s Operator tests with flags
     timeout_in_minutes: 180
     notify:


### PR DESCRIPTION
In the following release the buildkite job was created that was noop. 

https://buildkite.com/redpanda/redpanda-operator/builds/2754#01922a35-710a-4614-914b-277ac77f9f28/327-346