### PR TITLE
operator v1: avoid warnings about type mismatch

### DIFF
--- a/operator/pkg/resources/configuration/patch.go
+++ b/operator/pkg/resources/configuration/patch.go
@@ -146,6 +146,10 @@ func PropertiesEqual(
 ) bool {
 	log := l.WithName("PropertiesEqual")
 
+	if metadata.Nullable && v1 == nil && v2 == nil {
+		return true
+	}
+
 	switch metadata.Type {
 	case "number":
 		if f1, f2, ok := bothFloat64(v1, v2); ok {


### PR DESCRIPTION
this is a cosmetic change only.
The operator logs "Warning: property values do not match their type if both are nil. It does not detect a drift, because a later function considers them equal, but the log happens still.
This patch adds an early check for this condition, if both are nil and the type is nullable, we can immediately return true.