### PR TITLE
operator v1: don't return both result and error

### DIFF
--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -233,11 +233,11 @@ func (r *ClusterReconciler) Reconcile(
 	}
 
 	result, errs := ar.Ensure()
-	if !result.IsZero() && errs == nil {
-		return result, nil
-	}
 	if errs != nil {
-		return result, errs
+		return ctrl.Result{}, errs
+	}
+	if !result.IsZero() {
+		return result, nil
 	}
 
 	adminAPI, err := r.AdminAPIClientFactory(ctx, r.Client, &vectorizedCluster, ar.getHeadlessServiceFQDN(), pki.AdminAPIConfigProvider())

--- a/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
+++ b/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
@@ -92,7 +92,15 @@ func (a *attachedResources) Ensure() (ctrl.Result, error) {
 			errs = errors.Join(errs, err)
 		}
 	}
-	return result, errs
+	// Controller-runtime does not allow returning a result and an error at the same time.
+	// We choose to prioritize the error - if there is an error, this is more important
+	// to us to return than the reconcile.
+	// Downstream functions are expected to only return errors, if there is an
+	// actual error condition, not generally to cause a requeue (must use result for this purpose).
+	if errs != nil {
+		return ctrl.Result{}, errs
+	}
+	return result, nil
 }
 
 func (a *attachedResources) bootstrapService() {


### PR DESCRIPTION
Controller-runtime forbids returning both result and error. However, ar.Ensure() code provoked such cases; because it reconciles multiple "inner" resources, and some of them might return an error, in addition to some other returning a ctrl.Result.

to over come this, ar.Ensure now makes the deliberate choice to prioritize errors - if any non-requeue error is returned by an attached resource, it will return just the error, and ignore the ctrl.Result.