### PR TITLE
Fix build targets

### DIFF
--- a/ci/scripts/run-in-nix-docker.sh
+++ b/ci/scripts/run-in-nix-docker.sh
@@ -33,7 +33,7 @@ fi
 set -e
 
 # BUILDKITE environment variables are used by `buildkite-agent` cli to upload artifact
-printenv | grep BUILDKITE > env-file-for-buildkite
+printenv | grep 'BUILDKITE.*=' > env-file-for-buildkite
 
 # Build the base image and grab the SHA.
 IMAGE_SHA=$(docker build --quiet -f ./ci/docker/nix.Dockerfile .)

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -15,11 +15,6 @@ tasks:
     cmds:
     - go build -o ../.build/genschema .
 
-  genpartial:
-    dir: genpartial
-    cmds:
-    - go build -o ../.build/genpartial .
-
   gotohelm:
     dir: gotohelm
     sources:

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -5,8 +5,6 @@ tasks:
     dir: ./genpartial
     sources:
     - ./genpartial/**.go
-    generates:
-    - ../.build/genpartial
     cmds:
     - go build -o ../.build/genpartial .
 

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -23,7 +23,7 @@ tasks:
   gotohelm:
     dir: gotohelm
     sources:
-    - ./genpartial/**.go
+    - ./gotohelm/**.go
     cmds:
     - go build -o ../.build/gotohelm .
 


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda-operator/pull/411

#### https://github.com/redpanda-data/redpanda-operator/commit/5f6cd8ddb4650a68151673b98a1e3be630c6e712

Fix gotohelm sources directive

#### https://github.com/redpanda-data/redpanda-operator/commit/5f6cd8ddb4650a68151673b98a1e3be630c6e712

Remove duplicated genpartial build target

#### https://github.com/redpanda-data/redpanda-operator/commit/5f6cd8ddb4650a68151673b98a1e3be630c6e712

Remove wrong generates directive

No other build target is using generates and generates is referencing .build folder
outside of the redpanda-operator repository.
