### PR TITLE
Add build info command and metrics

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,10 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+    - -X "github.com/redpanda-data/redpanda-operator/operator/cmd/version.version={{.Version}}"
+    - -X "github.com/redpanda-data/redpanda-operator/operator/cmd/version.commit={{.Commit}}"
+    - -X "github.com/redpanda-data/redpanda-operator/operator/cmd/version.buildDate={{.Date}}"
 
   - id: manager-alias
     dir: ./alias

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/envsubst"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/run"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/version"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -42,6 +43,7 @@ func init() {
 		envsubst.Command(),
 		run.Command(),
 		syncclusterconfig.Command(),
+		version.Command(),
 	)
 
 	logOptions.BindFlags(rootCmd.PersistentFlags())

--- a/operator/cmd/version/version.go
+++ b/operator/cmd/version/version.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package version
+
+import (
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// these variables are set via ldflags in our goreleaser build.
+
+	version   string
+	commit    string
+	buildDate string
+)
+
+func init() {
+	buildInfoGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "redpanda_operator",
+		Name:      "build_info",
+		Help:      "A gauge always set to 1 that provides build information as labels.",
+		ConstLabels: prometheus.Labels{
+			"version":    version,
+			"commit":     commit,
+			"go_version": runtime.Version(),
+		},
+	})
+
+	buildInfoGauge.Set(1)
+
+	metrics.Registry.MustRegister(buildInfoGauge)
+}
+
+func Command() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print build information",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Printf("Version: %s\n", version)
+			cmd.Printf("Commit: %s\n", commit)
+			cmd.Printf("Go Version: %s\n", runtime.Version())
+			cmd.Printf("Build Date: %s\n", buildDate)
+		},
+	}
+}

--- a/taskfiles/goreleaser.yml
+++ b/taskfiles/goreleaser.yml
@@ -1,45 +1,8 @@
 version: '3'
 
 tasks:
-  release:
-    dir: '{{.SRC_DIR}}'
-    desc: release go binaries using the .goreleaser.yml file in given directory
-    deps:
-      - task: :k8s:generate
-    env:
-      GORELEASER_CURRENT_TAG: '{{.TAG_NAME}}'
-      GITHUB_TOKEN:
-        sh: echo "${GITHUB_TOKEN:-$GITHUB_API_TOKEN}"
-    cmds:
-      - |
-        EMPTY_NOTES="/tmp/empty_notes"
-        mkdir -p /tmp
-        echo "" >> "$EMPTY_NOTES"
-
-        goreleaser release --clean --release-notes "$EMPTY_NOTES"
-    preconditions:
-      - test -n "$GITHUB_API_TOKEN" || test -n "$GITHUB_TOKEN"
-      - test -n "{{.TAG_NAME}}"
-
-  build:
-    dir: '{{.SRC_DIR}}'
-    # A .goreleaser.yml file is required at the GO_SRC_DIR
-    desc: build go binaries with goreleaser and a given id
-    deps:
-      - task: :k8s:generate
-    env:
-      GORELEASER_CURRENT_TAG: '{{.TAG_NAME}}'
-    cmds:
-      - |
-        export PATH="{{.GORELEASER_INSTALL_DIR}}:$PATH"
-        goreleaser build --clean --id {{.GORELEASER_BUILD_ID}} {{.CLI_ARGS}}
-    preconditions:
-      - test -n "{{.GORELEASER_BUILD_ID}}"
-      - test -n "{{.TAG_NAME}}"
-
   build-operator-binaries:
     deps:
       - task: :k8s:generate
     cmds:
-      - go version
-      - 'goreleaser build --snapshot --clean'
+      - 'goreleaser build --snapshot --clean {{.CLI_ARGS}}'


### PR DESCRIPTION
Prior to this commit the operator was unaware of its release version and other such build information. This made tracking down issues across fleets of instances a bit difficult.

This commit add the `version` subcommand to allow interrogating a binary and the `redpanda_operator_build_info` metric which reports the same information via labels on a gauge.