### PR TITLE
Fix generation of env file that has only BUILDKITE variables

### DIFF
--- a/ci/scripts/run-in-nix-docker.sh
+++ b/ci/scripts/run-in-nix-docker.sh
@@ -33,7 +33,7 @@ fi
 set -e
 
 # BUILDKITE environment variables are used by `buildkite-agent` cli to upload artifact
-printenv | grep BUILDKITE > env-file-for-buildkite
+printenv | grep 'BUILDKITE.*=' > env-file-for-buildkite
 
 # Build the base image and grab the SHA.
 IMAGE_SHA=$(docker build --quiet -f ./ci/docker/nix.Dockerfile .)


### PR DESCRIPTION
The following 2 environment variables was added to each buildkite job
```
BASH_FUNC___buildkite_clean_unused_paths%%=() {  REDPANDA_BUILD_CHECKOUT_PATH=$(dirname "$BUILDKITE_BUILD_CHECKOUT_PATH");
 cd $REDPANDA_BUILD_CHECKOUT_PATH;
 for i in $(ls -1 . | grep -v "^${BUILDKITE_PIPELINE_NAME}\$");
 do
 echo "Cleaning $i";
 rm -rf ./$i;
 done;
 cd -
}
BASH_FUNC___buildkite_chown_checkout_path%%=() {  user_id=$UID;
 group_id=$(id -g);
 REDPANDA_BUILD_CHECKOUT_PATH=$(dirname "$BUILDKITE_BUILD_CHECKOUT_PATH");
 echo "Changing ownership of $REDPANDA_BUILD_CHECKOUT_PATH to '${user_id}:${group_id}'";
 docker run --rm --privileged --userns=host -t -v "$REDPANDA_BUILD_CHECKOUT_PATH":"$REDPANDA_BUILD_CHECKOUT_PATH" --workdir="$REDPANDA_BUILD_CHECKOUT_PATH" public.ecr.aws/docker/library/alpine:3 chown -R ${user_id}:${group_id} $REDPANDA_BUILD_CHECKOUT_PATH
}
```

As grep was looking for any BUILDKITE word 3 lines from the above functions was added to `env-file-for-buildkite` which was passed to `docker run` command.