### PR TITLE
Fix artifacts path in junit-annotate plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,7 +122,7 @@ steps:
         plugins:
           - seek-oss/aws-sm#v2.3.2: *aws-sm-plugin
           - junit-annotate#v2.4.1:
-              artifacts: operator/tests/_e2e_artifacts_v2/kuttl-report.xml
+              artifacts: work/operator/tests/_e2e_artifacts_v2/kuttl-report.xml
               report-slowest: 5
         timeout_in_minutes: 0
         agents:


### PR DESCRIPTION
The artifact has exact path which should be prefixed with `work`.
```
:junit: Download the junits
2024-11-19 08:19:37 INFO   Searching for artifacts: "operator/tests/_e2e_artifacts_v2/kuttl-report.xml"
fatal: failed to download artifacts: No artifacts found for downloading
💥 Could not download artifacts
🚨 Error: The command exited with status 2
```
https://buildkite.com/redpanda/redpanda-operator/builds/3328#01934368-daa3-46d2-b2b8-56feda4f6616/346