### PR TITLE
testutil: add `SkipIfNotIntegration` and `RequireTimeout`

### DIFF
--- a/pkg/testutil/integration_off.go
+++ b/pkg/testutil/integration_off.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build !integration
+
+package testutil
+
+const skipIntegrationTests = true

--- a/pkg/testutil/integration_on.go
+++ b/pkg/testutil/integration_on.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build integration
+
+package testutil
+
+const skipIntegrationTests = false

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package testutil
+
+import "testing"
+
+func TestIntegrationSkipIfNotIntegration(t *testing.T) {
+	SkipIfNotIntegration(t)
+}


### PR DESCRIPTION
This commit adds the beginnings of a dedicated integration test suite to help segment intensive and long running tests from shorter ones. This comes in the form of the `testutil.SkipIfNotIntegration` helper.