### PR TITLE
operator v1: store NodePoolSpec in STS annotations & refactor nodePool deletion slightly

### DIFF
--- a/operator/pkg/labels/labels.go
+++ b/operator/pkg/labels/labels.go
@@ -36,6 +36,11 @@ const (
 	// PodNodeIDKey is used to store the Redpanda NodeID of this pod.
 	PodNodeIDKey = "operator.redpanda.com/node-id"
 
+	// NodePoolSpecKey is used to store the NodePoolSpec in a StatefulSet's annotations.
+	// This allows the operator to correctly reconstruct a NodePoolSpec even
+	// after it was removed from Spec already.
+	NodePoolSpecKey = "cluster.redpanda.com/node-pool-spec"
+
 	nameKeyRedpandaVal   = "redpanda"
 	nameKeyConsoleVal    = "redpanda-console"
 	managedByOperatorVal = "redpanda-operator"

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -428,11 +428,19 @@ func (r *StatefulSetResource) obj(
 		nodePoolSelector = clusterLabels.AsAPISelector()
 	}
 
+	nodePoolSpecJSON, err := json.Marshal(r.nodePool.NodePoolSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal NodePoolSpec as JSON: %w", err)
+	}
+
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.Key().Namespace,
 			Name:      r.Key().Name,
 			Labels:    nodePoolLabels,
+			Annotations: map[string]string{
+				labels.NodePoolSpecKey: string(nodePoolSpecJSON),
+			},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",

--- a/operator/pkg/resources/statefulset_scale.go
+++ b/operator/pkg/resources/statefulset_scale.go
@@ -102,9 +102,8 @@ func (r *StatefulSetResource) handleScaling(ctx context.Context) error {
 		return r.setCurrentReplicas(ctx, *r.nodePool.Replicas, r.nodePool.Name, r.logger)
 	}
 
-	if ptr.Deref(r.nodePool.Replicas, 0) == npCurrentReplicas && !r.nodePool.Deleted {
+	if ptr.Deref(r.nodePool.Replicas, 0) == npCurrentReplicas {
 		log.V(logger.DebugLevel).Info("No scaling changes required for this nodepool", "replicas", *r.nodePool.Replicas, "spec replicas", *r.LastObservedState.Spec.Replicas) // No changes to replicas, we do nothing here
-
 		return nil
 	}
 


### PR DESCRIPTION
we encountered corner cases, where it becomes extremely difficult to synthesize a NodePoolSpec just by looking at the StatefulSet - which is our fallback, if a nodePool was removed from the spec. AdditionalCommandlineArguments is hard to reconstruct, because we'd need to pull that out of the args field in the pod spec of the STS, removing all "other default" args - very error prone.

in practice, this caused a rolling restart of a nodePool, because its arguments were not assembled correctly. in the moment it got deleted from spec, a diff came up (args missing).

To fix / solve correctly, we change our strategy. We now store the NodePoolSpec used to create the STS in the STS as an annotation. This way we can always find the NodePoolSpec to create the (deleted) STS.

In addition, we take this chance to remove small special cases for
handling delete nodepools:
- Do not set replicas=currentReplicas anymore. It was more of a trick.
  Instead, we now set for a deleted nodePool replicas=0, which exactly
  represents what should happen with it (intent to scale down to zero).
- Add check for Deleted bool in scale-down handler. It prevented
  replicas=currentReplicas being accepted as "do notthing"
  if it's a deleted nodepool. Then, the control flow would proceed and
  downscaling happens. This was not very explicit and very hard to find
  out, why downscale even works in deleted NodePools. With the refactor,
  replicas is 0, and no special case is needed for deleting anymore.

This way, nodePool deletion works more like an ordinary scale down.

