### PR TITLE
taskfile: add caching to chart generation

### DIFF
--- a/.licenseupdater.yaml
+++ b/.licenseupdater.yaml
@@ -15,6 +15,8 @@ ignore:
   # Ignore go files from gotohelm's rewrite tests, they'll have the header but
   # after a build directive.
   - match: .+\.rewritten\.go$
+  # Ignore go files from genpartial, they utilize a -header flag.
+  - match: .+\.gen\.go$
 files:
   - name: licenses/boilerplate.go.txt
     type: go

--- a/charts/connectors/values_partial.gen.go
+++ b/charts/connectors/values_partial.gen.go
@@ -6,7 +6,6 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
-
 //go:build !generate
 
 // +gotohelm:ignore=true

--- a/charts/console/values_partial.gen.go
+++ b/charts/console/values_partial.gen.go
@@ -6,7 +6,6 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
-
 //go:build !generate
 
 // +gotohelm:ignore=true

--- a/charts/operator/values_partial.gen.go
+++ b/charts/operator/values_partial.gen.go
@@ -6,7 +6,6 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
-
 //go:build !generate
 
 // +gotohelm:ignore=true

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -6,7 +6,6 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
-
 //go:build !generate
 
 // +gotohelm:ignore=true

--- a/genpartial/main.go
+++ b/genpartial/main.go
@@ -48,13 +48,14 @@ func main() {
 	cwd, _ := os.Getwd()
 
 	outFlag := flag.String("out", "-", "The file to output to or `-` for stdout")
+	headerFlag := flag.String("header", "", "A file that will be used as a header for the generated file")
 	structFlag := flag.String("struct", "Values", "The struct name to generate a partial for")
 
 	flag.Parse()
 
 	if len(flag.Args()) != 1 {
 		fmt.Printf("Usage: genpartial <pkg>\n")
-		fmt.Printf("Example: genpartial -struct Values ./charts/redpanda\n")
+		fmt.Printf("Example: genpartial [-header ./path/to/license] -struct Values ./charts/redpanda\n")
 		os.Exit(1)
 	}
 
@@ -64,6 +65,15 @@ func main() {
 	}, flag.Arg(0)))
 
 	var buf bytes.Buffer
+
+	if *headerFlag != "" {
+		header, err := os.ReadFile(*headerFlag)
+		if err != nil {
+			panic(err)
+		}
+		_, _ = buf.Write(header)
+	}
+
 	if err := GeneratePartial(pkgs[0], *structFlag, &buf); err != nil {
 		panic(err)
 	}

--- a/taskfiles/charts.yml
+++ b/taskfiles/charts.yml
@@ -4,49 +4,105 @@ tasks:
   generate:
     desc: "Run all file generation tasks"
     cmds:
-      # Generate chart README.md's
-      - nix develop -c helm-docs -c ./charts/
       - task: generate:console
       - task: generate:operator
       - task: generate:redpanda
       - task: generate:connectors
+      # Generate chart README.md's
+      - helm-docs -c ./charts/
 
   generate:console:
     desc: "Generate files for the console Helm chart"
     cmds:
-      # Generate a "partial" version of the Values struct.
-      - go run ./genpartial -out charts/console/values_partial.gen.go -struct Values ./charts/console
-      # Generate helm templates from Go definitions
-      - go run ./gotohelm -write ./charts/console/templates ./charts/console
+    - task: genpartial
+      vars: { CHART: console }
+    - task: gotohelm
+      vars: { CHART: console }
 
   generate:operator:
     desc: "Generate files for the operator Helm chart"
     cmds:
-      # Generate a "partial" version of the Values struct.
-      - go run ./genpartial -out charts/operator/values_partial.gen.go -struct Values ./charts/operator
-      # Generate the values JSON schema from the Values struct
-      - go run ./genschema operator > charts/operator/values.schema.json
-      # Generate helm templates from Go definitions
-      - go run ./gotohelm -write ./charts/operator/templates ./charts/operator
+    - task: genpartial
+      vars: { CHART: operator }
+    - task: genschema
+      vars: { CHART: operator }
+    - task: gotohelm
+      vars: { CHART: operator }
 
   generate:redpanda:
     desc: "Generate files for the redpanda Helm chart"
     cmds:
-      # Generate a "partial" version of the Values struct.
-      - go run ./genpartial -out charts/redpanda/values_partial.gen.go -struct Values ./charts/redpanda
-      # Generate the values JSON schema from the Values struct
-      - go run ./genschema redpanda > charts/redpanda/values.schema.json
-      # Generate helm templates from Go definitions
-      - go run ./gotohelm -write ./charts/redpanda/templates ./charts/redpanda ./charts/...
+    - task: genpartial
+      vars: { CHART: redpanda }
+    - task: genschema
+      vars: { CHART: redpanda }
+    - task: gotohelm
+      vars: { CHART: redpanda, DEPS: ./charts/... }
 
   generate:connectors:
     desc: "Generate files for the connectors Helm chart"
     cmds:
-      # Generate a "partial" version of the Values struct.
-      - go run ./genpartial -out charts/connectors/values_partial.gen.go -struct Values ./charts/connectors
-      # Generate helm templates from Go definitions
-      - go run ./gotohelm -write ./charts/connectors/templates ./charts/connectors
+    - task: genpartial
+      vars: { CHART: connectors }
+    - task: gotohelm
+      vars: { CHART: connectors }
 
   kind-cluster:
     cmds:
       - kind create cluster --config operator/kind.yaml
+
+  # Below this line are internal helper tasks that configuring caching for generation tasks.
+
+  genpartial:
+    internal: true
+    run: when_changed
+    label: "genpartial:{{ .CHART }}"
+    desc: "Generate a 'partial' version of the Values struct"
+    var:
+      CHART: ""
+    requires:
+      vars: [CHART]
+    sources:
+    - ./charts/{{ .CHART }}/*.go
+    - ./charts/{{ .CHART }}/**/*.go
+    - exclude: ./charts/{{ .CHART }}/values_partial.gen.go
+    generates:
+    - ./charts/{{ .CHART }}/values_partial.gen.go
+    cmds:
+    - go run ./genpartial -header ./licenses/boilerplate.go.txt -out charts/{{ .CHART }}/values_partial.gen.go -struct Values ./charts/{{ .CHART }}
+
+  genschema:
+    internal: true
+    run: when_changed
+    label: "genschema:{{ .CHART }}"
+    desc: "Generate the values JSON schema from the Values struct"
+    var:
+      CHART: ""
+    requires:
+      vars: [CHART]
+    sources:
+    - ./charts/{{ .CHART }}/*.go
+    generates:
+    - ./charts/{{ .CHART}}/values.schema.json
+    cmds:
+    - go run ./genschema {{ .CHART }} > charts/{{ .CHART }}/values.schema.json
+
+  gotohelm:
+    internal: true
+    run: when_changed
+    label: "gotohelm:{{ .CHART }}"
+    desc: "Generate helm templates from Go definitions"
+    var:
+      CHART: ""
+      DEPS: ""
+    requires:
+      vars: [CHART]
+    sources:
+    - ./charts/{{ .CHART }}/*.go
+    - ./charts/{{ .CHART }}/**/*.go
+    generates:
+      - ./charts/{{ .CHART }}/templates/*
+      - ./charts/{{ .CHART }}/templates/**/*
+    cmds:
+    # Generate helm templates from Go definitions
+    - go run ./gotohelm -write ./charts/{{ .CHART }}/templates ./charts/{{ .CHART }} {{ .DEPS }}


### PR DESCRIPTION
Prior to this commit `task generate` would run all operations regardless of
whether or not the generated files where up to date or not.

This process would take about 50s:
```
________________________________________________________
Executed in   48.47 secs    fish           external
   usr time   96.28 secs    0.09 millis   96.28 secs
   sys time   54.03 secs    1.27 millis   54.03 secs
```

This commit uses taskfile's `sources` and `generates` clauses to add caching to
gotohelm, genschema, and genpartial. A cached instance will now take around 8s:
```
________________________________________________________
Executed in    7.99 secs    fish           external
   usr time   15.45 secs    0.10 millis   15.45 secs
   sys time   14.95 secs    1.65 millis   14.95 secs
```

As the primary area of develop is the operator, developers should notice a
dramatic speed up if they habitually run `task generate`.