### PR TITLE
*: lint go.mod directives

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
 	github.com/redpanda-data/redpanda-operator/harpoon v0.0.0-00010101000000-000000000000
-	github.com/redpanda-data/redpanda-operator/operator v0.0.0-00010101000000-000000000000
+	github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250123152815-98530dc8f04d
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74
 	github.com/stretchr/testify v1.10.0
 	github.com/twmb/franz-go v1.18.0
@@ -240,7 +240,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace (
-	github.com/redpanda-data/redpanda-operator/harpoon => ../harpoon
-	github.com/redpanda-data/redpanda-operator/operator => ../operator
-)
+replace github.com/redpanda-data/redpanda-operator/harpoon => ../harpoon

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -661,6 +661,8 @@ github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
 github.com/redpanda-data/redpanda-operator/charts v0.0.0-20250117101058-ffdbfad7bc6b h1:3M4OLinhrcMO5hlKNMwLHPq6OLA2XlbACvdV0HIHkew=
 github.com/redpanda-data/redpanda-operator/charts v0.0.0-20250117101058-ffdbfad7bc6b/go.mod h1:lI25qZ21w4dOrGb8NbussBlHMK22BVqVMoV3iY3foz4=
+github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250123152815-98530dc8f04d h1:JtWS8TYK10ucCWq/LpwTqFjZXFfMeqqOCCEqPB8v6ho=
+github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250123152815-98530dc8f04d/go.mod h1:ujOb7b3jt/JIGgX18H+jRSOeLcS86NDI+9tBNNlCFmk=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74 h1:kUQfTikTwGpspksa78MyeC5LoqlRTY0XCeBId0VGAyU=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74/go.mod h1:RLmeTQHyGNaTMZLzf+wPD7hFjkDMQMKz5gSG8X4Gp58=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.32.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
+	golang.org/x/mod v0.22.0
 	golang.org/x/net v0.34.0
 	golang.org/x/tools v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -192,7 +193,6 @@ require (
 	go.starlark.net v0.0.0-20231121155337-90ade8b19d09 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect


### PR DESCRIPTION
Prior to this commit, replace directives were readily used to ease local development and dependencies on orphaned commits could be easily introduced.

This commit introduces a new linter that prevents replace directives with local paths from being added and asserts that any dependencies of modules in this repository are present in either the main or release/* branches.