### PR TITLE
Make generic controller for cluster-based resources

### DIFF
--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -31,9 +31,9 @@ func userIsSuccessfullySynced(ctx context.Context, t framework.TestingT, user st
 
 	// make sure it's synchronized
 	t.RequireCondition(metav1.Condition{
-		Type:   redpandav1alpha2.UserConditionTypeSynced,
+		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
 		Status: metav1.ConditionTrue,
-		Reason: redpandav1alpha2.UserConditionReasonSynced,
+		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
 	}, userObject.Status.Conditions)
 }
 

--- a/operator/api/redpanda/v1alpha2/common.go
+++ b/operator/api/redpanda/v1alpha2/common.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redpanda-data/console/backend/pkg/config"
 	"github.com/twmb/franz-go/pkg/kadm"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -270,4 +271,33 @@ func (c *ClusterSource) GetAdminAPISpec() *AdminAPISpec {
 
 func (c *ClusterSource) GetClusterRef() *ClusterRef {
 	return c.ClusterRef
+}
+
+const (
+	ResourceConditionTypeSynced = "Synced"
+
+	ResourceConditionReasonPending              = "Pending"
+	ResourceConditionReasonSynced               = "Synced"
+	ResourceConditionReasonClusterRefInvalid    = "ClusterRefInvalid"
+	ResourceConditionReasonConfigurationInvalid = "ConfigurationInvalid"
+	ResourceConditionReasonTerminalClientError  = "TerminalClientError"
+	ResourceConditionReasonUnexpectedError      = "UnexpectedError"
+)
+
+func ResourceSyncedCondition(name string) metav1.Condition {
+	return metav1.Condition{
+		Type:    ResourceConditionTypeSynced,
+		Status:  metav1.ConditionTrue,
+		Reason:  ResourceConditionReasonSynced,
+		Message: fmt.Sprintf("Successfully %q synced to cluster.", name),
+	}
+}
+
+func ResourceNotSyncedCondition(reason string, err error) metav1.Condition {
+	return metav1.Condition{
+		Type:    ResourceConditionTypeSynced,
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: fmt.Sprintf("Error: %v", err),
+	}
 }

--- a/operator/api/redpanda/v1alpha2/user_types.go
+++ b/operator/api/redpanda/v1alpha2/user_types.go
@@ -12,9 +12,9 @@ package v1alpha2
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -460,35 +460,6 @@ func (s ACLResourceSpec) GetName() string {
 	return s.Name
 }
 
-const (
-	UserConditionTypeSynced = "Synced"
-
-	UserConditionReasonPending              = "Pending"
-	UserConditionReasonSynced               = "Synced"
-	UserConditionReasonClusterRefInvalid    = "ClusterRefInvalid"
-	UserConditionReasonConfigurationInvalid = "ConfigurationInvalid"
-	UserConditionReasonTerminalClientError  = "TerminalClientError"
-	UserConditionReasonUnexpectedError      = "UnexpectedError"
-)
-
-func UserSyncedCondition(name string) metav1.Condition {
-	return metav1.Condition{
-		Type:    UserConditionTypeSynced,
-		Status:  metav1.ConditionTrue,
-		Reason:  UserConditionReasonSynced,
-		Message: fmt.Sprintf("User %q successfully synced to cluster.", name),
-	}
-}
-
-func UserNotSyncedCondition(reason string, err error) metav1.Condition {
-	return metav1.Condition{
-		Type:    UserConditionTypeSynced,
-		Status:  metav1.ConditionFalse,
-		Reason:  reason,
-		Message: fmt.Sprintf("Error: %v", err),
-	}
-}
-
 // UserStatus defines the observed state of a Redpanda user
 type UserStatus struct {
 	// Specifies the last observed generation.
@@ -510,4 +481,8 @@ type UserList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// Specifies a list of Redpanda user resources.
 	Items []User `json:"items"`
+}
+
+func (u *UserList) GetItems() []*User {
+	return functional.MapFn(ptr.To, u.Items)
 }

--- a/operator/api/redpanda/v1alpha2/user_types_test.go
+++ b/operator/api/redpanda/v1alpha2/user_types_test.go
@@ -505,9 +505,9 @@ func TestUserDefaults(t *testing.T) {
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "name"}, &user))
 
 	require.Len(t, user.Status.Conditions, 1)
-	require.Equal(t, UserConditionTypeSynced, user.Status.Conditions[0].Type)
+	require.Equal(t, ResourceConditionTypeSynced, user.Status.Conditions[0].Type)
 	require.Equal(t, metav1.ConditionUnknown, user.Status.Conditions[0].Status)
-	require.Equal(t, UserConditionReasonPending, user.Status.Conditions[0].Reason)
+	require.Equal(t, ResourceConditionReasonPending, user.Status.Conditions[0].Reason)
 
 	require.NotNil(t, user.Spec.Authentication.Type)
 	require.True(t, user.Spec.Authentication.Type.Equals(SASLMechanismScramSHA512))

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -547,10 +547,7 @@ func Run(
 			os.Exit(1)
 		}
 
-		if err = (&redpandacontrollers.UserReconciler{
-			Client:        mgr.GetClient(),
-			ClientFactory: factory,
-		}).SetupWithManager(ctx, mgr); err != nil {
+		if err = redpandacontrollers.SetupUserController(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "User")
 			os.Exit(1)
 		}

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -39,9 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	v2 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2"
 
 	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
@@ -119,10 +117,10 @@ type RedpandaReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RedpandaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	if err := registerStatefulSetClusterIndex(ctx, mgr); err != nil {
+	if err := registerHelmReferencedIndex(ctx, mgr, "statefulset", &appsv1.StatefulSet{}); err != nil {
 		return err
 	}
-	if err := registerDeploymentClusterIndex(ctx, mgr); err != nil {
+	if err := registerHelmReferencedIndex(ctx, mgr, "deployment", &appsv1.Deployment{}); err != nil {
 		return err
 	}
 
@@ -147,20 +145,13 @@ func (r *RedpandaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 
 	managedWatchOption := builder.WithPredicates(helmManagedComponentPredicate)
 
-	enqueueRequestFromManaged := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		if nn, found := clusterForHelmManagedObject(o); found {
-			return []reconcile.Request{{NamespacedName: nn}}
-		}
-		return nil
-	})
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha2.Redpanda{}).
 		Owns(&sourcev1.HelmRepository{}).
 		Owns(&helmv2beta1.HelmRelease{}).
 		Owns(&helmv2beta2.HelmRelease{}).
-		Watches(&appsv1.StatefulSet{}, enqueueRequestFromManaged, managedWatchOption).
-		Watches(&appsv1.Deployment{}, enqueueRequestFromManaged, managedWatchOption).
+		Watches(&appsv1.StatefulSet{}, enqueueClusterFromHelmManagedObject(), managedWatchOption).
+		Watches(&appsv1.Deployment{}, enqueueClusterFromHelmManagedObject(), managedWatchOption).
 		Complete(r)
 }
 

--- a/operator/internal/controller/redpanda/resource_controller.go
+++ b/operator/internal/controller/redpanda/resource_controller.go
@@ -1,0 +1,153 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const fieldOwner client.FieldOwner = "redpanda-operator"
+
+type Resource[T any] interface {
+	*T
+	client.Object
+}
+
+type ResourceRequest[T client.Object] struct {
+	factory internalclient.ClientFactory
+	logger  logr.Logger
+	object  T
+}
+
+type ResourceReconciler[T client.Object] interface {
+	FinalizerPatch(request ResourceRequest[T]) client.Patch
+	SyncResource(ctx context.Context, request ResourceRequest[T]) (client.Patch, error)
+	DeleteResource(ctx context.Context, request ResourceRequest[T]) error
+}
+
+type ResourceController[T any, U Resource[T]] struct {
+	client.Client
+	internalclient.ClientFactory
+
+	reconciler      ResourceReconciler[U]
+	name            string
+	periodicTimeout time.Duration
+}
+
+func NewResourceController[T any, U Resource[T]](c client.Client, factory internalclient.ClientFactory, reconciler ResourceReconciler[U], name string) *ResourceController[T, U] {
+	return &ResourceController[T, U]{
+		Client:        c,
+		ClientFactory: factory,
+		reconciler:    reconciler,
+		name:          name,
+	}
+}
+
+func (r *ResourceController[T, U]) PeriodicallyReconcile(timeout time.Duration) *ResourceController[T, U] {
+	r.periodicTimeout = timeout
+	return r
+}
+
+func (r *ResourceController[T, U]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := log.FromContext(ctx).WithName(fmt.Sprintf("%s.Reconcile", r.name))
+	l.V(1).Info("Starting reconcile loop")
+	start := time.Now()
+	defer func() {
+		l.V(1).Info("Finished reconciling", "elapsed", time.Since(start))
+	}()
+
+	object := U(new(T))
+	if err := r.Get(ctx, req.NamespacedName, object); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	request := ResourceRequest[U]{
+		factory: r.ClientFactory,
+		logger:  l,
+		object:  object,
+	}
+
+	if !object.GetDeletionTimestamp().IsZero() {
+		if err := r.reconciler.DeleteResource(ctx, request); err != nil {
+			return ctrl.Result{}, err
+		}
+		if controllerutil.RemoveFinalizer(object, FinalizerKey) {
+			return ctrl.Result{}, r.Update(ctx, object)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(object, FinalizerKey) {
+		patch := r.reconciler.FinalizerPatch(request)
+		if patch != nil {
+			if err := r.Patch(ctx, object, patch, client.ForceOwnership, fieldOwner); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	patch, err := r.reconciler.SyncResource(ctx, request)
+	var syncError error
+	if patch != nil {
+		syncError = r.Status().Patch(ctx, object, patch, client.ForceOwnership, fieldOwner)
+	}
+
+	result := ctrl.Result{}
+	if r.periodicTimeout != 0 {
+		result.RequeueAfter = r.periodicTimeout
+	}
+
+	return result, errors.Join(err, syncError)
+}
+
+func ignoreAllConnectionErrors(logger logr.Logger, err error) error {
+	// If we have known errors where we're unable to actually establish
+	// a connection to the cluster due to say, invalid connection parameters
+	// we're going to just skip the cleanup phase since we likely won't be
+	// able to clean ourselves up anyway.
+	if internalclient.IsTerminalClientError(err) ||
+		internalclient.IsConfigurationError(err) ||
+		internalclient.IsInvalidClusterError(err) {
+		// We use Info rather than Error here because we don't want
+		// to ignore the verbosity settings. This is really only for
+		// debugging purposes.
+		logger.V(2).Info("Ignoring non-retryable client error", "error", err)
+		return nil
+	}
+	return err
+}
+
+func handleResourceSyncErrors(err error) (metav1.Condition, error) {
+	// If we have a known terminal error, just set the sync condition and don't re-run reconciliation.
+	if internalclient.IsInvalidClusterError(err) {
+		return redpandav1alpha2.ResourceNotSyncedCondition(redpandav1alpha2.ResourceConditionReasonClusterRefInvalid, err), nil
+	}
+	if internalclient.IsConfigurationError(err) {
+		return redpandav1alpha2.ResourceNotSyncedCondition(redpandav1alpha2.ResourceConditionReasonConfigurationInvalid, err), nil
+	}
+	if internalclient.IsTerminalClientError(err) {
+		return redpandav1alpha2.ResourceNotSyncedCondition(redpandav1alpha2.ResourceConditionReasonTerminalClientError, err), nil
+	}
+
+	// otherwise, set a generic unexpected error and return an error so we can re-reconcile.
+	return redpandav1alpha2.ResourceNotSyncedCondition(redpandav1alpha2.ResourceConditionReasonUnexpectedError, err), err
+}

--- a/operator/internal/controller/redpanda/resource_controller_test.go
+++ b/operator/internal/controller/redpanda/resource_controller_test.go
@@ -1,0 +1,343 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+type ResourceReconcilerTestEnvironment[T any, U Resource[T]] struct {
+	Reconciler                 *ResourceController[T, U]
+	Factory                    *internalclient.Factory
+	ClusterSourceValid         *redpandav1alpha2.ClusterSource
+	ClusterSourceNoSASL        *redpandav1alpha2.ClusterSource
+	ClusterSourceBadPassword   *redpandav1alpha2.ClusterSource
+	ClusterSourceInvalidRef    *redpandav1alpha2.ClusterSource
+	SyncedCondition            metav1.Condition
+	InvalidClusterRefCondition metav1.Condition
+	ClientErrorCondition       metav1.Condition
+	AdminURL                   string
+	KafkaURL                   string
+	SchemaRegistryURL          string
+}
+
+func InitializeResourceReconcilerTest[T any, U Resource[T]](t *testing.T, ctx context.Context, reconciler ResourceReconciler[U]) *ResourceReconcilerTestEnvironment[T, U] {
+	server := &envtest.APIServer{}
+	etcd := &envtest.Etcd{}
+
+	testEnv := testutils.RedpandaTestEnv{
+		Environment: envtest.Environment{
+			ControlPlane: envtest.ControlPlane{
+				APIServer: server,
+				Etcd:      etcd,
+			},
+		},
+	}
+	cfg, err := testEnv.StartRedpandaTestEnv(false)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	t.Cleanup(func() {
+		_ = testEnv.Stop()
+	})
+
+	container, err := redpanda.Run(ctx, "docker.redpanda.com/redpandadata/redpanda:v23.2.8",
+		redpanda.WithEnableSchemaRegistryHTTPBasicAuth(),
+		redpanda.WithEnableKafkaAuthorization(),
+		redpanda.WithEnableSASL(),
+		redpanda.WithSuperusers("superuser"),
+		redpanda.WithNewServiceAccount("superuser", "password"),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	kafkaAddress, err := container.KafkaSeedBroker(ctx)
+	require.NoError(t, err)
+
+	adminAPI, err := container.AdminAPIAddress(ctx)
+	require.NoError(t, err)
+
+	schemaRegistry, err := container.SchemaRegistryAddress(ctx)
+	require.NoError(t, err)
+
+	err = redpandav1alpha2.AddToScheme(scheme.Scheme)
+	require.NoError(t, err)
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	factory := internalclient.NewFactory(cfg, c)
+
+	// ensure we have a secret which we can pull a password from
+	err = c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "superuser",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Data: map[string][]byte{
+			"password": []byte("password"),
+		},
+	})
+	require.NoError(t, err)
+
+	err = c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalidsuperuser",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Data: map[string][]byte{
+			"password": []byte("invalid"),
+		},
+	})
+	require.NoError(t, err)
+
+	validClusterSource := &redpandav1alpha2.ClusterSource{
+		StaticConfiguration: &redpandav1alpha2.StaticConfigurationSource{
+			Kafka: &redpandav1alpha2.KafkaAPISpec{
+				Brokers: []string{kafkaAddress},
+				SASL: &redpandav1alpha2.KafkaSASL{
+					Username: "superuser",
+					Password: redpandav1alpha2.SecretKeyRef{
+						Name: "superuser",
+						Key:  "password",
+					},
+					Mechanism: redpandav1alpha2.SASLMechanismScramSHA256,
+				},
+			},
+			Admin: &redpandav1alpha2.AdminAPISpec{
+				URLs: []string{adminAPI},
+				SASL: &redpandav1alpha2.AdminSASL{
+					Username: "superuser",
+					Password: redpandav1alpha2.SecretKeyRef{
+						Name: "superuser",
+						Key:  "password",
+					},
+					Mechanism: redpandav1alpha2.SASLMechanismScramSHA256,
+				},
+			},
+		},
+	}
+
+	invalidAuthClusterSourceBadPassword := &redpandav1alpha2.ClusterSource{
+		StaticConfiguration: &redpandav1alpha2.StaticConfigurationSource{
+			Kafka: &redpandav1alpha2.KafkaAPISpec{
+				Brokers: []string{kafkaAddress},
+				SASL: &redpandav1alpha2.KafkaSASL{
+					Username: "superuser",
+					Password: redpandav1alpha2.SecretKeyRef{
+						Name: "invalidsuperuser",
+						Key:  "password",
+					},
+					Mechanism: redpandav1alpha2.SASLMechanismScramSHA256,
+				},
+			},
+			Admin: &redpandav1alpha2.AdminAPISpec{
+				URLs: []string{adminAPI},
+				SASL: &redpandav1alpha2.AdminSASL{
+					Username: "superuser",
+					Password: redpandav1alpha2.SecretKeyRef{
+						Name: "invalidsuperuser",
+						Key:  "password",
+					},
+					Mechanism: redpandav1alpha2.SASLMechanismScramSHA256,
+				},
+			},
+		},
+	}
+
+	invalidAuthClusterSourceNoSASL := &redpandav1alpha2.ClusterSource{
+		StaticConfiguration: &redpandav1alpha2.StaticConfigurationSource{
+			Kafka: &redpandav1alpha2.KafkaAPISpec{
+				Brokers: []string{kafkaAddress},
+			},
+			Admin: &redpandav1alpha2.AdminAPISpec{
+				URLs: []string{adminAPI},
+			},
+		},
+	}
+
+	invalidClusterRefSource := &redpandav1alpha2.ClusterSource{
+		ClusterRef: &redpandav1alpha2.ClusterRef{
+			Name: "nonexistent",
+		},
+	}
+
+	syncedClusterRefCondition := redpandav1alpha2.ResourceSyncedCondition("test")
+
+	invalidClusterRefCondition := redpandav1alpha2.ResourceNotSyncedCondition(
+		redpandav1alpha2.ResourceConditionReasonClusterRefInvalid, errors.New("test"),
+	)
+
+	clientErrorCondition := redpandav1alpha2.ResourceNotSyncedCondition(
+		redpandav1alpha2.ResourceConditionReasonTerminalClientError, errors.New("test"),
+	)
+
+	return &ResourceReconcilerTestEnvironment[T, U]{
+		Reconciler:                 NewResourceController(c, factory, reconciler, "Test"),
+		Factory:                    factory,
+		ClusterSourceValid:         validClusterSource,
+		ClusterSourceNoSASL:        invalidAuthClusterSourceNoSASL,
+		ClusterSourceBadPassword:   invalidAuthClusterSourceBadPassword,
+		ClusterSourceInvalidRef:    invalidClusterRefSource,
+		SyncedCondition:            syncedClusterRefCondition,
+		InvalidClusterRefCondition: invalidClusterRefCondition,
+		ClientErrorCondition:       clientErrorCondition,
+		AdminURL:                   adminAPI,
+		KafkaURL:                   kafkaAddress,
+		SchemaRegistryURL:          schemaRegistry,
+	}
+}
+
+type testReconciler struct {
+	syncs   atomic.Int32
+	deletes atomic.Int32
+}
+
+type testObject struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (t *testObject) DeepCopyObject() runtime.Object {
+	return &testObject{
+		TypeMeta:   t.TypeMeta,
+		ObjectMeta: t.ObjectMeta,
+	}
+}
+
+func (r *testReconciler) FinalizerPatch(request ResourceRequest[*testObject]) client.Patch {
+	request.object.Finalizers = []string{FinalizerKey}
+	request.object.TypeMeta = metav1.TypeMeta{
+		Kind:       "testObject",
+		APIVersion: redpandav1alpha2.GroupVersion.Identifier(),
+	}
+	return client.Apply
+}
+
+func (r *testReconciler) SyncResource(ctx context.Context, request ResourceRequest[*testObject]) (client.Patch, error) {
+	r.syncs.Add(1)
+	return nil, nil
+}
+
+func (r *testReconciler) DeleteResource(ctx context.Context, request ResourceRequest[*testObject]) error {
+	r.deletes.Add(1)
+	return nil
+}
+
+func TestResourceController(t *testing.T) { // nolint:funlen // These tests have clear subtests.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancel()
+
+	apiextensionsv1.AddToScheme(scheme.Scheme)
+
+	reconciler := &testReconciler{}
+	redpandav1alpha2.SchemeBuilder.Register(&testObject{})
+	environment := InitializeResourceReconcilerTest(t, ctx, reconciler)
+
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testobjects." + redpandav1alpha2.GroupVersion.Group,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: redpandav1alpha2.GroupVersion.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "testobjects",
+				Singular: "testobject",
+				Kind:     "testObject",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: redpandav1alpha2.GroupVersion.Version,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+					},
+				},
+				Served:  true,
+				Storage: true,
+			}},
+			Scope: apiextensionsv1.NamespaceScoped,
+		},
+	}
+
+	err := environment.Factory.Client.Create(ctx, crd)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		key := client.ObjectKeyFromObject(crd)
+		err = environment.Factory.Client.Get(ctx, key, crd)
+		require.NoError(t, err)
+
+		for _, cond := range crd.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+				return true
+			}
+		}
+
+		return false
+	}, 60*time.Second, 1*time.Second)
+
+	doReconcileLifecycle := func(obj *testObject, delete bool) {
+		require.NoError(t, environment.Factory.Client.Create(ctx, obj))
+
+		key := client.ObjectKeyFromObject(obj)
+		req := ctrl.Request{NamespacedName: key}
+
+		_, err := environment.Reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+
+		require.NoError(t, environment.Factory.Client.Get(ctx, key, obj))
+		require.Contains(t, obj.Finalizers, FinalizerKey)
+
+		if delete {
+			require.NoError(t, environment.Factory.Client.Delete(ctx, obj))
+
+			_, err := environment.Reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+
+			require.Error(t, environment.Factory.Client.Get(ctx, key, obj))
+		}
+	}
+
+	size := 100
+	for i := 0; i < size; i++ {
+		doReconcileLifecycle(&testObject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-%d", i),
+				Namespace: metav1.NamespaceDefault,
+			},
+		}, i%2 == 0)
+	}
+
+	require.Equal(t, int32(size/2), reconciler.deletes.Load())
+	require.Equal(t, int32(size), reconciler.syncs.Load())
+}

--- a/operator/internal/controller/redpanda/resource_controller_test.go
+++ b/operator/internal/controller/redpanda/resource_controller_test.go
@@ -258,7 +258,7 @@ func TestResourceController(t *testing.T) { // nolint:funlen // These tests have
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
 	defer cancel()
 
-	apiextensionsv1.AddToScheme(scheme.Scheme)
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme.Scheme))
 
 	reconciler := &testReconciler{}
 	redpandav1alpha2.SchemeBuilder.Register(&testObject{})

--- a/operator/pkg/functional/doc.go
+++ b/operator/pkg/functional/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package functional contains some helpers that allow for functional-style
+// programming, often through list/map functions and closures.
+package functional

--- a/operator/pkg/functional/map.go
+++ b/operator/pkg/functional/map.go
@@ -1,0 +1,18 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package functional
+
+func MapFn[T any, U any](fn func(T) U, a []T) []U {
+	s := make([]U, len(a))
+	for i := 0; i < len(a); i++ {
+		s[i] = fn(a[i])
+	}
+	return s
+}


### PR DESCRIPTION
This tries to extract the core of the Users controller into a generic controller implementation that wraps a `ResourceReconciler` interface that controls the guts of the three operations that we pretty much need to do for _every_ cluster-based resource:

1. Patching finalizers (this could probably be removed if we want to do it in an even more generic way)
2. Syncing (upserting) a resource
3. Deleting a resource

Hence the interface looks like this:

```go
	FinalizerPatch(request ResourceRequest[T]) client.Patch
	SyncResource(ctx context.Context, request ResourceRequest[T]) (client.Patch, error)
	DeleteResource(ctx context.Context, request ResourceRequest[T]) error
```

Most of the sync/delete logic can either then be inlined into the controllers, or, ideally wrapped in a "high-level" client/synchronizer (see the ACL synchronization code) in the `clients` package.

I'm intending on using this for CRD-defined schemas, and if y'all like the structure, would want to take a pass at refactoring `TopicReconciler` to use this as well for consistency.

This allows us to follow a really simple pattern for any additional CRDs. Basically anything that we're controlling via CRD and putting in a cluster should:

1. Add a `ClusterSource` field.
2. Generate some applyconfiguration structures
3. If it's complex, implement a high-level synchronizer that handles the heavy lifting of the Redpanda operations
4. Add a reconciler that implements the above interface

Doing so would give you:

1. Consistent status conditions
2. Consistent ways of connecting to a referenced cluster
3. Server-side apply pretty much everywhere
4. Similarly structured code patterns