### PR TITLE
re-enable integration tests

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller_integration_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_integration_test.go
@@ -31,7 +31,6 @@ import (
 // Annotations of all objects created by the controller are stable across flux
 // and de-fluxed.
 func (s *RedpandaControllerSuite) TestIntegrationStableUIDAndGeneration() {
-	s.T().Skip("Too flaky")
 	testutil.SkipIfNotIntegration(s.T())
 	testutil.RequireTimeout(s.T(), time.Minute*20)
 

--- a/operator/internal/decommissioning/statefulset_decommissioner_test.go
+++ b/operator/internal/decommissioning/statefulset_decommissioner_test.go
@@ -48,7 +48,6 @@ import (
 var decommissionerRBAC []byte
 
 func TestIntegrationStatefulSetDecommissioner(t *testing.T) {
-	t.Skip("Too flaky")
 	testutil.SkipIfNotIntegration(t)
 	testutil.RequireTimeout(t, time.Minute*10)
 


### PR DESCRIPTION
On top of #363

The flaky tests are re-enabled to see how stable they are.

With new year the lint step failed at the license header year change. 