### PR TITLE
Add kitchen sink test for TLS connections

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cucumber/godog v0.14.1
 	github.com/go-logr/logr v1.4.2
 	github.com/redpanda-data/common-go/rpadmin v0.1.9
-	github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a
+	github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0
 	github.com/redpanda-data/redpanda-operator/harpoon v0.0.0-00010101000000-000000000000
 	github.com/redpanda-data/redpanda-operator/operator v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cucumber/godog v0.14.1
 	github.com/go-logr/logr v1.4.2
 	github.com/redpanda-data/common-go/rpadmin v0.1.9
-	github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0
+	github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15
 	github.com/redpanda-data/redpanda-operator/harpoon v0.0.0-00010101000000-000000000000
 	github.com/redpanda-data/redpanda-operator/operator v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -192,10 +192,13 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fluxcd/helm-controller/api v0.37.2 h1:tkLezpRdqPDz7HoKHFu92sV+ppOCVDxkjFTh8/lpff8=
 github.com/fluxcd/helm-controller/api v0.37.2/go.mod h1:BuXZhAX9blQviil6yUN5zNM4RB753yhyBTJXxXff7Mo=
+github.com/fluxcd/pkg/apis/acl v0.1.0 h1:EoAl377hDQYL3WqanWCdifauXqXbMyFuK82NnX6pH4Q=
 github.com/fluxcd/pkg/apis/kustomize v1.2.0 h1:vkVs+OumxaWso0jNCqdgFFfMHdh+qtZhykTkjl7OgmA=
 github.com/fluxcd/pkg/apis/kustomize v1.2.0/go.mod h1:VF7tR/WuVFeum+HaMTHwp+eCtsHiiQlY6ihgqtAnW/M=
 github.com/fluxcd/pkg/apis/meta v1.2.0 h1:O766PzGAdMdQKybSflGL8oV0+GgCNIkdsxfalRyzeO8=
 github.com/fluxcd/pkg/apis/meta v1.2.0/go.mod h1:fU/Az9AoVyIxC0oI4ihG0NVMNnvrcCzdEym3wxjIQsc=
+github.com/fluxcd/source-controller v1.2.3 h1:g+lleTMyaS2yPfOHuXGJIjQLyiIPjPxM1/m59vwMdgs=
+github.com/fluxcd/source-controller/api v1.2.3 h1:71mXv3Qg9HEhcpqOq1ObmoE+P/HuZNaAvxfI7dqZMo8=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=
 github.com/foxcpp/go-mockdns v1.0.0/go.mod h1:lgRN6+KxQBawyIghpnl5CezHFGS9VLzvtVlwxvzXTQ4=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -640,7 +643,7 @@ github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPF
 github.com/redpanda-data/common-go/rpadmin v0.1.9 h1:X5a95P7Dc+7EaidU7dusWJyiG3eJmk4zJtUttfvhmc4=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
-github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a h1:QrCC2sX/A0ffiJEUJmZhDS8/NWJI4rbcbtCC+NQOGZY=
+github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0 h1:qdi8QHkk21DPiywrYqAYvVzIvBdYC1KzAgCXRWPl6Zk=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8/go.mod h1:97qkjcMI3gDL+y+aY/w5o0xF2qGHFof6rCXIYjnTalM=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -643,7 +643,7 @@ github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPF
 github.com/redpanda-data/common-go/rpadmin v0.1.9 h1:X5a95P7Dc+7EaidU7dusWJyiG3eJmk4zJtUttfvhmc4=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
-github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0 h1:qdi8QHkk21DPiywrYqAYvVzIvBdYC1KzAgCXRWPl6Zk=
+github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15 h1:OkWn3PL9PbIegbYfEZ9LbVAnZpQd/MzUbFdJLxWbX+s=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8/go.mod h1:97qkjcMI3gDL+y+aY/w5o0xF2qGHFof6rCXIYjnTalM=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1806,6 +1806,7 @@ github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240916201938-8d748d9ac10b/
 github.com/redpanda-data/helm-charts v0.0.0-20240911060052-2bf9dd6f0996/go.mod h1:uEMmuH+gTppAsZZNYlUbh6tuxN3fqffWY0Bi8AcE2Zk=
 github.com/redpanda-data/helm-charts v0.0.0-20240916201426-9ca3b128bb8e/go.mod h1:uEMmuH+gTppAsZZNYlUbh6tuxN3fqffWY0Bi8AcE2Zk=
 github.com/redpanda-data/helm-charts v0.0.0-20241025092026-69353dfce9a1/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
+github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240105044330-c094966ca0cf/go.mod h1:SaSp5/JwdLHu8ZU82wFbXD8/oE4UWB+8ZkjWWreAt7Y=
 github.com/rhnvrm/simples3 v0.6.1 h1:H0DJwybR6ryQE+Odi9eqkHuzjYAeJgtGcGtuBwOhsH8=
 github.com/rickb777/period v1.0.6 h1:f4TcHBtL/4qa4D44eqgxs7785/kfLKUjRI7XYI2HCvk=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1807,6 +1807,7 @@ github.com/redpanda-data/helm-charts v0.0.0-20240911060052-2bf9dd6f0996/go.mod h
 github.com/redpanda-data/helm-charts v0.0.0-20240916201426-9ca3b128bb8e/go.mod h1:uEMmuH+gTppAsZZNYlUbh6tuxN3fqffWY0Bi8AcE2Zk=
 github.com/redpanda-data/helm-charts v0.0.0-20241025092026-69353dfce9a1/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
+github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240105044330-c094966ca0cf/go.mod h1:SaSp5/JwdLHu8ZU82wFbXD8/oE4UWB+8ZkjWWreAt7Y=
 github.com/rhnvrm/simples3 v0.6.1 h1:H0DJwybR6ryQE+Odi9eqkHuzjYAeJgtGcGtuBwOhsH8=
 github.com/rickb777/period v1.0.6 h1:f4TcHBtL/4qa4D44eqgxs7785/kfLKUjRI7XYI2HCvk=

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cucumber/godog v0.14.1
 	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a
+	github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	k8s.io/api v0.30.3

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cucumber/godog v0.14.1
 	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0
+	github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	k8s.io/api v0.30.3

--- a/harpoon/go.sum
+++ b/harpoon/go.sum
@@ -401,7 +401,7 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0 h1:qdi8QHkk21DPiywrYqAYvVzIvBdYC1KzAgCXRWPl6Zk=
+github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15 h1:OkWn3PL9PbIegbYfEZ9LbVAnZpQd/MzUbFdJLxWbX+s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/harpoon/go.sum
+++ b/harpoon/go.sum
@@ -401,7 +401,7 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a h1:QrCC2sX/A0ffiJEUJmZhDS8/NWJI4rbcbtCC+NQOGZY=
+github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0 h1:qdi8QHkk21DPiywrYqAYvVzIvBdYC1KzAgCXRWPl6Zk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -55,7 +55,7 @@ type ChartRef struct {
 	// UseFlux flag set to `false` will prevent helm controller from reconciling helm chart. The operator would be
 	// tight with `go` based Redpanda helm chart version. The rest of the ChartRef fields would be ignored.
 	//
-	// Before setting UseFlux flag to `false` please alight your ChartVersion to at least `5.9.9`
+	// Before setting UseFlux flag to `false` please alight your ChartVersion to at least `5.9.10`
 	// version of the Redpanda chart.
 	//
 	// RedpandaStatus might not be accurate if flag is set to `false` and HelmRelease is manually deleted.

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -118,7 +118,7 @@ spec:
                       UseFlux flag set to `false` will prevent helm controller from reconciling helm chart. The operator would be
                       tight with `go` based Redpanda helm chart version. The rest of the ChartRef fields would be ignored.
 
-                      Before setting UseFlux flag to `false` please alight your ChartVersion to at least `5.9.9`
+                      Before setting UseFlux flag to `false` please alight your ChartVersion to at least `5.9.10`
                       version of the Redpanda chart.
 
                       RedpandaStatus might not be accurate if flag is set to `false` and HelmRelease is manually deleted.
@@ -9905,7 +9905,7 @@ spec:
                       UseFlux flag set to `false` will prevent helm controller from reconciling helm chart. The operator would be
                       tight with `go` based Redpanda helm chart version. The rest of the ChartRef fields would be ignored.
 
-                      Before setting UseFlux flag to `false` please alight your ChartVersion to at least `5.9.9`
+                      Before setting UseFlux flag to `false` please alight your ChartVersion to at least `5.9.10`
                       version of the Redpanda chart.
 
                       RedpandaStatus might not be accurate if flag is set to `false` and HelmRelease is manually deleted.

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/common v0.55.0
 	github.com/redpanda-data/common-go/rpadmin v0.1.9
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
-	github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0
+	github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/scalalang2/golang-fifo v1.0.2
 	github.com/spf13/afero v1.11.0

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/common v0.55.0
 	github.com/redpanda-data/common-go/rpadmin v0.1.9
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
-	github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a
+	github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/scalalang2/golang-fifo v1.0.2
 	github.com/spf13/afero v1.11.0

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1093,8 +1093,8 @@ github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a4
 github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240/go.mod h1:5KLXArOMFOrwb3BihpFaRNiPCyo9AXsXhvMdUmrCdUg=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19 h1:sJjDhnIbTMOuP4Rnhm1N3GNfgv6BJlocCnGliNvhgbw=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19/go.mod h1:T39OECA7eOlhpHZPBSGg+bpuwtt/G4m03fjBkJ821CM=
-github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a h1:QrCC2sX/A0ffiJEUJmZhDS8/NWJI4rbcbtCC+NQOGZY=
-github.com/redpanda-data/helm-charts v0.0.0-20241031235426-99ca96105c9a/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
+github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0 h1:qdi8QHkk21DPiywrYqAYvVzIvBdYC1KzAgCXRWPl6Zk=
+github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e h1:8HB05vSCY+0MwjT2DIVq6gJV5iw7nQNIDfMqcc1NEC8=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e/go.mod h1:jF5kbQy3qT/zufL27DE3lecfYTRWeAzSiVmrbDDQwUw=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1093,8 +1093,8 @@ github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a4
 github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240/go.mod h1:5KLXArOMFOrwb3BihpFaRNiPCyo9AXsXhvMdUmrCdUg=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19 h1:sJjDhnIbTMOuP4Rnhm1N3GNfgv6BJlocCnGliNvhgbw=
 github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19/go.mod h1:T39OECA7eOlhpHZPBSGg+bpuwtt/G4m03fjBkJ821CM=
-github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0 h1:qdi8QHkk21DPiywrYqAYvVzIvBdYC1KzAgCXRWPl6Zk=
-github.com/redpanda-data/helm-charts v0.0.0-20241113221319-230a32adcee0/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
+github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15 h1:OkWn3PL9PbIegbYfEZ9LbVAnZpQd/MzUbFdJLxWbX+s=
+github.com/redpanda-data/helm-charts v0.0.0-20241114193526-f53a0adc8f15/go.mod h1:dmmGZo7DuHNnCy0QOykXN2sY9QI8kbdlkSKgIkCT978=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e h1:8HB05vSCY+0MwjT2DIVq6gJV5iw7nQNIDfMqcc1NEC8=
 github.com/redpanda-data/helm-controller v0.37.3-0.20240119022335-c90fadbd044e/go.mod h1:jF5kbQy3qT/zufL27DE3lecfYTRWeAzSiVmrbDDQwUw=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=


### PR DESCRIPTION
This updates our `helm-charts` dependency and adds a test to exercise a more complex TLS/listener setup for a redpanda cluster in our factory to act as a higher-level "e2e" style test of the changes made in https://github.com/redpanda-data/helm-charts/pull/1597.