### PR TITLE
operator v1: alternative solution for drift detection with "null"

### DIFF
--- a/operator/internal/controller/vectorized/cluster_controller_configuration_drift_test.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration_drift_test.go
@@ -17,6 +17,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDiffWithNull(t *testing.T) {
+	assert := require.New(t)
+
+	schema := map[string]rpadmin.ConfigPropertyMetadata{
+		"kafka_rpc_server_tcp_send_buf": {
+			Type:         "integer",
+			Description:  "Size of the Kafka server TCP receive buffer. If `null`, the property is disabled.",
+			Nullable:     true,
+			NeedsRestart: true,
+			IsSecret:     false,
+			Visibility:   "user",
+		},
+	}
+
+	_, ok := hasDrift(logr.Discard(), map[string]any{
+		"kafka_rpc_server_tcp_send_buf": "null",
+	}, map[string]any{
+		"kafka_rpc_server_tcp_send_buf": nil,
+	}, schema)
+	assert.False(ok)
+}
+
 func TestHasDrift(t *testing.T) {
 	assert := require.New(t)
 

--- a/operator/pkg/resources/configuration/patch.go
+++ b/operator/pkg/resources/configuration/patch.go
@@ -80,7 +80,7 @@ func ThreeWayMerge(
 	for k, v := range apply {
 		if oldValue, ok := current[k]; !ok || !PropertiesEqual(log, v, oldValue, schema[k]) {
 			metadata := schema[k]
-			patch.Upsert[k] = parseConfigValueBeforeUpsert(log, v, &metadata)
+			patch.Upsert[k] = ParseConfigValueBeforeUpsert(log, v, &metadata)
 		}
 	}
 	invalidSet := make(map[string]bool, len(invalidProperties))
@@ -99,7 +99,7 @@ func ThreeWayMerge(
 	return patch
 }
 
-func parseConfigValueBeforeUpsert(log logr.Logger, value interface{}, metadata *rpadmin.ConfigPropertyMetadata) interface{} {
+func ParseConfigValueBeforeUpsert(log logr.Logger, value interface{}, metadata *rpadmin.ConfigPropertyMetadata) interface{} {
 	tempValue := fmt.Sprintf("%v", value)
 
 	//nolint:gocritic // no need to be a switch case
@@ -145,6 +145,7 @@ func PropertiesEqual(
 	l logr.Logger, v1, v2 interface{}, metadata rpadmin.ConfigPropertyMetadata,
 ) bool {
 	log := l.WithName("PropertiesEqual")
+
 	switch metadata.Type {
 	case "number":
 		if f1, f2, ok := bothFloat64(v1, v2); ok {


### PR DESCRIPTION
This is an alternative to https://github.com/redpanda-data/redpanda-operator/pull/320 .

Instead of adding a special case for "null", use the existing method that normalizes the values already when talking to redpanda (writing cluster config).
This way, both ends are normalized via the same function:
- Writing done by cluster controller
- Reading done by cluster configuration drift controller

The function used has a special case, similar to #320 : https://github.com/redpanda-data/redpanda-operator/blob/jb%2Fdrift-detection-alternative/operator/pkg/resources/configuration/patch.go#L106

This way, we don't need to have the "null" special code twice.

Very interested in review from @RafalKorepta , who may know this code better than i do.