### PR TITLE
Retry when Redpanda Pod is being deleted

### DIFF
--- a/operator/pkg/resources/statefulset_update.go
+++ b/operator/pkg/resources/statefulset_update.go
@@ -457,6 +457,10 @@ func (r *StatefulSetResource) podEviction(ctx context.Context, pod, artificialPo
 		ignoreExistingVolumes(newVolumes),
 	}
 
+	if pod.DeletionTimestamp != nil {
+		return &RequeueAfterError{RequeueAfter: RequeueDuration, Msg: "waiting for pod to be deleted"}
+	}
+
 	managedDecommission, err := r.IsManagedDecommission()
 	if err != nil {
 		log.Error(err, "not performing a managed decommission")


### PR DESCRIPTION
It's not the ultimate fix for managed decommission test failure. In the [buildkite run](https://buildkite.com/redpanda/redpanda-operator/builds/3445) pod with ordinal 1 was deleted twice which broke the raft consensus. There was 10 seconds stall within statefulset rollingUpdate function (from `2024-11-29T06:12:33.811Z` to `2024-11-29T06:12:43.819Z`) which I think allowed second PVC and Pod deletion. As a precaution reconciliation would retry if Pod has delete timestamp.