### PR TITLE
operator v1: use cached admin API factory

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -256,7 +256,7 @@ func Run(
 			Client:                    mgr.GetClient(),
 			Log:                       ctrl.Log.WithName("controllers").WithName("redpanda").WithName("Cluster"),
 			Scheme:                    mgr.GetScheme(),
-			AdminAPIClientFactory:     adminutils.NewNodePoolInternalAdminAPI,
+			AdminAPIClientFactory:     adminAPIClientFactory,
 			DecommissionWaitInterval:  decommissionWaitInterval,
 			MetricsTimeout:            metricsTimeout,
 			RestrictToRedpandaVersion: restrictToRedpandaVersion,


### PR DESCRIPTION
I suspect that some merge conflict resolution was not quite correct, and did not use the cached admin API factory introduced by @chrisseto . we're seeing high memory usage and the "known leak problems".
This patches passes the cached factory into cluster_controller.

draft because i first want to test it in cloud.