### PR TITLE
Rework PVC Unbinder into sidecar entrypoint

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -39,6 +39,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/flux"
 	redpandacontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
 	vectorizedcontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/decommissioning"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	consolepkg "github.com/redpanda-data/redpanda-operator/operator/pkg/console"
@@ -483,7 +484,7 @@ func Run(
 	} else {
 		setupLog.Info("starting PVCUnbinder controller", "unbind-after", unbindPVCsAfter, "selector", unbinderSelector)
 
-		if err := (&vectorizedcontrollers.PVCUnbinderReconciler{
+		if err := (&decommissioning.PVCUnbinder{
 			Client:   mgr.GetClient(),
 			Timeout:  unbindPVCsAfter,
 			Selector: unbinderSelector,

--- a/operator/internal/decommissioning/pvcunbinder_test.go
+++ b/operator/internal/decommissioning/pvcunbinder_test.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package vectorized
+package decommissioning_test
 
 import (
 	"context"
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/redpanda-data/redpanda-operator/operator/internal/decommissioning"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )
@@ -109,7 +110,7 @@ func TestPVCUnbinderShouldRemediate(t *testing.T) {
 		},
 	}
 
-	r := &PVCUnbinderReconciler{
+	r := &decommissioning.PVCUnbinder{
 		Timeout: 30 * time.Second,
 		Selector: labels.SelectorFromSet(labels.Set{
 			"key": "value",
@@ -122,7 +123,7 @@ func TestPVCUnbinderShouldRemediate(t *testing.T) {
 			fn(&pod)
 		}
 
-		ok, requeue := r.shouldRemediate(context.Background(), &pod)
+		ok, requeue := r.ShouldRemediate(context.Background(), &pod)
 		require.Equal(t, tc.Should, ok)
 		require.InDelta(t, tc.RequeueAfter, requeue, float64(500*time.Millisecond) /* Leeway so we don't have to monkey patch time.Now */)
 	}
@@ -229,7 +230,7 @@ func TestPVCUnbinder(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	r := PVCUnbinderReconciler{Client: c}
+	r := decommissioning.PVCUnbinder{Client: c}
 	require.NoError(t, r.SetupWithManager(mgr))
 
 	tgo(t, ctx, func(ctx context.Context) error {


### PR DESCRIPTION
This adds the PVC unbinder to the sidecar entrypoint. Aside from moving the unbinder file to be in the `decommissioning` package, the main thing it adds to the implementation is a more generic Selector mechanism that just takes a function and keeps or filters out the pod passed into it, this brings it inline with the decommissioner implementation so that their selection mechanisms are fairly close to identical.