### PR TITLE
Fix artifact path

### DIFF
--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -22,6 +22,7 @@ tasks:
 
   kuttl-artifact-upload:
     desc: uploads artifact when kuttl fails
+    dir: operator
     summary: |
       kuttl-artifact-upload should be called in `defer` with EXIT_CODE.
       https://taskfile.dev/usage/#doing-task-cleanup-with-defer


### PR DESCRIPTION
Logic defined in `k8s:run-kuttl-tests` was moved to `ci:kuttl-artifact-upload`, but the `dir` option was not set. Dynamic variable resolution failed as the file was not found.

```
task: [ci:run-kuttl-tests] task ci:kuttl-artifact-upload EXIT_CODE=1 KUTTL_CONFIG_FILE=kuttl-v2-test.yaml
cat: kuttl-v2-test.yaml: No such file or directory
task: [ci:kuttl-artifact-upload] echo "Kuttl returned exit code 1. Creating artifacts tarball"
Kuttl returned exit code 1. Creating artifacts tarball
task: [ci:kuttl-artifact-upload] tar -czf ..tar.gz
tar: Cowardly refusing to create an empty archive
Try 'tar --help' or 'tar --usage' for more information.
task: Failed to run task "ci:kuttl-artifact-upload": exit status 2
```

https://buildkite.com/redpanda/redpanda-operator/builds/3169#01930b86-b67a-4c62-a63e-46e5fb673693/1296-1308