### PR TITLE
v2: Add de-flux test harness

### DIFF
--- a/operator/config/rbac/bases/operator/role.yaml
+++ b/operator/config/rbac/bases/operator/role.yaml
@@ -290,8 +290,10 @@ rules:
   - create
   - delete
   - get
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - cluster.redpanda.com
   resources:
@@ -415,17 +417,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - redpanda.vectorized.io
-  resources:
-  - clusters
-  - consoles
-  verbs:
   - get
   - list
   - patch

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -239,7 +239,7 @@ func (r *RedpandaReconciler) reconcileDefluxed(ctx context.Context, rp *v1alpha2
 	desiredChartVersion := redpanda.Chart.Metadata().Version
 
 	if !(chartVersion == "" || chartVersion == desiredChartVersion) {
-		msg := fmt.Sprintf(".spec.chartRef.chartVersion version needs to be %q or %q. got %q", desiredChartVersion, "", chartVersion)
+		msg := fmt.Sprintf(".spec.chartRef.chartVersion needs to be %q or %q. got %q", desiredChartVersion, "", chartVersion)
 
 		// NB: passing `nil` as err is acceptable for log.Error.
 		log.Error(nil, msg, "chart version", rp.Spec.ChartRef.ChartVersion)

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -100,14 +100,10 @@ type RedpandaReconciler struct {
 // +kubebuilder:rbac:groups=apps,namespace=default,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=policy,namespace=default,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,namespace=default,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=cert-manager.io,namespace=default,resources=certificates,verbs=get;create;update;patch;delete
-// +kubebuilder:rbac:groups=cert-manager.io,namespace=default,resources=issuers,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,namespace=default,resources=certificates,verbs=get;create;update;patch;delete;list;watch
+// +kubebuilder:rbac:groups=cert-manager.io,namespace=default,resources=issuers,verbs=get;create;update;patch;delete;list;watch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=default,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,namespace=default,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
-
-// for the migration purposes to disable reconciliation of cluster and console custom resources
-// +kubebuilder:rbac:groups=redpanda.vectorized.io,namespace=default,resources=clusters,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=redpanda.vectorized.io,namespace=default,resources=consoles,verbs=get;list;watch;update;patch
 
 // redpanda resources
 // +kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=redpandas,verbs=get;list;watch;create;update;patch;delete

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -1,0 +1,324 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	helmcontrollerv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
+	helmcontrollerv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
+	fluxclient "github.com/fluxcd/pkg/runtime/client"
+	sourcecontrollerv1 "github.com/fluxcd/source-controller/api/v1"
+	sourcecontrollerv1beta1 "github.com/fluxcd/source-controller/api/v1beta1"
+	sourcecontrollerv1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/go-logr/logr/testr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/flux"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	goclientscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NB: This test setup is largely incompatible with webhooks. Though we might
+// be able to figure something freaky out.
+func TestRedpandaController(t *testing.T) {
+	suite.Run(t, new(RedpandaControllerSuite))
+}
+
+type RedpandaControllerSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	env    *testenv.Env
+	client client.Client
+}
+
+var _ suite.SetupAllSuite = (*RedpandaControllerSuite)(nil)
+
+// TestStableUIDAndGeneration asserts that UIDs, Generations, Labels, and
+// Annotations of all objects created by the controller are stable across flux
+// and de-fluxed.
+func (s *RedpandaControllerSuite) TestStableUIDAndGeneration() {
+	s.T().Skip("not currently implemented")
+
+	isStable := func(a, b client.Object) {
+		assert.Equal(s.T(), a.GetUID(), b.GetUID(), "%T %q's UID changed (Something recreated it)", a, a.GetName())
+		assert.Equal(s.T(), a.GetLabels(), b.GetLabels(), "%T %q's Labels changed", a, a.GetName())
+		assert.Equal(s.T(), a.GetAnnotations(), b.GetAnnotations(), "%T %q's Labels changed", a, a.GetName())
+		assert.Equal(s.T(), a.GetGeneration(), b.GetGeneration(), "%T %q's Generation changed (Something changed .Spec)", a, a.GetName())
+	}
+
+	// A loop makes this easier to maintain but not to read. We're testing that
+	// the following paths from "fresh" hold the isStable property defined
+	// above.
+	// - NoFlux (Fresh) -> Flux (Toggled) -> NoFlux (Toggled)
+	// - Flux (Fresh) -> NoFlux (Toggled) -> Flux (Toggled)
+	for _, useFlux := range []bool{true, false} {
+		rp := s.minimalRP(useFlux)
+		s.applyAndWait(rp)
+
+		filter := client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}
+
+		fresh := s.snapshotCluster(filter)
+
+		rp.Spec.ChartRef.UseFlux = ptr.To(!useFlux)
+		s.applyAndWait(rp)
+
+		flipped := s.snapshotCluster(filter)
+		s.compareSnapshot(fresh, flipped, isStable)
+
+		rp.Spec.ChartRef.UseFlux = ptr.To(useFlux)
+		s.applyAndWait(rp)
+
+		flippedBack := s.snapshotCluster(filter)
+		s.compareSnapshot(flipped, flippedBack, isStable)
+
+		s.deleteAndWait(rp)
+	}
+}
+
+func (s *RedpandaControllerSuite) TestObjectsGCed() {
+	s.T().Skip("not currently implemented")
+
+	rp := s.minimalRP(false)
+	rp.Spec.ClusterSpec.Console.Enabled = ptr.To(true)
+	s.applyAndWait(rp)
+
+	// Assert that the console deployment exists
+	var deployments appsv1.DeploymentList
+	s.NoError(s.client.List(s.ctx, &deployments, client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}))
+	s.Len(deployments.Items, 1)
+
+	rp.Spec.ClusterSpec.Console.Enabled = ptr.To(false)
+	s.applyAndWait(rp)
+
+	// Assert that the console deployment has been garbage collected.
+	s.NoError(s.client.List(s.ctx, &deployments, client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}))
+	s.Len(deployments.Items, 0)
+
+	s.deleteAndWait(rp)
+}
+
+func (s *RedpandaControllerSuite) SetupSuite() {
+	t := s.T()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, certmanagerv1.AddToScheme(scheme))
+	require.NoError(t, goclientscheme.AddToScheme(scheme))
+	require.NoError(t, helmcontrollerv2beta1.AddToScheme(scheme))
+	require.NoError(t, helmcontrollerv2beta2.AddToScheme(scheme))
+	require.NoError(t, monitoringv1.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.AddToScheme(scheme))
+	require.NoError(t, sourcecontrollerv1.AddToScheme(scheme))
+	require.NoError(t, sourcecontrollerv1beta1.AddToScheme(scheme))
+	require.NoError(t, sourcecontrollerv1beta2.AddToScheme(scheme))
+
+	// TODO SetupManager currently runs with admin permissions on the cluster.
+	// This will allow the operator's ClusterRole and Role to get out of date.
+	// Ideally, we should bind the declared permissions of the operator to the
+	// rest config given to the manager.
+	s.ctx = context.Background()
+	s.env = testenv.New(t, testenv.Options{
+		Scheme: scheme,
+		CRDs:   crds.All(),
+		Logger: testr.New(t),
+	})
+
+	s.client = s.env.Client()
+
+	s.env.SetupManager(func(mgr ctrl.Manager) error {
+		controllers := flux.NewFluxControllers(mgr, fluxclient.Options{}, fluxclient.KubeConfigOptions{})
+		for _, controller := range controllers {
+			if err := controller.SetupWithManager(s.ctx, mgr); err != nil {
+				return err
+			}
+		}
+
+		// TODO should probably run other reconcilers here.
+		return (&redpanda.RedpandaReconciler{
+			Client:        mgr.GetClient(),
+			Scheme:        mgr.GetScheme(),
+			EventRecorder: mgr.GetEventRecorderFor("Redpanda"),
+		}).SetupWithManager(s.ctx, mgr)
+	})
+}
+
+func (s *RedpandaControllerSuite) minimalRP(useFlux bool) *v1alpha2.Redpanda {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+	name := "rp-"
+	for i := 0; i < 6; i++ {
+		//nolint:gosec // not meant to be a secure random string.
+		name += string(alphabet[rand.Intn(len(alphabet))])
+	}
+
+	return &v1alpha2.Redpanda{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha2.RedpandaSpec{
+			ChartRef: v1alpha2.ChartRef{
+				UseFlux: ptr.To(useFlux),
+			},
+			ClusterSpec: &v1alpha2.RedpandaClusterSpec{
+				Image: &v1alpha2.RedpandaImage{
+					Repository: ptr.To("redpandadata/redpanda"), // Override the default to make use of the docker-io image cache.
+				},
+				Console: &v1alpha2.RedpandaConsole{
+					Enabled: ptr.To(false), // Speed up most cases by not enabling console to start.
+				},
+				Statefulset: &redpandav1alpha2.Statefulset{
+					Replicas: ptr.To(1), // Speed up tests ever so slightly.
+				},
+			},
+		},
+	}
+}
+
+func (s *RedpandaControllerSuite) deleteAndWait(obj client.Object) {
+	gvk, err := s.client.GroupVersionKindFor(obj)
+	s.NoError(err)
+
+	obj.SetManagedFields(nil)
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+
+	if err := s.client.Delete(s.ctx, obj, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+		// obj, might not exist at all. If so, no-op.
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		s.Require().NoError(err)
+	}
+
+	s.NoError(wait.PollUntilContextTimeout(s.ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+		if err := s.client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}))
+}
+
+func (s *RedpandaControllerSuite) applyAndWait(obj client.Object) {
+	gvk, err := s.client.GroupVersionKindFor(obj)
+	s.NoError(err)
+
+	obj.SetManagedFields(nil)
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+
+	s.Require().NoError(s.client.Patch(s.ctx, obj, client.Apply, client.ForceOwnership, client.FieldOwner("tests")))
+
+	s.NoError(wait.PollUntilContextTimeout(s.ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+		if err := s.client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return false, err
+		}
+
+		switch obj := obj.(type) {
+		case *redpandav1alpha2.Redpanda:
+			ready := apimeta.IsStatusConditionTrue(obj.Status.Conditions, "Ready")
+			upToDate := obj.Generation != 0 && obj.Generation == obj.Status.ObservedGeneration
+			return upToDate && ready, nil
+
+		default:
+			s.Fail("unhandled object %T in applyAndWait", obj)
+
+		}
+
+		s.T().Logf("waiting for %T %q to be ready", obj, obj.GetName())
+		return false, nil
+	}))
+}
+
+func (s *RedpandaControllerSuite) snapshotCluster(opts ...client.ListOption) []kube.Object {
+	var objs []kube.Object
+
+	// TODO export a list of object types from the redpanda chart.
+	// for _, t := range chart.Types() {
+	for _, t := range []kube.Object{} {
+		gvk, err := s.client.GroupVersionKindFor(t)
+		s.NoError(err)
+
+		gvk.Kind += "List"
+
+		list, err := s.client.Scheme().New(gvk)
+		s.NoError(err)
+
+		if err := s.client.List(s.ctx, list.(client.ObjectList), opts...); err != nil {
+			if meta.IsNoMatchError(err) {
+				s.T().Logf("skipping unknown list type %T", list)
+				continue
+			}
+			s.NoError(err)
+		}
+
+		s.NoError(meta.EachListItem(list, func(o runtime.Object) error {
+			obj := o.(client.Object)
+			obj.SetManagedFields(nil)
+			objs = append(objs, obj)
+			return nil
+		}))
+	}
+
+	return objs
+}
+
+func (s *RedpandaControllerSuite) compareSnapshot(a, b []client.Object, fn func(a, b client.Object)) {
+	assert.Equal(s.T(), len(a), len(b))
+
+	getGVKName := func(o client.Object) string {
+		gvk, err := s.client.GroupVersionKindFor(o)
+		s.NoError(err)
+		return gvk.String() + client.ObjectKeyFromObject(o).String()
+	}
+
+	groupedA := mapBy(a, getGVKName)
+	groupedB := mapBy(b, getGVKName)
+
+	for key, a := range groupedA {
+		b := groupedB[key]
+		fn(a, b)
+	}
+}
+
+func mapBy[T any, K comparable](items []T, fn func(T) K) map[K]T {
+	out := make(map[K]T, len(items))
+	for _, item := range items {
+		key := fn(item)
+		if _, ok := out[key]; ok {
+			panic(fmt.Sprintf("duplicate key: %v", key))
+		}
+		out[key] = item
+	}
+	return out
+}

--- a/operator/internal/testenv/owned_client.go
+++ b/operator/internal/testenv/owned_client.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package testenv
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newOwnedClient(c client.Client, owner metav1.OwnerReference) client.Client {
+	return &ownedClient{
+		Client: c,
+		owner:  owner,
+	}
+}
+
+var _ client.Client = &ownedClient{}
+
+// ownedClient is a Client that wraps another Client in order to enforce
+// ownership to at least the provided reference.
+type ownedClient struct {
+	client.Client
+	owner metav1.OwnerReference
+}
+
+// Create implements client.Client.
+func (n *ownedClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	n.maybeAddOwnerRef(obj)
+	return n.Client.Create(ctx, obj, opts...)
+}
+
+// Update implements client.Client.
+func (n *ownedClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	n.maybeAddOwnerRef(obj)
+	return n.Client.Update(ctx, obj, opts...)
+}
+
+// Patch implements client.Client.
+func (n *ownedClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	n.maybeAddOwnerRef(obj)
+	return n.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *ownedClient) maybeAddOwnerRef(obj client.Object) {
+	// We don't care about namespace objects as deleting the namespace will GC
+	// them.
+	if ok, _ := c.IsObjectNamespaced(obj); ok {
+		return
+	}
+
+	// If this obj already has an owner, rely on that owner to GC it.
+	if len(obj.GetOwnerReferences()) > 0 {
+		return
+	}
+
+	// Otherwise inject a reference to our owner.
+	obj.SetOwnerReferences([]metav1.OwnerReference{*c.owner.DeepCopy()})
+}

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -1,0 +1,216 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package testenv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/helm-charts/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	goclientscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+const k3dClusterName = "testenv"
+
+func init() {
+	ctrl.SetLogger(logr.Discard()) // Silence the dramatic logger messages.
+}
+
+type Env struct {
+	t         *testing.T
+	logger    logr.Logger
+	scheme    *runtime.Scheme
+	namespace *corev1.Namespace
+	config    *rest.Config
+	ctx       context.Context
+	cancel    context.CancelFunc
+	group     *errgroup.Group
+}
+
+type Options struct {
+	Scheme *runtime.Scheme
+	CRDs   []*apiextensionsv1.CustomResourceDefinition
+	Logger logr.Logger
+}
+
+// New returns a configured [Env] that utilizes an isolated namespace in a
+// shared k3d cluster.
+//
+// Isolation is implemented at the [client.Client] level by limiting namespaced
+// requests to the provisioned namespace and attaching an owner reference to
+// the provisioned namespace to all non-namespaced requests.
+//
+// Due to the shared nature, the k3d cluster will NOT be shutdown at the end of
+// tests.
+func New(t *testing.T, options Options) *Env {
+	if options.Scheme == nil {
+		options.Scheme = goclientscheme.Scheme
+	}
+
+	if options.Logger.IsZero() {
+		options.Logger = logr.Discard()
+	}
+
+	// TODO maybe allow customizing name?
+	cluster, err := k3d.GetOrCreate(k3dClusterName)
+	require.NoError(t, err)
+
+	if len(options.CRDs) > 0 {
+		// CRDs are cluster scoped, so there's not a great way for us to safely
+		// allow multi-tenancy. Instead, we're just crossing our fingers and
+		// hoping for the best.
+		crds, err := envtest.InstallCRDs(cluster.RESTConfig(), envtest.CRDInstallOptions{
+			CRDs: options.CRDs,
+		})
+		require.NoError(t, err)
+		require.Equal(t, len(options.CRDs), len(crds))
+	}
+
+	c, err := client.New(cluster.RESTConfig(), client.Options{Scheme: options.Scheme})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Create a unique Namespace to perform tests within.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		GenerateName: "testenv-",
+	}}
+
+	require.NoError(t, c.Create(ctx, ns))
+
+	env := &Env{
+		t:         t,
+		scheme:    options.Scheme,
+		logger:    options.Logger,
+		namespace: ns,
+		group:     g,
+		ctx:       ctx,
+		cancel:    cancel,
+		config:    cluster.RESTConfig(),
+	}
+
+	t.Logf("Executing in namespace '%s'", ns.Name)
+
+	t.Cleanup(env.shutdown)
+
+	return env
+}
+
+func (e *Env) Client() client.Client {
+	return e.wrapClient(e.client())
+}
+
+func (e *Env) SetupManager(fn func(ctrl.Manager) error) {
+	// TODO: Webhooks likely aren't going to place nicely with this method of
+	// testing. The Kube API server will have to dial out of the cluster to the
+	// local machine which could prove to be difficult across all docker/docker
+	// in docker environments.
+	// See also https://k3d.io/v5.4.6/faq/faq/?h=host#how-to-access-services-like-a-database-running-on-my-docker-host-machine
+	manager, err := ctrl.NewManager(e.config, ctrl.Options{
+		Cache: cache.Options{
+			// Limit this manager to only interacting with objects within our
+			// namespace.
+			DefaultNamespaces: map[string]cache.Config{
+				e.namespace.Name: {},
+			},
+		},
+		Metrics: server.Options{BindAddress: "0"}, // Disable metrics server to avoid port conflicts.
+		Scheme:  e.scheme,
+		Logger:  e.logger,
+		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
+			c, err := client.New(config, options)
+			if err != nil {
+				return nil, err
+			}
+			// Wrap any clients created by the manager to ensure namespace
+			// isolation or GC tracking.
+			return e.wrapClient(c), nil
+		},
+		BaseContext: func() context.Context {
+			return e.ctx
+		},
+	})
+	require.NoError(e.t, err)
+
+	require.NoError(e.t, fn(manager))
+
+	e.group.Go(func() error {
+		return manager.Start(e.ctx)
+	})
+
+	// No Without leader election enabled, this is just a wait for the manager
+	// to start up.
+	<-manager.Elected()
+}
+
+func (e *Env) client() client.Client {
+	c, err := client.New(e.config, client.Options{
+		Scheme: e.scheme,
+	})
+	require.NoError(e.t, err)
+	return c
+}
+
+func (e *Env) wrapClient(c client.Client) client.Client {
+	// Bind all operations to this namespace. We'll delete it at the end of this test.
+	c = client.NewNamespacedClient(c, e.namespace.Name)
+	// For any non-namespaced resources, we'll attach an OwnerReference to our
+	// Namespace to ensure they get cleaned up as well.
+	c = newOwnedClient(c, metav1.OwnerReference{
+		APIVersion:         e.namespace.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Kind:               e.namespace.GetObjectKind().GroupVersionKind().Kind,
+		UID:                e.namespace.UID,
+		Name:               e.namespace.Name,
+		BlockOwnerDeletion: ptr.To(true),
+	})
+	return c
+}
+
+func (e *Env) shutdown() {
+	if !testutil.Retain() {
+		// NB: Namespace deletion MUST happen before calling e.cancel.
+		// Otherwise we risk stopping controllers that would remove finalizers
+		// from various resources in the cluster which would hang the namespace
+		// deletion forever.
+		c := e.client()
+
+		assert.NoError(e.t, c.Delete(e.ctx, e.namespace, client.PropagationPolicy(metav1.DeletePropagationForeground)))
+
+		// Poll until the namespace is fully deleted.
+		assert.NoError(e.t, wait.PollUntilContextTimeout(e.ctx, time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+			err = c.Get(ctx, client.ObjectKeyFromObject(e.namespace), e.namespace)
+			return apierrors.IsNotFound(err), client.IgnoreNotFound(err)
+		}))
+	}
+
+	e.cancel()
+	assert.NoError(e.t, e.group.Wait())
+}

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -112,20 +112,7 @@ func TestClientFactory(t *testing.T) {
 		KubeConfig: restcfg,
 	})
 	require.NoError(t, err)
-	require.NoError(t, helmClient.RepoAdd(ctx, "jetstack", "https://charts.jetstack.io"))
 	require.NoError(t, helmClient.RepoAdd(ctx, "redpandadata", "https://charts.redpanda.com"))
-
-	_, err = helmClient.Install(ctx, "jetstack/cert-manager", helm.InstallOptions{
-		CreateNamespace: true,
-		Name:            "cert-manager",
-		Namespace:       "cert-manager",
-		Values: map[string]any{
-			"crds": map[string]any{
-				"enabled": true,
-			},
-		},
-	})
-	require.NoError(t, err)
 
 	factory := NewFactory(restcfg, kubeClient).WithDialer(kube.NewPodDialer(restcfg).DialContext)
 


### PR DESCRIPTION
#### c007a78077d2526737d3d41fe48c4bc21089aad1 k3d: fix embedded manifests in CI

Prior to this commit the newly added functionality to install cert-manager by
default in k3d would silently fail in CI due to complexities of volume binding
in docker in docker setups.

This commit drops the usage of the `--volume` flag in favor of applying the
manifests immediately after cluster creation and removes the duplicate
cert-manager installation from `pkg/client`.


#### 330d5861fb81eaddad6c212cc376711a0c9d78c7 v2: update permissions for de-fluxing

Due to the usage of the manager's caching, the operator will automatically
attempt to establish a watch on `Issuer`s and `Certificates` when run in
de-fluxed mode.

This commit adds the missing `watch` and `list` permissions to cert-manager's
`Issuer` and `Certificate` CRs and prunes the unused permissions on the v1
cluster resource.


#### d952ee35d1803a3a4a46310d0e68f1fcdf1a35e5 v2: add skipped de-flux test suite

This commit adds a new test harness for the upcoming de-fluxed operator mode
with it's initial set of tests skipped. This tests are being merged in ahead of
time to allow others to utilize this test harness and to showcase the expected
behavior of the de-fluxed mode.

This test suite runs the relevant controllers outside of the Kubernetes cluster
to avoid the need to have to continuously rebuild and deploy the operator
image. It also introduces a mechanism for performing tests within an anonymous
namespace which should allow Kubernetes clusters to be safely re-used across
test runs further shorting the test feedback loop.


