### PR TITLE
enable `importas` and `stylecheck` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,15 +9,30 @@ linters:
   - gosec
   - gosimple
   - govet
+  - importas
   - ineffassign
   - misspell
   - staticcheck
+  - stylecheck
   - unused
 
 linters-settings:
+  goimports:
+    local-prefixes: github.com/redpanda-data/redpanda-operator,github.com/redpanda-data/helm-charts
+
   gosec:
     excludes:
     - G115 # integer overflows aren't super likely to be a problem for us and we're really just at the mercy of the APIs we use.
 
     config:
       G306: "0644" # Maximum allowed os.WriteFile Permissions
+
+  importas:
+    alias:
+    - pkg: k8s.io/api/(\w+)/(v\d)
+      alias: $1$2
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+
+  stylecheck:
+    checks: ["*", "-ST1005"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,13 +28,13 @@ tasks:
     cmds:
       # NB: go list -f takes a go template string, It needs to be escaped in
       # taskfile land to get properly passed to go list.
-      - golangci-lint run $(go list -f '{{"{{.Dir}}"}}/...' -m) {{.ARGS}}
+      - golangci-lint run $(go list -f '{{"{{.Dir}}"}}/...' -m) {{.CLI_ARGS}}
 
   lint-fix:
     cmds:
       - task: lint
         vars:
-          ARGS: "--fix"
+          CLI_ARGS: "--fix"
 
   fmt:
     cmds:

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -17,13 +17,14 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/redpanda-data/helm-charts/pkg/helm"
 	_ "github.com/redpanda-data/redpanda-operator/acceptance/steps"
 	framework "github.com/redpanda-data/redpanda-operator/harpoon"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (

--- a/acceptance/steps/cluster.go
+++ b/acceptance/steps/cluster.go
@@ -13,10 +13,11 @@ import (
 	"context"
 	"time"
 
-	framework "github.com/redpanda-data/redpanda-operator/harpoon"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func checkClusterAvailability(ctx context.Context, t framework.TestingT, clusterName string) {

--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -19,12 +19,6 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/redpanda-data/common-go/rpadmin"
-	"github.com/redpanda-data/helm-charts/pkg/kube"
-	framework "github.com/redpanda-data/redpanda-operator/harpoon"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -34,6 +28,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/users"
 )
 
 type clusterClients struct {

--- a/acceptance/steps/manifest.go
+++ b/acceptance/steps/manifest.go
@@ -14,8 +14,9 @@ import (
 	"os"
 
 	"github.com/cucumber/godog"
-	framework "github.com/redpanda-data/redpanda-operator/harpoon"
 	"github.com/stretchr/testify/require"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
 )
 
 func iApplyKubernetesManifest(ctx context.Context, t framework.TestingT, manifest *godog.DocString) {

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -12,10 +12,11 @@ package steps
 import (
 	"context"
 
-	framework "github.com/redpanda-data/redpanda-operator/harpoon"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schema string) {

--- a/acceptance/steps/topics.go
+++ b/acceptance/steps/topics.go
@@ -12,11 +12,12 @@ package steps
 import (
 	"context"
 
-	framework "github.com/redpanda-data/redpanda-operator/harpoon"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func topicIsSuccessfullySynced(ctx context.Context, t framework.TestingT, topic string) {

--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -14,12 +14,13 @@ import (
 	"fmt"
 
 	"github.com/cucumber/godog"
-	framework "github.com/redpanda-data/redpanda-operator/harpoon"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 func userIsSuccessfullySynced(ctx context.Context, t framework.TestingT, user string) {

--- a/harpoon/internal/testing/helm.go
+++ b/harpoon/internal/testing/helm.go
@@ -12,9 +12,10 @@ package testing
 import (
 	"context"
 
-	"github.com/redpanda-data/helm-charts/pkg/helm"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
+
+	"github.com/redpanda-data/helm-charts/pkg/helm"
 )
 
 func (t *TestingT) InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions) {

--- a/harpoon/internal/tracking/features.go
+++ b/harpoon/internal/tracking/features.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/formatters"
 	messages "github.com/cucumber/messages/go/v21"
+
 	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 )
 

--- a/harpoon/internal/tracking/scenarios.go
+++ b/harpoon/internal/tracking/scenarios.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/cucumber/godog"
+
 	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 )
 

--- a/harpoon/steps.go
+++ b/harpoon/steps.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 
 	"github.com/cucumber/godog"
+
 	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 )
 

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/redpanda-data/helm-charts/pkg/helm"
 	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 	"github.com/redpanda-data/redpanda-operator/harpoon/internal/tracking"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func setShortTimeout(timeout *time.Duration, short time.Duration) {

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -16,10 +16,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
-	"github.com/redpanda-data/helm-charts/pkg/helm"
-	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/helm-charts/pkg/helm"
+	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 )
 
 // Redefine the interfaces from the internal package

--- a/operator/api/apiutil/apiutil_test.go
+++ b/operator/api/apiutil/apiutil_test.go
@@ -14,8 +14,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 )
 
 func TestJSONBoolean(t *testing.T) {

--- a/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
@@ -11,11 +11,12 @@ package v1alpha2
 
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 )
 
 // RedpandaClusterSpec defines the desired state of a Redpanda cluster. These settings are the same as those defined in the Redpanda Helm chart. The values in these settings are passed to the Redpanda Helm chart through Flux. For all default values and links to more documentation, see https://docs.redpanda.com/current/reference/redpanda-helm-spec/.

--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -16,14 +16,15 @@ import (
 	"github.com/cockroachdb/errors"
 	helmv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
 	"github.com/fluxcd/pkg/apis/meta"
-	redpandachart "github.com/redpanda-data/helm-charts/charts/redpanda"
-	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
-	"github.com/redpanda-data/helm-charts/pkg/kube"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
+
+	redpandachart "github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
 
 	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )

--- a/operator/api/redpanda/v1alpha2/redpanda_types_test.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types_test.go
@@ -17,13 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redpanda-data/helm-charts/charts/connectors"
-	"github.com/redpanda-data/helm-charts/charts/console"
-	"github.com/redpanda-data/helm-charts/charts/redpanda"
-	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,6 +27,14 @@ import (
 	"k8s.io/utils/ptr"
 	"pgregory.net/rapid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/helm-charts/charts/connectors"
+	"github.com/redpanda-data/helm-charts/charts/console"
+	"github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
+	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 )
 
 var (

--- a/operator/api/redpanda/v1alpha2/schema_types.go
+++ b/operator/api/redpanda/v1alpha2/schema_types.go
@@ -13,10 +13,11 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 	"github.com/twmb/franz-go/pkg/sr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 )
 
 func init() {

--- a/operator/api/redpanda/v1alpha2/schema_types_test.go
+++ b/operator/api/redpanda/v1alpha2/schema_types_test.go
@@ -14,12 +14,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 )
 
 func TestSchemaValidation(t *testing.T) {

--- a/operator/api/redpanda/v1alpha2/user_types.go
+++ b/operator/api/redpanda/v1alpha2/user_types.go
@@ -14,13 +14,14 @@ import (
 	"errors"
 	"slices"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 )
 
 func init() {

--- a/operator/cmd/configurator/configurator_test.go
+++ b/operator/cmd/configurator/configurator_test.go
@@ -12,9 +12,10 @@ package configurator
 import (
 	"testing"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 )
 
 func TestPopulateRack(t *testing.T) {

--- a/operator/cmd/envsubst/envsubst_test.go
+++ b/operator/cmd/envsubst/envsubst_test.go
@@ -14,9 +14,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/envsubst"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils/testutils"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCommand(t *testing.T) {

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -14,13 +14,14 @@ import (
 	"os"
 
 	"github.com/fluxcd/pkg/runtime/logger"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/configurator"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/envsubst"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/run"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/version"
-	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var (

--- a/operator/cmd/syncclusterconfig/sync_test.go
+++ b/operator/cmd/syncclusterconfig/sync_test.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/redpanda-data/common-go/rpadmin"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils/testutils"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
+
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils/testutils"
 )
 
 func TestSync(t *testing.T) {

--- a/operator/config/crd/bases/crds.go
+++ b/operator/config/crd/bases/crds.go
@@ -16,9 +16,10 @@ import (
 	"io/fs"
 
 	"github.com/cockroachdb/errors"
-	"github.com/redpanda-data/helm-charts/pkg/kube"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/redpanda-data/helm-charts/pkg/kube"
 )
 
 var (

--- a/operator/config/crd/bases/crds_test.go
+++ b/operator/config/crd/bases/crds_test.go
@@ -12,8 +12,9 @@ package crds_test
 import (
 	"testing"
 
-	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"github.com/stretchr/testify/require"
+
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 )
 
 func TestCRDS(t *testing.T) {

--- a/operator/internal/controller/redpanda/index.go
+++ b/operator/internal/controller/redpanda/index.go
@@ -15,8 +15,6 @@ import (
 	"reflect"
 	"slices"
 
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,6 +23,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
 )
 
 type clientList[T client.Object] interface {

--- a/operator/internal/controller/redpanda/managed_decommission_controller.go
+++ b/operator/internal/controller/redpanda/managed_decommission_controller.go
@@ -30,6 +30,7 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	"github.com/redpanda-data/helm-charts/charts/redpanda"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/helm-charts/pkg/kube"

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -25,16 +25,6 @@ import (
 	fluxclient "github.com/fluxcd/pkg/runtime/client"
 	sourcecontrollerv1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/go-logr/logr/testr"
-	redpandachart "github.com/redpanda-data/helm-charts/charts/redpanda"
-	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
-	"github.com/redpanda-data/helm-charts/pkg/kube"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/flux"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -50,6 +40,17 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpandachart "github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/flux"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 // operatorRBAC is the ClusterRole and Role generated via controller-gen and
@@ -329,10 +330,10 @@ func (s *RedpandaControllerSuite) TestClusterSettings() {
 	s.applyAndWait(rp)
 
 	setConfig := func(cfg map[string]any) {
-		asJson, err := json.Marshal(cfg)
+		asJSON, err := json.Marshal(cfg)
 		s.Require().NoError(err)
 
-		rp.Spec.ClusterSpec.Config.Cluster = &runtime.RawExtension{Raw: asJson}
+		rp.Spec.ClusterSpec.Config.Cluster = &runtime.RawExtension{Raw: asJSON}
 		s.applyAndWait(rp)
 		s.applyAndWaitFor(func(o client.Object) bool {
 			rp := o.(*redpandav1alpha2.Redpanda)

--- a/operator/internal/controller/redpanda/redpanda_controller_utils.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_utils.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 const (

--- a/operator/internal/controller/redpanda/resource_controller.go
+++ b/operator/internal/controller/redpanda/resource_controller.go
@@ -16,13 +16,14 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 const fieldOwner client.FieldOwner = "redpanda-operator"

--- a/operator/internal/controller/redpanda/resource_controller_test.go
+++ b/operator/internal/controller/redpanda/resource_controller_test.go
@@ -17,9 +17,6 @@ import (
 	"testing"
 	"time"
 
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +27,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 type ResourceReconcilerTestEnvironment[T any, U Resource[T]] struct {

--- a/operator/internal/controller/redpanda/schema_controller.go
+++ b/operator/internal/controller/redpanda/schema_controller.go
@@ -14,14 +14,15 @@ import (
 	"context"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/kubernetes"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //+kubebuilder:rbac:groups=cluster.redpanda.com,resources=schemas,verbs=get;list;watch;update;patch

--- a/operator/internal/controller/redpanda/schema_controller_test.go
+++ b/operator/internal/controller/redpanda/schema_controller_test.go
@@ -16,12 +16,13 @@ import (
 	"testing"
 	"time"
 
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func TestSchemaReconcile(t *testing.T) { // nolint:funlen // These tests have clear subtests.

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -134,7 +134,7 @@ func (r *TopicReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *TopicReconciler) reconcile(ctx context.Context, topic *redpandav1alpha2.Topic, l logr.Logger) (*redpandav1alpha2.Topic, ctrl.Result, error) {
 	l = l.WithName("reconcile")
 
-	interval := v1.Duration{Duration: time.Second * 3}
+	interval := metav1.Duration{Duration: time.Second * 3}
 	if topic.Spec.SynchronizationInterval != nil {
 		interval = *topic.Spec.SynchronizationInterval
 	}

--- a/operator/internal/controller/redpanda/user_controller.go
+++ b/operator/internal/controller/redpanda/user_controller.go
@@ -14,6 +14,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/twmb/franz-go/pkg/kgo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
@@ -21,11 +27,6 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/kubernetes"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/users"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
-	"github.com/twmb/franz-go/pkg/kgo"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //+kubebuilder:rbac:groups=cluster.redpanda.com,resources=users,verbs=get;list;watch;update;patch

--- a/operator/internal/controller/redpanda/user_controller_test.go
+++ b/operator/internal/controller/redpanda/user_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -25,6 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func TestUserReconcile(t *testing.T) { // nolint:funlen // These tests have clear subtests.

--- a/operator/internal/controller/scheme.go
+++ b/operator/internal/controller/scheme.go
@@ -16,12 +16,13 @@ import (
 	sourceControllerAPIv1 "github.com/fluxcd/source-controller/api/v1"
 	sourceControllerAPIv1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
 var (

--- a/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
+++ b/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
@@ -16,13 +16,14 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/nodepools"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/certmanager"
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 type attachedResources struct {

--- a/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"

--- a/operator/internal/controller/vectorized/console_controller.go
+++ b/operator/internal/controller/vectorized/console_controller.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -333,7 +333,7 @@ func (r *ConsoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}, builder.WithPredicates(utils.DeletePredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
-		Owns(&netv1.Ingress{}).
+		Owns(&networkingv1.Ingress{}).
 		Watches(
 			&vectorizedv1alpha1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.reconcileConsoleForCluster),

--- a/operator/internal/controller/vectorized/pvcunbinder_test.go
+++ b/operator/internal/controller/vectorized/pvcunbinder_test.go
@@ -15,8 +15,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr/testr"
-	"github.com/redpanda-data/helm-charts/pkg/testutil"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/redpanda-data/helm-charts/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 )
 
 func TestPVCUnbinderShouldRemediate(t *testing.T) {

--- a/operator/internal/controller/vectorized/test/cluster_controller_configuration_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_configuration_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/configuration"

--- a/operator/internal/controller/vectorized/test/cluster_controller_scale_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_scale_test.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"
 )

--- a/operator/internal/controller/vectorized/test/cluster_controller_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_test.go
@@ -18,10 +18,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	types2 "github.com/onsi/gomega/types"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
 
 	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
@@ -226,7 +227,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Creating ClusterRole")
-			var cr v1.ClusterRole
+			var cr rbacv1.ClusterRole
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), clusterRoleKey, &cr)
 				return err == nil &&
@@ -235,7 +236,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Creating ClusterRoleBinding")
-			var crb v1.ClusterRoleBinding
+			var crb rbacv1.ClusterRoleBinding
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), clusterRoleKey, &crb)
 				found := false

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/redpanda-data/common-go/rpadmin"
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -38,6 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 
 	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"

--- a/operator/internal/testenv/owned_client.go
+++ b/operator/internal/testenv/owned_client.go
@@ -50,10 +50,10 @@ func (n *ownedClient) Patch(ctx context.Context, obj client.Object, patch client
 	return n.Client.Patch(ctx, obj, patch, opts...)
 }
 
-func (c *ownedClient) maybeAddOwnerRef(obj client.Object) {
+func (n *ownedClient) maybeAddOwnerRef(obj client.Object) {
 	// We don't care about namespace objects as deleting the namespace will GC
 	// them.
-	if ok, _ := c.IsObjectNamespaced(obj); ok {
+	if ok, _ := n.IsObjectNamespaced(obj); ok {
 		return
 	}
 
@@ -63,5 +63,5 @@ func (c *ownedClient) maybeAddOwnerRef(obj client.Object) {
 	}
 
 	// Otherwise inject a reference to our owner.
-	obj.SetOwnerReferences([]metav1.OwnerReference{*c.owner.DeepCopy()})
+	obj.SetOwnerReferences([]metav1.OwnerReference{*n.owner.DeepCopy()})
 }

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -16,8 +16,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/redpanda-data/helm-charts/pkg/testutil"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -35,6 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/redpanda-data/helm-charts/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 )
 
 const k3dClusterName = "testenv"

--- a/operator/internal/testutils/delete_all_in_namespace.go
+++ b/operator/internal/testutils/delete_all_in_namespace.go
@@ -17,7 +17,7 @@ import (
 
 	//nolint:stylecheck // gomega
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,7 +39,7 @@ func DeleteAllInNamespace(testEnv *RedpandaTestEnv, k8sClient client.Client, nam
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, obj))).Should(Succeed())
 
 		//nolint:nestif // this is not as complex as it looks
-		if ns, ok := obj.(*v1.Namespace); ok {
+		if ns, ok := obj.(*corev1.Namespace); ok {
 			// Normally the kube-controller-manager would handle finalization
 			// and garbage collection of namespaces, but with envtest, we aren't
 			// running a kube-controller-manager. Instead we're gonna approximate
@@ -96,7 +96,7 @@ func DeleteAllInNamespace(testEnv *RedpandaTestEnv, k8sClient client.Client, nam
 				}
 				// remove `kubernetes` finalizer
 				const kubernetes = "kubernetes"
-				finalizers := []v1.FinalizerName{}
+				finalizers := []corev1.FinalizerName{}
 				for _, f := range ns.Spec.Finalizers {
 					if f != kubernetes {
 						finalizers = append(finalizers, f)

--- a/operator/internal/testutils/setup_envtest.go
+++ b/operator/internal/testutils/setup_envtest.go
@@ -17,9 +17,10 @@ import (
 	"runtime"
 	"strings"
 
-	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 )
 
 // /internal/testutils is a depth of 2

--- a/operator/pkg/admin/admin.go
+++ b/operator/pkg/admin/admin.go
@@ -18,12 +18,13 @@ import (
 	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
-	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
 	"github.com/scalalang2/golang-fifo/sieve"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
 )
 
 // NoInternalAdminAPI signal absence of the internal admin API endpoint

--- a/operator/pkg/client/acls/rules.go
+++ b/operator/pkg/client/acls/rules.go
@@ -10,9 +10,10 @@
 package acls
 
 import (
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"k8s.io/utils/ptr"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 type rule struct {

--- a/operator/pkg/client/acls/set.go
+++ b/operator/pkg/client/acls/set.go
@@ -10,9 +10,10 @@
 package acls
 
 import (
+	"github.com/twmb/franz-go/pkg/kmsg"
+
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
-	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func rulesetFromDescribeResponse(acls []kmsg.DescribeACLsResponseResource) collections.Set[rule] {

--- a/operator/pkg/client/acls/syncer.go
+++ b/operator/pkg/client/acls/syncer.go
@@ -13,11 +13,12 @@ import (
 	"context"
 	"fmt"
 
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
 )
 
 // Syncer synchronizes ACLs for the given object to Redpanda.

--- a/operator/pkg/client/acls/syncer_test.go
+++ b/operator/pkg/client/acls/syncer_test.go
@@ -15,12 +15,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"k8s.io/utils/ptr"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func TestSyncer(t *testing.T) {

--- a/operator/pkg/client/cluster.go
+++ b/operator/pkg/client/cluster.go
@@ -12,12 +12,13 @@ package client
 import (
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/console/backend/pkg/config"
-	"github.com/redpanda-data/helm-charts/pkg/redpanda"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
+
+	"github.com/redpanda-data/helm-charts/pkg/redpanda"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 // RedpandaAdminForCluster returns a simple kgo.Client able to communicate with the given cluster specified via a Redpanda cluster.

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -14,11 +14,6 @@ import (
 	"errors"
 
 	"github.com/redpanda-data/common-go/rpadmin"
-	"github.com/redpanda-data/helm-charts/pkg/redpanda"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/schemas"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/users"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
@@ -26,6 +21,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/helm-charts/pkg/redpanda"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/schemas"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/users"
 )
 
 var (

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -20,12 +20,6 @@ import (
 	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
-	"github.com/redpanda-data/helm-charts/pkg/helm"
-	"github.com/redpanda-data/helm-charts/pkg/kube"
-	"github.com/redpanda-data/helm-charts/pkg/testutil"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +28,13 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/redpanda-data/helm-charts/pkg/helm"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	"github.com/redpanda-data/helm-charts/pkg/testutil"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 )
 
 var chartVersion = ""

--- a/operator/pkg/client/schemas/schema.go
+++ b/operator/pkg/client/schemas/schema.go
@@ -13,9 +13,10 @@ import (
 	"reflect"
 	"slices"
 
+	"github.com/twmb/franz-go/pkg/sr"
+
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
-	"github.com/twmb/franz-go/pkg/sr"
 )
 
 type schema struct {

--- a/operator/pkg/client/schemas/syncer.go
+++ b/operator/pkg/client/schemas/syncer.go
@@ -13,8 +13,9 @@ import (
 	"context"
 	"errors"
 
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/twmb/franz-go/pkg/sr"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 // Syncer synchronizes Schemas for the given object to Redpanda.

--- a/operator/pkg/client/schemas/syncer_test.go
+++ b/operator/pkg/client/schemas/syncer_test.go
@@ -14,12 +14,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 	"github.com/twmb/franz-go/pkg/sr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 const (

--- a/operator/pkg/client/spec.go
+++ b/operator/pkg/client/spec.go
@@ -18,12 +18,13 @@ import (
 
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/console/backend/pkg/config"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 // KafkaForSpec returns a simple kgo.Client able to communicate with the given cluster specified via KafkaAPISpec.

--- a/operator/pkg/client/spec_sasl.go
+++ b/operator/pkg/client/spec_sasl.go
@@ -17,7 +17,6 @@ import (
 	krbconfig "github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/keytab"
 	"github.com/redpanda-data/console/backend/pkg/config"
-	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/aws"
@@ -27,6 +26,8 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func (c *Factory) configureAdminSpecSASL(ctx context.Context, namespace string, spec *redpandav1alpha2.AdminAPISpec) (username, password, token string, err error) {

--- a/operator/pkg/client/spec_tls.go
+++ b/operator/pkg/client/spec_tls.go
@@ -17,9 +17,10 @@ import (
 	"fmt"
 	"net"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/redpanda-data/helm-charts/pkg/redpanda"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func wrapTLSDialer(dialer redpanda.DialContextFunc, config *tls.Config) redpanda.DialContextFunc {

--- a/operator/pkg/client/users/client_test.go
+++ b/operator/pkg/client/users/client_test.go
@@ -16,8 +16,6 @@ import (
 	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -29,6 +27,9 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 )
 
 func TestClient(t *testing.T) {

--- a/operator/pkg/console/deployment.go
+++ b/operator/pkg/console/deployment.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,7 +76,7 @@ func (d *Deployment) Ensure(ctx context.Context) error {
 	}
 
 	objLabels := labels.ForConsole(d.consoleobj)
-	obj := &v1.Deployment{
+	obj := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      d.consoleobj.GetName(),
 			Namespace: d.consoleobj.GetNamespace(),
@@ -86,7 +86,7 @@ func (d *Deployment) Ensure(ctx context.Context) error {
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &d.consoleobj.Spec.Deployment.Replicas,
 			Selector: objLabels.AsAPISelector(),
 			Template: corev1.PodTemplateSpec{
@@ -101,9 +101,9 @@ func (d *Deployment) Ensure(ctx context.Context) error {
 					ImagePullSecrets:              d.consoleobj.Spec.Deployment.ImagePullSecrets,
 				},
 			},
-			Strategy: v1.DeploymentStrategy{
-				Type: v1.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &v1.RollingUpdateDeployment{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
 					MaxUnavailable: &intstr.IntOrString{
 						Type:   intstr.Int,
 						IntVal: d.consoleobj.Spec.Deployment.MaxUnavailable,
@@ -129,7 +129,7 @@ func (d *Deployment) Ensure(ctx context.Context) error {
 
 	if !created {
 		// Update resource if not created.
-		var current v1.Deployment
+		var current appsv1.Deployment
 		err = d.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, &current)
 		if err != nil {
 			return fmt.Errorf("fetching Console deployment: %w", err)

--- a/operator/pkg/console/deployment_internal_test.go
+++ b/operator/pkg/console/deployment_internal_test.go
@@ -19,8 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
 func TestGenEnvVars(t *testing.T) { //nolint:funlen // test table is long

--- a/operator/pkg/k3d/k3d.go
+++ b/operator/pkg/k3d/k3d.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/redpanda-data/helm-charts/pkg/kube"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,6 +34,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	"github.com/redpanda-data/helm-charts/pkg/kube"
 )
 
 const (

--- a/operator/pkg/kube/envexpander_test.go
+++ b/operator/pkg/kube/envexpander_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -32,7 +32,7 @@ func TestEnvExpander(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, c.Create(ctx, &corev1.ConfigMap{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "configs",
 			Namespace: "default",
 		},
@@ -43,7 +43,7 @@ func TestEnvExpander(t *testing.T) {
 	}))
 
 	require.NoError(t, c.Create(ctx, &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secrets",
 			Namespace: "default",
 		},

--- a/operator/pkg/nodepools/pools.go
+++ b/operator/pkg/nodepools/pools.go
@@ -23,12 +23,13 @@ import (
 	"slices"
 	"strings"
 
-	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 )
 
 // GetNodePools gets all NodePoolSpecs within a cluster.

--- a/operator/pkg/patch/patch.go
+++ b/operator/pkg/patch/patch.go
@@ -16,8 +16,9 @@ import (
 	"context"
 	"fmt"
 
-	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
 // PatchStatus persforms a mutation as done by mutator, calls k8s-api with PATCH, and then returns the

--- a/operator/pkg/resources/certmanager/keystore_password.go
+++ b/operator/pkg/resources/certmanager/keystore_password.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -75,7 +75,7 @@ func (r *KeystoreSecretResource) Ensure(ctx context.Context) error {
 // obj returns secret that consist password for jks and pkcs#12 keystores
 func (r *KeystoreSecretResource) obj() (k8sclient.Object, error) {
 	objLabels := labels.ForCluster(r.pandaCluster)
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Key().Name,
 			Namespace: r.Key().Namespace,

--- a/operator/pkg/resources/certmanager/type_helpers_test.go
+++ b/operator/pkg/resources/certmanager/type_helpers_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -34,7 +34,7 @@ import (
 //nolint:funlen // the subtests might causes linter to complain
 func TestClusterCertificates(t *testing.T) {
 	secret := corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster-tls-secret-node-certificate",
 			Namespace: "cert-manager",
 		},
@@ -45,7 +45,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 	}
 	issuer := cmapiv1.Issuer{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "issuer",
 			Namespace: "test",
 		},
@@ -91,7 +91,7 @@ func TestClusterCertificates(t *testing.T) {
 		expectedBrokerTLS *config.ServerTLS
 	}{
 		{"kafka tls disabled", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -105,7 +105,7 @@ func TestClusterCertificates(t *testing.T) {
 			},
 		}, []string{}, 0, nil, nil},
 		{"kafka tls", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -130,7 +130,7 @@ func TestClusterCertificates(t *testing.T) {
 			TruststoreFile: "/etc/tls/certs/ca.crt",
 		}},
 		{"kafka tls on external only", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -149,7 +149,7 @@ func TestClusterCertificates(t *testing.T) {
 			return true
 		}, nil},
 		{"kafka tls with two tls listeners", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -174,7 +174,7 @@ func TestClusterCertificates(t *testing.T) {
 			TruststoreFile: "/etc/tls/certs/ca.crt",
 		}},
 		{"kafka tls with external node issuer", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -206,7 +206,7 @@ func TestClusterCertificates(t *testing.T) {
 			Enabled: true,
 		}},
 		{"kafka mutual tls", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -255,7 +255,7 @@ func TestClusterCertificates(t *testing.T) {
 			TruststoreFile: "/etc/tls/certs/ca.crt",
 		}},
 		{"kafka mutual tls with two tls listeners", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					KafkaAPI: []v1alpha1.KafkaAPI{
@@ -275,7 +275,7 @@ func TestClusterCertificates(t *testing.T) {
 			TruststoreFile: "/etc/tls/certs/ca.crt",
 		}},
 		{"admin api tls disabled", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					AdminAPI: []v1alpha1.AdminAPI{
@@ -289,7 +289,7 @@ func TestClusterCertificates(t *testing.T) {
 			},
 		}, []string{}, 0, nil, nil},
 		{"admin api tls", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					AdminAPI: []v1alpha1.AdminAPI{
@@ -303,7 +303,7 @@ func TestClusterCertificates(t *testing.T) {
 			},
 		}, []string{"test-admin-selfsigned-issuer", "test-admin-root-certificate", "test-admin-root-issuer", "test-admin-api-node"}, 1, nil, nil},
 		{"admin api mutual tls", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					AdminAPI: []v1alpha1.AdminAPI{
@@ -318,7 +318,7 @@ func TestClusterCertificates(t *testing.T) {
 			},
 		}, []string{"test-admin-selfsigned-issuer", "test-admin-root-certificate", "test-admin-root-issuer", "test-admin-api-node", "test-admin-api-client"}, 2, nil, nil},
 		{"pandaproxy api tls disabled", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					PandaproxyAPI: []v1alpha1.PandaproxyAPI{
@@ -333,7 +333,7 @@ func TestClusterCertificates(t *testing.T) {
 		}, []string{}, 0, nil, nil},
 		{
 			"pandaproxy api tls", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						PandaproxyAPI: []v1alpha1.PandaproxyAPI{
@@ -351,7 +351,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 		{
 			"pandaproxy api mutual tls", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						PandaproxyAPI: []v1alpha1.PandaproxyAPI{
@@ -371,7 +371,7 @@ func TestClusterCertificates(t *testing.T) {
 		{
 			"pandaproxy api mutual tls with external ca provided by customer",
 			&v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						PandaproxyAPI: []v1alpha1.PandaproxyAPI{
@@ -394,7 +394,7 @@ func TestClusterCertificates(t *testing.T) {
 		{
 			"pandaproxy api mutual tls with external ca provided by customer and external node issuer",
 			&v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						PandaproxyAPI: []v1alpha1.PandaproxyAPI{
@@ -419,7 +419,7 @@ func TestClusterCertificates(t *testing.T) {
 			2, validateVolumesFn("tlspandaproxycert", []string{"tls.crt", "tls.key"}), nil,
 		},
 		{"schematregistry api tls disabled", &v1alpha1.Cluster{
-			ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 			Spec: v1alpha1.ClusterSpec{
 				Configuration: v1alpha1.RedpandaConfig{
 					SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
@@ -432,7 +432,7 @@ func TestClusterCertificates(t *testing.T) {
 		}, []string{}, 0, nil, nil},
 		{
 			"schematregistry api tls", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
@@ -448,7 +448,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 		{
 			"schematregistry api mutual tls", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
@@ -465,7 +465,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 		{
 			"schematregistry with tls, nodesecretref and without requireClientAuth", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
@@ -486,7 +486,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 		{
 			"kafka and schematregistry with nodesecretref", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
@@ -524,7 +524,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 		{
 			"schematregistry api mutual tls with external ca provided by customer", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
@@ -544,7 +544,7 @@ func TestClusterCertificates(t *testing.T) {
 		},
 		{
 			"schematregistry api mutual tls with external ca provided by customer and external node issuer", &v1alpha1.Cluster{
-				ObjectMeta: v1.ObjectMeta{Name: "test", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 				Spec: v1alpha1.ClusterSpec{
 					Configuration: v1alpha1.RedpandaConfig{
 						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{

--- a/operator/pkg/resources/cluster_role.go
+++ b/operator/pkg/resources/cluster_role.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -57,7 +57,7 @@ func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	if err != nil || created {
 		return err
 	}
-	var cr v1.ClusterRole
+	var cr rbacv1.ClusterRole
 	err = r.Get(ctx, r.Key(), &cr)
 	if err != nil {
 		return fmt.Errorf("error while fetching ClusterRole resource: %w", err)
@@ -71,7 +71,7 @@ func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 // The cluster.redpanda.vectorized.io custom resource is namespaced resource, that's
 // why v1.ClusterRole can not have assigned controller reference.
 func (r *ClusterRoleResource) obj() k8sclient.Object {
-	return &v1.ClusterRole{
+	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			// metav1.ObjectMeta can NOT have namespace set as
 			// ClusterRole is the cluster wide resource.
@@ -82,7 +82,7 @@ func (r *ClusterRoleResource) obj() k8sclient.Object {
 			Kind:       "ClusterRole",
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
-		Rules: []v1.PolicyRule{
+		Rules: []rbacv1.PolicyRule{
 			{
 				Verbs:     []string{"get"},
 				APIGroups: []string{corev1.GroupName},

--- a/operator/pkg/resources/cluster_role_binding.go
+++ b/operator/pkg/resources/cluster_role_binding.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,7 +52,7 @@ func NewClusterRoleBinding(
 
 // Ensure manages v1.ClusterRoleBinding that is assigned to v1.ServiceAccount used in initContainer
 func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
-	var crb v1.ClusterRoleBinding
+	var crb rbacv1.ClusterRoleBinding
 
 	err := r.Get(ctx, r.Key(), &crb)
 	if err != nil && !errors.IsNotFound(err) {
@@ -85,7 +85,7 @@ func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
 		}
 	}
 	if !found {
-		crb.Subjects = append(crb.Subjects, v1.Subject{
+		crb.Subjects = append(crb.Subjects, rbacv1.Subject{
 			Kind:      "ServiceAccount",
 			Name:      sa.Key().Name,
 			Namespace: sa.Key().Namespace,
@@ -104,7 +104,7 @@ func (r *ClusterRoleBindingResource) Obj() (k8sclient.Object, error) {
 	role := &ClusterRoleResource{}
 	sa := &ServiceAccountResource{pandaCluster: r.pandaCluster}
 
-	return &v1.ClusterRoleBinding{
+	return &rbacv1.ClusterRoleBinding{
 		// metav1.ObjectMeta can NOT have namespace set as
 		// ClusterRoleBinding is the cluster wide resource.
 		ObjectMeta: metav1.ObjectMeta{
@@ -115,15 +115,15 @@ func (r *ClusterRoleBindingResource) Obj() (k8sclient.Object, error) {
 			Kind:       "ClusterRoleBinding",
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
-		Subjects: []v1.Subject{
+		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      sa.Key().Name,
 				Namespace: sa.Key().Namespace,
 			},
 		},
-		RoleRef: v1.RoleRef{
-			APIGroup: v1.GroupName,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
 			Name:     role.Key().Name,
 		},
@@ -141,7 +141,7 @@ func (r *ClusterRoleBindingResource) Key() types.NamespacedName {
 func (r *ClusterRoleBindingResource) RemoveSubject(
 	ctx context.Context, cluster types.NamespacedName,
 ) error {
-	var crb v1.ClusterRoleBinding
+	var crb rbacv1.ClusterRoleBinding
 
 	err := r.Get(ctx, r.Key(), &crb)
 	if errors.IsNotFound(err) {

--- a/operator/pkg/resources/configmap_test.go
+++ b/operator/pkg/resources/configmap_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -81,7 +81,7 @@ func TestEnsureConfigMap(t *testing.T) {
 	for i, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().Build()
-			secret := v1.Secret{
+			secret := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "archival",
 					Namespace: "default",
@@ -102,7 +102,7 @@ func TestEnsureConfigMap(t *testing.T) {
 				ctrl.Log.WithName("test"))
 			require.NoError(t, cfgRes.Ensure(context.TODO()))
 
-			actual := &v1.ConfigMap{}
+			actual := &corev1.ConfigMap{}
 			err := c.Get(context.Background(), cfgRes.Key(), actual)
 			require.NoError(t, err)
 			data := actual.Data["redpanda.yaml"]
@@ -155,7 +155,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 			panda := pandaCluster().DeepCopy()
 			panda.Spec.AdditionalConfiguration = tc.additionalConfiguration
 			c := fake.NewClientBuilder().Build()
-			secret := v1.Secret{
+			secret := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "archival",
 					Namespace: "default",
@@ -176,7 +176,7 @@ func TestEnsureConfigMap_AdditionalConfig(t *testing.T) {
 				ctrl.Log.WithName("test"))
 			require.NoError(t, cfgRes.Ensure(context.TODO()))
 
-			actual := &v1.ConfigMap{}
+			actual := &corev1.ConfigMap{}
 			err := c.Get(context.Background(), cfgRes.Key(), actual)
 			require.NoError(t, err)
 			data := actual.Data["redpanda.yaml"]
@@ -338,7 +338,7 @@ func TestConfigmap_BrokerTLSClients(t *testing.T) {
 		{Port: 8082},
 	}
 	c := fake.NewClientBuilder().Build()
-	secret := v1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "archival",
 			Namespace: "default",
@@ -359,7 +359,7 @@ func TestConfigmap_BrokerTLSClients(t *testing.T) {
 		ctrl.Log.WithName("test"))
 	require.NoError(t, cfgRes.Ensure(context.TODO()))
 
-	actual := &v1.ConfigMap{}
+	actual := &corev1.ConfigMap{}
 	err := c.Get(context.Background(), cfgRes.Key(), actual)
 	require.NoError(t, err)
 	data := actual.Data["redpanda.yaml"]

--- a/operator/pkg/resources/resource_integration_test.go
+++ b/operator/pkg/resources/resource_integration_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -109,7 +109,7 @@ func TestEnsure_StatefulSet(t *testing.T) {
 	err = sts.Ensure(context.Background())
 	assert.NoError(t, err)
 
-	actual := &v1.StatefulSet{}
+	actual := &appsv1.StatefulSet{}
 	err = c.Get(context.Background(), sts.Key(), actual)
 	assert.NoError(t, err)
 	originalResourceVersion := actual.ResourceVersion

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -33,13 +33,14 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"
 	resourcetypes "github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 )
 
 var _ Resource = &StatefulSetResource{}

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -109,7 +109,7 @@ func TestEnsure(t *testing.T) {
 		name           string
 		existingObject client.Object
 		pandaCluster   *vectorizedv1alpha1.Cluster
-		expectedObject *v1.StatefulSet
+		expectedObject *appsv1.StatefulSet
 		clusterHealth  bool
 		expectedError  error
 		nodePoolName   string
@@ -197,7 +197,7 @@ func TestEnsure(t *testing.T) {
 					case errors.Is(err, &resources.RequeueAfterError{RequeueAfter: resources.RequeueDuration, Msg: "wait for sts to be deleted"}):
 						// with ownerreferences, a orphan delete adds a finalizer to allow kube-controller-manager to manage the deletion.
 						// for this test, we don't need to worry about that.
-						deleteFinalizer := &v1.StatefulSet{}
+						deleteFinalizer := &appsv1.StatefulSet{}
 						err = c.Get(ctx, sts.Key(), deleteFinalizer)
 						assert.NoError(t, err)
 						deleteFinalizer.Finalizers = nil
@@ -212,7 +212,7 @@ func TestEnsure(t *testing.T) {
 			}
 			cancel()
 
-			actual := &v1.StatefulSet{}
+			actual := &appsv1.StatefulSet{}
 			err = c.Get(context.Background(), sts.Key(), actual)
 			assert.NoError(t, err, tt.name)
 
@@ -253,15 +253,15 @@ func TestEnsure(t *testing.T) {
 	_ = testEnv.Stop()
 }
 
-func defaultNodePoolstsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *v1.StatefulSet {
+func defaultNodePoolstsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *appsv1.StatefulSet {
 	fileSystemMode := corev1.PersistentVolumeFilesystem
 
-	sts := &v1.StatefulSet{
+	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pandaCluster.Namespace,
 			Name:      pandaCluster.Name,
 		},
-		Spec: v1.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pandaCluster.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -351,15 +351,15 @@ func defaultNodePoolstsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *v1
 	return sts
 }
 
-func stsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *v1.StatefulSet {
+func stsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *appsv1.StatefulSet {
 	fileSystemMode := corev1.PersistentVolumeFilesystem
 
-	sts := &v1.StatefulSet{
+	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pandaCluster.Namespace,
 			Name:      pandaCluster.Name,
 		},
-		Spec: v1.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pandaCluster.Spec.NodePools[0].Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -551,8 +551,8 @@ func TestVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		sts := &resources.StatefulSetResource{
-			LastObservedState: &v1.StatefulSet{
-				Spec: v1.StatefulSetSpec{
+			LastObservedState: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: tt.Containers,
@@ -654,8 +654,8 @@ func TestCurrentVersion(t *testing.T) {
 				0,
 				vectorizedv1alpha1.NodePoolSpecWithDeleted{NodePoolSpec: redpanda.Spec.NodePools[0]},
 				true)
-			sts.LastObservedState = &v1.StatefulSet{
-				Spec: v1.StatefulSetSpec{
+			sts.LastObservedState = &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
 					Replicas: &tests[i].expectedReplicas,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{

--- a/operator/pkg/resources/statefulset_update.go
+++ b/operator/pkg/resources/statefulset_update.go
@@ -34,6 +34,7 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"

--- a/operator/pkg/resources/statefulset_update_test.go
+++ b/operator/pkg/resources/statefulset_update_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"

--- a/operator/pkg/utils/patch_test.go
+++ b/operator/pkg/utils/patch_test.go
@@ -17,14 +17,14 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
 )
 
 func TestPatchComputation(t *testing.T) {
 	currObj := corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "res",
 			Annotations: map[string]string{
 				"redpanda.vectorized.io/configmap-hash": "6fb7ad08cabb116f7c1c8dc1127997a0",
@@ -66,7 +66,7 @@ func TestStatefulSetPatchComputation(t *testing.T) {
 	sts := appsv1.StatefulSet{
 		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"a": "b",
 						"c": "d",


### PR DESCRIPTION
Prior to this commit is was possible for double imports to accidentally go unnoticed.

This commit enables the `stylecheck` linter, which catches double imports as well as other minor style issues; enables `importas`, to enforce consistent importing of kubernetes' "versioned" packages; and corrects any discovered issues.