### PR TITLE
Add Basic Health Prober

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 require (
 	github.com/cucumber/godog v0.14.1
 	github.com/go-logr/logr v1.4.2
-	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7
+	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
 	github.com/redpanda-data/redpanda-operator/harpoon v0.0.0-00010101000000-000000000000
 	github.com/redpanda-data/redpanda-operator/operator v0.0.0-00010101000000-000000000000
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20241216191615-bb41e7cd4a6e
@@ -88,6 +88,12 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/gonvenience/bunt v1.3.5 // indirect
+	github.com/gonvenience/neat v1.3.13 // indirect
+	github.com/gonvenience/term v1.0.2 // indirect
+	github.com/gonvenience/text v1.0.7 // indirect
+	github.com/gonvenience/wrap v1.2.0 // indirect
+	github.com/gonvenience/ytbx v1.4.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -104,6 +110,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/homeport/dyff v1.7.1 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -125,14 +132,18 @@ require (
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
@@ -164,6 +175,7 @@ require (
 	github.com/rubenv/sql-migrate v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
+	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sethgrid/pester v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
@@ -171,9 +183,11 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
 	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 // indirect
 	github.com/twmb/tlscfg v1.2.1 // indirect
+	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -579,9 +579,11 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
@@ -649,7 +651,7 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7 h1:/6knwISCCzTU/DcTqoG1DzahDykxUz45rStvCuUsyys=
+github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95 h1:TmbXxlIHlKEF2wO5z82sQz98Su/WSgs+bC0k8s26Lsg=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=
@@ -987,6 +989,7 @@ gopkg.in/evanphx/json-patch.v5 v5.7.0/go.mod h1:/kvTRh1TVm5wuM6OkHxqXtE/1nUZZpih
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/charts/go.mod
+++ b/charts/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2
-	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7
+	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-00010101000000-000000000000
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/charts/go.sum
+++ b/charts/go.sum
@@ -433,7 +433,7 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7 h1:/6knwISCCzTU/DcTqoG1DzahDykxUz45rStvCuUsyys=
+github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95 h1:TmbXxlIHlKEF2wO5z82sQz98Su/WSgs+bC0k8s26Lsg=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8/go.mod h1:97qkjcMI3gDL+y+aY/w5o0xF2qGHFof6rCXIYjnTalM=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.20.0
 	github.com/prometheus/common v0.55.0
 	github.com/redpanda-data/common-go/net v0.1.0
-	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7
+	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
 	github.com/redpanda-data/redpanda-operator/charts v0.0.0-00010101000000-000000000000
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20241216191615-bb41e7cd4a6e
@@ -449,7 +449,6 @@ replace (
 	github.com/fluxcd/helm-controller/shim => github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240
 	github.com/fluxcd/source-controller/shim => github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19
 	github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.1-0.20230815154656-802ce17c4f59
-	github.com/redpanda-data/common-go/rpadmin => ../../common-go/rpadmin
 	github.com/redpanda-data/redpanda-operator/charts => ../charts
 	github.com/redpanda-data/redpanda-operator/pkg => ../pkg
 	pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -449,6 +449,7 @@ replace (
 	github.com/fluxcd/helm-controller/shim => github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240
 	github.com/fluxcd/source-controller/shim => github.com/redpanda-data/flux-controller-shim/source/shim v0.0.0-20240113100428-5e301ef97b19
 	github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.1-0.20230815154656-802ce17c4f59
+	github.com/redpanda-data/common-go/rpadmin => ../../common-go/rpadmin
 	github.com/redpanda-data/redpanda-operator/charts => ../charts
 	github.com/redpanda-data/redpanda-operator/pkg => ../pkg
 	pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1085,8 +1085,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7 h1:/6knwISCCzTU/DcTqoG1DzahDykxUz45rStvCuUsyys=
-github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20241219194551-05ac5889aee7/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
+github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95 h1:TmbXxlIHlKEF2wO5z82sQz98Su/WSgs+bC0k8s26Lsg=
+github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
 github.com/redpanda-data/flux-controller-shim/helm/shim v0.0.0-20231227162419-a45126310240 h1:rSfpkaQSBkz3uqEMN1ftVEXBMyx0uibyXPHGCp1kRy8=

--- a/operator/internal/probes/broker.go
+++ b/operator/internal/probes/broker.go
@@ -1,0 +1,189 @@
+package probes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/rpadmin"
+	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+)
+
+type Option func(*Prober)
+
+func WithFactory(factory internalclient.ClientFactory) Option {
+	return func(prober *Prober) {
+		prober.factory = factory
+	}
+}
+
+func WithLogger(logger logr.Logger) Option {
+	return func(prober *Prober) {
+		prober.logger = logger
+	}
+}
+
+func WithFS(fs afero.Fs) Option {
+	return func(prober *Prober) {
+		prober.fs = fs
+	}
+}
+
+// Prober wraps the logic used in checking broker health and readiness.
+type Prober struct {
+	logger     logr.Logger
+	factory    internalclient.ClientFactory
+	configPath string
+	fs         afero.Fs
+}
+
+func NewProber(mgr ctrl.Manager, configPath string, options ...Option) *Prober {
+	prober := &Prober{
+		configPath: configPath,
+		fs:         afero.NewOsFs(),
+		logger:     mgr.GetLogger(),
+		factory:    internalclient.NewFactory(mgr.GetConfig(), mgr.GetClient()),
+	}
+
+	for _, opt := range options {
+		opt(prober)
+	}
+
+	return prober
+}
+
+// IsClusterBrokerHealthy checks that a cluster broker is up and ready to serve requests
+// but additionally serves as a gate for StatefulSet rolling restarts. It's a relaxed form
+// of our previous readiness probe which only looked at the `IsHealthy` return value from
+// the cluster health overview endpoint. This had the unfortunate effect of marking all brokers
+// as "unready" when a single broker was marked as a downed node due to being a reflection of
+// the overall cluster health rather than an individual broker's health.
+func (p *Prober) IsClusterBrokerHealthy(ctx context.Context, brokerID int) (bool, error) {
+	client, err := p.getClient(ctx, brokerID)
+	if err != nil {
+		return false, fmt.Errorf("initializing client to check broker health: %w", err)
+	}
+	defer client.Close()
+
+	// This check is a more relaxed version of our previous "readiness" probe that was
+	// based solely off of the cluster health. It works via doing the following:
+	//
+	// 1. Gets the broker status, making sure it's marked as `is_alive` and is not in maintenance mode.
+	// 2. Lists the local summary of partitions for the broker, making sure there are no leaderless or
+	//    underreplicated partitions.
+	// 3. Gets the cluster health and makes sure that the broker is part of the quorum by having a
+	//    controller id set.
+	//
+	// These allow us to ensure we aren't fully coupled to the overall cluster health status,
+	// which previously caused brokers to be marked as "not ready" when *any* broker in the cluster
+	// was unhealthy.
+
+	broker, err := client.Broker(ctx, brokerID)
+	if err != nil {
+		return false, fmt.Errorf("fetching broker status: %w", err)
+	}
+
+	// is the broker proxied API down?
+	if !ptr.Deref(broker.IsAlive, false) {
+		return false, nil
+	}
+
+	// is the broker in maintenance mode?
+	if broker.Maintenance != nil {
+		return false, nil
+	}
+
+	summary, err := client.GetLocalPartitionsSummary(ctx)
+	if err != nil {
+		return false, fmt.Errorf("fetching broker partitions: %w", err)
+	}
+
+	// do we have any leaderless or under-replicated nodes?
+	if summary.Leaderless != 0 || summary.UnderReplicated != 0 {
+		return false, nil
+	}
+
+	clusterHealth, err := client.GetHealthOverview(ctx)
+	if err != nil {
+		return false, fmt.Errorf("fetching cluster health: %w", err)
+	}
+
+	// do we have an elected cluster leader (i.e. are we part of quorum)
+	if clusterHealth.ControllerID < 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// IsClusterBrokerReady checks if a cluster broker should be servicing requests. It does
+// this by issuing a request to the given broker which should get proxied through to the
+// underlying Kafka API, checking that the broker is marked as alive, not in maintenance
+// mode, and that we actually get a response should inform us that:
+//
+// 1. The Kafka API is up and servicing requests.
+// 2. The Admin API is up and servicing requests.
+// 3. The broker is not in a mode where it shouldn't be servicing anything (i.e. maintenance).
+func (p *Prober) IsClusterBrokerReady(ctx context.Context, brokerID int) (bool, error) {
+	client, err := p.getClient(ctx, brokerID)
+	if err != nil {
+		return false, fmt.Errorf("initializing client to check broker readiness: %w", err)
+	}
+	defer client.Close()
+
+	// unlike the above check which includes cluster quorum and partition status, this just
+	// checks that a broker is up and not in maintenance mode
+
+	broker, err := client.Broker(ctx, brokerID)
+	if err != nil {
+		return false, fmt.Errorf("fetching broker status: %w", err)
+	}
+
+	// is the broker proxied API down?
+	if !ptr.Deref(broker.IsAlive, false) {
+		return false, nil
+	}
+
+	// is the broker in maintenance mode?
+	if broker.Maintenance != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (p *Prober) getClient(ctx context.Context, brokerID int) (*rpadmin.AdminAPI, error) {
+	profile, err := p.readProfile()
+	if err != nil {
+		return nil, fmt.Errorf("reading profile: %w", err)
+	}
+
+	client, err := p.factory.RedpandaAdminClient(ctx, profile)
+	if err != nil {
+		return nil, fmt.Errorf("initializing client: %w", err)
+	}
+	defer client.Close()
+
+	scopedClient, err := client.ForBroker(ctx, brokerID)
+	if err != nil {
+		return nil, fmt.Errorf("initializing client for broker %d: %w", brokerID, err)
+	}
+
+	return scopedClient, nil
+}
+
+func (p *Prober) readProfile() (*rpkconfig.RpkProfile, error) {
+	params := rpkconfig.Params{ConfigFlag: p.configPath}
+
+	config, err := params.Load(p.fs)
+	if err != nil {
+		return nil, fmt.Errorf("loading profile: %w", err)
+	}
+
+	return config.VirtualProfile(), nil
+}

--- a/operator/internal/probes/broker_test.go
+++ b/operator/internal/probes/broker_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/common-go/rpadmin"
+
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/probes"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
@@ -224,7 +225,7 @@ func (s *ProberSuite) installChart(name, version string) *chart {
 	s.Require().True(ok, "redpanda.yaml not found in config map")
 
 	fs := afero.NewMemMapFs()
-	err = afero.WriteFile(fs, "/redpanda.yaml", []byte(data), 0644)
+	err = afero.WriteFile(fs, "/redpanda.yaml", []byte(data), 0o644)
 	s.Require().NoError(err)
 
 	var secret corev1.Secret
@@ -234,7 +235,7 @@ func (s *ProberSuite) installChart(name, version string) *chart {
 	cert, ok := secret.Data["ca.crt"]
 	s.Require().True(ok, "ca.crt not found in secret")
 
-	err = afero.WriteFile(fs, fmt.Sprintf("/etc/tls/certs/%s/ca.crt", name), []byte(cert), 0644)
+	err = afero.WriteFile(fs, fmt.Sprintf("/etc/tls/certs/%s/ca.crt", name), []byte(cert), 0o644)
 	s.Require().NoError(err)
 
 	prober := probes.NewProber(s.manager, "/redpanda.yaml", probes.WithFS(fs), probes.WithFactory(s.clientFactory.WithFS(fs)))

--- a/operator/internal/probes/broker_test.go
+++ b/operator/internal/probes/broker_test.go
@@ -1,0 +1,333 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package probes_test
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/probes"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+	"github.com/redpanda-data/redpanda-operator/pkg/helm"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
+	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+)
+
+func TestIntegrationProber(t *testing.T) {
+	testutil.SkipIfNotIntegration(t)
+
+	suite.Run(t, new(ProberSuite))
+}
+
+type ProberSuite struct {
+	suite.Suite
+
+	manager       ctrl.Manager
+	ctx           context.Context
+	env           *testenv.Env
+	client        client.Client
+	helm          *helm.Client
+	clientFactory *internalclient.Factory
+}
+
+var _ suite.SetupAllSuite = (*ProberSuite)(nil)
+
+func (s *ProberSuite) TestProbes() {
+	chart := s.installChart("default", "")
+	adminClient := s.adminClientFor(chart)
+	defer adminClient.Close()
+
+	// we wrap the first check in a waitFor since there's no guarantee that
+	// the broker will be ready when the helm install completes
+	prober := chart.prober
+	s.waitFor(func(ctx context.Context) (bool, error) {
+		healthy, err := prober.IsClusterBrokerHealthy(s.ctx, 0)
+		if err != nil {
+			s.T().Logf("error checking broker health, retrying: %v", err)
+			return false, nil
+		}
+		return healthy, nil
+	})
+
+	ready, err := prober.IsClusterBrokerReady(s.ctx, 0)
+	s.Require().NoError(err)
+	s.Require().True(ready)
+
+	// now create an under-replicated partition, decommissioning a broker in the process
+	kafkaClient := s.kafkaClientFor(chart)
+	kafkaAdminClient := kadm.NewClient(kafkaClient)
+	defer kafkaAdminClient.Close()
+
+	s.waitFor(func(ctx context.Context) (bool, error) {
+		s.T().Log("attempting to create test-topic")
+		topicResponse, err := kafkaAdminClient.CreateTopic(s.ctx, 1, 3, nil, "test-topic")
+		if err != nil || topicResponse.Err != nil {
+			s.T().Logf("error creating test topic, retrying: %v", errors.Join(err, topicResponse.Err))
+			return false, nil
+		}
+		return true, nil
+	})
+
+	// decommission a broker to make a topic under-replicated
+	err = adminClient.DecommissionBroker(s.ctx, 1)
+	s.Require().NoError(err)
+
+	s.waitFor(func(ctx context.Context) (bool, error) {
+		healthy, err := prober.IsClusterBrokerHealthy(s.ctx, 0)
+		if err != nil {
+			s.T().Logf("error checking broker health, retrying: %v", err)
+			return false, nil
+		}
+		s.T().Logf("checking that broker is no longer healthy due to under-replicated partitions, healthy: %v", healthy)
+		return healthy == false, nil
+	})
+
+	// this should still be true since we don't care about under-replicated partitions here
+	ready, err = prober.IsClusterBrokerReady(s.ctx, 0)
+	s.Require().NoError(err)
+	s.Require().True(ready)
+
+	// now decommission broker 0 to ensure it now fails readiness checks too
+	s.waitFor(func(ctx context.Context) (bool, error) {
+		s.T().Log("attempting to decommission broker 0")
+		err = adminClient.DecommissionBroker(s.ctx, 0)
+		if err != nil {
+			s.T().Logf("error decommissioning broker, retrying: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	s.waitFor(func(ctx context.Context) (bool, error) {
+		ready, err := prober.IsClusterBrokerReady(s.ctx, 0)
+		if err != nil {
+			s.T().Logf("error checking broker readiness, retrying: %v", err)
+			return false, nil
+		}
+		s.T().Logf("checking that broker is no longer ready after decommission, ready: %v", ready)
+		return ready == false, nil
+	})
+
+	s.cleanupChart(chart)
+}
+
+func (s *ProberSuite) SetupSuite() {
+	t := s.T()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	log := testr.NewWithOptions(t, testr.Options{
+		Verbosity: 10,
+	})
+
+	s.ctx = context.Background()
+	s.env = testenv.New(t, testenv.Options{
+		Name:   "probes",
+		Agents: 3,
+		Scheme: scheme,
+		Logger: log,
+	})
+
+	s.client = s.env.Client()
+
+	s.env.SetupManager(s.setupRBAC(), func(mgr ctrl.Manager) error {
+		helmClient, err := helm.New(helm.Options{
+			KubeConfig: mgr.GetConfig(),
+		})
+		if err != nil {
+			return err
+		}
+		if err := helmClient.RepoAdd(s.ctx, "redpandadata", "https://charts.redpanda.com"); err != nil {
+			return err
+		}
+
+		s.manager = mgr
+		s.helm = helmClient
+		dialer := kube.NewPodDialer(mgr.GetConfig())
+		s.clientFactory = internalclient.NewFactory(mgr.GetConfig(), mgr.GetClient()).WithDialer(dialer.DialContext)
+
+		return nil
+	})
+}
+
+type chart struct {
+	name    string
+	version string
+	release helm.Release
+	values  map[string]any
+	prober  *probes.Prober
+}
+
+func (s *ProberSuite) installChart(name, version string) *chart {
+	values := map[string]any{
+		"statefulset": map[string]any{
+			"replicas": 3,
+		},
+		"console": map[string]any{
+			"enabled": false,
+		},
+		"external": map[string]any{
+			"enabled": false,
+		},
+		"image": map[string]any{
+			"repository": "redpandadata/redpanda",
+			"tag":        "v24.3.1",
+		},
+	}
+
+	release, err := s.helm.Install(s.ctx, "redpandadata/redpanda", helm.InstallOptions{
+		Version:         version,
+		CreateNamespace: true,
+		Name:            name,
+		Namespace:       s.env.Namespace(),
+		Values:          values,
+	})
+	s.Require().NoError(err)
+
+	var configMap corev1.ConfigMap
+	err = s.client.Get(s.ctx, types.NamespacedName{Namespace: s.env.Namespace(), Name: name}, &configMap)
+	s.Require().NoError(err)
+
+	data, ok := configMap.Data["redpanda.yaml"]
+	s.Require().True(ok, "redpanda.yaml not found in config map")
+
+	fs := afero.NewMemMapFs()
+	err = afero.WriteFile(fs, "/redpanda.yaml", []byte(data), 0644)
+	s.Require().NoError(err)
+
+	var secret corev1.Secret
+	err = s.client.Get(s.ctx, types.NamespacedName{Namespace: s.env.Namespace(), Name: fmt.Sprintf("%s-default-cert", name)}, &secret)
+	s.Require().NoError(err)
+
+	cert, ok := secret.Data["ca.crt"]
+	s.Require().True(ok, "ca.crt not found in secret")
+
+	err = afero.WriteFile(fs, fmt.Sprintf("/etc/tls/certs/%s/ca.crt", name), []byte(cert), 0644)
+	s.Require().NoError(err)
+
+	prober := probes.NewProber(s.manager, "/redpanda.yaml", probes.WithFS(fs), probes.WithFactory(s.clientFactory.WithFS(fs)))
+
+	return &chart{
+		name:    name,
+		version: version,
+		values:  values,
+		release: release,
+		prober:  prober,
+	}
+}
+
+func (s *ProberSuite) cleanupChart(chart *chart) {
+	s.Require().NoError(s.helm.Uninstall(s.ctx, chart.release))
+}
+
+func (s *ProberSuite) adminClientFor(chart *chart) *rpadmin.AdminAPI {
+	adminClient, err := s.clientFactory.RedpandaAdminClient(s.ctx, s.clusterFor(chart))
+	s.Require().NoError(err)
+
+	return adminClient
+}
+
+func (s *ProberSuite) kafkaClientFor(chart *chart) *kgo.Client {
+	kafkaClient, err := s.clientFactory.KafkaClient(s.ctx, s.clusterFor(chart))
+	s.Require().NoError(err)
+
+	return kafkaClient
+}
+
+func (s *ProberSuite) clusterFor(chart *chart) *redpandav1alpha2.Redpanda {
+	data, err := json.Marshal(chart.values)
+	s.Require().NoError(err)
+
+	cluster := &redpandav1alpha2.Redpanda{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      chart.name,
+			Namespace: s.env.Namespace(),
+		},
+		Spec: redpandav1alpha2.RedpandaSpec{ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{}},
+	}
+
+	err = json.Unmarshal(data, cluster)
+	s.Require().NoError(err)
+
+	return cluster
+}
+
+func (s *ProberSuite) setupRBAC() string {
+	objs := []client.Object{
+		&rbacv1.Role{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Role",
+				APIVersion: "rbac.authorization.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-role",
+				Namespace: s.env.Namespace(),
+			},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{""},
+				Resources: []string{"pods/portforward"},
+				Verbs:     []string{"*"},
+			}},
+		},
+		&rbacv1.RoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "RoleBinding",
+				APIVersion: "rbac.authorization.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-role",
+				Namespace: s.env.Namespace(),
+			},
+			Subjects: []rbacv1.Subject{
+				{Kind: "ServiceAccount", Namespace: s.env.Namespace(), Name: "user"},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "test-role",
+			},
+		},
+	}
+
+	for _, obj := range objs {
+		s.Require().NoError(s.client.Patch(s.ctx, obj, client.Apply, client.ForceOwnership, client.FieldOwner("tests")))
+	}
+
+	return "user"
+}
+
+func (s *ProberSuite) waitFor(cond func(ctx context.Context) (bool, error)) {
+	s.NoError(wait.PollUntilContextTimeout(s.ctx, 5*time.Second, 5*time.Minute, false, cond))
+}


### PR DESCRIPTION
This adds a basic health probe implementation that can be reusable across an exec entrypoint (for current v1 purposes) and a sidecar http readiness api (for current v2 purposes).

~~It's blocked by https://github.com/redpanda-data/common-go/pull/45 which introduces support for the local partition summary endpoint in the redpanda admin API, so I'm marking it as a Draft for now.~~

Additionally it fixes up some issues with our kube pod dialer that we use in tests. Namely it seems like there's a limit to the number of streams that can be multiplexed across a single port-forward, and after a few forwards the connection was incurring i/o write timeouts (I believe this is what we sometimes ran into in some tests). The fix strips out the reference counting implemented to allow for connection multiplexing and just opens up a new port-forward every time that the dialer dials out, which makes all of this go away.