### PR TITLE
operator: refactor flux controller setup

### DIFF
--- a/operator/internal/controller/flux/flux.go
+++ b/operator/internal/controller/flux/flux.go
@@ -1,0 +1,169 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package flux
+
+import (
+	"context"
+	"time"
+
+	helmController "github.com/fluxcd/helm-controller/shim"
+	"github.com/fluxcd/pkg/runtime/client"
+	helper "github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/metrics"
+	helmSourceController "github.com/fluxcd/source-controller/shim"
+	"helm.sh/helm/v3/pkg/getter"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	helmReleaseControllerName    = "redpanda-helmrelease-controller"
+	helmChartControllerName      = "redpanda-helmchart-reconciler"
+	helmRepositoryControllerName = "redpanda-helmrepository-controller"
+
+	indexTTL    = 15 * time.Minute
+	storageAddr = ":9090"
+)
+
+var getters = getter.Providers{
+	getter.Provider{
+		Schemes: []string{"http", "https"},
+		New:     getter.NewHTTPGetter,
+	},
+	getter.Provider{
+		Schemes: []string{"oci"},
+		New:     getter.NewOCIGetter,
+	},
+}
+
+type ControllerSetup func(context.Context, ctrl.Manager) error
+
+func (fn ControllerSetup) SetupWithManager(ctx context.Context, manager ctrl.Manager) error {
+	return fn(ctx, manager)
+}
+
+func NewFluxControllers(
+	mgr ctrl.Manager,
+	clientOptions client.Options,
+	kubeConfigOptions client.KubeConfigOptions,
+) []ControllerSetup {
+	cacheRecorder := helmSourceController.MustMakeCacheMetrics()
+	helmIndexCache := helmSourceController.NewCache(0, indexTTL)
+	metrics := helper.NewMetrics(mgr, metrics.MustMakeRecorder())
+
+	storageAdvAddr := DetermineAdvStorageAddr(storageAddr, mgr.GetLogger())
+	storage := MustInitStorage("/tmp", storageAdvAddr, 60*time.Second, 2, mgr.GetLogger())
+
+	return []ControllerSetup{
+		NewHelmChartController(mgr, helmIndexCache, cacheRecorder, metrics, storage),
+		NewHelmRepositoryController(mgr, cacheRecorder, helmIndexCache, metrics, storage),
+		NewHelmReleaseController(mgr, metrics, clientOptions, kubeConfigOptions),
+	}
+}
+
+func NewHelmRepositoryController(
+	mgr ctrl.Manager,
+	cacheRecorder helmSourceController.CacheRecorder,
+	cache helmSourceController.Cache,
+	metrics helper.Metrics,
+	storage helmSourceController.Storage,
+) ControllerSetup {
+	recorder := mgr.GetEventRecorderFor("HelmReleaseReconciler")
+
+	controller := helmSourceController.HelmRepositoryReconcilerFactory{
+		Client:         mgr.GetClient(),
+		EventRecorder:  recorder,
+		Getters:        getters,
+		ControllerName: helmRepositoryControllerName,
+		Cache:          cache,
+		CacheRecorder:  cacheRecorder,
+		TTL:            indexTTL,
+		Metrics:        metrics,
+		Storage:        storage,
+	}
+
+	return func(ctx context.Context, m ctrl.Manager) error {
+		go func() {
+			// Block until our controller manager is elected leader. We presume our
+			// entire process will terminate if we lose leadership, so we don't need
+			// to handle that.
+			<-mgr.Elected()
+
+			StartFileServer(storage.BasePath, storageAddr, m.GetLogger())
+		}()
+
+		opts := helmSourceController.HelmRepositoryReconcilerOptions{
+			RateLimiter: helper.GetDefaultRateLimiter(),
+		}
+
+		return controller.SetupWithManager(ctx, mgr, opts)
+	}
+}
+
+func NewHelmChartController(
+	mgr ctrl.Manager,
+	cache helmSourceController.Cache,
+	cacheRecorder helmSourceController.CacheRecorder,
+	metrics helper.Metrics,
+	storage helmSourceController.Storage,
+) ControllerSetup {
+	helmChart := helmSourceController.HelmChartReconcilerFactory{
+		Cache:                   cache,
+		CacheRecorder:           cacheRecorder,
+		TTL:                     indexTTL,
+		Client:                  mgr.GetClient(),
+		RegistryClientGenerator: ClientGenerator,
+		Getters:                 getters,
+		Metrics:                 metrics,
+		Storage:                 storage,
+		EventRecorder:           mgr.GetEventRecorderFor("HelmChartReconciler"),
+		ControllerName:          helmChartControllerName,
+	}
+
+	return func(ctx context.Context, m ctrl.Manager) error {
+		chartOpts := helmSourceController.HelmChartReconcilerOptions{
+			RateLimiter: helper.GetDefaultRateLimiter(),
+		}
+
+		return helmChart.SetupWithManager(ctx, mgr, chartOpts)
+	}
+}
+
+func NewHelmReleaseController(
+	mgr ctrl.Manager,
+	metrics helper.Metrics,
+	clientOptions client.Options,
+	kubeConfigOptions client.KubeConfigOptions,
+) ControllerSetup {
+	// Helm Release Controller
+	helmRelease := helmController.HelmReleaseReconcilerFactory{
+		Client:         mgr.GetClient(),
+		EventRecorder:  mgr.GetEventRecorderFor("HelmReleaseReconciler"),
+		ClientOpts:     clientOptions,
+		KubeConfigOpts: kubeConfigOptions,
+		FieldManager:   helmReleaseControllerName,
+		Metrics:        metrics,
+		GetClusterConfig: func() (*rest.Config, error) {
+			return mgr.GetConfig(), nil
+		},
+	}
+
+	return func(ctx context.Context, m ctrl.Manager) error {
+		// TODO fill this in with options
+		helmOpts := helmController.HelmReleaseReconcilerOptions{
+			DependencyRequeueInterval: 30 * time.Second, // The interval at which failing dependencies are reevaluated.
+			HTTPRetry:                 9,                // The maximum number of retries when failing to fetch artifacts over HTTP.
+			RateLimiter:               workqueue.NewItemExponentialFailureRateLimiter(30*time.Second, 60*time.Second),
+		}
+
+		return helmRelease.SetupWithManager(ctx, mgr, helmOpts)
+	}
+}

--- a/operator/internal/controller/flux/utils.go
+++ b/operator/internal/controller/flux/utils.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package flux
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	controllers "github.com/fluxcd/source-controller/shim"
+	"github.com/go-logr/logr"
+	"helm.sh/helm/v3/pkg/registry"
+	"k8s.io/apimachinery/pkg/util/errors"
+)
+
+func MustInitStorage(path, storageAdvAddr string, artifactRetentionTTL time.Duration, artifactRetentionRecords int, l logr.Logger) controllers.Storage {
+	if path == "" {
+		p, _ := os.Getwd()
+		path = filepath.Join(p, "bin")
+		err := os.MkdirAll(path, 0o700)
+		if err != nil {
+			l.Error(err, "unable make directory with right permissions")
+		}
+	}
+
+	storage, err := controllers.NewStorage(path, storageAdvAddr, artifactRetentionTTL, artifactRetentionRecords)
+	if err != nil {
+		l.Error(err, "unable to initialize storage")
+		os.Exit(1)
+	}
+
+	return storage
+}
+
+func DetermineAdvStorageAddr(storageAddr string, l logr.Logger) string {
+	host, port, err := net.SplitHostPort(storageAddr)
+	if err != nil {
+		l.Error(err, "unable to parse storage address")
+		os.Exit(1)
+	}
+	switch host {
+	case "":
+		host = "localhost"
+	case "0.0.0.0":
+		host = os.Getenv("HOSTNAME")
+		if host == "" {
+			hn, err := os.Hostname()
+			if err != nil {
+				l.Error(err, "0.0.0.0 specified in storage addr but hostname is invalid")
+				os.Exit(1)
+			}
+			host = hn
+		}
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func StartFileServer(path, address string, l logr.Logger) {
+	l.Info("starting file server")
+	fs := http.FileServer(http.Dir(path))
+	mux := http.NewServeMux()
+	mux.Handle("/", fs)
+	//nolint:gosec // we are aware there are no timeouts supported
+	err := http.ListenAndServe(address, mux)
+	if err != nil {
+		l.Error(err, "file server error")
+	}
+}
+
+// ClientGenerator generates a registry client and a temporary credential file.
+// The client is meant to be used for a single reconciliation.
+// The file is meant to be used for a single reconciliation and deleted after.
+func ClientGenerator(tlsConfig *tls.Config, isLogin, insecureHTTP bool) (*registry.Client, string, error) {
+	if !isLogin {
+		rClient, err := newClient("", tlsConfig, insecureHTTP)
+		if err != nil {
+			return nil, "", err
+		}
+		return rClient, "", nil
+	}
+	// create a temporary file to store the credentials
+	// this is needed because otherwise the credentials are stored in ~/.docker/config.json.
+	credentialsFile, err := os.CreateTemp("", "credentials")
+	if err != nil {
+		return nil, "", err
+	}
+
+	var errs []error
+	rClient, err := newClient(credentialsFile.Name(), tlsConfig, insecureHTTP)
+	if err != nil {
+		errs = append(errs, err)
+		// attempt to delete the temporary file
+		if credentialsFile != nil {
+			err := os.Remove(credentialsFile.Name())
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return nil, "", errors.NewAggregate(errs)
+	}
+	return rClient, credentialsFile.Name(), nil
+}
+
+func newClient(credentialsFile string, tlsConfig *tls.Config, insecureHTTP bool) (*registry.Client, error) {
+	opts := []registry.ClientOption{
+		registry.ClientOptWriter(io.Discard),
+	}
+	if insecureHTTP {
+		opts = append(opts, registry.ClientOptPlainHTTP())
+	}
+	if tlsConfig != nil {
+		opts = append(opts, registry.ClientOptHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		}))
+	}
+	if credentialsFile != "" {
+		opts = append(opts, registry.ClientOptCredentialsFile(credentialsFile))
+	}
+
+	return registry.NewClient(opts...)
+}

--- a/operator/internal/controller/redpanda/redpanda_controller_utils.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_utils.go
@@ -11,24 +11,15 @@ package redpanda
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"io"
-	"net"
-	"net/http"
 	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/fluxcd/pkg/runtime/logger"
-	controllers "github.com/fluxcd/source-controller/shim"
 	"github.com/go-logr/logr"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
-	"helm.sh/helm/v3/pkg/registry"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -95,116 +86,6 @@ func bestTrySetRetainPV(c client.Client, log logr.Logger, ctx context.Context, n
 			// no need to place error here. we simply move on and not attempt to remove the pv
 			Infof(log, "could not set reclaim policy for %s; continuing: %s", pv.Name, updateErr.Error())
 		}
-	}
-}
-
-// ClientGenerator generates a registry client and a temporary credential file.
-// The client is meant to be used for a single reconciliation.
-// The file is meant to be used for a single reconciliation and deleted after.
-
-func ClientGenerator(tlsConfig *tls.Config, isLogin, insecureHTTP bool) (*registry.Client, string, error) {
-	if !isLogin {
-		rClient, err := newClient("", tlsConfig, insecureHTTP)
-		if err != nil {
-			return nil, "", err
-		}
-		return rClient, "", nil
-	}
-	// create a temporary file to store the credentials
-	// this is needed because otherwise the credentials are stored in ~/.docker/config.json.
-	credentialsFile, err := os.CreateTemp("", "credentials")
-	if err != nil {
-		return nil, "", err
-	}
-
-	var errs []error
-	rClient, err := newClient(credentialsFile.Name(), tlsConfig, insecureHTTP)
-	if err != nil {
-		errs = append(errs, err)
-		// attempt to delete the temporary file
-		if credentialsFile != nil {
-			err := os.Remove(credentialsFile.Name())
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
-		return nil, "", errors.NewAggregate(errs)
-	}
-	return rClient, credentialsFile.Name(), nil
-}
-
-func newClient(credentialsFile string, tlsConfig *tls.Config, insecureHTTP bool) (*registry.Client, error) {
-	opts := []registry.ClientOption{
-		registry.ClientOptWriter(io.Discard),
-	}
-	if insecureHTTP {
-		opts = append(opts, registry.ClientOptPlainHTTP())
-	}
-	if tlsConfig != nil {
-		opts = append(opts, registry.ClientOptHTTPClient(&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
-		}))
-	}
-	if credentialsFile != "" {
-		opts = append(opts, registry.ClientOptCredentialsFile(credentialsFile))
-	}
-
-	return registry.NewClient(opts...)
-}
-
-func MustInitStorage(path, storageAdvAddr string, artifactRetentionTTL time.Duration, artifactRetentionRecords int, l logr.Logger) controllers.Storage {
-	if path == "" {
-		p, _ := os.Getwd()
-		path = filepath.Join(p, "bin")
-		err := os.MkdirAll(path, 0o700)
-		if err != nil {
-			l.Error(err, "unable make directory with right permissions")
-		}
-	}
-
-	storage, err := controllers.NewStorage(path, storageAdvAddr, artifactRetentionTTL, artifactRetentionRecords)
-	if err != nil {
-		l.Error(err, "unable to initialize storage")
-		os.Exit(1)
-	}
-
-	return storage
-}
-
-func DetermineAdvStorageAddr(storageAddr string, l logr.Logger) string {
-	host, port, err := net.SplitHostPort(storageAddr)
-	if err != nil {
-		l.Error(err, "unable to parse storage address")
-		os.Exit(1)
-	}
-	switch host {
-	case "":
-		host = "localhost"
-	case "0.0.0.0":
-		host = os.Getenv("HOSTNAME")
-		if host == "" {
-			hn, err := os.Hostname()
-			if err != nil {
-				l.Error(err, "0.0.0.0 specified in storage addr but hostname is invalid")
-				os.Exit(1)
-			}
-			host = hn
-		}
-	}
-	return net.JoinHostPort(host, port)
-}
-
-func StartFileServer(path, address string, l logr.Logger) {
-	l.Info("starting file server")
-	fs := http.FileServer(http.Dir(path))
-	mux := http.NewServeMux()
-	mux.Handle("/", fs)
-	//nolint:gosec // we are aware there are no timeouts supported
-	err := http.ListenAndServe(address, mux)
-	if err != nil {
-		l.Error(err, "file server error")
 	}
 }
 


### PR DESCRIPTION
This commit extracts the setup of flux's controllers from run.go into their own package. As we have no need for managing each controller individually and they share many dependencies, creation of them is exposed via single function which returns a slice of controllers.

This extract will facilitate future test suites which require flux and eventually the metaphorical sawing off of flux.