### PR TITLE
Enhance Redpanda spec to execute tpl functionality

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/common v0.55.0
 	github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
-	github.com/redpanda-data/helm-charts v0.0.0-20241030170802-ad1edfc56b70
+	github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/scalalang2/golang-fifo v1.0.2
 	github.com/spf13/afero v1.11.0

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1093,8 +1093,8 @@ github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a4
 github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240/go.mod h1:5KLXArOMFOrwb3BihpFaRNiPCyo9AXsXhvMdUmrCdUg=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19 h1:sJjDhnIbTMOuP4Rnhm1N3GNfgv6BJlocCnGliNvhgbw=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19/go.mod h1:T39OECA7eOlhpHZPBSGg+bpuwtt/G4m03fjBkJ821CM=
-github.com/redpanda-data/helm-charts v0.0.0-20241030170802-ad1edfc56b70 h1:zp9erNYgwkQK7YZOE/dluuuYrdrsNDXM1KXR48k0SLg=
-github.com/redpanda-data/helm-charts v0.0.0-20241030170802-ad1edfc56b70/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
+github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a h1:QrCC2sX/A0ffiJEUJmZhDS8/NWJI4rbcbtCC+NQOGZY=
+github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e h1:8HB05vSCY+0MwjT2DIVq6gJV5iw7nQNIDfMqcc1NEC8=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e/go.mod h1:jF5kbQy3qT/zufL27DE3lecfYTRWeAzSiVmrbDDQwUw=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=


### PR DESCRIPTION
Similarly to https://github.com/redpanda-data/helm-charts/commit/99ca96105c9a68f59e7cc27bea9fdb7b40ee2ac2
Redpanda resource spec have fields that are translated using go tpl engine with
sprig functions.

Few functions like `toToml`, `fromYamlArray`, `fromJsonArray`, `tpl`, `required`
and `include` are not handled.