### PR TITLE
Add ability to merge users.txt file into bootstrap.yaml

### DIFF
--- a/operator/cmd/syncclusterconfig/sync.go
+++ b/operator/cmd/syncclusterconfig/sync.go
@@ -142,8 +142,8 @@ func loadBoostrapYAML(path string) (map[string]any, error) {
 // actually exists in the bootstrap.yaml.
 func maybeMergeSuperusers(logger logr.Logger, clusterConfig map[string]any, path string) {
 	if path == "" {
-		// we have no path to a users.txt, so don't do anything
-		logger.Info("--users-txt not specified. Skipping superusers merge.")
+		// we have no path to a users directory, so don't do anything
+		logger.Info("--users-directory not specified. Skipping superusers merge.")
 		return
 	}
 
@@ -156,7 +156,7 @@ func maybeMergeSuperusers(logger logr.Logger, clusterConfig map[string]any, path
 
 	superusers, err := loadUsersFiles(logger, path)
 	if err != nil {
-		logger.Info(fmt.Sprintf("Error reading users.txt file %q: %v. Skipping superusers merge.", path, err))
+		logger.Info(fmt.Sprintf("Error reading users directory %q: %v. Skipping superusers merge.", path, err))
 		return
 	}
 
@@ -186,7 +186,8 @@ func loadUsersFiles(logger logr.Logger, path string) ([]string, error) {
 
 		usersFile, err := os.ReadFile(filename)
 		if err != nil {
-			return nil, err
+			logger.Info(fmt.Sprintf("Cannot read user file %q: %v. Skipping.", filename, err))
+			continue
 		}
 
 		scanner := bufio.NewScanner(bytes.NewReader(usersFile))

--- a/operator/cmd/syncclusterconfig/sync_test.go
+++ b/operator/cmd/syncclusterconfig/sync_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -170,7 +171,7 @@ func TestSync(t *testing.T) {
 
 		cmd := Command()
 		cmd.SetArgs([]string{
-			"--users-txt", usersTxtYAMLPath,
+			"--users-directory", filepath.Dir(usersTxtYAMLPath),
 			"--redpanda-yaml", redpandaYAMLPath,
 			"--bootstrap-yaml", testutils.WriteFile(t, "bootstrap-*.yaml", configBytes),
 		})


### PR DESCRIPTION
This adds a routine to merge `users.txt` into the bootstrap.yaml read when performing post install/update jobs. This is needed due to the bootstrap user additions added in [this commit](https://github.com/redpanda-data/helm-charts/commit/081c08b6b83ba196994ec3312a7c6011e4ef0a22#diff-84c6555620e4e5f79262384a9fa3e8f4876b36bb3a64748cbd8fbdcb66e8c1b9R247) causing https://github.com/redpanda-data/helm-charts/issues/1566.

What is essentially occuring is this:

1. When creating a bootstrap user via the `REDPANDA_BOOTSTRAP_USER` environment variable said user isn't marked automatically as a superuser
2. If you want to use something like `admin_api_require_auth` then the _only_ way you can actually run management operations on your installation is to pass in the above user in to the nodes' `bootstrap.yaml` so that the user is immediately marked as a superuser and all of the config-watcher scripts that manage other specified users can leverage it to create the rest of the users.
3. The bootstrap user changes that added the user to `bootstrap.yaml` uncovered that setting any sort of `superusers` values in the bootstrap.yaml is incompatible with the users created by a pre-existing `users.txt` secret. This is due to the `superusers` entry found in the bootstrap.yaml not containing them. When an upgrade finishes the jobs reset the configuration to only contain what is found in `superusers` without regard to anything managed by the pre-existing secret/config-watcher.
4. The above manifested in all users from a pre-existing secret getting unmarked as superusers when an upgrade occurred. Restarting any StatefulSet pod clears this up.

Since we _must_ still set the bootstrap user in the `superusers` section of `bootstrap.yaml` in order for `admin_api_require_auth` to function correctly on installations, this makes the config synchronization code aware of our `users.txt`.

It needs to be coupled with a change in the `helm-charts` code to add in a `--users-txt` flag as needed and an additional secrets mount to mount the `users.txt` file into our job containers.