### PR TITLE
gotohelm: fix map indexing and zeroOf

### DIFF
--- a/pkg/gotohelm/testdata/src/example/aaacommon/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/aaacommon/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/astrewrites/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/astrewrites/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/directives/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/directives/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/flowcontrol/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/flowcontrol/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/inputs/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/k8s/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/k8s/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.go
@@ -181,9 +181,16 @@ func quantity(dot *helmette.Dot) map[string]any {
 		value = append(value, q.Value())
 	}
 
+	// Intentionally generate zero values of resource.Quantity to assert that
+	// zeroOf handles it.
+	var varZero resource.Quantity
+	resources := corev1.ResourceList{}
+
 	return map[string]any{
 		"MustParse": quantities,
 		"Value":     value,
 		"String":    strs,
+		"dictZero":  resources[corev1.ResourceCPU],
+		"varZero":   varZero,
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.rewritten.go
@@ -182,9 +182,16 @@ func quantity(dot *helmette.Dot) map[string]any {
 		value = append(value, q.Value())
 	}
 
+	// Intentionally generate zero values of resource.Quantity to assert that
+	// zeroOf handles it.
+	var varZero resource.Quantity
+	resources := corev1.ResourceList{}
+
 	return map[string]any{
 		"MustParse": quantities,
 		"Value":     value,
 		"String":    strs,
+		"dictZero":  resources[corev1.ResourceCPU],
+		"varZero":   varZero,
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
@@ -90,8 +90,10 @@
 {{- if $_is_returning -}}
 {{- break -}}
 {{- end -}}
+{{- $varZero := "0" -}}
+{{- $resources := (dict ) -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (dict "MustParse" $quantities "Value" $value "String" $strs )) | toJson -}}
+{{- (dict "r" (dict "MustParse" $quantities "Value" $value "String" $strs "dictZero" (ternary (index $resources "cpu") "0" (hasKey $resources "cpu")) "varZero" $varZero )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/labels/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/labels/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/sprig/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/syntax/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/syntax/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -236,6 +236,12 @@ func binaryExprs() []any {
 		s1 + s2,
 		"one" + s2,
 		s1 + "two",
+		// Ensure that indexing into a map with a missing key generates the
+		// correct zero value.
+		map[string]int{}["missing"],
+		map[string]string{}["missing"],
+		map[string]bool{}["missing"],
+		map[string]struct{ Foo int }{}["missing"],
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -237,6 +237,12 @@ func binaryExprs() []any {
 		s1 + s2,
 		"one" + s2,
 		s1 + "two",
+		// Ensure that indexing into a map with a missing key generates the
+		// correct zero value.
+		map[string]int{}["missing"],
+		map[string]string{}["missing"],
+		map[string]bool{}["missing"],
+		map[string]struct{ Foo int }{}["missing"],
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -212,7 +212,7 @@
 {{- $s1 := "one " -}}
 {{- $s2 := "two" -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (gt (1 | int) (2 | int)) (lt (1 | int) (2 | int)) (ge (1 | int) (2 | int)) (le (1 | int) (2 | int)) (ge (2 | int) (2 | int)) (le (2 | int) (2 | int)) (printf "%s%s" "string " "concatenation") (printf "%s%s" $s1 $s2) (printf "%s%s" "one" $s2) (printf "%s%s" $s1 "two"))) | toJson -}}
+{{- (dict "r" (list (gt (1 | int) (2 | int)) (lt (1 | int) (2 | int)) (ge (1 | int) (2 | int)) (le (1 | int) (2 | int)) (ge (2 | int) (2 | int)) (le (2 | int) (2 | int)) (printf "%s%s" "string " "concatenation") (printf "%s%s" $s1 $s2) (printf "%s%s" "one" $s2) (printf "%s%s" $s1 "two") (ternary (index (dict ) "missing") 0 (hasKey (dict ) "missing")) (ternary (index (dict ) "missing") "" (hasKey (dict ) "missing")) (ternary (index (dict ) "missing") false (hasKey (dict ) "missing")) (ternary (index (dict ) "missing") (dict "Foo" 0 ) (hasKey (dict ) "missing")))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/typing/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/typing/_shims.tpl
@@ -301,7 +301,7 @@
 {{- $_ := (fail (printf "invalid Duration: %q" $original)) -}}
 {{- end -}}
 {{- $repr = (substr ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int) -1 $repr) -}}
-{{- $value = ((add $value (((mul (int64 $n) (index $unitMap $unit)) | int64))) | int64) -}}
+{{- $value = ((add $value (((mul (int64 $n) (ternary (index $unitMap $unit) 0 (hasKey $unitMap $unit))) | int64))) | int64) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}


### PR DESCRIPTION
#### 66671ba87f3611e211cf1c460325b1af6204901a gotohelm: correct map indexing for non-nil zero values

Prior to this commit all map indexing operations in helm world would return
`nil` thanks to `index`'s behavior under the hood. This worked for 70% of all
cases as the zero value of most map elements was zero. However, non-nil zero
values would be handled incorrectly:

```go
map[string]string{}["missing"] // returns nil in helm
```

This commit updates the transpiler to appropriately detect such cases and
injects the zero value of the map's element type.


#### e6cc8bc235a93d2c63b3914be958d9d9f843f7c8 gotohelm: improve special case detection in zeroOf

Prior to this commit gotohelm would incorrectly attempt to compute the zero
value of types that implemented `json.{Unm,M}arshaller`. In most cases, this
would lead to a transpiler crash all together. In some corner cases, it was
possible to silently generate incorrect values.

This commit improves `zeroOf` to detect and reject implementers of
`json.{Unm,M}arshaller` with a helpful error message and adds a special case
for Kubernetes' `resource.Quantity` type.


