### PR TITLE
Fix for converting secret scopes to config map

### DIFF
--- a/operator/pkg/console/configmap.go
+++ b/operator/pkg/console/configmap.go
@@ -432,19 +432,13 @@ func (cm *ConfigMap) genSecretStore() EnterpriseSecretStore {
 			})
 		}
 	}
-	s := EnterpriseSecretStoreScopes{}
-	if ss.Scopes != nil {
-		s = EnterpriseSecretStoreScopes{
-			Scopes: ss.Scopes,
-		}
-	}
 	return EnterpriseSecretStore{
 		Enabled:          ss.Enabled,
 		SecretNamePrefix: ss.SecretNamePrefix,
 		GCPSecretManager: smGCP,
 		AWSSecretManager: smAWS,
 		KafkaConnect:     kc,
-		Scopes:           s,
+		Scopes:           ss.Scopes,
 	}
 }
 

--- a/operator/pkg/console/console.go
+++ b/operator/pkg/console/console.go
@@ -165,7 +165,7 @@ type EnterpriseSecretStore struct {
 	GCPSecretManager EnterpriseSecretManagerGCP        `json:"gcpSecretManager" yaml:"gcpSecretManager"`
 	AWSSecretManager EnterpriseSecretManagerAWS        `json:"awsSecretManager" yaml:"awsSecretManager"`
 	KafkaConnect     EnterpriseSecretStoreKafkaConnect `json:"kafkaConnect" yaml:"kafkaConnect"`
-	Scopes           EnterpriseSecretStoreScopes       `json:"scopes" yaml:"scopes"`
+	Scopes           []string                          `json:"scopes" yaml:"scopes"`
 }
 
 type EnterpriseSecretManagerGCP struct {
@@ -185,10 +185,6 @@ type EnterpriseSecretManagerAWS struct {
 type EnterpriseSecretStoreKafkaConnect struct {
 	Enabled  bool                                       `json:"enabled" yaml:"enabled"`
 	Clusters []EnterpriseSecretStoreKafkaConnectCluster `json:"clusters" yaml:"clusters"`
-}
-
-type EnterpriseSecretStoreScopes struct {
-	Scopes []string `json:"scopes" yaml:"scopes"`
 }
 
 type EnterpriseSecretStoreKafkaConnectCluster struct {


### PR DESCRIPTION
Currently operator generates (additional nested field):

```
      scopes:
        scopes:
        - SCOPE_REDPANDA_CONNECT
```

Should be:

```
      scopes:
      - SCOPE_REDPANDA_CONNECT
```
