### PR TITLE
Fix leaking goroutines with non-closed kgo Clients

### DIFF
--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -182,6 +182,8 @@ func (c *clusterClients) checkTopic(ctx context.Context, topic string, exists bo
 	if !assert.Eventually(t, func() bool {
 		t.Logf("Pulling list of topics from cluster")
 		admin := kadm.NewClient(c.Kafka(ctx))
+		defer admin.Close()
+
 		topics, err = admin.ListTopics(ctx)
 		require.NoError(t, err)
 		require.NoError(t, topics.Error())

--- a/acceptance/steps/topics.go
+++ b/acceptance/steps/topics.go
@@ -65,4 +65,6 @@ func iShouldBeAbleToProduceAndConsumeFrom(ctx context.Context, t framework.Testi
 	records := fetches.Records()
 	require.Len(t, records, 1)
 	require.Equal(t, string(payload), string(records[0].Value))
+	kafkaClient.Close()
+	consumerClient.Close()
 }

--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -85,6 +85,7 @@ func iDeleteTheCRDUser(ctx context.Context, t framework.TestingT, user string) {
 func thereAreAlreadyTheFollowingACLsInCluster(ctx context.Context, t framework.TestingT, cluster string, acls *godog.Table) {
 	clients := clientsForCluster(ctx, cluster)
 	aclClient := clients.ACLs(ctx)
+	defer aclClient.Close()
 
 	for _, user := range usersFromACLTable(t, cluster, acls) {
 		user := user
@@ -108,6 +109,7 @@ func thereAreTheFollowingPreexistingUsersInCluster(ctx context.Context, t framew
 	clients := clientsForCluster(ctx, cluster)
 	adminClient := clients.RedpandaAdmin(ctx)
 	usersClient := clients.Users(ctx)
+	defer usersClient.Close()
 
 	for _, user := range usersFromAuthTable(t, cluster, users) {
 		user := user
@@ -152,7 +154,10 @@ func shouldExistAndBeAbleToAuthenticateToTheCluster(ctx context.Context, t frame
 }
 
 func thereShouldBeACLsInTheClusterForUser(ctx context.Context, t framework.TestingT, cluster, user string) {
-	rules, err := clientsForCluster(ctx, cluster).ACLs(ctx).ListACLs(ctx, fmt.Sprintf("User:%s", user))
+	aclClient := clientsForCluster(ctx, cluster).ACLs(ctx)
+	defer aclClient.Close()
+
+	rules, err := aclClient.ListACLs(ctx, fmt.Sprintf("User:%s", user))
 	require.NoError(t, err)
 	require.NotEmpty(t, rules)
 }

--- a/operator/internal/controller/redpanda/user_controller.go
+++ b/operator/internal/controller/redpanda/user_controller.go
@@ -80,6 +80,8 @@ func (r *UserReconciler) SyncResource(ctx context.Context, request ResourceReque
 	if err != nil {
 		return createPatch(err)
 	}
+	defer usersClient.Close()
+	defer syncer.Close()
 
 	if !hasUser && shouldManageUser {
 		if err := usersClient.Create(ctx, user); err != nil {
@@ -122,6 +124,8 @@ func (r *UserReconciler) DeleteResource(ctx context.Context, request ResourceReq
 	if err != nil {
 		return ignoreAllConnectionErrors(request.logger, err)
 	}
+	defer usersClient.Close()
+	defer syncer.Close()
 
 	if hasUser && hasManagedUser {
 		request.logger.V(2).Info("Deleting managed user")

--- a/operator/internal/controller/redpanda/user_controller_test.go
+++ b/operator/internal/controller/redpanda/user_controller_test.go
@@ -156,8 +156,11 @@ func TestUserReconcile(t *testing.T) { // nolint:funlen // These tests have clea
 			if tt.expectedCondition.Status == metav1.ConditionTrue { //nolint:nestif // ignore
 				syncer, err := environment.Factory.ACLs(ctx, user)
 				require.NoError(t, err)
+				defer syncer.Close()
+
 				userClient, err := environment.Factory.Users(ctx, user)
 				require.NoError(t, err)
+				defer userClient.Close()
 
 				// if we're supposed to have synced, then check to make sure we properly
 				// set the management flags
@@ -184,6 +187,8 @@ func TestUserReconcile(t *testing.T) { // nolint:funlen // These tests have clea
 						Pass: "password",
 					}.AsSha512Mechanism()))
 					require.NoError(t, err)
+					defer kafkaClient.Close()
+
 					kafkaAdminClient := kadm.NewClient(kafkaClient)
 
 					// first do an operation that anyone can do just to make

--- a/operator/pkg/client/acls/syncer.go
+++ b/operator/pkg/client/acls/syncer.go
@@ -44,6 +44,11 @@ func (s *Syncer) Sync(ctx context.Context, o redpandav1alpha2.AuthorizedObject) 
 	return err
 }
 
+// Close closes the underlying kgo client connection.
+func (s *Syncer) Close() {
+	s.client.Close()
+}
+
 func (s *Syncer) deleteAll(ctx context.Context, principal string) error {
 	ptrUsername := kmsg.StringPtr(principal)
 

--- a/operator/pkg/client/acls/syncer_test.go
+++ b/operator/pkg/client/acls/syncer_test.go
@@ -46,6 +46,7 @@ func TestSyncer(t *testing.T) {
 	require.NoError(t, err)
 
 	syncer := NewSyncer(kafkaClient)
+	defer syncer.Close()
 
 	sortACLs := func(acls []v1alpha2.ACLRule) {
 		sort.SliceStable(acls, func(i, j int) bool {

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -57,7 +57,8 @@ type UserAuth struct {
 type ClientFactory interface {
 	// KafkaClient initializes a kgo.Client based on the spec of the passed in struct.
 	// The struct *must* implement either the v1alpha2.KafkaConnectedObject interface or the v1alpha2.ClusterReferencingObject
-	// interface to properly initialize.
+	// interface to properly initialize. Callers should always call Close on the returned *kgo.Client, or it will leak
+	// goroutines.
 	KafkaClient(ctx context.Context, object client.Object, opts ...kgo.Opt) (*kgo.Client, error)
 
 	// RedpandaAdminClient initializes a rpadmin.AdminAPI client based on the spec of the passed in struct.
@@ -70,10 +71,12 @@ type ClientFactory interface {
 	// interface to properly initialize.
 	SchemaRegistryClient(ctx context.Context, object client.Object) (*sr.Client, error)
 
-	// ACLs returns a high-level client for synchronizing ACLs.
+	// ACLs returns a high-level client for synchronizing ACLs. Callers should always call Close on the returned *acls.Syncer, or it will leak
+	// goroutines.
 	ACLs(ctx context.Context, object redpandav1alpha2.ClusterReferencingObject, opts ...kgo.Opt) (*acls.Syncer, error)
 
-	// Users returns a high-level client for managing users.
+	// Users returns a high-level client for managing users. Callers should always call Close on the returned *users.Client, or it will leak
+	// goroutines.
 	Users(ctx context.Context, object redpandav1alpha2.ClusterReferencingObject, opts ...kgo.Opt) (*users.Client, error)
 
 	// Schemas returns a high-level client for synchronizing Schemas.

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -192,6 +192,7 @@ func TestClientFactory(t *testing.T) {
 				metadata, err := kadm.NewClient(kafkaClient).BrokerMetadata(ctx)
 				require.NoError(t, err)
 				require.Len(t, metadata.Brokers.NodeIDs(), 1)
+				kafkaClient.Close()
 			})
 
 			t.Run("KafkaAPISpec", func(t *testing.T) {
@@ -230,6 +231,7 @@ func TestClientFactory(t *testing.T) {
 				metadata, err := kadm.NewClient(kafkaClient).BrokerMetadata(ctx)
 				require.NoError(t, err)
 				require.Len(t, metadata.Brokers.NodeIDs(), 1)
+				kafkaClient.Close()
 			})
 		})
 	}

--- a/operator/pkg/client/users/client.go
+++ b/operator/pkg/client/users/client.go
@@ -86,6 +86,11 @@ func (c *Client) Has(ctx context.Context, user *redpandav1alpha2.User) (bool, er
 	return c.has(ctx, user.Name)
 }
 
+// Close closes the underlying kafka connection
+func (c *Client) Close() {
+	c.kafkaAdminClient.Close()
+}
+
 func (c *Client) delete(ctx context.Context, username string) error {
 	if c.scramAPISupported {
 		resp, err := c.kafkaAdminClient.AlterUserSCRAMs(ctx, []kadm.DeleteSCRAM{{

--- a/operator/pkg/client/users/client_test.go
+++ b/operator/pkg/client/users/client_test.go
@@ -76,6 +76,7 @@ func TestClient(t *testing.T) {
 
 	usersClient, err := NewClient(ctx, c, kadm.NewClient(kafkaClient), rpadminClient)
 	require.NoError(t, err)
+	defer usersClient.Close()
 
 	for _, mechanism := range []kadm.ScramMechanism{
 		kadm.ScramSha256, kadm.ScramSha512,
@@ -149,6 +150,7 @@ func TestClientPasswordCreation(t *testing.T) {
 
 	usersClient, err := NewClient(ctx, c, kadm.NewClient(kafkaClient), rpadminClient)
 	require.NoError(t, err)
+	defer usersClient.Close()
 
 	runTest := func(t *testing.T, username, password, secret string) {
 		annotations := map[string]string{


### PR DESCRIPTION
I think I traced all of these calls down. Basically if a `kgo.Client` doesn't get explicitly `Close`d, it'll leak a goroutine. An underlying kgo client is used in both our high-level Users client as well as our high-level ACL client, neither called `Close`. This closes our connections everywhere so we don't keep leaking.