### PR TITLE
Decouple acceptance tests from integration, move to their own task and fix them up

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,3 +97,15 @@ tasks:
         GO_TEST_RUNNER:
           ref: .GO_TEST_RUNNER
         CLI_ARGS: '{{.CLI_ARGS}} -run "^TestIntegration" -timeout 20m'
+
+  test:acceptance:
+    vars:
+      GO_TEST_RUNNER: '{{default "go test" .GO_TEST_RUNNER}}'
+      CLI_ARGS: '{{.CLI_ARGS}} -tags=acceptance -run "^TestAcceptance" -timeout 20m -v'
+    cmds:
+    - task: k8s:build-operator-images
+    - kind delete cluster --name acceptance || true
+    - kind create cluster --name acceptance
+    - defer: kind delete cluster --name acceptance
+    - kind load --name acceptance docker-image localhost/redpanda-operator:dev localhost/configurator:dev
+    - '{{.GO_TEST_RUNNER}} {{.CLI_ARGS}} ./acceptance'

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 		WithCRDDirectory("../operator/config/crd/bases/toolkit.fluxcd.io").
 		OnFeature(func(ctx context.Context, t framework.TestingT) {
 			t.Log("Installing Redpanda operator chart")
-			t.InstallHelmChart(ctx, "https://charts.redpanda.com", "redpanda", "operator", helm.InstallOptions{
+			t.InstallLocalHelmChart(ctx, "../charts/operator", helm.InstallOptions{
 				Name:      "redpanda-operator",
 				Namespace: t.IsolateNamespace(ctx),
 				Values: map[string]any{
@@ -88,9 +88,8 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestIntegrationSuite(t *testing.T) {
-	testutil.SkipIfNotIntegration(t)
-	t.Skipf("Currently failing. Needs to be debugged and corrected.")
+func TestAcceptanceSuite(t *testing.T) {
+	testutil.SkipIfNotAcceptance(t)
 	suite.RunT(t)
 }
 

--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -86,7 +86,11 @@ func iDeleteTheCRDUser(ctx context.Context, t framework.TestingT, user string) {
 func thereAreAlreadyTheFollowingACLsInCluster(ctx context.Context, t framework.TestingT, cluster string, acls *godog.Table) {
 	clients := clientsForCluster(ctx, cluster)
 	aclClient := clients.ACLs(ctx)
-	defer aclClient.Close()
+	// throw this in a cleanup instead of a defer since we use it in a cleanup
+	// below and it needs to stay alive until then
+	t.Cleanup(func(_ context.Context) {
+		aclClient.Close()
+	})
 
 	for _, user := range usersFromACLTable(t, cluster, acls) {
 		user := user
@@ -109,7 +113,12 @@ func thereAreAlreadyTheFollowingACLsInCluster(ctx context.Context, t framework.T
 func thereAreTheFollowingPreexistingUsersInCluster(ctx context.Context, t framework.TestingT, cluster string, users *godog.Table) {
 	clients := clientsForCluster(ctx, cluster)
 	adminClient := clients.RedpandaAdmin(ctx)
-	defer adminClient.Close()
+	// throw this in a cleanup instead of a defer since we use it in a cleanup
+	// below and it needs to stay alive until then
+	t.Cleanup(func(_ context.Context) {
+		adminClient.Close()
+	})
+
 	usersClient := clients.Users(ctx)
 	defer usersClient.Close()
 

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -40,6 +40,7 @@ type TestingT interface {
 	IsolateNamespace(ctx context.Context) string
 
 	InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions)
+	InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions)
 
 	Namespace() string
 	RestConfig() *rest.Config

--- a/pkg/testutil/acceptance_off.go
+++ b/pkg/testutil/acceptance_off.go
@@ -1,0 +1,14 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build !acceptance
+
+package testutil
+
+const skipAcceptanceTests = true

--- a/pkg/testutil/acceptance_on.go
+++ b/pkg/testutil/acceptance_on.go
@@ -1,0 +1,14 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build acceptance
+
+package testutil
+
+const skipAcceptanceTests = false

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -106,6 +106,22 @@ func SkipIfNotIntegration(t *testing.T) {
 	}
 }
 
+func SkipIfNotAcceptance(t *testing.T) {
+	const prefix = "TestAcceptance"
+
+	if skipAcceptanceTests {
+		t.Skipf("acceptance build flag not set; skipping acceptance test")
+	} else if testing.Short() {
+		t.Skipf("-short specified; skipping acceptance test")
+	} else {
+		RequireTimeout(t, 20*time.Minute)
+	}
+
+	if !strings.HasPrefix(t.Name(), prefix) {
+		t.Fatalf("tests calling SkipIfNotAcceptance must be prefixed with %q; got: %s", prefix, t.Name())
+	}
+}
+
 // RequireTimeout asserts that the `-timeout` flag is at least `minimum`.
 // Usage:
 //


### PR DESCRIPTION
This does a few things:

1. Introduces a `task test:acceptance` to run acceptance tests (sorry, it just uses `kind` for now still to get things off the ground)
2. Mirrors the `SkipIfNotIntegration` pattern with `SkipIfNotAcceptance`.
3. Fixes some bad defers v. cleanup calls that were causing failures due to clients being closed in a defer and then used after the scope of a function call ended in a `t.Cleanup` call.
4. Makes the acceptance tests use a locally installed helm chart of the operator rather than an already released one.

There are no jobs for this yet in CI, but I figured we'd probably want to separate out the two types of tests as is.