### PR TITLE
Fix panic when comparing array values

### DIFF
--- a/operator/cmd/syncclusterconfig/sync.go
+++ b/operator/cmd/syncclusterconfig/sync.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -261,7 +262,7 @@ func (s *Syncer) Sync(ctx context.Context, desired map[string]any, usersTXT map[
 	for key, value := range desired {
 		if currentValue, ok := current[key]; !ok {
 			added = append(added, key)
-		} else if value != currentValue {
+		} else if !reflect.DeepEqual(value, currentValue) {
 			changed = append(changed, key)
 		}
 	}


### PR DESCRIPTION
Previously we were comparing the unmarshaled values from a `map[string]any` fetched from our yaml files via `!=`. The problem is that some of our values can be arrays, in which case we get a value that is of type `[]interface{}` (due to how the yaml library unmarshals). This was causing runtime panics when attempting to compare with `!=`.

This fixes it by changing the comparison call to use `reflect.DeepEqual` and adds a regression test.