### PR TITLE
Fix buildkite artifact upload when kuttl suite fails

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,9 +20,6 @@ steps:
         TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh task ci:k8s
     agents:
       queue: v6-amd64-builders
-    artifact_paths:
-      - operator/*.tar.gz
-      - operator/tests/_e2e_artifacts/kuttl-report.xml
     plugins:
       - seek-oss/aws-sm#v2.3.2: &aws-sm-plugin
           json-to-env:
@@ -66,9 +63,6 @@ steps:
         TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh task ci:run-k8s-tests-with-flags
     agents:
       queue: v6-amd64-builders
-    artifact_paths:
-      - operator/*.tar.gz
-      - operator/tests/_e2e_with_flags_artifacts/kuttl-report.xml
     plugins:
       - seek-oss/aws-sm#v2.3.2: &aws-sm-plugin
           json-to-env:
@@ -113,9 +107,6 @@ steps:
           - ./ci/scripts/run-in-nix-docker.sh task ci:k8s-v2
         agents:
           queue: v6-amd64-builders
-        artifact_paths:
-          - operator/*.tar.gz
-          - operator/tests/_e2e_artifacts_v2/kuttl-report.xml
         plugins:
           - seek-oss/aws-sm#v2.3.2: *aws-sm-plugin
           - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
@@ -158,12 +149,10 @@ steps:
           # `hack/v2-helm-setup.sh` takes all files currently and disables only handful of them.
 
           - touch operator/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
+          - buildkite-agent artifact upload operator/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
           - echo Noop
         agents:
           queue: v6-amd64-builders
-        artifact_paths:
-          - operator/*.tar.gz
-          - operator/tests/_e2e_helm_artifacts_v2/kuttl-report.xml
         plugins:
           - seek-oss/aws-sm#v2.3.2: *aws-sm-plugin
           - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:

--- a/ci/scripts/run-in-nix-docker.sh
+++ b/ci/scripts/run-in-nix-docker.sh
@@ -32,6 +32,9 @@ fi
 # Spray and pray work is done, now we want to fail on errors.
 set -e
 
+# BUILDKITE environment variables are used by `buildkite-agent` cli to upload artifact
+printenv | grep BUILDKITE > env-file-for-buildkite
+
 # Build the base image and grab the SHA.
 IMAGE_SHA=$(docker build --quiet -f ./ci/docker/nix.Dockerfile .)
 
@@ -40,6 +43,7 @@ IMAGE_SHA=$(docker build --quiet -f ./ci/docker/nix.Dockerfile .)
 # build artifacts.
 # The nix image in use doesn't work if run as a non-root user.
 docker run --rm -it \
+	--env-file env-file-for-buildkite \
 	-e DOCKER_HOST=unix:///var/run/docker.sock \
 	-e PWD \
 	-e CI \

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,16 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1711099426,
-        "narHash": "sha256-HzpgM/wc3aqpnHJJ2oDqPBkNsqWbW0WfWUO8lKu8nGk=",
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "2d45b54ca4a183f2fdcf4b19c895b64fbf620ee8",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "type": "github"
       },
       "original": {
@@ -26,44 +25,26 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726937504,
-        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -74,20 +55,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "root": {
@@ -95,21 +70,6 @@
         "devshell": "devshell",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/operator/pkg/lint/testdata/tool-versions.txtar
+++ b/operator/pkg/lint/testdata/tool-versions.txtar
@@ -1,6 +1,6 @@
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.23.1
+go version go1.23.2
 
 -- goreleaser --
 # goreleaser --version | awk 'NR>2 {print last} {last=$0}'
@@ -11,36 +11,36 @@ go version go1.23.1
 goreleaser: Deliver Go Binaries as fast and easily as possible
 https://goreleaser.com
 
-GitVersion:    2.2.0
+GitVersion:    2.3.2
 GitCommit:     unknown
 GitTreeState:  unknown
 BuildDate:     unknown
 BuiltBy:       nixpkgs
-GoVersion:     go1.22.7
+GoVersion:     go1.23.2
 Compiler:      gc
 ModuleSum:     unknown
 
 -- helm --
 # helm version
-version.BuildInfo{Version:"v3.16.1", GitCommit:"v3.16.1", GitTreeState:"", GoVersion:"go1.22.7"}
+version.BuildInfo{Version:"v3.16.2", GitCommit:"v3.16.2", GitTreeState:"", GoVersion:"go1.23.2"}
 
 -- k3d --
 # k3d version
-k3d version v5.7.3
+k3d version v5.7.4
 k3s version v1.21.7-k3s1 (default)
 
 -- kind --
 # kind version | cut -d ' ' -f 1-3
-kind v0.24.0 go1.22.7
+kind v0.24.0 go1.23.2
 
 -- kubectl --
 # kubectl version --client=true
-Client Version: v1.31.0
+Client Version: v1.31.2
 Kustomize Version: v5.4.2
 
 -- kustomize --
 # kustomize version
-5.4.3
+5.5.0
 
 -- kuttl --
 # kuttl version | cut -d ' ' -f 1-7
@@ -48,7 +48,7 @@ KUTTL Version: version.Info{GitVersion:"0.19.0", GitCommit:"733ad16", BuildDate:
 
 -- task --
 # task --version
-Task version: 3.38.0 ()
+Task version: 3.39.2 ()
 
 -- yq --
 # yq --version

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -13,6 +13,37 @@ tasks:
     preconditions:
       - test -n "$GITHUB_API_TOKEN" || test -n "$GITHUB_TOKEN"
 
+  run-kuttl-tests:
+    cmds:
+      - defer: 'task ci:kuttl-artifact-upload EXIT_CODE={{.EXIT_CODE}} KUTTL_CONFIG_FILE={{.KUTTL_CONFIG_FILE}}'
+      - task: :k8s:run-kuttl-tests
+        vars:
+          KUTTL_CONFIG_FILE: '{{.KUTTL_CONFIG_FILE}}'
+
+  kuttl-artifact-upload:
+    desc: uploads artifact when kuttl fails
+    summary: |
+      kuttl-artifact-upload should be called in `defer` with EXIT_CODE.
+      https://taskfile.dev/usage/#doing-task-cleanup-with-defer
+      
+      As buildkite pipeline step are wrapped with shell script, that executes
+      docker run of a NIX container, where the permission are set to user of
+      ID 0 (root). The buildkite agent executor can not resolve glob due to
+      not sufficient permission. All invocation, within taskfile, of
+      `buildkite-agent artifact upload` will have sufficient permission.
+    vars:
+      KUTTL_CONFIG_FILE: '{{default "kuttl-test.yaml" .KUTTL_CONFIG_FILE}}'
+      KUTTL_ARTIFACTS_DIR:
+        sh: |
+          cat {{.KUTTL_CONFIG_FILE}} | grep artifactsDir | awk '{print $2}'
+    cmds:
+      - echo "Kuttl returned exit code {{.EXIT_CODE}}. Creating artifacts tarball"
+      - tar -czf {{.KUTTL_ARTIFACTS_DIR | base}}.tar.gz {{.KUTTL_ARTIFACTS_DIR}}
+      - buildkite-agent artifact upload "{{.SRC_DIR}}/operator/{{.KUTTL_ARTIFACTS_DIR | base}}.tar.gz"
+      - buildkite-agent artifact upload "{{.SRC_DIR}}/operator/{{.KUTTL_ARTIFACTS_DIR}}/kuttl-report.xml"
+    status:
+      - exit {{.EXIT_CODE}}
+
   k8s:
     cmds:
       - task: run-k8s-tests
@@ -35,23 +66,17 @@ tasks:
       - task: :k8s:generate
       - task: :dev:update-licenses
       - task: assert-no-diffs
-      - task: :k8s:run-kuttl-tests
+      - task: run-kuttl-tests
         vars:
           KUTTL_CONFIG_FILE: kuttl-v2-test.yaml
-      - cp "{{.SRC_DIR}}/operator/kuttl-exit-code" ./k8s-stable-test-exit-code
-      # fail explicitly if stable operator tests failed
-      - "grep -q '0' ./k8s-stable-test-exit-code"
 
   run-k8s-v2-helm-tests:
     cmds:
       - 'echo "~~~ Running operator v2 helm-ci e2e tests :k8s:"'
       - task: configure-git-private-repo
-      - task: :k8s:run-kuttl-tests
+      - task: run-kuttl-tests
         vars:
           KUTTL_CONFIG_FILE: kuttl-v2-helm-test.yaml
-      - cp "{{.SRC_DIR}}/operator/kuttl-exit-code" ./k8s-stable-test-exit-code
-      # fail explicitly if stable operator tests failed
-      - "grep -q '0' ./k8s-stable-test-exit-code"
 
   run-k8s-tests:
     deps:
@@ -75,10 +100,7 @@ tasks:
       - 'echo "~~~ Run operator code unit tests :golang:"'
       - task: :k8s:run-unit-tests
       - 'echo "~~~ Running operator e2e tests :k8s:"'
-      - task: :k8s:run-kuttl-tests
-      - cp "{{.SRC_DIR}}/operator/kuttl-exit-code" ./k8s-stable-test-exit-code
-      # fail explicitly if stable operator tests failed
-      - "grep -q '0' ./k8s-stable-test-exit-code"
+      - task: run-kuttl-tests
     status:
       - test -n '{{.TAG_NAME}}' # skip on tagged commit builds
 
@@ -89,12 +111,9 @@ tasks:
       - task: :dev:update-licenses
       - task: assert-no-diffs
       - 'echo "~~~ Running operator e2e tests :k8s:"'
-      - task: :k8s:run-kuttl-tests
+      - task: run-kuttl-tests
         vars:
           KUTTL_CONFIG_FILE: kuttl-test-with-flags.yaml
-      - cp "{{.SRC_DIR}}/operator/kuttl-exit-code" ./k8s-stable-test-exit-code
-      # fail explicitly if stable operator tests failed
-      - "grep -q '0' ./k8s-stable-test-exit-code"
     status:
       - test -n '{{.TAG_NAME}}' # skip on tagged commit builds
 

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -131,15 +131,7 @@ tasks:
       - task: build-operator-images
     cmds:
       - mkdir -p {{.KUTTL_ARTIFACTS_DIR}}
-      - docker image list
-      - |
-        KUTTL_EXIT_CODE=0
-        kuttl test --config "{{.KUTTL_CONFIG_FILE}}" {{.CLI_ARGS}} || KUTTL_EXIT_CODE=$?
-        echo "$KUTTL_EXIT_CODE" > kuttl-exit-code
-        if ! grep -q "0" kuttl-exit-code; then
-          echo "Kuttl returned exit code $(cat kuttl-exit-code). Creating artifacts tarball"
-          tar -czf {{.KUTTL_ARTIFACTS_DIR | base}}.tar.gz {{.KUTTL_ARTIFACTS_DIR}}
-        fi
+      - kuttl test --config "{{.KUTTL_CONFIG_FILE}}" {{.CLI_ARGS}}
 
   set-inotify-watches:
     desc: |


### PR DESCRIPTION
As buildkite pipeline step are wrapped with shell script, that executes
docker run of a NIX container, where the permission are set to user of
ID 0 (root). The buildkite agent executor can not resolve glob due to
not sufficient permission. All invocation, within taskfile, of
`buildkite-agent artifact upload` will have sufficient permission.

The error from buildkite execution:
```
fatal: failed to upload artifacts: collecting artifacts: resolving glob operator/*.tar.gz: permission denied
```
https://buildkite.com/redpanda/redpanda-operator/builds/3135#01930398-d67c-4ff7-87b6-9652e7f1a575/1040-1042