### PR TITLE
golangci-lint: enable unparam linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
   - misspell
   - staticcheck
   - stylecheck
+  - unparam
   - unused
 
 linters-settings:
@@ -36,3 +37,13 @@ linters-settings:
 
   stylecheck:
     checks: ["*", "-ST1005"]
+
+issues:
+  exclude-rules:
+    # unparam will complain about functions that are called with a constant
+    # parameter. In production code, that may be helpful but it harms the
+    # readability of test code to eliminate such cases.
+    - linters:
+      - unparam
+      text: "always receives"
+      path: '(.+)_test\.go'

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -189,7 +189,7 @@ func (r *RedpandaReconciler) Reconcile(c context.Context, req ctrl.Request) (ctr
 
 	// Examine if the object is under deletion
 	if !rp.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, rp)
+		return ctrl.Result{}, r.reconcileDelete(ctx, rp)
 	}
 
 	if !isRedpandaManaged(ctx, rp) {
@@ -796,14 +796,14 @@ func (r *RedpandaReconciler) reconcileHelmRepository(ctx context.Context, rp *v1
 	return nil
 }
 
-func (r *RedpandaReconciler) reconcileDelete(ctx context.Context, rp *v1alpha2.Redpanda) (ctrl.Result, error) {
+func (r *RedpandaReconciler) reconcileDelete(ctx context.Context, rp *v1alpha2.Redpanda) error {
 	if controllerutil.ContainsFinalizer(rp, FinalizerKey) {
 		controllerutil.RemoveFinalizer(rp, FinalizerKey)
 		if err := r.Client.Update(ctx, rp); err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func (r *RedpandaReconciler) createHelmReleaseFromTemplate(ctx context.Context, rp *v1alpha2.Redpanda) (*helmv2beta2.HelmRelease, error) {

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -749,7 +749,7 @@ func (s *RedpandaControllerSuite) randString(length int) string {
 	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 	name := ""
-	for i := 0; i < 6; i++ {
+	for i := 0; i < length; i++ {
 		//nolint:gosec // not meant to be a secure random string.
 		name += string(alphabet[rand.Intn(len(alphabet))])
 	}

--- a/operator/pkg/client/acls/rules.go
+++ b/operator/pkg/client/acls/rules.go
@@ -26,7 +26,7 @@ type rule struct {
 	PermissionType      kmsg.ACLPermissionType
 }
 
-func rulesFromV1Alpha2ACL(principal string, r redpandav1alpha2.ACLRule) ([]rule, error) { //nolint:gocritic // pass by value here is fine
+func rulesFromV1Alpha2ACL(principal string, r redpandav1alpha2.ACLRule) []rule {
 	rules := []rule{}
 	for _, operation := range r.Operations {
 		rules = append(rules, rule{
@@ -40,7 +40,7 @@ func rulesFromV1Alpha2ACL(principal string, r redpandav1alpha2.ACLRule) ([]rule,
 		})
 	}
 
-	return rules, nil
+	return rules
 }
 
 func ruleToV1Alpha2Rule(r rule) redpandav1alpha2.ACLRule {

--- a/operator/pkg/client/acls/set.go
+++ b/operator/pkg/client/acls/set.go
@@ -40,7 +40,7 @@ func rulesetFromDescribeResponse(acls []kmsg.DescribeACLsResponseResource) colle
 	return rules
 }
 
-func calculateACLs(principal string, rules []redpandav1alpha2.ACLRule, existing []kmsg.DescribeACLsResponseResource) ([]kmsg.CreateACLsRequestCreation, []kmsg.DeleteACLsRequestFilter, error) {
+func calculateACLs(principal string, rules []redpandav1alpha2.ACLRule, existing []kmsg.DescribeACLsResponseResource) ([]kmsg.CreateACLsRequestCreation, []kmsg.DeleteACLsRequestFilter) {
 	// initially mark all existing acls as needing deletion
 	existingRules := rulesetFromDescribeResponse(existing)
 	desiredRules := collections.NewSet[rule]()
@@ -49,10 +49,7 @@ func calculateACLs(principal string, rules []redpandav1alpha2.ACLRule, existing 
 	// exist from our deletion set and adding them to the creation set
 	// if they don't yet exist
 	for _, rule := range rules {
-		rules, err := rulesFromV1Alpha2ACL(principal, rule)
-		if err != nil {
-			return nil, nil, err
-		}
+		rules := rulesFromV1Alpha2ACL(principal, rule)
 
 		for _, acl := range rules {
 			desiredRules.Add(acl)
@@ -62,5 +59,5 @@ func calculateACLs(principal string, rules []redpandav1alpha2.ACLRule, existing 
 	toCreate := collections.MapSet(desiredRules.LeftDisjoint(existingRules), ruleToCreationRequest)
 	toDelete := collections.MapSet(desiredRules.RightDisjoint(existingRules), ruleToDeletionFilter)
 
-	return toCreate, toDelete, nil
+	return toCreate, toDelete
 }

--- a/operator/pkg/client/acls/syncer.go
+++ b/operator/pkg/client/acls/syncer.go
@@ -82,10 +82,7 @@ func (s *Syncer) sync(ctx context.Context, principal string, rules []redpandav1a
 		return 0, 0, fmt.Errorf("listing ACLs: %w", err)
 	}
 
-	creations, deletions, err := calculateACLs(principal, rules, acls)
-	if err != nil {
-		return 0, 0, fmt.Errorf("calculating ACLs: %w", err)
-	}
+	creations, deletions := calculateACLs(principal, rules, acls)
 
 	if err := s.createACLs(ctx, creations); err != nil {
 		return 0, 0, fmt.Errorf("creating ACLs: %w", err)


### PR DESCRIPTION
Prior to this commit it was possible for unused parameters to accidentally go unnoticed [^1].

As a linter would have saved a bit of heartache, this commit enables the `unparam` linter and fixes a few cases in violation.

The `unused` linter was considered for the job but it's configured by default to ignore all parameters. Disabling that config (`parameters-are-used`) causes massive false positives on interface definitions making it useless.

[^1]: https://github.com/redpanda-data/redpanda-operator/pull/331/files#diff-0119f751e27a1f5c78bb3132cee1aee1b87644699eb02fab03e9a1c28edcb68fR806