### PR TITLE
Add probe server to sidecar entrypoint

### DIFF
--- a/operator/internal/probes/broker.go
+++ b/operator/internal/probes/broker.go
@@ -17,18 +17,11 @@ import (
 	"github.com/redpanda-data/common-go/rpadmin"
 	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 type Option func(*Prober)
-
-func WithFactory(factory internalclient.ClientFactory) Option {
-	return func(prober *Prober) {
-		prober.factory = factory
-	}
-}
 
 func WithLogger(logger logr.Logger) Option {
 	return func(prober *Prober) {
@@ -50,12 +43,12 @@ type Prober struct {
 	fs         afero.Fs
 }
 
-func NewProber(mgr ctrl.Manager, configPath string, options ...Option) *Prober {
+func NewProber(factory internalclient.ClientFactory, configPath string, options ...Option) *Prober {
 	prober := &Prober{
 		configPath: configPath,
 		fs:         afero.NewOsFs(),
-		logger:     mgr.GetLogger(),
-		factory:    internalclient.NewFactory(mgr.GetConfig(), mgr.GetClient()),
+		logger:     logr.Discard(),
+		factory:    factory,
 	}
 
 	for _, opt := range options {

--- a/operator/internal/probes/broker.go
+++ b/operator/internal/probes/broker.go
@@ -64,8 +64,8 @@ func NewProber(factory internalclient.ClientFactory, configPath string, options 
 // the cluster health overview endpoint. This had the unfortunate effect of marking all brokers
 // as "unready" when a single broker was marked as a downed node due to being a reflection of
 // the overall cluster health rather than an individual broker's health.
-func (p *Prober) IsClusterBrokerHealthy(ctx context.Context, brokerID int) (bool, error) {
-	client, err := p.getClient(ctx, brokerID)
+func (p *Prober) IsClusterBrokerHealthy(ctx context.Context, brokerURL string) (bool, error) {
+	client, brokerID, err := p.getClient(ctx, brokerURL)
 	if err != nil {
 		return false, fmt.Errorf("initializing client to check broker health: %w", err)
 	}
@@ -135,8 +135,8 @@ func (p *Prober) IsClusterBrokerHealthy(ctx context.Context, brokerID int) (bool
 // 1. The Kafka API is up and servicing requests (through the broker active membership check).
 // 2. The Admin API is up and servicing requests (through receiving a valid request).
 // 3. We aren't currently draining in maintenance mode.
-func (p *Prober) IsClusterBrokerReady(ctx context.Context, brokerID int) (bool, error) {
-	client, err := p.getClient(ctx, brokerID)
+func (p *Prober) IsClusterBrokerReady(ctx context.Context, brokerURL string) (bool, error) {
+	client, brokerID, err := p.getClient(ctx, brokerURL)
 	if err != nil {
 		return false, fmt.Errorf("initializing client to check broker readiness: %w", err)
 	}
@@ -168,24 +168,29 @@ func (p *Prober) IsClusterBrokerReady(ctx context.Context, brokerID int) (bool, 
 	return true, nil
 }
 
-func (p *Prober) getClient(ctx context.Context, brokerID int) (*rpadmin.AdminAPI, error) {
+func (p *Prober) getClient(ctx context.Context, brokerURL string) (*rpadmin.AdminAPI, int, error) {
 	profile, err := p.readProfile()
 	if err != nil {
-		return nil, fmt.Errorf("reading profile: %w", err)
+		return nil, -1, fmt.Errorf("reading profile: %w", err)
 	}
 
 	client, err := p.factory.RedpandaAdminClient(ctx, profile)
 	if err != nil {
-		return nil, fmt.Errorf("initializing client: %w", err)
+		return nil, -1, fmt.Errorf("initializing client: %w", err)
 	}
 	defer client.Close()
 
-	scopedClient, err := client.ForBroker(ctx, brokerID)
+	scopedClient, err := client.ForHost(brokerURL)
 	if err != nil {
-		return nil, fmt.Errorf("initializing client for broker %d: %w", brokerID, err)
+		return nil, -1, fmt.Errorf("initializing client for broker %q: %w", brokerURL, err)
 	}
 
-	return scopedClient, nil
+	config, err := scopedClient.GetNodeConfig(ctx)
+	if err != nil {
+		return nil, -1, fmt.Errorf("fetching node config for broker %q: %w", brokerURL, err)
+	}
+
+	return scopedClient, config.NodeID, nil
 }
 
 func (p *Prober) readProfile() (*rpkconfig.RpkProfile, error) {

--- a/operator/internal/probes/broker_test.go
+++ b/operator/internal/probes/broker_test.go
@@ -41,10 +41,11 @@ import (
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
+	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )
 
 func TestIntegrationProber(t *testing.T) {
-	// testutil.SkipIfNotIntegration(t)
+	testutil.SkipIfNotIntegration(t)
 
 	suite.Run(t, new(ProberSuite))
 }

--- a/operator/internal/probes/broker_test.go
+++ b/operator/internal/probes/broker_test.go
@@ -238,7 +238,7 @@ func (s *ProberSuite) installChart(name, version string) *chart {
 	err = afero.WriteFile(fs, fmt.Sprintf("/etc/tls/certs/%s/ca.crt", name), []byte(cert), 0o644)
 	s.Require().NoError(err)
 
-	prober := probes.NewProber(s.manager, "/redpanda.yaml", probes.WithFS(fs), probes.WithFactory(s.clientFactory.WithFS(fs)))
+	prober := probes.NewProber(s.clientFactory.WithFS(fs), "/redpanda.yaml", probes.WithFS(fs), probes.WithLogger(s.manager.GetLogger()))
 
 	return &chart{
 		name:    name,

--- a/operator/internal/probes/server.go
+++ b/operator/internal/probes/server.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package probes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+type Server struct {
+	prober *Prober
+	id     int
+
+	logger logr.Logger
+
+	shutdownTimeout time.Duration
+
+	server *http.Server
+}
+
+type Config struct {
+	Prober          *Prober
+	ShutdownTimeout time.Duration
+	Address         string
+	Logger          logr.Logger
+	ID              int
+}
+
+func NewServer(config Config) (*Server, error) {
+	if config.Prober == nil {
+		return nil, errors.New("must specify a prober")
+	}
+
+	logger := config.Logger
+	if logger.IsZero() {
+		logger = logr.Discard()
+	}
+
+	shutdownTimeout := config.ShutdownTimeout
+	if shutdownTimeout == 0 {
+		shutdownTimeout = 5 * time.Second
+	}
+
+	address := config.Address
+	if address == "" {
+		address = ":9999"
+	}
+
+	server := &Server{
+		shutdownTimeout: shutdownTimeout,
+		logger:          logger,
+		prober:          config.Prober,
+		id:              config.ID,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", server.HandleHealthyCheck)
+	mux.HandleFunc("/readyz", server.HandleReadyCheck)
+
+	server.server = &http.Server{
+		Addr:    address,
+		Handler: mux,
+		// just some sane defaults
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+
+	return server, nil
+}
+
+func (s *Server) HandleHealthyCheck(w http.ResponseWriter, r *http.Request) {
+	healthy, err := s.prober.IsClusterBrokerHealthy(r.Context(), s.id)
+	if err != nil {
+		s.logger.Error(err, "error running health check")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if healthy {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func (s *Server) HandleReadyCheck(w http.ResponseWriter, r *http.Request) {
+	ready, err := s.prober.IsClusterBrokerReady(r.Context(), s.id)
+	if err != nil {
+		s.logger.Error(err, "error running ready check")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if ready {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	shutdownServer := func() error {
+		// we use the background context here since the parent context might
+		// already be canceled
+		ctx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer cancel()
+
+		return s.server.Shutdown(ctx)
+	}
+
+	serverExitedCh := make(chan error, 1)
+
+	// This goroutine is responsible for starting the server.
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				s.logger.Info("server exited", "error", err)
+				serverExitedCh <- err
+			}
+		}
+		close(serverExitedCh)
+	}()
+
+	var err error
+
+	select {
+	case err = <-serverExitedCh:
+	case <-ctx.Done():
+		err = shutdownServer()
+	}
+
+	return err
+}

--- a/operator/internal/probes/server.go
+++ b/operator/internal/probes/server.go
@@ -20,7 +20,7 @@ import (
 
 type Server struct {
 	prober *Prober
-	id     int
+	url    string
 
 	logger logr.Logger
 
@@ -34,7 +34,7 @@ type Config struct {
 	ShutdownTimeout time.Duration
 	Address         string
 	Logger          logr.Logger
-	ID              int
+	URL             string
 }
 
 func NewServer(config Config) (*Server, error) {
@@ -61,7 +61,7 @@ func NewServer(config Config) (*Server, error) {
 		shutdownTimeout: shutdownTimeout,
 		logger:          logger,
 		prober:          config.Prober,
-		id:              config.ID,
+		url:             config.URL,
 	}
 
 	mux := http.NewServeMux()
@@ -82,7 +82,7 @@ func NewServer(config Config) (*Server, error) {
 }
 
 func (s *Server) HandleHealthyCheck(w http.ResponseWriter, r *http.Request) {
-	healthy, err := s.prober.IsClusterBrokerHealthy(r.Context(), s.id)
+	healthy, err := s.prober.IsClusterBrokerHealthy(r.Context(), s.url)
 	if err != nil {
 		s.logger.Error(err, "error running health check")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -97,7 +97,7 @@ func (s *Server) HandleHealthyCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) HandleReadyCheck(w http.ResponseWriter, r *http.Request) {
-	ready, err := s.prober.IsClusterBrokerReady(r.Context(), s.id)
+	ready, err := s.prober.IsClusterBrokerReady(r.Context(), s.url)
 	if err != nil {
 		s.logger.Error(err, "error running ready check")
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This adds the broker probe to the sidecar entrypoint, running a simple unauthenticated HTTP server on the host that Kubernetes can hit for readiness checks via http rather than using exec.