### PR TITLE
Add docs tags to acceptance test

### DIFF
--- a/.github/workflows/dispatch-crd-docs.yml
+++ b/.github/workflows/dispatch-crd-docs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/go/k8s/api/**'
+      - 'operator/api/**'
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-crd-docs.yml
+++ b/.github/workflows/dispatch-crd-docs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/k8s/api/**'
+      - 'src/go/k8s/api/**'
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-trigger-acceptance-test-pull.yml
+++ b/.github/workflows/dispatch-trigger-acceptance-test-pull.yml
@@ -1,0 +1,32 @@
+---
+  # This workflow triggers the action in redpanda-data/docs that
+  # pulls new acceptance tests into the docs and submits the change as a PR.
+
+  name: Trigger acceptance test change in docs
+  on:
+    push:
+      branches: [main]
+      paths:
+        - 'acceptance/features/**'
+  jobs:
+    dispatch:
+      runs-on: ubuntu-latest
+      permissions:
+        id-token: write
+        contents: read
+      steps:
+        - uses: aws-actions/configure-aws-credentials@v4
+          with:
+            aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+            role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+        - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          with:
+            secret-ids: |
+              ,sdlc/prod/github/actions_bot_token
+            parse-json-secrets: true
+        - name: Trigger trigger-acceptance-test-pull event
+          uses: peter-evans/repository-dispatch@v2
+          with:
+            token: ${{ env.ACTIONS_BOT_TOKEN }}
+            repository: redpanda-data/docs
+            event-type: trigger-acceptance-test-pull

--- a/acceptance/features/topic-crds.feature
+++ b/acceptance/features/topic-crds.feature
@@ -8,17 +8,20 @@ Feature: Topic CRDs
     Given there is no topic "topic1" in cluster "basic"
     When I apply Kubernetes manifest:
     """
+# tag::basic-topic-example[]
+# In this example manifest, a topic called "topic1" is created in a cluster called "basic". It has a replication factor of 1 and is distributed across a single partition.
     ---
     apiVersion: cluster.redpanda.com/v1alpha2
     kind: Topic
     metadata:
-        name: topic1
+      name: topic1
     spec:
-        cluster:
-            clusterRef:
-                name: basic
-        partitions: 1
-        replicationFactor: 1
+      cluster:
+        clusterRef:
+          name: basic
+      partitions: 1
+      replicationFactor: 1
+# end::basic-topic-example[]
     """
     And topic "topic1" is successfully synced
     Then I should be able to produce and consume from "topic1" in cluster "basic"

--- a/acceptance/features/user-crds.feature
+++ b/acceptance/features/user-crds.feature
@@ -4,7 +4,7 @@ Feature: User CRDs
     Given cluster "sasl" is available
 
   @skip:gke @skip:aks @skip:eks
-  Scenario: Managing Users
+  Scenario: Manage users
     Given there is no user "bob" in cluster "sasl"
     And there is no user "james" in cluster "sasl"
     And there is no user "alice" in cluster "sasl"
@@ -18,58 +18,68 @@ Feature: User CRDs
     And "alice" should exist and be able to authenticate to the "sasl" cluster
 
   @skip:gke @skip:aks @skip:eks
-  Scenario: Managing Authentication-only Users
+  Scenario: Manage authentication-only users
     Given there is no user "jason" in cluster "sasl"
     And there are already the following ACLs in cluster "sasl":
       | user   | acls |
       | jason  | [{"type":"allow","resource":{"type":"cluster"},"operations":["Read"]}] |
     When I apply Kubernetes manifest:
     """
+# tag::manage-authn-only-manifest[]
+# In this example manifest, a user called "jason" is created in a cluster called "sasl".
+# The user's password is defined in a Secret called "jason-password".
+# This example assumes that you will create ACLs for this user separately.
     ---
     apiVersion: cluster.redpanda.com/v1alpha2
     kind: User
     metadata:
-        name: jason
+      name: jason
     spec:
-        cluster:
-            clusterRef:
-                name: sasl
-        authentication:
-            type: scram-sha-512
-            password:
-                valueFrom:
-                    secretKeyRef:
-                        name: jason-password
-                        key: password
+      cluster:
+        clusterRef:
+          name: sasl
+      authentication:
+        type: scram-sha-512
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: jason-password
+              key: password
+# end::manage-auth-only-manifest[]
     """
     And user "jason" is successfully synced
     And I delete the CRD user "jason"
     Then there should be ACLs in the cluster "sasl" for user "jason"
 
   @skip:gke @skip:aks @skip:eks
-  Scenario: Managing Authorization-only Users
+  Scenario: Manage authorization-only users
     Given there are the following pre-existing users in cluster "sasl"
       | name    | password | mechanism     |
       | travis  | password | SCRAM-SHA-256 |
     When I apply Kubernetes manifest:
     """
+# tag::manage-authz-only-manifest[]
+# In this example manifest, an ACL called "travis" is created in a cluster called "sasl".
+# The ACL give an existing user called "travis" permissions to read from all topics whose names start with some-topic.
+# This example assumes that you already have a user called "travis" in your cluster.
     ---
     apiVersion: cluster.redpanda.com/v1alpha2
     kind: User
     metadata:
-        name: travis
+      name: travis
     spec:
-        cluster:
-            clusterRef:
-                name: sasl
-        authorization:
-            acls:
-            -   type: allow
-                resource:
-                    type: topic
-                    name: some-topic
-                    patternType: prefixed
-                operations: [Read]
+      cluster:
+        clusterRef:
+          name: sasl
+      authorization:
+        acls:
+        - type: allow
+          resource:
+            type: topic
+            name: some-topic
+            patternType: prefixed
+          operations: [Read]
+# end::manage-authz-only-manifest[]
     """
     And user "travis" is successfully synced
     And I delete the CRD user "travis"

--- a/acceptance/features/user-crds.feature
+++ b/acceptance/features/user-crds.feature
@@ -45,7 +45,7 @@ Feature: User CRDs
             secretKeyRef:
               name: jason-password
               key: password
-# end::manage-auth-only-manifest[]
+# end::manage-authn-only-manifest[]
     """
     And user "jason" is successfully synced
     And I delete the CRD user "jason"


### PR DESCRIPTION
Adds Asciidoc tagged regions to the user acceptance tests in code comments to allow docs to display the example manifests.

A GitHub Action defined in https://github.com/redpanda-data/docs/pull/773 will pull all files in the `acceptance/features` directory into the docs repository whenever a change occurs or a run is triggered manually.

For an example of how these tags get used, see:

https://github.com/redpanda-data/docs/blob/6bc505bf00d0a6653748b408b4850cde0c29e57b/modules/manage/pages/kubernetes/security/authentication/k-user-controller.adoc?plain=1#L36