### PR TITLE
Fix `generate:changelog`

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,6 +6,8 @@ versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '* {{.Body}}'
+body:
+  block: true
 # All changes specify auto as 'patch' to avoid unintentional major or minor
 # version bumps as those are handled manually.
 kinds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,7 +62,8 @@ tasks:
     - charts/*/CHANGELOG.md
     - operator/CHANGELOG.md
     sources:
-    - ./changes/**/*.md
+    - ./.changes/**/*.md
+    - ./.changes/**/*.yaml
     cmds:
     - changie merge -u '## Unreleased' # Ensure CHANGELOG.mds are up to date.
 

--- a/pkg/gotohelm/rewrite_test.go
+++ b/pkg/gotohelm/rewrite_test.go
@@ -12,7 +12,6 @@ package gotohelm
 import (
 	"bytes"
 	"go/format"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,11 +27,6 @@ func TestLoadPackages(t *testing.T) {
 
 	pkgs, err := LoadPackages(&packages.Config{
 		Dir: filepath.Join(td, "src/example"),
-		Env: append(
-			os.Environ(),
-			"GOPATH="+td,
-			"GO111MODULE=on",
-		),
 	}, "./...")
 	require.NoError(t, err)
 

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -154,11 +153,6 @@ func TestTranspile(t *testing.T) {
 	pkgs, err := LoadPackages(&packages.Config{
 		Dir:   td + "/src/example",
 		Tests: true,
-		Env: append(
-			os.Environ(),
-			"GOPATH="+td,
-			"GO111MODULE=on",
-		),
 	}, "./...")
 	require.NoError(t, err)
 
@@ -426,11 +420,6 @@ type GoRunner struct {
 func NewGoRunner(t *testing.T, root string) *GoRunner {
 	cmd := exec.Command("go", "run", "main.go")
 	cmd.Dir = filepath.Join(root, "src", "example")
-	cmd.Env = append(
-		os.Environ(),
-		"GOPATH="+root,
-		"GO111MODULE=on",
-	)
 
 	runner := &GoRunner{
 		cmd:      cmd,


### PR DESCRIPTION
The `sources` stanza in `generate:changelog` we're previously incorrect as they omitted the leading `.` and yaml files.

This commit corrects the task and tweaks changie's configuration to manage `body` as a block property.