### PR TITLE
Add JSON schema support

### DIFF
--- a/operator/api/redpanda/v1alpha2/schema_types.go
+++ b/operator/api/redpanda/v1alpha2/schema_types.go
@@ -49,20 +49,23 @@ func (s *Schema) GetClusterSource() *ClusterSource {
 }
 
 // SchemaType specifies the type of the given schema.
-// +kubebuilder:validation:Enum=avro;protobuf
+// +kubebuilder:validation:Enum=avro;protobuf;json
 type SchemaType string
 
 const (
 	SchemaTypeAvro     SchemaType = "avro"
+	SchemaTypeJSON     SchemaType = "json"
 	SchemaTypeProtobuf SchemaType = "protobuf"
 )
 
 var (
 	schemaTypesFromKafka = map[sr.SchemaType]SchemaType{
+		sr.TypeJSON:     SchemaTypeJSON,
 		sr.TypeAvro:     SchemaTypeAvro,
 		sr.TypeProtobuf: SchemaTypeProtobuf,
 	}
 	schemaTypesToKafka = map[SchemaType]sr.SchemaType{
+		SchemaTypeJSON:     sr.TypeJSON,
 		SchemaTypeAvro:     sr.TypeAvro,
 		SchemaTypeProtobuf: sr.TypeProtobuf,
 	}

--- a/operator/config/crd/bases/cluster.redpanda.com_schemas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_schemas.yaml
@@ -573,6 +573,7 @@ spec:
                 enum:
                 - avro
                 - protobuf
+                - json
                 type: string
               text:
                 description: Text is the actual unescaped text of a schema.


### PR DESCRIPTION
Somewhat recent versions of Redpanda added support for jsonschema-based Schemas to the registry. This adds support for leveraging them.