### PR TITLE
add support for host-index-offset for advertised listeners

### DIFF
--- a/operator/api/vectorized/v1alpha1/cluster_types.go
+++ b/operator/api/vectorized/v1alpha1/cluster_types.go
@@ -228,6 +228,12 @@ type NodePoolSpec struct {
 	// These are applied last and will override any other command line arguments that may be defined,
 	// including the ones added when setting `DeveloperMode` to `true`.
 	AdditionalCommandlineArguments map[string]string `json:"additionalCommandlineArguments,omitempty"`
+
+	// HostIndexOffset is an additional offset on top of the host index - which
+	// is practically the pod ordinal.
+	// This makes it possible to have PrivateLink separate port ranges per NodePool.
+	// +optional
+	HostIndexOffset int `json:"hostIndexOffset"`
 }
 
 // RestartConfig contains strategies to configure how the cluster behaves when restarting, because of upgrades

--- a/operator/api/vectorized/v1alpha1/cluster_webhook.go
+++ b/operator/api/vectorized/v1alpha1/cluster_webhook.go
@@ -496,7 +496,7 @@ func (r *Cluster) validateKafkaListeners(l logr.Logger) field.ErrorList {
 
 func checkValidEndpointTemplate(tmpl string) error {
 	// Using an example input to ensure that the template expression is allowed
-	data := utils.NewEndpointTemplateData(0, "1.2.3.4")
+	data := utils.NewEndpointTemplateData(0, "1.2.3.4", 0)
 	_, err := utils.ComputeEndpoint(tmpl, data)
 	return err
 }

--- a/operator/cmd/configurator/configurator_test.go
+++ b/operator/cmd/configurator/configurator_test.go
@@ -348,7 +348,7 @@ func TestAdditionalListeners(t *testing.T) { //nolint
 	}
 	for i := 0; i < len(tests); i++ {
 		tt := &tests[i]
-		err := setAdditionalListeners(tt.addtionalListenersCfg, tt.hostIP, tt.hostIndex, &tt.nodeCfg)
+		err := setAdditionalListeners(tt.addtionalListenersCfg, tt.hostIP, tt.hostIndex, &tt.nodeCfg, 0)
 		if tt.expectedError {
 			assert.Error(t, err)
 		} else {

--- a/operator/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/operator/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -1050,6 +1050,12 @@ spec:
                           description: Storage class name - https://kubernetes.io/docs/concepts/storage/storage-classes/
                           type: string
                       type: object
+                    hostIndexOffset:
+                      description: |-
+                        HostIndexOffset is an additional offset on top of the host index - which
+                        is practically the pod ordinal.
+                        This makes it possible to have PrivateLink separate port ranges per NodePool.
+                      type: integer
                     name:
                       description: Name of the NodePool. Must be unique, and must
                         not be "default".

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -498,6 +498,10 @@ func (r *StatefulSetResource) obj(
 							ImagePullPolicy: r.configuratorSettings.ImagePullPolicy,
 							Env: append([]corev1.EnvVar{
 								{
+									Name:  "HOST_INDEX_OFFSET",
+									Value: strconv.Itoa(r.nodePool.NodePoolSpec.HostIndexOffset),
+								},
+								{
 									Name:  "SERVICE_FQDN",
 									Value: r.serviceFQDN,
 								},
@@ -1025,7 +1029,7 @@ func (r *StatefulSetResource) GetPortsForListenersInAdditionalConfig() []corev1.
 	additionalNode0Config := config.ProdDefault()
 	for _, k := range additionalListenerCfgNames {
 		if v, found := r.pandaCluster.Spec.AdditionalConfiguration[k]; found {
-			res, err := utils.Compute(v, utils.NewEndpointTemplateData(0, "dummy"), false)
+			res, err := utils.Compute(v, utils.NewEndpointTemplateData(0, "dummy", 0), false)
 			if err != nil {
 				r.logger.Error(err, "failed to evaluate template", "template", v)
 				continue

--- a/operator/pkg/utils/template.go
+++ b/operator/pkg/utils/template.go
@@ -30,13 +30,19 @@ type EndpointTemplateData struct {
 	// value of hostIP that is also available in pod status (status.hostIP,
 	// available also in Kubernetes downward API).
 	HostIP string
+
+	// HostIndexOffset is an offset based on the NodePool.
+	// This allows users to build endpoint templates, that have non-overlapping
+	// port ranges on different nodepools.
+	HostIndexOffset int
 }
 
 // NewEndpointTemplateData creates endpoint template data with all required fields.
-func NewEndpointTemplateData(index int, hostIP string) EndpointTemplateData {
+func NewEndpointTemplateData(index int, hostIP string, hostIndexOffset int) EndpointTemplateData {
 	return EndpointTemplateData{
-		Index:  index,
-		HostIP: hostIP,
+		Index:           index,
+		HostIP:          hostIP,
+		HostIndexOffset: hostIndexOffset,
 	}
 }
 

--- a/operator/pkg/utils/template_test.go
+++ b/operator/pkg/utils/template_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestTemplateGen(t *testing.T) {
-	data := utils.NewEndpointTemplateData(2, "1.1.1.1")
+	data := utils.NewEndpointTemplateData(2, "1.1.1.1", 100)
 	tests := []struct {
 		tmpl                 string
 		endpointContainsPort bool
@@ -65,6 +65,11 @@ func TestTemplateGen(t *testing.T) {
 		{
 			tmpl:                 "'address': '{{.Index}}-{{.HostIP | sha256sum | substr 0 8}}.redpanda.com', 'port': {{30092 | add (.Index | sub .Index )}}",
 			expected:             "'address': '2-f1412386.redpanda.com', 'port': 30092",
+			endpointContainsPort: true,
+		},
+		{
+			tmpl:                 "'address': '{{.Index}}-{{.HostIP | sha256sum | substr 0 8}}.redpanda.com', 'port': {{30092 | add (.Index | sub .Index | add .HostIndexOffset )}}",
+			expected:             "'address': '2-f1412386.redpanda.com', 'port': 30192",
 			endpointContainsPort: true,
 		},
 	}


### PR DESCRIPTION
This is required for the combination of NodePools and Private Link.
PrivateLink has a different advertised port per broker, based on Pod ordinal. Since we can have multiple STS, we need an additional offset that makes sure basePort + ordinal does not overlap. Therefore, nodePool Spec can provide an offset. It defaults to 0, so nothing changes for existing clusters. In Gen2 NodePools, cloud controlplane provides the offset for each nodepool, e.g. 100.

This PR is targeting jb/nodepools - if that one gets merged, the target will be changed to main.