### PR TITLE
Change vectorized container registry to redpanda-data

### DIFF
--- a/operator/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
+++ b/operator/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: additional-configuration
 spec:
-  image: "vectorized/redpanda"
+  image: "docker.redpanda.com/redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 1
   resources:

--- a/operator/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
+++ b/operator/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: additional-configuration
 spec:
-  image: "docker.redpanda.com/redpandadata/redpanda"
+  image: "redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 1
   resources:

--- a/operator/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-upgrade
 spec:
-  image: "vectorized/redpanda"
+  image: "docker.redpanda.com/redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 2
   resources:

--- a/operator/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/00-redpanda-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-upgrade
 spec:
-  image: "docker.redpanda.com/redpandadata/redpanda"
+  image: "redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 2
   resources:

--- a/operator/tests/e2e/centralized-configuration-upgrade/01-assert.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/01-assert.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:v24.2.5"
+      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.5"
 status:
   phase: "Running"
 ---
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:v24.2.5"
+      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.5"
 status:
   phase: "Running"
 ---

--- a/operator/tests/e2e/centralized-configuration-upgrade/01-assert.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/01-assert.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.5"
+      image: "redpandadata/redpanda:v24.2.5"
 status:
   phase: "Running"
 ---
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.5"
+      image: "redpandadata/redpanda:v24.2.5"
 status:
   phase: "Running"
 ---

--- a/operator/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-upgrade
 spec:
-  image: "vectorized/redpanda"
+  image: "docker.redpanda.com/redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 2
   resources:

--- a/operator/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/01-first-upgrade.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-upgrade
 spec:
-  image: "docker.redpanda.com/redpandadata/redpanda"
+  image: "redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 2
   resources:

--- a/operator/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-upgrade
 spec:
-  image: "vectorized/redpanda"
+  image: "docker.redpanda.com/redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 2
   resources:

--- a/operator/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
+++ b/operator/tests/e2e/centralized-configuration-upgrade/02-update-to-central-config-with-prop.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: centralized-configuration-upgrade
 spec:
-  image: "docker.redpanda.com/redpandadata/redpanda"
+  image: "redpandadata/redpanda"
   version: "v24.2.5"
   replicas: 2
   resources:

--- a/operator/tests/e2e/update-image-and-node-port/00-assert.yaml
+++ b/operator/tests/e2e/update-image-and-node-port/00-assert.yaml
@@ -42,7 +42,7 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 status:
-  version: "v23.3.20"
+  version: "v24.1.15"
   readyReplicas: 3
   replicas: 3
   upgrading: false

--- a/operator/tests/e2e/update-image-and-node-port/00-v24-1-15.yaml
+++ b/operator/tests/e2e/update-image-and-node-port/00-v24-1-15.yaml
@@ -22,8 +22,8 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 spec:
-  image: "vectorized/redpanda"
-  version: "v23.3.20"
+  image: "docker.redpanda.com/redpandadata/redpanda"
+  version: "v24.1.15"
   replicas: 3
   restartConfig:
     underReplicatedPartitionThreshold: 0

--- a/operator/tests/e2e/update-image-and-node-port/00-v24-1-15.yaml
+++ b/operator/tests/e2e/update-image-and-node-port/00-v24-1-15.yaml
@@ -22,7 +22,7 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 spec:
-  image: "docker.redpanda.com/redpandadata/redpanda"
+  image: "redpandadata/redpanda"
   version: "v24.1.15"
   replicas: 3
   restartConfig:

--- a/operator/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/operator/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.12"
+      image: "redpandadata/redpanda:v24.2.12"
 status:
   phase: "Running"
 ---
@@ -31,7 +31,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.12"
+      image: "redpandadata/redpanda:v24.2.12"
 status:
   phase: "Running"
 ---
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.12"
+      image: "redpandadata/redpanda:v24.2.12"
 status:
   phase: "Running"
 ---

--- a/operator/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/operator/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:v24.1.15"
+      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.12"
 status:
   phase: "Running"
 ---
@@ -31,7 +31,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:v24.1.15"
+      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.12"
 status:
   phase: "Running"
 ---
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:v24.1.15"
+      image: "docker.redpanda.com/redpandadata/redpanda:v24.2.12"
 status:
   phase: "Running"
 ---
@@ -75,7 +75,7 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 status:
-  version: "v24.1.15"
+  version: "v24.2.12"
   readyReplicas: 3
   replicas: 3
   upgrading: false

--- a/operator/tests/e2e/update-image-and-node-port/02-v24-2-12.yaml
+++ b/operator/tests/e2e/update-image-and-node-port/02-v24-2-12.yaml
@@ -11,4 +11,4 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 spec:
-  version: "v24.1.15"
+  version: "v24.2.12"

--- a/operator/tests/e2e/update-image-tls-client-auth-external-ca/01-assert.yaml
+++ b/operator/tests/e2e/update-image-tls-client-auth-external-ca/01-assert.yaml
@@ -80,7 +80,7 @@ kind: Cluster
 metadata:
   name: update-img-external-client-ca
 status:
-  version: "v24.1.15"
+  version: "v24.2.12"
   readyReplicas: 1
   replicas: 1
   upgrading: false

--- a/operator/tests/e2e/update-image-tls-client-auth-external-ca/01-v24-2-12.yaml
+++ b/operator/tests/e2e/update-image-tls-client-auth-external-ca/01-v24-2-12.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: update-img-external-client-ca
 spec:
-  image: "docker.redpanda.com/redpandadata/redpanda"
+  image: "redpandadata/redpanda"
   version: "v24.2.12"
   replicas: 1
   resources:

--- a/operator/tests/e2e/update-image-tls-client-auth-external-ca/01-v24-2-12.yaml
+++ b/operator/tests/e2e/update-image-tls-client-auth-external-ca/01-v24-2-12.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: update-img-external-client-ca
 spec:
-  image: "redpandadata/redpanda"
-  version: "v24.1.15"
+  image: "docker.redpanda.com/redpandadata/redpanda"
+  version: "v24.2.12"
   replicas: 1
   resources:
     requests:

--- a/operator/tests/e2e/update-image-tls-client-auth-external-ca/02-console.yaml
+++ b/operator/tests/e2e/update-image-tls-client-auth-external-ca/02-console.yaml
@@ -12,6 +12,6 @@ spec:
     name: update-img-external-client-ca
     namespace: redpanda-system
   deployment:
-    image: docker.redpanda.com/redpandadata/console:v2.8.0
+    image: redpandadata/console:v2.8.0
   connect:
     enabled: false

--- a/operator/tests/e2e/update-image-tls-client-auth-external-ca/02-console.yaml
+++ b/operator/tests/e2e/update-image-tls-client-auth-external-ca/02-console.yaml
@@ -12,6 +12,6 @@ spec:
     name: update-img-external-client-ca
     namespace: redpanda-system
   deployment:
-    image: vectorized/console:v2.6.1
+    image: docker.redpanda.com/redpandadata/console:v2.8.0
   connect:
     enabled: false


### PR DESCRIPTION
The vectorized container registry was shut down last night. All references was switch to redpanda-data container registry.