### PR TITLE
Change snapshot version to influence compiled version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,3 +58,5 @@ release:
   discussion_category_name: Releases
 announce:
   skip: "true"
+snapshot:
+  version_template: "{{ .Version }}"


### PR DESCRIPTION
Previously the operator had compiled Version generated from goreleaser using snapshoot option. Now version template (go template) will not add suffix.

Previously:
```
$ redpanda-operator-darwin-arm64 version
Version: 2.3.6-24.3.3-SNAPSHOT-b6403b75
Commit: b6403b75ce256794ac89fe077d0b8c8d121357af
Go Version: go1.23.2
Build Date: 2025-01-22T14:07:24Z
```

Now:
```
$ redpanda-operator-darwin-arm64 version
Version: v2.3.6-24.3.3
Commit: b6403b75ce256794ac89fe077d0b8c8d121357af
Go Version: go1.23.2
Build Date: 2025-01-22T14:10:08Z
```

Reference

```
Generate an unversioned snapshot build, skipping all validations
```

https://github.com/goreleaser/goreleaser/blob/e3b0e8fd9bb6145b3a50ddab4359e96d7ce7d89d/internal/pipe/snapshot/snapshot.go#L22-L24