### PR TITLE
Add configwatcher replacement

### DIFF
--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -47,7 +47,6 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/Microsoft/hcsshim v0.12.3 h1:LS9NXqXhMoqNCplK1ApmVSfB4UnVLRDWRapB6EIlxE0=
 github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6CtY2Qg/JVQ=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
-github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -398,7 +397,6 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
-github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/homeport/dyff v1.7.1 h1:B3KJUtnU53H2UryxGcfYKQPrde8VjjbwlHZbczH3giQ=

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -47,6 +47,7 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/Microsoft/hcsshim v0.12.3 h1:LS9NXqXhMoqNCplK1ApmVSfB4UnVLRDWRapB6EIlxE0=
 github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6CtY2Qg/JVQ=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
+github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -397,6 +398,7 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
+github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/homeport/dyff v1.7.1 h1:B3KJUtnU53H2UryxGcfYKQPrde8VjjbwlHZbczH3giQ=

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fluxcd/pkg/runtime v0.43.3
 	github.com/fluxcd/source-controller/api v1.2.3
 	github.com/fluxcd/source-controller/shim v0.0.0-00010101000000-000000000000
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.2
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/json-iterator/go v1.1.12
@@ -191,7 +192,6 @@ require (
 	github.com/fluxcd/pkg/tar v0.4.0 // indirect
 	github.com/fluxcd/pkg/version v0.2.2 // indirect
 	github.com/fluxcd/source-controller v1.2.3 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getsentry/sentry-go v0.18.0 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/chi/v5 v5.0.12 // indirect

--- a/operator/internal/configwatcher/configwatcher.go
+++ b/operator/internal/configwatcher/configwatcher.go
@@ -1,0 +1,241 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package configwatcher
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/console/backend/pkg/config"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	defaultConfigPath     = "/var/lib/redpanda.yaml"
+	defaultUsersDirectory = "/etc/secret/users"
+)
+
+type Option func(c *ConfigWatcher)
+
+// ConfigWatcher replaces the old bash scripts we leveraged for waiting
+// for a cluster to become stable and then creating superusers
+type ConfigWatcher struct {
+	adminClient    *rpadmin.AdminAPI
+	configPath     string
+	usersDirectory string
+	watch          bool
+	fs             afero.Fs
+	log            logr.Logger
+
+	// for testing mostly
+	initialized chan struct{}
+}
+
+func WithRedpandaConfigPath(path string) Option {
+	return func(c *ConfigWatcher) {
+		c.configPath = path
+	}
+}
+
+func WithUsersDirectory(path string) Option {
+	return func(c *ConfigWatcher) {
+		c.usersDirectory = path
+	}
+}
+
+func WithFs(fs afero.Fs) Option {
+	return func(c *ConfigWatcher) {
+		c.fs = fs
+	}
+}
+
+func WithInitializedSignal(ch chan struct{}) Option {
+	return func(c *ConfigWatcher) {
+		c.initialized = ch
+	}
+}
+
+func NewConfigWatcher(log logr.Logger, watch bool, options ...Option) *ConfigWatcher {
+	watcher := &ConfigWatcher{
+		log:            log,
+		watch:          watch,
+		configPath:     defaultConfigPath,
+		usersDirectory: defaultUsersDirectory,
+		fs:             afero.NewOsFs(),
+		initialized:    make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(watcher)
+	}
+
+	return watcher
+}
+
+func (w *ConfigWatcher) Start(ctx context.Context) error {
+	params := rpkconfig.Params{ConfigFlag: w.configPath}
+
+	config, err := params.Load(w.fs)
+	if err != nil {
+		return fmt.Errorf("loading rpk config: %w", err)
+	}
+
+	factory := internalclient.NewFactory(&rest.Config{}, nil).WithFS(w.fs)
+	client, err := factory.RedpandaAdminClient(ctx, config.VirtualProfile())
+	if err != nil {
+		return fmt.Errorf("initializing Redpanda admin API client: %w", err)
+	}
+
+	w.adminClient = client
+
+	close(w.initialized)
+
+	w.syncInitial(ctx)
+
+	return w.watchFilesystem(ctx)
+}
+
+func (w *ConfigWatcher) syncInitial(ctx context.Context) {
+	files, err := os.ReadDir(w.usersDirectory)
+	if err != nil {
+		w.log.Error(err, "unable to get user directory files")
+		return
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		filePath := path.Join(w.usersDirectory, file.Name())
+		w.SyncUsers(ctx, filePath)
+	}
+}
+
+func (w *ConfigWatcher) watchFilesystem(ctx context.Context) error {
+	if !w.watch {
+		<-ctx.Done()
+		return nil
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(w.usersDirectory); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case err := <-watcher.Errors:
+			// here we don't return as that'd crash the broker, instead
+			// just log the error and move on after some sleep time.
+			w.log.Error(err, "watcher returned an error")
+			time.Sleep(5 * time.Second)
+		case event := <-watcher.Events:
+			file := path.Join(w.usersDirectory, event.Name)
+			w.SyncUsers(ctx, file)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (w *ConfigWatcher) SyncUsers(ctx context.Context, path string) {
+	file, err := w.fs.Open(path)
+	if err != nil {
+		w.log.Error(err, "unable to open superusers file", "file", path)
+		return
+	}
+	defer file.Close()
+
+	// sync our internal superuser first
+	internalSuperuser, password, mechanism := getInternalUser()
+	// the internal user should only ever be created once, so don't
+	// update its password ever.
+	w.syncUser(ctx, internalSuperuser, password, mechanism, false)
+
+	users := []string{internalSuperuser}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		tokens := strings.SplitN(line, ":", 3)
+		if len(tokens) != 3 && len(tokens) != 2 {
+			w.log.Error(err, "malformed line: %s", line)
+			continue
+		}
+
+		mechanism := config.SASLMechanismScramSHA256
+
+		user, password := tokens[0], tokens[1]
+		if len(tokens) == 3 {
+			mechanism = tokens[2]
+		}
+
+		if !slices.Contains(users, user) {
+			users = append(users, user)
+		}
+
+		w.syncUser(ctx, user, password, mechanism, true)
+	}
+
+	w.setSuperusers(ctx, users)
+}
+
+func (w *ConfigWatcher) setSuperusers(ctx context.Context, users []string) {
+	if _, err := w.adminClient.PatchClusterConfig(ctx, map[string]any{
+		"superusers": users,
+	}, []string{}); err != nil {
+		w.log.Error(err, "could not set superusers")
+	}
+}
+
+func (w *ConfigWatcher) syncUser(ctx context.Context, user, password, mechanism string, recreate bool) {
+	if err := w.adminClient.CreateUser(ctx, user, password, mechanism); err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			if recreate {
+				// the original implementation did an update via Delete + Create, so do that here
+				if err := w.adminClient.DeleteUser(ctx, user); err != nil {
+					w.log.Error(err, "could not delete user for recreation", "user", user)
+					return
+				}
+				if err := w.adminClient.CreateUser(ctx, user, password, mechanism); err != nil {
+					w.log.Error(err, "could not recreate user", "user", user)
+				}
+			}
+			return
+		}
+		w.log.Error(err, "could not create user", "user", user)
+	}
+}
+
+func getInternalUser() (string, string, string) {
+	mechanism := os.Getenv("RPK_SASL_MECHANISM")
+	if mechanism == "" {
+		mechanism = config.SASLMechanismScramSHA256
+	}
+
+	return os.Getenv("RPK_USER"), os.Getenv("RPK_PASS"), mechanism
+}

--- a/operator/internal/configwatcher/configwatcher.go
+++ b/operator/internal/configwatcher/configwatcher.go
@@ -23,10 +23,11 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/console/backend/pkg/config"
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"k8s.io/client-go/rest"
+
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 const (

--- a/operator/internal/configwatcher/configwatcher_test.go
+++ b/operator/internal/configwatcher/configwatcher_test.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package configwatcher_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/configwatcher"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestConfigWatcher(t *testing.T) {
+	const user = "user"
+	const password = "password"
+	const saslMechanism = "SCRAM-SHA-512"
+
+	ctx := context.Background()
+	logger := testr.New(t)
+	ctx = log.IntoContext(ctx, logger)
+
+	// No auth is easy, only test on a cluster with auth on admin API.
+	container, err := redpanda.Run(
+		ctx,
+		"redpandadata/redpanda:v24.2.4",
+		redpanda.WithSuperusers("user"),
+		testcontainers.WithEnv(map[string]string{
+			"RP_BOOTSTRAP_USER": fmt.Sprintf("%s:%s:%s", user, password, saslMechanism),
+		}),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		container.Terminate(context.Background())
+	})
+
+	adminAPI, err := container.AdminAPIAddress(ctx)
+	require.NoError(t, err)
+	adminClient, err := rpadmin.NewAdminAPI([]string{adminAPI}, &rpadmin.BasicAuth{Username: user, Password: password}, nil)
+	require.NoError(t, err)
+
+	t.Setenv("RPK_USER", user)
+	t.Setenv("RPK_PASS", password)
+	t.Setenv("RPK_SASL_MECHANISM", saslMechanism)
+
+	redpandaYaml := createRedpandaYaml(adminAPI, user, password, saslMechanism)
+
+	users := []string{
+		createUserLine("foo", "bar", "SCRAM-SHA-512"),
+		createUserLine("baz", "zoiks", "SCRAM-SHA-256"),
+		// repeat, make sure it merges and updates to the last
+		createUserLine("baz", "bar", "SCRAM-SHA-512"),
+		// invalid mechanism, shouldn't fail regardless
+		createUserLine("baz", "bar", "INVALID"),
+	}
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/var/lib", 0755))
+	require.NoError(t, fs.MkdirAll("/etc/secret/users", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/var/lib/redpanda.yaml", []byte(redpandaYaml), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/etc/secret/users/users.txt", []byte(strings.Join(users, "\n")), 0644))
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	initialized := make(chan struct{})
+	watcher := configwatcher.NewConfigWatcher(logger, false, configwatcher.WithFs(fs), configwatcher.WithInitializedSignal(initialized))
+
+	errCh := make(chan error, 1)
+	done := make(chan struct{}, 1)
+	go func() {
+		if err := watcher.Start(ctx); err != nil {
+			select {
+			case <-ctx.Done():
+				close(done)
+				return
+			default:
+				errCh <- err
+			}
+		}
+		close(done)
+	}()
+
+	select {
+	case <-initialized:
+	case err := <-errCh:
+		require.NoError(t, err)
+	}
+
+	watcher.SyncUsers(ctx, "/etc/secret/users/users.txt")
+	clusterUsers, err := adminClient.ListUsers(ctx)
+	require.NoError(t, err)
+	require.Len(t, clusterUsers, 3)
+
+	superuserConfig, err := adminClient.SingleKeyConfig(ctx, "superusers")
+	require.NoError(t, err)
+
+	superusers := superuserConfig["superusers"]
+	require.Len(t, superusers, 3)
+
+	require.ElementsMatch(t, superusers, clusterUsers)
+
+	cancel()
+
+	select {
+	case <-done:
+	case err := <-errCh:
+		require.NoError(t, err)
+	}
+}
+
+func createRedpandaYaml(host, user, password, mechanism string) string {
+	return fmt.Sprintf(`
+rpk:
+    admin_api:
+        addresses:
+            - %q
+    kafka_api:
+        sasl:
+            user: %q
+            password: %q
+            mechanism: %q
+`, host, user, password, mechanism)
+}
+
+func createUserLine(user, password, mechanism string) string {
+	return user + ":" + password + ":" + mechanism
+}

--- a/operator/internal/configwatcher/configwatcher_test.go
+++ b/operator/internal/configwatcher/configwatcher_test.go
@@ -17,12 +17,13 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/redpanda-data/common-go/rpadmin"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/configwatcher"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/redpanda-data/redpanda-operator/operator/internal/configwatcher"
 )
 
 func TestConfigWatcher(t *testing.T) {
@@ -46,7 +47,7 @@ func TestConfigWatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		container.Terminate(context.Background())
+		_ = container.Terminate(context.Background())
 	})
 
 	adminAPI, err := container.AdminAPIAddress(ctx)
@@ -70,10 +71,10 @@ func TestConfigWatcher(t *testing.T) {
 	}
 
 	fs := afero.NewMemMapFs()
-	require.NoError(t, fs.MkdirAll("/var/lib", 0755))
-	require.NoError(t, fs.MkdirAll("/etc/secret/users", 0755))
-	require.NoError(t, afero.WriteFile(fs, "/var/lib/redpanda.yaml", []byte(redpandaYaml), 0644))
-	require.NoError(t, afero.WriteFile(fs, "/etc/secret/users/users.txt", []byte(strings.Join(users, "\n")), 0644))
+	require.NoError(t, fs.MkdirAll("/var/lib", 0o755))
+	require.NoError(t, fs.MkdirAll("/etc/secret/users", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/var/lib/redpanda.yaml", []byte(redpandaYaml), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/etc/secret/users/users.txt", []byte(strings.Join(users, "\n")), 0o644))
 
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/operator/pkg/k3d/k3d.go
+++ b/operator/pkg/k3d/k3d.go
@@ -146,6 +146,7 @@ func NewCluster(name string, opts ...ClusterOpt) (*Cluster, error) {
 		// Pod eviction happens in a timely fashion.
 		`--k3s-arg`, `--kube-apiserver-arg=default-not-ready-toleration-seconds=10@server:*`,
 		`--k3s-arg`, `--kube-apiserver-arg=default-unreachable-toleration-seconds=10@server:*`,
+		`--verbose`,
 	}
 
 	out, err := exec.Command("k3d", args...).CombinedOutput()
@@ -155,14 +156,15 @@ func NewCluster(name string, opts ...ClusterOpt) (*Cluster, error) {
 		}
 
 		// If k3d cluster create will fail please uncomment the following debug logs from containers
-		// for i := 0; i < config.agents; i++ {
-		// 	containerLogs, _ := exec.Command("docker", "logs", fmt.Sprintf("k3d-%s-agent-%d", name, i)).CombinedOutput()
-		// 	fmt.Printf("Agent-%d logs:\n%s\n", i, string(containerLogs))
-		// }
-		// containerLogs, _ = exec.Command("docker", "logs", fmt.Sprintf("k3d-%s-server-0", name)).CombinedOutput()
-		// fmt.Printf("server-0 logs:\n%s\n", string(containerLogs))
-		// containerLogs, _ = exec.Command("docker", "network", "inspect", fmt.Sprintf("k3d-%s", name)).CombinedOutput()
-		// fmt.Printf("docker network inspect:\n%s\n", string(containerLogs))
+		for i := 0; i < config.agents; i++ {
+			containerLogs, _ := exec.Command("docker", "logs", fmt.Sprintf("k3d-%s-agent-%d", name, i)).CombinedOutput()
+			fmt.Printf("Agent-%d logs:\n%s\n", i, string(containerLogs))
+		}
+		containerLogs, _ := exec.Command("docker", "logs", fmt.Sprintf("k3d-%s-server-0", name)).CombinedOutput()
+		fmt.Printf("server-0 logs:\n%s\n", string(containerLogs))
+		containerLogs, _ = exec.Command("docker", "network", "inspect", fmt.Sprintf("k3d-%s", name)).CombinedOutput()
+		fmt.Printf("docker network inspect:\n%s\n", string(containerLogs))
+
 		return nil, errors.Wrapf(err, "%s", out)
 	}
 


### PR DESCRIPTION
This is meant to replace the entirety of [our configwatcher script](https://github.com/redpanda-data/helm-charts/blob/b0a8f611127d405d0811eae052fe75d56a70799d/charts/redpanda/secrets.go#L239) from our helm chart and move all of the ad-hoc bash/secret mounts into a unified go entrypoint in our operator.