### PR TITLE
Operator v1: use uncached client for Get Cluster, to avoid races

### DIFF
--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -233,11 +233,11 @@ func (r *ClusterReconciler) Reconcile(
 	}
 
 	result, errs := ar.Ensure()
-	if !result.IsZero() && errs == nil {
-		return result, nil
-	}
 	if errs != nil {
-		return result, errs
+		return ctrl.Result{}, errs
+	}
+	if !result.IsZero() {
+		return result, nil
 	}
 
 	adminAPI, err := r.AdminAPIClientFactory(ctx, r.Client, &vectorizedCluster, ar.getHeadlessServiceFQDN(), pki.AdminAPIConfigProvider())

--- a/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
+++ b/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
@@ -92,7 +92,15 @@ func (a *attachedResources) Ensure() (ctrl.Result, error) {
 			errs = errors.Join(errs, err)
 		}
 	}
-	return result, errs
+	// Controller-runtime does not allow returning a result and an error at the same time.
+	// We choose to prioritize the error - if there is an error, this is more important
+	// to us to return than the reconcile.
+	// Downstream functions are expected to only return errors, if there is an
+	// actual error condition, not generally to cause a requeue (must use result for this purpose).
+	if errs != nil {
+		return ctrl.Result{}, errs
+	}
+	return result, nil
 }
 
 func (a *attachedResources) bootstrapService() {

--- a/operator/pkg/resources/statefulset_scale.go
+++ b/operator/pkg/resources/statefulset_scale.go
@@ -291,12 +291,12 @@ func (r *StatefulSetResource) handleDecommission(ctx context.Context, l logr.Log
 			if err != nil {
 				return err
 			}
-			cluster.Status.DecommissioningNode = nil
+			cluster.SetDecommissionBrokerID(nil)
 			err = r.Status().Update(ctx, cluster)
 			if err == nil {
 				log.Info("Cleared decomm broker ID from status")
 				// sync original cluster variable to avoid conflicts on subsequent operations
-				r.pandaCluster.Status = cluster.Status
+				r.pandaCluster.SetDecommissionBrokerID(nil)
 			}
 			return err
 		})

--- a/operator/tests/e2e/decommission/05-assert.yaml
+++ b/operator/tests/e2e/decommission/05-assert.yaml
@@ -1,3 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- timeout: 300
+  script: |
+    kubectl wait --for=condition=ClusterConfigured=True cluster/decommission --timeout 300s --namespace $NAMESPACE
+    kubectl wait --for=condition=OperatorQuiescent=True cluster/decommission --timeout 300s --namespace $NAMESPACE
+---
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
@@ -5,13 +13,6 @@ metadata:
 status:
   replicas: 2
   currentReplicas: 2
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
-- timeout: 300
-  script: |
-    kubectl wait --for=condition=ClusterConfigured=True cluster/decommission --timeout 300s --namespace $NAMESPACE
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert


### PR DESCRIPTION
This PR is targeted at jb/nodepools-requeue until we're merging that one.

## Problem statement

I've been debugging a rare condition - in about 1-2% of cloud certification runs (need about 50-100 clusters, with 6 decommissions each) where we decom brokers and move them over to another NodePool, where the cluster ends up with status.decommissionBrokerID being set, but that broker has been decommissioned already.

- **The initial Get Cluster in the reconcile loop gets a stale value returned**, that does not contain a previous (single digit MS previously) Patch status change.
- We changed status Update calls to Patch calls; this was requested as code review comments in multiple PRs (and i understand, its generally more desirable)
- This has some negative side effects; Patch updates do not fail with Conflict, if the specific fields updated are not conflicting. Update calls however do fail, always, if there was a concurrent change. In practice, we're updating setDecommission broker ID - based on incorrect currentReplicas from a stale Get Cluster. (bad decision; that broker has finished decom already)
- All of this behavior was shadowed by other bugs, e.g. in a concrete case, we had a bug where we returned both a ctrl.Result AND an error. this is not allowed, controller-runtime then performs an exponential backoff. the stale read does in practice not happen then.


All happens within minute 06:27 UTC.

(Logs are available internally)

(Following times are the second within 06:27)

52.579: Cleared decom in status
52.651: set currentReplicas to 2 (down from 3)
52.686: Finished reconcile loop
52.689: Start of new loop, Get Cluster returns currentReplicas 3 (stale read. it's supposed to be 2). Initiates a new Scale-down - because it read currentReplicas 3 (outdated), but replicas is 2. That scale down was already performed previously, and has finished (decom finished), but the pod was not removed yet.
53.154: Patch status (to update observedGen) fails, because it would change currentReplicas to 3 - which is wrong, as the value 3 is based on a stale read, and kube API server rejects it as it's a conflict)

## Variants how to fix this
(In this PR, we're picking A, but i am very open to other variants)

A)

At the start of the reconcile loop, always perform an uncached Get to read Cluster resource. this ensures that all actions are based on up to date data. even more so - it ensures the happens-before relationship between write (Patch call in previous reconcile) and and the next iteration exists.

B)

After every Patch(), loop to run Get() until we see the values changed. Then, the next reconcile loop will not have a stale cache, because we've read back the data before.
i am not sure about corner cases; IMHO it feels quite brittle.

C)

Change writing of status changes to Update or use resource version in Patch, to fail update calls that are based on old data.

This will work as well, but it will fail late - when doing status changes while working off stale data already.
i fear that other code paths can make bad decisions if they act based on old data; especially status.currentReplicas is very dangerous - code can easily make decision we will very much regret (eg. eliminating a node). Currently, this would be fine i think, because a Patch/Update call will set DecomBrokerID in status, and would fail. however, it's unpredictable, if code changes, and some actions are first performed outside of kube api (eg. a call to RP admin api).

D)
Update code so it does not get stuck forever, e.g. update code to check if a broker has been decommissioned already, before setting status.decommissionBrokerID. Most of problems of C) still apply; it does not solve this generally, but only for the specifically observed case.

E)

We could store in-memory in ClusterReconciler the last seen resource version (eg. returned by Patch), and use this ResourceVersion in reconcile's Get Cluster. This would guarantee we get "no older than" this version. See https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list

Note: controller-runtime does not locally invalidate the cache if Patch/Update was done, it relies on watches to do this, so it's async and no happens-before relationship between Patch/Update and subsequent Get exists.

# Refs
- https://github.com/kubernetes-sigs/controller-runtime/issues/1464
- slightly related: https://github.com/neondatabase/autoscaling/issues/794
- https://github.com/kubernetes-sigs/controller-runtime/issues/1622