### PR TITLE
syncclusterconfig: handle missing `--users-directory`

### DIFF
--- a/operator/cmd/syncclusterconfig/sync.go
+++ b/operator/cmd/syncclusterconfig/sync.go
@@ -149,6 +149,10 @@ func loadBoostrapYAML(path string) (map[string]any, error) {
 func loadUsersFiles(ctx context.Context, path string) (map[string][]byte, error) {
 	files, err := os.ReadDir(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			log.FromContext(ctx).Info(fmt.Sprintf("users directory doesn't exist; skipping: %q", path))
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Prior to this commit the syncclusterconfig command would fail if the directory specified by `--users-directory` did not exist. As the flag had a default value and our helm chart always specifies the flag, this command could frequently fail with no solution.

This commit updates the command to handle non-existent directories by simply skipping the check.