### PR TITLE
Relax constraints to fix potentially flaky test condition

### DIFF
--- a/operator/internal/decommissioning/statefulset_decommissioner_test.go
+++ b/operator/internal/decommissioning/statefulset_decommissioner_test.go
@@ -89,7 +89,8 @@ func (s *StatefulSetDecommissionerSuite) TestDecommission() {
 	s.waitFor(func(ctx context.Context) (bool, error) {
 		health, err := adminClient.GetHealthOverview(ctx)
 		if err != nil {
-			return false, err
+			s.T().Log("failed to fetch health overview", "error", err)
+			return false, nil
 		}
 		// make sure that we've removed all stale nodes
 		return len(health.NodesDown) == 0, nil
@@ -111,7 +112,8 @@ func (s *StatefulSetDecommissionerSuite) TestDecommission() {
 	s.waitFor(func(ctx context.Context) (bool, error) {
 		health, err := adminClient.GetHealthOverview(ctx)
 		if err != nil {
-			return false, err
+			s.T().Log("failed to fetch health overview", "error", err)
+			return false, nil
 		}
 		// make sure that the pod has been taken offline
 		return len(health.NodesDown) == 1, nil
@@ -125,7 +127,8 @@ func (s *StatefulSetDecommissionerSuite) TestDecommission() {
 	s.waitFor(func(ctx context.Context) (bool, error) {
 		health, err := adminClient.GetHealthOverview(ctx)
 		if err != nil {
-			return false, err
+			s.T().Log("failed to fetch health overview", "error", err)
+			return false, nil
 		}
 		// now make sure it comes back online and the broker is decommissioned
 		return len(health.NodesDown) == 0, nil


### PR DESCRIPTION
This attempts to fix some potential flakiness in the new decommissioner test. The error trace from CI is:

```
    statefulset_decommissioner_test.go:397:
        	Error Trace:	/work/operator/internal/decommissioning/statefulset_decommissioner_test.go:397
        	            				/work/operator/internal/decommissioning/statefulset_decommissioner_test.go:125
        	Error:      	Received unexpected error:
        	            	Get "https://basic-1.basic.testenv-qg6gb.svc.cluster.local.:9644/v1/cluster/health_overview": write tcp 127.0.0.1:46712->127.0.0.1:35321: i/o timeout
        	Test:       	TestStatefulSetDecommissioner/TestDecommission
```

Internally the rpadmin client attempts requests to every broker in its url list prior to failing (see the [body](https://github.com/redpanda-data/common-go/blob/dd5f6c3e5d640ee307671f2510a1b25429ef0d92/rpadmin/admin.go#L333) of `sendAny`), so this likely tells me something may have happened systemically that crashed the k3d cluster this was running on (we shouldn't get this i/o timeout unless **every** broker failed to handle the request based on my reading of `sendAny`).

This happens late in the test, such that we see these controller logs prior:

```
  | statefulset_decomissioner.go:589: StatefulSetDecommissioner.Decomission: "level"=2 "msg"="healthy brokers: [1, 2, 3, 5], ignored: [], to decommission: [0], decommissioning: []" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="d2cee50e-cd69-4ff3-a1be-41055f6515ca" "namespace"="testenv-qg6gb" "name"="basic"
  | recorder.go:104: events: "level"=1 "msg"="brokers needing decommissioning: [0], decommissioning: 0" "type"="Normal" "object"={"kind"="StatefulSet" "namespace"="testenv-qg6gb" "name"="basic" "uid"="54f53ee1-4a0c-45bf-9833-5e2827420b56" "apiVersion"="apps/v1" "resourceVersion"="2418"} "reason"="DecommissioningBroker"
  | controller.go:326: "level"=5 "msg"="Reconcile done, requeueing after 2.090150722s" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="d2cee50e-cd69-4ff3-a1be-41055f6515ca"
  | controller.go:310: "level"=5 "msg"="Reconciling" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="f86eadcd-e0e0-4cf8-8d84-a5bdf40796fd"
  | statefulset_decomissioner.go:333: StatefulSetDecommissioner.Decomission: "level"=2 "msg"="fetched unbound volume claims" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="f86eadcd-e0e0-4cf8-8d84-a5bdf40796fd" "namespace"="testenv-qg6gb" "name"="basic" "claims"=[]
  | controller.go:339: "level"=5 "msg"="Reconcile successful" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="f86eadcd-e0e0-4cf8-8d84-a5bdf40796fd"
  | controller.go:310: "level"=5 "msg"="Reconciling" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="b3cf31ee-df04-445b-b5ec-d5cd372a6cff"
  | statefulset_decomissioner.go:333: StatefulSetDecommissioner.Decomission: "level"=2 "msg"="fetched unbound volume claims" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="b3cf31ee-df04-445b-b5ec-d5cd372a6cff" "namespace"="testenv-qg6gb" "name"="basic" "claims"=[]
  | controller.go:339: "level"=5 "msg"="Reconcile successful" "controller"="statefulset" "controllerGroup"="apps" "controllerKind"="StatefulSet" "StatefulSet"={"name"="basic" "namespace"="testenv-qg6gb"} "namespace"="testenv-qg6gb" "name"="basic" "reconcileID"="b3cf31ee-df04-445b-b5ec-d5cd372a6cff"
  | === NAME  TestStatefulSetDecommissioner/TestDecommission
  | statefulset_decommissioner_test.go:397:
  | Error Trace:	/work/operator/internal/decommissioning/statefulset_decommissioner_test.go:397
  | /work/operator/internal/decommissioning/statefulset_decommissioner_test.go:125
  | Error:      	Received unexpected error:
  | Get "https://basic-1.basic.testenv-qg6gb.svc.cluster.local.:9644/v1/cluster/health_overview": write tcp 127.0.0.1:46712->127.0.0.1:35321: i/o timeout
  | Test:       	TestStatefulSetDecommissioner/TestDecommission
```

So likely either one of a few things is happening:
1. The k3d cluster crashed somehow and so we got an i/o timeout
2. There's some issue with the underlying port-forwarding dialer such that all of a sudden the API server wasn't properly forwarding requests using it (this could also be caused by a k3d issue if somehow the API server gave up the ghost)
3. Calling the decommission endpoint on the Redpanda API crashed all of the nodes

I highly doubt that number 3 is happening, but I've seen number 1 happen before and I wouldn't rule out number 2. Either way, rather than fail immediately on an i/o timeout to all brokers, this PR relaxes the API call failures in case of a potentially transient blip (maybe case 2?) such that we retry across the entirety of the `waitFor` time prior to failing the test.