### PR TITLE
buildkite: remove retrieval of goreleaser pro key

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,6 @@ steps:
             - secret-id: sdlc/prod/buildkite/dockerhub
             - secret-id: sdlc/prod/buildkite/gh_token
             - secret-id: sdlc/prod/buildkite/github_api_token
-            - secret-id: sdlc/prod/buildkite/goreleaser_key
             - secret-id: sdlc/prod/buildkite/grafana_token
             - secret-id: sdlc/prod/buildkite/redpanda_sample_license
             - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
@@ -83,7 +82,6 @@ steps:
             - secret-id: sdlc/prod/buildkite/dockerhub
             - secret-id: sdlc/prod/buildkite/gh_token
             - secret-id: sdlc/prod/buildkite/github_api_token
-            - secret-id: sdlc/prod/buildkite/goreleaser_key
             - secret-id: sdlc/prod/buildkite/grafana_token
             - secret-id: sdlc/prod/buildkite/redpanda_sample_license
             - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,4 @@
-
+---
 env:
   BRANCH_NAME: $BUILDKITE_BRANCH
   PULL_REQUEST: $BUILDKITE_PULL_REQUEST
@@ -8,7 +8,6 @@ env:
   # CI run podman instead of linux. testcontainer's ryuk is reported to not
   # work well with podman.
   TESTCONTAINERS_RYUK_DISABLED: "true"
-
 steps:
   - key: k8s-operator
     label: K8s Operator
@@ -167,20 +166,18 @@ steps:
                 failed: true
                 branches:
                   - main
-
       - key: annotate-v2-testresults
         label: Parse Operator v2 Test Results
         plugins:
           - seek-oss/aws-sm#v2.3.2: *aws-sm-plugin
           - junit-annotate#v2.4.1:
-              artifacts: operator/tests/_e2e_artifacts_v2/kuttl-report.xml 
+              artifacts: operator/tests/_e2e_artifacts_v2/kuttl-report.xml
               report-slowest: 5
         timeout_in_minutes: 0
         agents:
           queue: v6-k8s-builders
         depends_on: k8s-operator-v2
         allow_dependency_failure: true
-
   - group: K8s Operator v2 Helm Jobs
     if: |
       build.tag == null ||
@@ -193,12 +190,13 @@ steps:
           - github_commit_status:
               context: k8s-operator-v2-helm
         commands:
-           # The tests that are generated from `ci` folder of the Redpanda helm chart
-           # generated too many test cases after introduction files with the `-novalues.yaml`
-           # suffix. Those would not be taken by chart testing (`ct`) program, but
-           # `hack/v2-helm-setup.sh` takes all files currently and disables only handful of them.
-#          - ./ci/scripts/run-in-nix-docker.sh task ci:k8s-v2-helm
+          # - ./ci/scripts/run-in-nix-docker.sh task ci:k8s-v2-helm
           - mkdir -p operator/tests/_e2e_helm_artifacts_v2
+          # The tests that are generated from `ci` folder of the Redpanda helm chart
+          # generated too many test cases after introduction files with the `-novalues.yaml`
+          # suffix. Those would not be taken by chart testing (`ct`) program, but
+          # `hack/v2-helm-setup.sh` takes all files currently and disables only handful of them.
+
           - touch operator/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
           - echo Noop
         agents:
@@ -216,7 +214,6 @@ steps:
                 failed: true
                 branches:
                   - main
-
       - key: annotate-v2-helm-testresults
         label: Parse Operator v2 Helm Test Results
         plugins:
@@ -229,4 +226,3 @@ steps:
           queue: v6-k8s-builders
         depends_on: k8s-operator-v2-helm
         allow_dependency_failure: true
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,44 +26,25 @@ steps:
     plugins:
       - seek-oss/aws-sm#v2.3.2: &aws-sm-plugin
           json-to-env:
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/active_directory
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/buildkite_analytics_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/buildkite_api_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/cdt_gcp
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/cdt_runner_aws
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/ci_db
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/cloudsmith
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/dockerhub
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/gh_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/github_api_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/goreleaser_key
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/grafana_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/redpanda_sample_license
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/rpk_test_client
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/seceng_audit_aws
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/slack_vbot_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/teleport_bot_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/test_result_dsn
+            - secret-id: sdlc/prod/buildkite/active_directory
+            - secret-id: sdlc/prod/buildkite/buildkite_analytics_token
+            - secret-id: sdlc/prod/buildkite/buildkite_api_token
+            - secret-id: sdlc/prod/buildkite/cdt_gcp
+            - secret-id: sdlc/prod/buildkite/cdt_runner_aws
+            - secret-id: sdlc/prod/buildkite/ci_db
+            - secret-id: sdlc/prod/buildkite/cloudsmith
+            - secret-id: sdlc/prod/buildkite/dockerhub
+            - secret-id: sdlc/prod/buildkite/gh_token
+            - secret-id: sdlc/prod/buildkite/github_api_token
+            - secret-id: sdlc/prod/buildkite/goreleaser_key
+            - secret-id: sdlc/prod/buildkite/grafana_token
+            - secret-id: sdlc/prod/buildkite/redpanda_sample_license
+            - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
+            - secret-id: sdlc/prod/buildkite/rpk_test_client
+            - secret-id: sdlc/prod/buildkite/seceng_audit_aws
+            - secret-id: sdlc/prod/buildkite/slack_vbot_token
+            - secret-id: sdlc/prod/buildkite/teleport_bot_token
+            - secret-id: sdlc/prod/buildkite/test_result_dsn
       - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
           message: ":cloud: K8s Operator v1 Jobs failed"
           channel_name: "kubernetes-tests"
@@ -92,44 +73,25 @@ steps:
     plugins:
       - seek-oss/aws-sm#v2.3.2: &aws-sm-plugin
           json-to-env:
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/active_directory
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/buildkite_analytics_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/buildkite_api_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/cdt_gcp
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/cdt_runner_aws
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/ci_db
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/cloudsmith
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/dockerhub
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/gh_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/github_api_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/goreleaser_key
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/grafana_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/redpanda_sample_license
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/rpk_test_client
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/seceng_audit_aws
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/slack_vbot_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/teleport_bot_token
-            - json-key: .
-              secret-id: sdlc/prod/buildkite/test_result_dsn
+            - secret-id: sdlc/prod/buildkite/active_directory
+            - secret-id: sdlc/prod/buildkite/buildkite_analytics_token
+            - secret-id: sdlc/prod/buildkite/buildkite_api_token
+            - secret-id: sdlc/prod/buildkite/cdt_gcp
+            - secret-id: sdlc/prod/buildkite/cdt_runner_aws
+            - secret-id: sdlc/prod/buildkite/ci_db
+            - secret-id: sdlc/prod/buildkite/cloudsmith
+            - secret-id: sdlc/prod/buildkite/dockerhub
+            - secret-id: sdlc/prod/buildkite/gh_token
+            - secret-id: sdlc/prod/buildkite/github_api_token
+            - secret-id: sdlc/prod/buildkite/goreleaser_key
+            - secret-id: sdlc/prod/buildkite/grafana_token
+            - secret-id: sdlc/prod/buildkite/redpanda_sample_license
+            - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
+            - secret-id: sdlc/prod/buildkite/rpk_test_client
+            - secret-id: sdlc/prod/buildkite/seceng_audit_aws
+            - secret-id: sdlc/prod/buildkite/slack_vbot_token
+            - secret-id: sdlc/prod/buildkite/teleport_bot_token
+            - secret-id: sdlc/prod/buildkite/test_result_dsn
       - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
           message: ":cloud: K8s Operator v1 Jobs failed"
           channel_name: "kubernetes-tests"


### PR DESCRIPTION
jira: [DEVPROD-2310]

no need to retrieve the pro key if it is not used by goreleaser-pro. besides, the key is already expired.

[DEVPROD-2310]: https://redpandadata.atlassian.net/browse/DEVPROD-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ