### PR TITLE
Fix the sidecar Use field

### DIFF
--- a/operator/cmd/sidecar/sidecar.go
+++ b/operator/cmd/sidecar/sidecar.go
@@ -46,7 +46,7 @@ func Command() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "run",
+		Use:   "sidecar",
 		Short: "Run the redpanda sidecar",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()


### PR DESCRIPTION
I'm not entirely sure how cobra does its command registration and why this seemingly worked (I'm guessing that any subsequent attempts at a matching `Use` flag that has already been registered, just no-op), but this needs to be fixed 😅 