### PR TITLE
Pin configurator container tag due to goreleaser snapshot version generation

### DIFF
--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -30,7 +30,11 @@ Kubernetes: `>= 1.25.0-0`
 
 Passes additional flags to the Redpanda Operator at startup. Additional flags include:  - `--additional-controllers`: Additional controllers to deploy. Valid values are nodeWatcher or decommission. For more information about the Nodewatcher controller, see [Install the Nodewatcher controller](https://docs.redpanda.com/current/manage/kubernetes/k-scale-redpanda/#node-pvc). For more information about the Decommission controller, see [Use the Decommission controller](https://docs.redpanda.com/current/manage/kubernetes/k-decommission-brokers/#Automated).
 
-**Default:** `[]`
+**Default:**
+
+```
+["--configurator-tag=v2.3.6-24.3.3"]
+```
 
 ### [affinity](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=affinity)
 

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -135,7 +135,8 @@ podLabels: {}
 # Additional flags include:
 #
 # - `--additional-controllers`: Additional controllers to deploy. Valid values are nodeWatcher or decommission. For more information about the Nodewatcher controller, see [Install the Nodewatcher controller](https://docs.redpanda.com/current/manage/kubernetes/k-scale-redpanda/#node-pvc). For more information about the Decommission controller, see [Use the Decommission controller](https://docs.redpanda.com/current/manage/kubernetes/k-decommission-brokers/#Automated).
-additionalCmdFlags: []
+additionalCmdFlags:
+- --configurator-tag=v2.3.6-24.3.3
 # - --additional-controllers="<controller-name"
 
 # -- Additional labels to add to all Kubernetes objects.


### PR DESCRIPTION
As operator helm chart is not yet released due to issue in https://github.com/redpanda-data/helm-charts/pull/1637 PR the configurator tag is pinned to the latest operator release version.

Reference
https://github.com/redpanda-data/redpanda-operator/pull/405
https://github.com/redpanda-data/redpanda-operator/pull/406