### PR TITLE
Add Schema controller

### DIFF
--- a/acceptance/features/schema-crds.feature
+++ b/acceptance/features/schema-crds.feature
@@ -1,0 +1,38 @@
+@cluster:basic
+Feature: Schema CRDs
+  Background: Cluster available
+    Given cluster "basic" is available
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Managing Schemas
+    Given there is no schema "schema1" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+        name: schema1
+    spec:
+        cluster:
+            clusterRef:
+                name: basic
+        text: |
+            {
+                "type": "record",
+                "name": "test",
+                "fields":
+                [
+                    {
+                        "type": "string",
+                        "name": "field1"
+                    },
+                    {
+                        "type": "int",
+                        "name": "field2"
+                    }
+                ]
+            }
+    """
+    And schema "schema1" is successfully synced
+    Then I should be able to check compatibility against "schema1" in cluster "basic"

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/twmb/franz-go v1.18.0
 	github.com/twmb/franz-go/pkg/kadm v1.12.0
+	github.com/twmb/franz-go/pkg/sr v1.2.0
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
@@ -159,7 +160,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
 	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 // indirect
-	github.com/twmb/franz-go/pkg/sr v1.2.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -642,6 +642,7 @@ github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b/
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
 github.com/redpanda-data/helm-charts v0.0.0-20241030170802-ad1edfc56b70 h1:zp9erNYgwkQK7YZOE/dluuuYrdrsNDXM1KXR48k0SLg=
+github.com/redpanda-data/helm-charts v0.0.0-20241030170802-ad1edfc56b70/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8/go.mod h1:97qkjcMI3gDL+y+aY/w5o0xF2qGHFof6rCXIYjnTalM=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
@@ -720,13 +721,16 @@ github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYg
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
 github.com/twmb/franz-go v1.7.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go v1.18.0 h1:25FjMZfdozBywVX+5xrWC2W+W76i0xykKjTdEeD2ejw=
+github.com/twmb/franz-go v1.18.0/go.mod h1:zXCGy74M0p5FbXsLeASdyvfLFsBvTubVqctIaa5wQ+I=
 github.com/twmb/franz-go/pkg/kadm v1.12.0 h1:I8P/gpXFzhl73QcAYmJu+1fOXvrynyH/MAotr2udEg4=
 github.com/twmb/franz-go/pkg/kadm v1.12.0/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/twmb/franz-go/pkg/kmsg v1.2.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 h1:alKdbddkPw3rDh+AwmUEwh6HNYgTvDSFIe/GWYRR9RM=
 github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0/go.mod h1:k8BoBjyUbFj34f0rRbn+Ky12sZFAPbmShrg0karAIMo=
 github.com/twmb/franz-go/pkg/sr v1.2.0 h1:zYr0Ly7KLFfeCGaSr8teN6LvAVeYVrZoUsyyPHTYB+M=
+github.com/twmb/franz-go/pkg/sr v1.2.0/go.mod h1:gpd2Xl5/prkj3gyugcL+rVzagjaxFqMgvKMYcUlrpDw=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=
 github.com/twmb/tlscfg v1.2.1/go.mod h1:GameEQddljI+8Es373JfQEBvtI4dCTLKWGJbqT2kErs=
 github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 h1:JwtAtbp7r/7QSyGz8mKUbYJBg2+6Cd7OjM8o/GNOcVo=

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -18,6 +18,11 @@ func init() {
 
 	framework.RegisterStep(`^I apply Kubernetes manifest:$`, iApplyKubernetesManifest)
 
+	// Schema scenario steps
+	framework.RegisterStep(`^there is no schema "([^"]*)" in cluster "([^"]*)"$`, thereIsNoSchema)
+	framework.RegisterStep(`^schema "([^"]*)" is successfully synced$`, schemaIsSuccessfullySynced)
+	framework.RegisterStep(`^I should be able to check compatibility against "([^"]*)" in cluster "([^"]*)"$`, iShouldBeAbleToCheckCompatibilityAgainst)
+
 	// Topic scenario steps
 	framework.RegisterStep(`^there is no topic "([^"]*)" in cluster "([^"]*)"$`, thereIsNoTopic)
 	framework.RegisterStep(`^topic "([^"]*)" is successfully synced$`, topicIsSuccessfullySynced)

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package steps
+
+import (
+	"context"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schema string) {
+	var schemaObject redpandav1alpha2.Schema
+	require.NoError(t, t.Get(ctx, t.ResourceKey(schema), &schemaObject))
+
+	// make sure the resource is stable
+	checkStableResource(ctx, t, &schemaObject)
+
+	// make sure it's synchronized
+	t.RequireCondition(metav1.Condition{
+		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
+		Status: metav1.ConditionTrue,
+		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
+	}, schemaObject.Status.Conditions)
+}
+
+func thereIsNoSchema(ctx context.Context, schema, cluster string) {
+	clientsForCluster(ctx, cluster).ExpectNoSchema(ctx, schema)
+}
+
+func iShouldBeAbleToCheckCompatibilityAgainst(ctx context.Context, schema, cluster string) {
+	clients := clientsForCluster(ctx, cluster)
+	clients.ExpectSchema(ctx, schema)
+}

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -405,6 +405,11 @@ func Run(
 			return err
 		}
 
+		if err = redpandacontrollers.SetupSchemaController(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Schema")
+			return err
+		}
+
 		if err = (&redpandacontrollers.ManagedDecommissionReconciler{
 			Client:        mgr.GetClient(),
 			EventRecorder: mgr.GetEventRecorderFor("ManagedDecommissionReconciler"),

--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - bases/redpanda.vectorized.io_clusters.yaml
 - bases/redpanda.vectorized.io_consoles.yaml
 - bases/cluster.redpanda.com_redpandas.yaml
+- bases/cluster.redpanda.com_schemas.yaml
 - bases/cluster.redpanda.com_topics.yaml
 - bases/cluster.redpanda.com_users.yaml
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/operator/config/rbac/bases/operator/role.yaml
+++ b/operator/config/rbac/bases/operator/role.yaml
@@ -97,6 +97,7 @@ rules:
 - apiGroups:
   - cluster.redpanda.com
   resources:
+  - schemas
   - topics
   - users
   verbs:
@@ -108,6 +109,7 @@ rules:
 - apiGroups:
   - cluster.redpanda.com
   resources:
+  - schemas/finalizers
   - topics/finalizers
   - users/finalizers
   verbs:
@@ -115,6 +117,7 @@ rules:
 - apiGroups:
   - cluster.redpanda.com
   resources:
+  - schemas/status
   - topics/status
   - users/status
   verbs:
@@ -310,6 +313,7 @@ rules:
   - cluster.redpanda.com
   resources:
   - redpandas/finalizers
+  - schemas/finalizers
   - topics/finalizers
   - users/finalizers
   verbs:
@@ -318,6 +322,7 @@ rules:
   - cluster.redpanda.com
   resources:
   - redpandas/status
+  - schemas/status
   - topics/status
   - users/status
   verbs:
@@ -327,6 +332,7 @@ rules:
 - apiGroups:
   - cluster.redpanda.com
   resources:
+  - schemas
   - topics
   - users
   verbs:

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-logr/logr/testr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redpanda-data/helm-charts/pkg/kube"
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/flux"
@@ -38,7 +37,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -178,7 +176,7 @@ func (s *RedpandaControllerSuite) SetupSuite() {
 	})
 }
 
-func (s *RedpandaControllerSuite) minimalRP(useFlux bool) *v1alpha2.Redpanda {
+func (s *RedpandaControllerSuite) minimalRP(useFlux bool) *redpandav1alpha2.Redpanda {
 	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 	name := "rp-"
@@ -187,19 +185,19 @@ func (s *RedpandaControllerSuite) minimalRP(useFlux bool) *v1alpha2.Redpanda {
 		name += string(alphabet[rand.Intn(len(alphabet))])
 	}
 
-	return &v1alpha2.Redpanda{
+	return &redpandav1alpha2.Redpanda{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1alpha2.RedpandaSpec{
-			ChartRef: v1alpha2.ChartRef{
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ChartRef: redpandav1alpha2.ChartRef{
 				UseFlux: ptr.To(useFlux),
 			},
-			ClusterSpec: &v1alpha2.RedpandaClusterSpec{
-				Image: &v1alpha2.RedpandaImage{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+				Image: &redpandav1alpha2.RedpandaImage{
 					Repository: ptr.To("redpandadata/redpanda"), // Override the default to make use of the docker-io image cache.
 				},
-				Console: &v1alpha2.RedpandaConsole{
+				Console: &redpandav1alpha2.RedpandaConsole{
 					Enabled: ptr.To(false), // Speed up most cases by not enabling console to start.
 				},
 				Statefulset: &redpandav1alpha2.Statefulset{
@@ -281,14 +279,14 @@ func (s *RedpandaControllerSuite) snapshotCluster(opts ...client.ListOption) []k
 		s.NoError(err)
 
 		if err := s.client.List(s.ctx, list.(client.ObjectList), opts...); err != nil {
-			if meta.IsNoMatchError(err) {
+			if apimeta.IsNoMatchError(err) {
 				s.T().Logf("skipping unknown list type %T", list)
 				continue
 			}
 			s.NoError(err)
 		}
 
-		s.NoError(meta.EachListItem(list, func(o runtime.Object) error {
+		s.NoError(apimeta.EachListItem(list, func(o runtime.Object) error {
 			obj := o.(client.Object)
 			obj.SetManagedFields(nil)
 			objs = append(objs, obj)

--- a/operator/internal/controller/redpanda/schema_controller.go
+++ b/operator/internal/controller/redpanda/schema_controller.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package redpanda reconciles resources that comes from Redpanda dictionary like Topic, ACL and more.
+package redpanda
+
+import (
+	"context"
+	"time"
+
+	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/kubernetes"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//+kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=schemas,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=schemas/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=schemas/finalizers,verbs=update
+
+// For cluster scoped operator
+
+//+kubebuilder:rbac:groups=cluster.redpanda.com,resources=schemas,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=cluster.redpanda.com,resources=schemas/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=cluster.redpanda.com,resources=schemas/finalizers,verbs=update
+
+// SchemaReconciler reconciles a schema object
+type SchemaReconciler struct{}
+
+func (r *SchemaReconciler) FinalizerPatch(request ResourceRequest[*redpandav1alpha2.Schema]) client.Patch {
+	schema := request.object
+	config := redpandav1alpha2ac.Schema(schema.Name, schema.Namespace)
+	return kubernetes.ApplyPatch(config.WithFinalizers(FinalizerKey))
+}
+
+func (r *SchemaReconciler) SyncResource(ctx context.Context, request ResourceRequest[*redpandav1alpha2.Schema]) (client.Patch, error) {
+	schema := request.object
+	createPatch := func(err error, hash string, versions []int) (client.Patch, error) {
+		var syncCondition metav1.Condition
+		config := redpandav1alpha2ac.Schema(schema.Name, schema.Namespace)
+
+		if err != nil {
+			syncCondition, err = handleResourceSyncErrors(err)
+		} else {
+			syncCondition = redpandav1alpha2.ResourceSyncedCondition(schema.Name)
+		}
+
+		return kubernetes.ApplyPatch(config.WithStatus(redpandav1alpha2ac.SchemaStatus().
+			WithObservedGeneration(schema.Generation).
+			WithVersions(versions...).
+			WithSchemaHash(hash).
+			WithConditions(utils.StatusConditionConfigs(schema.Status.Conditions, schema.Generation, []metav1.Condition{
+				syncCondition,
+			})...))), err
+	}
+
+	hash := schema.Status.SchemaHash
+	versions := schema.Status.Versions
+	syncer, err := request.factory.Schemas(ctx, schema)
+	if err != nil {
+		return createPatch(err, hash, versions)
+	}
+
+	hash, versions, err = syncer.Sync(ctx, schema)
+	return createPatch(err, hash, versions)
+}
+
+func (r *SchemaReconciler) DeleteResource(ctx context.Context, request ResourceRequest[*redpandav1alpha2.Schema]) error {
+	syncer, err := request.factory.Schemas(ctx, request.object)
+	if err != nil {
+		return ignoreAllConnectionErrors(request.logger, err)
+	}
+	if err := syncer.Delete(ctx, request.object); err != nil {
+		return ignoreAllConnectionErrors(request.logger, err)
+	}
+	return nil
+}
+
+func SetupSchemaController(ctx context.Context, mgr ctrl.Manager) error {
+	c := mgr.GetClient()
+	config := mgr.GetConfig()
+	factory := internalclient.NewFactory(config, c)
+	controller := NewResourceController(c, factory, &SchemaReconciler{}, "SchemaReconciler")
+
+	enqueueSchema, err := registerClusterSourceIndex(ctx, mgr, "schema", &redpandav1alpha2.Schema{}, &redpandav1alpha2.SchemaList{})
+	if err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&redpandav1alpha2.Schema{}).
+		Watches(&redpandav1alpha2.Redpanda{}, enqueueSchema).
+		// Every 5 minutes try and check to make sure no manual modifications
+		// happened on the resource synced to the cluster and attempt to correct
+		// any drift.
+		Complete(controller.PeriodicallyReconcile(5 * time.Minute))
+}

--- a/operator/internal/controller/redpanda/schema_controller_test.go
+++ b/operator/internal/controller/redpanda/schema_controller_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSchemaReconcile(t *testing.T) { // nolint:funlen // These tests have clear subtests.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancel()
+
+	environment := InitializeResourceReconcilerTest(t, ctx, &SchemaReconciler{})
+
+	baseSchema := &redpandav1alpha2.Schema{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: redpandav1alpha2.SchemaSpec{
+			ClusterSource: environment.ClusterSourceValid,
+			Text: `{
+			"type": "record",
+			"name": "test",
+			"fields":
+				[
+				{
+					"type": "string",
+					"name": "field1"
+				},
+				{
+					"type": "int",
+					"name": "field2"
+				}
+				]
+			}`,
+		},
+	}
+
+	for name, tt := range map[string]struct {
+		mutate            func(schema *redpandav1alpha2.Schema)
+		expectedCondition metav1.Condition
+	}{
+		"success": {
+			expectedCondition: environment.SyncedCondition,
+		},
+		"error - invalid cluster ref": {
+			mutate: func(schema *redpandav1alpha2.Schema) {
+				schema.Spec.ClusterSource = environment.ClusterSourceInvalidRef
+			},
+			expectedCondition: environment.InvalidClusterRefCondition,
+		},
+		"error - client error no SASL": {
+			mutate: func(schema *redpandav1alpha2.Schema) {
+				schema.Spec.ClusterSource = environment.ClusterSourceNoSASL
+			},
+			expectedCondition: environment.ClientErrorCondition,
+		},
+		"error - client error invalid credentials": {
+			mutate: func(schema *redpandav1alpha2.Schema) {
+				schema.Spec.ClusterSource = environment.ClusterSourceBadPassword
+			},
+			expectedCondition: environment.ClientErrorCondition,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			schema := baseSchema.DeepCopy()
+			schema.Name = "schema" + strconv.Itoa(int(time.Now().UnixNano()))
+
+			if tt.mutate != nil {
+				tt.mutate(schema)
+			}
+
+			key := client.ObjectKeyFromObject(schema)
+			req := ctrl.Request{NamespacedName: key}
+
+			require.NoError(t, environment.Factory.Create(ctx, schema))
+			_, err := environment.Reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+
+			require.NoError(t, environment.Factory.Get(ctx, key, schema))
+			require.Equal(t, []string{FinalizerKey}, schema.Finalizers)
+			require.Len(t, schema.Status.Conditions, 1)
+			require.Equal(t, tt.expectedCondition.Type, schema.Status.Conditions[0].Type)
+			require.Equal(t, tt.expectedCondition.Reason, schema.Status.Conditions[0].Reason)
+			require.Equal(t, tt.expectedCondition.Status, schema.Status.Conditions[0].Status)
+
+			if tt.expectedCondition.Status == metav1.ConditionTrue { //nolint:nestif // ignore
+				schemaClient, err := environment.Factory.SchemaRegistryClient(ctx, schema)
+				require.NoError(t, err)
+				require.NotNil(t, schemaClient)
+
+				_, err = schemaClient.SchemaByVersion(ctx, schema.Name, -1)
+				require.NoError(t, err)
+
+				// clean up and make sure we properly delete everything
+				require.NoError(t, environment.Factory.Delete(ctx, schema))
+				_, err = environment.Reconciler.Reconcile(ctx, req)
+				require.NoError(t, err)
+				require.True(t, apierrors.IsNotFound(environment.Factory.Get(ctx, key, schema)))
+
+				// make sure we no longer have a schema
+				_, err = schemaClient.SchemaByVersion(ctx, schema.Name, -1)
+				require.EqualError(t, err, fmt.Sprintf("Subject '%s' not found.", schema.Name))
+
+				return
+			}
+
+			// clean up and make sure we properly delete everything
+			require.NoError(t, environment.Factory.Delete(ctx, schema))
+			_, err = environment.Reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+			require.True(t, apierrors.IsNotFound(environment.Factory.Get(ctx, key, schema)))
+		})
+	}
+}

--- a/operator/pkg/client/errors.go
+++ b/operator/pkg/client/errors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sr"
 )
 
 var (
@@ -64,6 +65,16 @@ func IsTerminalClientError(err error) bool {
 	var restError *rpadmin.HTTPResponseError
 	if errors.As(err, &restError) {
 		code := restError.Response.StatusCode
+		if code >= 400 && code < 500 {
+			// we have a terminal error
+			return true
+		}
+	}
+
+	var srError *sr.ResponseError
+	if errors.As(err, &srError) {
+		// from https://github.com/redpanda-data/redpanda/blob/8a12c560f73773d2b5606d35f3b585c7af67ca82/src/v/pandaproxy/error.h#L70-L72
+		code := srError.ErrorCode / 100
 		if code >= 400 && code < 500 {
 			// we have a terminal error
 			return true


### PR DESCRIPTION
This adds the Schema controller and some acceptance tests for it. It also enables the CRD in our kustomize configuration. The operator RBAC depends on https://github.com/redpanda-data/helm-charts/pull/1588 to function properly.