### PR TITLE
Change Admin API client creation to use Redpanda custom resource

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -380,11 +380,8 @@ func Run(
 		}
 
 		// Redpanda Reconciler
-		if err = (&redpandacontrollers.RedpandaReconciler{
-			Client:        mgr.GetClient(),
-			Scheme:        mgr.GetScheme(),
-			EventRecorder: mgr.GetEventRecorderFor("RedpandaReconciler"),
-		}).SetupWithManager(ctx, mgr); err != nil {
+
+		if err = redpandacontrollers.SetupRedpandaController(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Redpanda")
 			return err
 		}
@@ -404,10 +401,7 @@ func Run(
 			return err
 		}
 
-		if err = (&redpandacontrollers.ManagedDecommissionReconciler{
-			Client:        mgr.GetClient(),
-			EventRecorder: mgr.GetEventRecorderFor("ManagedDecommissionReconciler"),
-		}).SetupWithManager(mgr); err != nil {
+		if err = redpandacontrollers.SetupManagedDecommissionController(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ManagedDecommission")
 			return err
 		}
@@ -423,11 +417,7 @@ func Run(
 		}
 
 		if runThisController(DecommissionController, additionalControllers) {
-			if err = (&redpandacontrollers.DecommissionReconciler{
-				Client:                   mgr.GetClient(),
-				OperatorMode:             operatorMode,
-				DecommissionWaitInterval: decommissionWaitInterval,
-			}).SetupWithManager(mgr); err != nil {
+			if err = redpandacontrollers.SetupDecommissionController(mgr, operatorMode, decommissionWaitInterval); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "DecommissionReconciler")
 				return err
 			}
@@ -458,11 +448,7 @@ func Run(
 		}
 
 		if runThisController(DecommissionController, additionalControllers) {
-			if err = (&redpandacontrollers.DecommissionReconciler{
-				Client:                   mgr.GetClient(),
-				OperatorMode:             operatorMode,
-				DecommissionWaitInterval: decommissionWaitInterval,
-			}).SetupWithManager(mgr); err != nil {
+			if err = redpandacontrollers.SetupDecommissionController(mgr, operatorMode, decommissionWaitInterval); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "DecommissionReconciler")
 				return err
 			}

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
 	github.com/prometheus/client_golang v1.20.0
 	github.com/prometheus/common v0.55.0
-	github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b
+	github.com/redpanda-data/common-go/rpadmin v0.1.9
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
 	github.com/redpanda-data/helm-charts v0.0.0-20241015140509-56e8cc7a5e8a
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1087,6 +1087,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b h1:0rC71VXYEjo/5f9pE5oiwRVxUejkIxRrrxwpKferA/s=
 github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
+github.com/redpanda-data/common-go/rpadmin v0.1.9 h1:X5a95P7Dc+7EaidU7dusWJyiG3eJmk4zJtUttfvhmc4=
+github.com/redpanda-data/common-go/rpadmin v0.1.9/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
 github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240 h1:rSfpkaQSBkz3uqEMN1ftVEXBMyx0uibyXPHGCp1kRy8=

--- a/operator/internal/controller/redpanda/redpanda_controller_utils.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_utils.go
@@ -48,17 +48,6 @@ var DeleteEventFilter = predicate.Funcs{
 	GenericFunc: func(e event.GenericEvent) bool { return false },
 }
 
-// Check to see if the release name of a helm chart matches the name of a redpanda object
-// this is by design for the operator
-func isValidReleaseName(releaseName string, redpandaNameList []string) bool {
-	for i := range redpandaNameList {
-		if releaseName == redpandaNameList[i] {
-			return true
-		}
-	}
-	return false
-}
-
 func getHelmValues(log logr.Logger, releaseName, namespace string) (map[string]interface{}, error) {
 	settings := cli.New()
 	actionConfig := new(action.Configuration)

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -196,17 +196,10 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Redpanda Reconciler
-	err = (&redpanda.RedpandaReconciler{
-		Client:        k8sManager.GetClient(),
-		Scheme:        k8sManager.GetScheme(),
-		EventRecorder: k8sManager.GetEventRecorderFor("RedpandaReconciler"),
-	}).SetupWithManager(ctx, k8sManager)
+	err = redpanda.SetupRedpandaController(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&redpanda.DecommissionReconciler{
-		Client:       k8sManager.GetClient(),
-		OperatorMode: false,
-	}).SetupWithManager(k8sManager)
+	err = redpanda.SetupDecommissionController(k8sManager, false, time.Second)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&redpanda.RedpandaNodePVCReconciler{


### PR DESCRIPTION
The `getHelmValues` function will not work in deFluxed Redpanda controller as new operator reconciler will not use helm driver (config map or secret) to store rendered values. All occurrence of `getHelmValues` and `buildAdminAPI` was changed to use Redpanda custom resource and the client factory. Due to the fact that operator have 2 controllers decommission reconciler and node PVC reconciler which could be deployed as side cars in Redpanda helm chart, the `getHelmValues` was left behind. Fortunately node PVC reconciler could be reimplemented to not use `getHelmValues` function. The decommission reconciler needs to work in sidecar mode which requires rendered helm values to create mentioned Admin API client (operatorMode set to `false`). As further improvement the decommission logic could be split between helm base deployment (sidecar container) and Redpanda reconciler (deFluxed) where the Admin API client could created without weird Redpanda custom resource rendering to unify decommission reconciliation.