### PR TITLE
Add a remediation for flux-based installation to add retries

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -933,6 +933,19 @@ func (r *RedpandaReconciler) createHelmReleaseFromTemplate(ctx context.Context, 
 			Interval: metav1.Duration{Duration: 30 * time.Second},
 			Timeout:  timeout,
 			Upgrade:  upgrade,
+			Install: &helmv2beta2.Install{
+				Remediation: &helmv2beta2.InstallRemediation{
+					// Per the flux helm remediation docs negative value is set to
+					// reconcile even if client-side cache has stale data.
+					//
+					// Flux Docs:
+					// Retries is the number of retries that should be attempted on
+					// failures before bailing. Remediation, using an uninstall,
+					// is performed between each attempt. Defaults to '0', a negative
+					// integer equals to unlimited retries.
+					Retries: -1,
+				},
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
Based on some issues uncovered in CI which may be due to staleness in the client-side cache such that the internal flux-based helm controllers don't properly fetch a helm release installation secret... I noticed that we never attempt a second installation if an installation failed once. Here are the logs showing this, notice `release not installed: no release in storage for object` followed by `terminal error: exceeded maximum retries: cannot remediate failed release`:

```
    helmchart_template.go:144: "level"=0 "msg"="Created HelmChart/testenv-jg8vs/testenv-jg8vs-rp-fv2vfj with SourceRef 'HelmRepository/testenv-jg8vs/redpanda-repository'" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="b6b3d0e9-0b1f-4a36-ab76-b27abb5d551b"
E1217 10:44:06.074973   69483 event.go:443] "Unsupported event type" eventType="Trace"
    helmrelease_controller.go:273: "level"=0 "msg"="HelmChart 'testenv-jg8vs/testenv-jg8vs-rp-fv2vfj' is not ready: latest generation of object has not been reconciled" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="b6b3d0e9-0b1f-4a36-ab76-b27abb5d551b"
...
    helmchart_controller.go:1225: "level"=0 "msg"="failed to cache index: Cache is full" "controller"="helmchart" "controllerGroup"="source.toolkit.fluxcd.io" "controllerKind"="HelmChart" "HelmChart"={"name"="testenv-jg8vs-rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="testenv-jg8vs-rp-fv2vfj" "reconcileID"="1404af8e-25c2-4169-9fc2-6cd8c3af2506"
E1217 10:44:07.315720   69483 event.go:443] "Unsupported event type" eventType="Trace"
    helmchart_controller.go:344: "level"=0 "msg"="pulled 'redpanda' chart with version '5.9.15'" "controller"="helmchart" "controllerGroup"="source.toolkit.fluxcd.io" "controllerKind"="HelmChart" "HelmChart"={"name"="testenv-jg8vs-rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="testenv-jg8vs-rp-fv2vfj" "reconcileID"="1404af8e-25c2-4169-9fc2-6cd8c3af2506"
    helmchart_template.go:151: "level"=0 "msg"="HelmChart/testenv-jg8vs/testenv-jg8vs-rp-fv2vfj with SourceRef 'HelmRepository/testenv-jg8vs/redpanda-repository' is in-sync" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="5efbf41d-4997-4fd6-8f68-06f03b013b03"
    atomic_release.go:344: "level"=0 "msg"="release not installed: no release in storage for object" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="5efbf41d-4997-4fd6-8f68-06f03b013b03"
    atomic_release.go:251: "level"=0 "msg"="running 'install' action with timeout of 15m0s" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="5efbf41d-4997-4fd6-8f68-06f03b013b03"
...
    atomic_release.go:419: "level"=0 "msg"="release is in a failed state" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="5efbf41d-4997-4fd6-8f68-06f03b013b03"
...
    controller.go:324: "msg"="Reconciler error" "error"="terminal error: exceeded maximum retries: cannot remediate failed release" "controller"="helmrelease" "controllerGroup"="helm.toolkit.fluxcd.io" "controllerKind"="HelmRelease" "HelmRelease"={"name"="rp-fv2vfj" "namespace"="testenv-jg8vs"} "namespace"="testenv-jg8vs" "name"="rp-fv2vfj" "reconcileID"="5efbf41d-4997-4fd6-8f68-06f03b013b03"
```

This change just makes it so we infinitely retry an installation when it fails. The doc comment for this field on the installation remediation struct:

> Retries is the number of retries that should be attempted on failures before bailing. Remediation, using an uninstall, is performed between each attempt. Defaults to '0', a negative integer equals to unlimited retries.