### PR TITLE
v2: implement post-install/upgrade job in controller

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1806,7 +1806,6 @@ github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b/
 github.com/redpanda-data/helm-charts v0.0.0-20240911060052-2bf9dd6f0996/go.mod h1:uEMmuH+gTppAsZZNYlUbh6tuxN3fqffWY0Bi8AcE2Zk=
 github.com/redpanda-data/helm-charts v0.0.0-20240916201426-9ca3b128bb8e/go.mod h1:uEMmuH+gTppAsZZNYlUbh6tuxN3fqffWY0Bi8AcE2Zk=
 github.com/redpanda-data/helm-charts v0.0.0-20241025092026-69353dfce9a1/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
-github.com/redpanda-data/helm-charts v0.0.0-20241030170802-ad1edfc56b70/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240105044330-c094966ca0cf/go.mod h1:SaSp5/JwdLHu8ZU82wFbXD8/oE4UWB+8ZkjWWreAt7Y=
 github.com/rhnvrm/simples3 v0.6.1 h1:H0DJwybR6ryQE+Odi9eqkHuzjYAeJgtGcGtuBwOhsH8=
 github.com/rickb777/period v1.0.6 h1:f4TcHBtL/4qa4D44eqgxs7785/kfLKUjRI7XYI2HCvk=

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -11,6 +11,7 @@ package redpanda_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -25,6 +26,8 @@ import (
 	sourcecontrollerv1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/go-logr/logr/testr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	chart "github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/helm-charts/pkg/kube"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
@@ -155,16 +158,21 @@ func (s *RedpandaControllerSuite) TestObjectsGCed() {
 	}
 
 	// Assert that the console deployment exists
-	var deployments appsv1.DeploymentList
-	s.NoError(s.client.List(s.ctx, &deployments, client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}))
-	s.Len(deployments.Items, 1)
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		var deployments appsv1.DeploymentList
+		assert.NoError(t, s.client.List(s.ctx, &deployments, client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}))
+		assert.Len(t, deployments.Items, 1)
+	}, time.Minute, time.Second, "console deployment not scheduled")
 
 	rp.Spec.ClusterSpec.Console.Enabled = ptr.To(false)
 	s.applyAndWait(rp)
 
 	// Assert that the console deployment has been garbage collected.
-	s.NoError(s.client.List(s.ctx, &deployments, client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}))
-	s.Len(deployments.Items, 0)
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		var deployments appsv1.DeploymentList
+		assert.NoError(t, s.client.List(s.ctx, &deployments, client.MatchingLabels{"app.kubernetes.io/instance": rp.Name}))
+		assert.Len(t, deployments.Items, 0)
+	}, time.Minute, time.Second, "console deployment not GC'd")
 
 	// Assert that our previously created secrets have not been GC'd.
 	for _, secret := range secrets {
@@ -270,7 +278,10 @@ func (s *RedpandaControllerSuite) TestManagedDecommission() {
 				return false
 			}
 		}
-		return true
+
+		_, ok := rp.Annotations["operator.redpanda.com/managed-decommission"]
+
+		return !ok // Managed decommission is finished when the annotation is removed.
 	})
 
 	afterBrokers, err := adminAPI.Brokers(s.ctx)
@@ -298,6 +309,115 @@ func (s *RedpandaControllerSuite) TestManagedDecommission() {
 
 	s.Len(beforeIDs, 3)
 	s.Len(afterIDs, 3)
+
+	s.deleteAndWait(rp)
+}
+
+func (s *RedpandaControllerSuite) TestClusterSettings() {
+	rp := s.minimalRP(false)
+	s.applyAndWait(rp)
+
+	setConfig := func(cfg map[string]any) {
+		asJson, err := json.Marshal(cfg)
+		s.Require().NoError(err)
+
+		rp.Spec.ClusterSpec.Config.Cluster = &runtime.RawExtension{Raw: asJson}
+		s.applyAndWait(rp)
+		s.applyAndWaitFor(rp, func(o client.Object) bool {
+			rp := o.(*redpandav1alpha2.Redpanda)
+			for _, cond := range rp.Status.Conditions {
+				if cond.Type == redpandav1alpha2.ClusterConfigSynced {
+					return cond.ObservedGeneration == rp.Generation && cond.Status == metav1.ConditionTrue
+				}
+			}
+			return false
+		})
+	}
+	s.applyAndWait(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "creds",
+		},
+		Data: map[string][]byte{
+			"access_key": []byte("VURYSECRET"),
+		},
+	})
+
+	// Ensure that some superusers exist.
+	rp.Spec.ClusterSpec.Auth = &redpandav1alpha2.Auth{
+		SASL: &redpandav1alpha2.SASL{
+			Enabled: ptr.To(true),
+			Users: []redpandav1alpha2.UsersItems{
+				{Name: ptr.To("bob"), Password: ptr.To("bobert")},
+				{Name: ptr.To("alice"), Password: ptr.To("alicert")},
+			},
+		},
+	}
+
+	rp.Spec.ClusterSpec.Storage = &redpandav1alpha2.Storage{
+		Tiered: &redpandav1alpha2.Tiered{
+			Config: &redpandav1alpha2.TieredConfig{
+				CloudStorageDisableTLS: ptr.To(true),
+			},
+			CredentialsSecretRef: &redpandav1alpha2.CredentialSecretRef{
+				AccessKey: &redpandav1alpha2.SecretWithConfigField{
+					Name: ptr.To("creds"),
+					Key:  ptr.To("access_key"),
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		In       map[string]any
+		Expected map[string]any
+	}{
+		{
+			In: map[string]any{
+				"admin_api_require_auth":      true,
+				"enable_schema_id_validation": "redpanda",
+				"enable_transactions":         false,
+			},
+			Expected: map[string]any{
+				"admin_api_require_auth":      true,
+				"cloud_storage_access_key":    "VURYSECRET",
+				"cloud_storage_disable_tls":   true,
+				"enable_schema_id_validation": "redpanda",
+				"enable_transactions":         false,
+				"superusers":                  []any{"alice", "bob", "kubernetes-controller"},
+			},
+		},
+		{
+			In: map[string]any{
+				"enable_transactions":         true,
+				"enable_schema_id_validation": "none",
+				// TODO: Minor bug in the helm chart here, setting superusers
+				// in cluster.config results in the bootstrap users getting
+				// excluded.
+				// "superusers":                  []any{"jimbob"},
+			},
+			Expected: map[string]any{
+				"admin_api_require_auth":    true,
+				"cloud_storage_access_key":  "VURYSECRET",
+				"cloud_storage_disable_tls": true,
+				"superusers":                []any{"alice", "bob", "kubernetes-controller"},
+				// "superusers":                []any{"alice", "bob", "jimbob", "kubernetes-controller"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		setConfig(c.In)
+
+		adminClient, err := s.clientFactory.RedpandaAdminClient(s.ctx, rp)
+		s.Require().NoError(err)
+
+		config, err := adminClient.Config(s.ctx, false)
+		s.Require().NoError(err)
+
+		// Only assert that c.Expected is a subset of the set config.
+		// The chart/operator injects a bunch of "useful" values by default.
+		s.Subset(config, c.Expected)
+	}
 
 	s.deleteAndWait(rp)
 }
@@ -554,4 +674,15 @@ func mapBy[T any, K comparable](items []T, fn func(T) K) map[K]T {
 		out[key] = item
 	}
 	return out
+}
+
+func TestPostInstallUpgradeJobIndex(t *testing.T) {
+	dot, err := chart.Chart.Dot(kube.Config{}, helmette.Release{}, map[string]any{})
+	require.NoError(t, err)
+
+	job := chart.PostInstallUpgradeJob(dot)
+
+	// Assert that index 0 is the envsubst container as that's what
+	// `clusterConfigfor` utilizes.
+	require.Equal(t, "bootstrap-yaml-envsubst", job.Spec.Template.Spec.InitContainers[0].Name)
 }

--- a/operator/pkg/kube/envexpander.go
+++ b/operator/pkg/kube/envexpander.go
@@ -1,0 +1,168 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kube
+
+import (
+	"context"
+	"maps"
+	"os"
+
+	"github.com/cockroachdb/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type EnvExpander struct {
+	Client    client.Client
+	Namespace string
+	Env       []corev1.EnvVar
+	EnvFrom   []corev1.EnvFromSource
+}
+
+// Expand expands the given string as if [os.ExpandEnv] was run on it
+// within a Pod having the env and envFrom of this EnvExpander.
+func (t *EnvExpander) Expand(ctx context.Context, s string) (string, error) {
+	vars := map[string]string{}
+	for _, src := range t.EnvFrom {
+		resolved, err := t.resolve(ctx, src)
+		if err != nil {
+			return "", err
+		}
+		maps.Copy(vars, resolved)
+	}
+
+	var errs []error
+	expanded := os.Expand(s, func(s string) string {
+		for _, e := range t.Env {
+			if e.Name == s {
+				value, err := t.valueOf(ctx, e)
+				if err != nil {
+					errs = append(errs, err)
+					return ""
+				}
+				return value
+			}
+		}
+		return vars[s]
+	})
+
+	if len(errs) > 0 {
+		return "", errors.Join(errs...)
+	}
+
+	return expanded, nil
+}
+
+func (t *EnvExpander) resolve(ctx context.Context, src corev1.EnvFromSource) (map[string]string, error) {
+	if src.SecretRef != nil {
+		ref := src.SecretRef
+		key := client.ObjectKey{Namespace: t.Namespace, Name: ref.Name}
+
+		var secret corev1.Secret
+		if err := t.Client.Get(ctx, key, &secret); err != nil {
+			if apierrors.IsNotFound(err) && ptr.Deref(ref.Optional, false) {
+				return map[string]string{}, nil
+			}
+		}
+
+		ret := make(map[string]string, len(secret.Data))
+		for k, v := range secret.Data {
+			ret[src.Prefix+k] = string(v)
+		}
+		return ret, nil
+	}
+
+	if src.ConfigMapRef != nil {
+		ref := src.ConfigMapRef
+		key := client.ObjectKey{Namespace: t.Namespace, Name: ref.Name}
+
+		var cm corev1.ConfigMap
+		if err := t.Client.Get(ctx, key, &cm); err != nil {
+			if apierrors.IsNotFound(err) && ptr.Deref(ref.Optional, false) {
+				return map[string]string{}, nil
+			}
+		}
+
+		ret := make(map[string]string, len(cm.Data))
+		for k, v := range cm.Data {
+			ret[src.Prefix+k] = string(v)
+		}
+		return ret, nil
+	}
+
+	return nil, errors.Newf("invalid %T: %#v", src, src)
+}
+
+func (t *EnvExpander) valueOf(ctx context.Context, e corev1.EnvVar) (string, error) {
+	if e.Value != "" {
+		return e.Value, nil
+	}
+
+	if vf := e.ValueFrom; vf != nil {
+		switch {
+		case vf.ConfigMapKeyRef != nil:
+			return t.resolveConfigMapRef(ctx, vf.ConfigMapKeyRef)
+
+		case vf.SecretKeyRef != nil:
+			return t.resolveSecretRef(ctx, vf.SecretKeyRef)
+
+		default:
+			return "", errors.Newf("not supported: %#v", vf)
+		}
+	}
+
+	return "", errors.Newf("invalid %T: %#v", e, e)
+}
+
+func (t *EnvExpander) resolveConfigMapRef(ctx context.Context, ref *corev1.ConfigMapKeySelector) (string, error) {
+	key := client.ObjectKey{Namespace: t.Namespace, Name: ref.Name}
+
+	var cm corev1.ConfigMap
+	if err := t.Client.Get(ctx, key, &cm); err != nil {
+		if apierrors.IsNotFound(err) && ptr.Deref(ref.Optional, false) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if value, ok := cm.Data[ref.Key]; ok {
+		return value, nil
+	}
+
+	if ptr.Deref(ref.Optional, false) {
+		return "", nil
+	}
+
+	return "", errors.Newf("missing key: %q", ref.Key)
+}
+
+func (t *EnvExpander) resolveSecretRef(ctx context.Context, ref *corev1.SecretKeySelector) (string, error) {
+	key := client.ObjectKey{Namespace: t.Namespace, Name: ref.Name}
+
+	var cm corev1.Secret
+	if err := t.Client.Get(ctx, key, &cm); err != nil {
+		if apierrors.IsNotFound(err) && ptr.Deref(ref.Optional, false) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if value, ok := cm.Data[ref.Key]; ok {
+		return string(value), nil
+	}
+
+	if ptr.Deref(ref.Optional, false) {
+		return "", nil
+	}
+
+	return "", errors.Newf("missing key: %q", ref.Key)
+}

--- a/operator/pkg/kube/envexpander_test.go
+++ b/operator/pkg/kube/envexpander_test.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kube
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestEnvExpander(t *testing.T) {
+	ctx := context.Background()
+
+	var env envtest.Environment
+	cfg, err := env.Start()
+	require.NoError(t, err)
+
+	c, err := client.New(cfg, client.Options{})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "configs",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"NODE_ENV": "PROD",
+			"KEY":      "Value!",
+		},
+	}))
+
+	require.NoError(t, c.Create(ctx, &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "secrets",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"ACCESS_KEY": []byte(`super!s3cret1`),
+		},
+	}))
+
+	cases := []struct {
+		In      string
+		Out     string
+		Err     error
+		Env     []corev1.EnvVar
+		EnvFrom []corev1.EnvFromSource
+	}{
+		{In: "${FOO}", Out: ""},
+		{
+			In:  "$BAR",
+			Out: "Hello!",
+			Env: []corev1.EnvVar{
+				{
+					Name:  "BAR",
+					Value: "Hello!",
+				},
+			},
+		},
+		{
+			In:  "$NODE_ENV uses ${ACCESS_KEY}",
+			Out: "PROD uses super!s3cret1",
+			Env: []corev1.EnvVar{
+				{
+					Name:  "BAR",
+					Value: "Hello!",
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "configs"}}},
+				{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secrets"}}},
+			},
+		},
+		{
+			In:  "Precedence is LIFO: ${ACCESS_KEY}",
+			Out: "Precedence is LIFO: Value!",
+			Env: []corev1.EnvVar{},
+			EnvFrom: []corev1.EnvFromSource{
+				{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secrets"}}},
+				{Prefix: "ACCESS_", ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "configs"}}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		expander := EnvExpander{
+			Client:    c,
+			Namespace: "default",
+			Env:       tc.Env,
+			EnvFrom:   tc.EnvFrom,
+		}
+
+		expanded, err := expander.Expand(ctx, tc.In)
+		assert.NoError(t, err)
+
+		assert.Equal(t, tc.Out, expanded)
+	}
+}

--- a/operator/tests/e2e-v2/connectors/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/connectors/00-assert-create-redpanda.yaml
@@ -19,6 +19,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: rp-connectors
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/decommission/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/decommission/00-assert-create-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: decommission
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/decommission/01-assert-scale-down-redpanda.yaml
+++ b/operator/tests/e2e-v2/decommission/01-assert-scale-down-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: decommission
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/decommission/02-assert-scale-down-redpanda.yaml
+++ b/operator/tests/e2e-v2/decommission/02-assert-scale-down-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: decommission
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/disable-helm-controllers/02-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/disable-helm-controllers/02-assert-create-redpanda.yaml
@@ -14,6 +14,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/node-deleted/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/node-deleted/00-assert-create-redpanda.yaml
@@ -13,6 +13,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-node-deleted
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/resource-redpanda-crud/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/resource-redpanda-crud/00-assert-create-redpanda.yaml
@@ -17,6 +17,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/resource-redpanda-crud/01-assert-update-chart-version.yaml
+++ b/operator/tests/e2e-v2/resource-redpanda-crud/01-assert-update-chart-version.yaml
@@ -17,6 +17,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/resource-redpanda-crud/02-assert-update-clusterspec.yaml
+++ b/operator/tests/e2e-v2/resource-redpanda-crud/02-assert-update-clusterspec.yaml
@@ -17,6 +17,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/resource-topic-crud/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/resource-topic-crud/00-assert-create-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-topic
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/upgrade-rollback/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/upgrade-rollback/00-assert-create-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-rollback
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/upgrade-rollback/01-assert-upgrade-bad-redpanda.yaml
+++ b/operator/tests/e2e-v2/upgrade-rollback/01-assert-upgrade-bad-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: ArtifactFailed
       status: "False"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-rollback
   helmReleaseReady: false
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/upgrade-rollback/02-assert-upgrade-good-redpanda.yaml
+++ b/operator/tests/e2e-v2/upgrade-rollback/02-assert-upgrade-good-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-rollback
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/upgrade-values-check/00-assert-create-redpanda.yaml
+++ b/operator/tests/e2e-v2/upgrade-values-check/00-assert-create-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-values-check
   helmReleaseReady: true
   helmRepository: redpanda-repository

--- a/operator/tests/e2e-v2/upgrade-values-check/01-assert-upgrade-redpanda.yaml
+++ b/operator/tests/e2e-v2/upgrade-values-check/01-assert-upgrade-redpanda.yaml
@@ -11,6 +11,7 @@ status:
       reason: RedpandaClusterDeployed
       status: "True"
       type: Ready
+    - type: ClusterConfigSynced
   helmRelease: redpanda-values-check
   helmReleaseReady: true
   helmRepository: redpanda-repository


### PR DESCRIPTION
Prior to this commit the "defluxed" operator would not reconcile the cluster configuration as it skips over helm hooks.

This commit adds support for cluster configuration reconciliation from the redpanda controller itself, reusing as much of the job functionality as possible.