### PR TITLE
operator v1: create internal admin api port (ClusterIP)

### DIFF
--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -1104,6 +1104,10 @@ func collectClusterPorts(
 		port := redpandaPorts.KafkaAPI.Internal.Port
 		clusterPorts = append(clusterPorts, resources.NamedServicePort{Name: resources.InternalListenerName, Port: port})
 	}
+	if redpandaPorts.AdminAPI.Internal != nil {
+		port := redpandaPorts.AdminAPI.Internal.Port
+		clusterPorts = append(clusterPorts, resources.NamedServicePort{Name: resources.AdminPortName, Port: port})
+	}
 
 	return clusterPorts
 }

--- a/operator/tests/e2e/kafka-api-cluster-service-internal/00-assert.yaml
+++ b/operator/tests/e2e/kafka-api-cluster-service-internal/00-assert.yaml
@@ -32,6 +32,10 @@ spec:
       port: 9092
       protocol: TCP
       targetPort: 9092
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
   type: ClusterIP
 ---
 apiVersion: kuttl.dev/v1beta1


### PR DESCRIPTION
add internal port to ClusterIP service for admin-api. this allows tools to "just" talk to the ClusterIP service, without thinking about individual brokers.

See also https://github.com/redpanda-data/redpanda/pull/23424 That core PR fixes redirects. Before, core couldn't redirect to the correct broker if you used a hostname that is not exactly a broker.