### PR TITLE
Fix multi arch nightly build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     label: ":gandalf: Nightly Operator release"
     timeout_in_minutes: 10
     agents:
-      queue: k8s-builders
+      queue: v6-amd64-builders-m6id
     commands:
       - |
         TAG_NAME=$(ci/scripts/tag-check.sh) ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:publish-k8s-nightly-artifacts

--- a/operator/tests/e2e-with-flags/nodepools-delete/00-one-nodepool.yaml
+++ b/operator/tests/e2e-with-flags/nodepools-delete/00-one-nodepool.yaml
@@ -8,6 +8,8 @@ spec:
   nodePools:
     - name: first
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"

--- a/operator/tests/e2e-with-flags/nodepools-delete/01-add-second-pool.yaml
+++ b/operator/tests/e2e-with-flags/nodepools-delete/01-add-second-pool.yaml
@@ -8,6 +8,8 @@ spec:
   nodePools:
     - name: first
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"
@@ -17,6 +19,8 @@ spec:
           memory: 256Mi
     - name: second
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "101m"

--- a/operator/tests/e2e-with-flags/nodepools-delete/02-delete-first-nodepool.yaml
+++ b/operator/tests/e2e-with-flags/nodepools-delete/02-delete-first-nodepool.yaml
@@ -11,6 +11,8 @@ spec:
   nodePools:
     - name: second
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "101m"

--- a/operator/tests/e2e-with-flags/nodepools/00-one-nodepool.yaml
+++ b/operator/tests/e2e-with-flags/nodepools/00-one-nodepool.yaml
@@ -8,6 +8,8 @@ spec:
   nodePools:
     - name: nodepool1
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"

--- a/operator/tests/e2e-with-flags/nodepools/01-two-nodepools.yaml
+++ b/operator/tests/e2e-with-flags/nodepools/01-two-nodepools.yaml
@@ -8,6 +8,8 @@ spec:
   nodePools:
     - name: nodepool1
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"
@@ -17,6 +19,8 @@ spec:
           memory: 256Mi
     - name: nodepool2
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"

--- a/operator/tests/e2e-with-flags/nodepools/02-scale-down-first.yaml
+++ b/operator/tests/e2e-with-flags/nodepools/02-scale-down-first.yaml
@@ -8,6 +8,8 @@ spec:
   nodePools:
     - name: nodepool1
       replicas: 0
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"
@@ -17,6 +19,8 @@ spec:
           memory: 256Mi
     - name: nodepool2
       replicas: 3
+      storage: {}
+      cloudCacheStorage: {}
       resources:
         requests:
           cpu: "100m"

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -156,12 +156,23 @@ tasks:
         silent: true
       - 'echo "~~~ :docker: Build & Push operator container"'
       - docker buildx build
-        --platform linux/arm64,linux/amd64
+        --provenance false --sbom false --platform linux/amd64
         --file operator/Dockerfile
         --target manager
-        --tag docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}
+        --tag docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}-amd64
         --push
         ./dist
+      - docker buildx build
+        --provenance false --sbom false --platform linux/arm64
+        --file operator/Dockerfile
+        --target manager
+        --tag docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}-arm64
+        --push
+        ./dist
+      - docker manifest create docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}
+        --amend docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}-amd64
+        --amend docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}-arm64
+      - docker manifest push docker.io/redpandadata/{{.OPERATOR_REPO}}:{{.TAG_NAME}}
       - cmd: docker logout
     preconditions:
       - test -n "$DOCKERHUB_USER"


### PR DESCRIPTION
Based on:

- https://github.com/redpanda-data/redpanda-operator/pull/364
- https://github.com/redpanda-data/redpanda-operator/pull/367

Fix nightly container build

In the CI the following error poped up when helm chart was pushed to docker hub
container registry:
```
[+] Building 0.0s (0/0)                                          docker:default
ERROR: Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/build-multi-platform/
```

https://buildkite.com/redpanda/redpanda-operator/builds/3741#0193d2e2-385c-4b84-9a23-8b047814b3fe/332-333

As machine in `k8s-builder` buildkite queue couldn't finish container build within 10 minutes change the buildkite queue name to `v6-amd64-builders-m6id`.