### PR TITLE
implement ephemeral port reservation for k3d

### DIFF
--- a/operator/pkg/k3d/k3d_test.go
+++ b/operator/pkg/k3d/k3d_test.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"net"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +58,46 @@ func TestMultiInstance(t *testing.T) {
 	}
 
 	assert.NoError(t, errors.Join(errs...))
+}
+
+func TestReservePort(t *testing.T) {
+	const network = "tcp4"
+	const iterations = 100
+
+	reserved := map[int]struct{}{}
+	for i := 0; i < iterations; i++ {
+		port, err := reserveEphemeralPort("tcp4")
+		assert.NoError(t, err)
+		assert.NotZero(t, port)
+
+		// Assert that we can listen on the provided port.
+		lis, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", port))
+		assert.NoError(t, err)
+		assert.NoError(t, lis.Close())
+
+		reserved[port] = struct{}{}
+	}
+
+	// Not the best test as failures are exceptionally unlikely to be
+	// reproducible.
+	// Bind a bunch of ephemeral ports and assert that we don't get allocated
+	// any of the ports we've reserved.
+	for i := 0; i < iterations; i++ {
+		lis, err := net.Listen(network, "127.0.0.1:0")
+		assert.NoError(t, err)
+
+		// Defer closing of this listener to ensure we always get new ports
+		// from listening to 0.
+		defer lis.Close()
+
+		_, portStr, err := net.SplitHostPort(lis.Addr().String())
+		assert.NoError(t, err)
+
+		port, err := strconv.Atoi(portStr)
+		assert.NoError(t, err)
+
+		t.Logf("%d", port)
+
+		assert.NotContains(t, reserved, port)
+	}
 }


### PR DESCRIPTION
Prior to this commit we discovered that CI can flake when standing up multiple k3d clusters due to port conflicts.

This commit attempts to implement "port reservation" such that pkg/k3d can always create k3d clusters without conflicts without coordination across different processes.

It's unclear if this will actually work as engineering an intentional failure is not feasible.