### PR TITLE
gotohelm: mostly support tpl and include

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
 	github.com/redpanda-data/redpanda-operator/harpoon v0.0.0-00010101000000-000000000000
-	github.com/redpanda-data/redpanda-operator/operator v0.0.0-00010101000000-000000000000
+	github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250123152815-98530dc8f04d
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74
 	github.com/stretchr/testify v1.10.0
 	github.com/twmb/franz-go v1.18.0
@@ -240,7 +240,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace (
-	github.com/redpanda-data/redpanda-operator/harpoon => ../harpoon
-	github.com/redpanda-data/redpanda-operator/operator => ../operator
-)
+replace github.com/redpanda-data/redpanda-operator/harpoon => ../harpoon

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -661,6 +661,8 @@ github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
 github.com/redpanda-data/redpanda-operator/charts v0.0.0-20250117101058-ffdbfad7bc6b h1:3M4OLinhrcMO5hlKNMwLHPq6OLA2XlbACvdV0HIHkew=
 github.com/redpanda-data/redpanda-operator/charts v0.0.0-20250117101058-ffdbfad7bc6b/go.mod h1:lI25qZ21w4dOrGb8NbussBlHMK22BVqVMoV3iY3foz4=
+github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250123152815-98530dc8f04d h1:JtWS8TYK10ucCWq/LpwTqFjZXFfMeqqOCCEqPB8v6ho=
+github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250123152815-98530dc8f04d/go.mod h1:ujOb7b3jt/JIGgX18H+jRSOeLcS86NDI+9tBNNlCFmk=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74 h1:kUQfTikTwGpspksa78MyeC5LoqlRTY0XCeBId0VGAyU=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74/go.mod h1:RLmeTQHyGNaTMZLzf+wPD7hFjkDMQMKz5gSG8X4Gp58=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -5,6 +5,7 @@ go 1.23.2
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 
 require (
+	github.com/Masterminds/goutils v1.1.1
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/cockroachdb/errors v1.11.3
 	github.com/gonvenience/ytbx v1.4.4
@@ -39,7 +40,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.32.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
+	golang.org/x/mod v0.22.0
 	golang.org/x/net v0.34.0
 	golang.org/x/tools v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -192,7 +193,6 @@ require (
 	go.starlark.net v0.0.0-20231121155337-90ade8b19d09 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect

--- a/pkg/gotohelm/helmette/helm.go
+++ b/pkg/gotohelm/helmette/helm.go
@@ -10,13 +10,16 @@
 package helmette
 
 import (
-	"bytes"
 	"context"
+	"io/fs"
+	"maps"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/cockroachdb/errors"
 	"helm.sh/helm/v3/pkg/chartutil"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
@@ -36,6 +39,13 @@ type Dot struct {
 	// transport into the `go run` test runner.
 	// WARNING: DO NOT USE OR REFERENCE IN HELM CHARTS. IT WILL NOT WORK.
 	KubeConfig kube.Config
+
+	// Templates, similar to KubeConfig, is a hacked in value to support `tpl`.
+	// It is an FS containing the contents of the charts template/ directory.
+	// As fs.FS is not trivial to serialize, the `go run` test runner has a
+	// special case to rehydrate it.
+	// WARNING: DO NOT USE OR REFERENCE IN HELM CHARTS. IT WILL NOT WORK.
+	Templates fs.FS `json:"-"`
 }
 
 type Release struct {
@@ -56,35 +66,94 @@ type Chart struct {
 type Values = chartutil.Values
 
 // https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
-// +gotohelm:builtin=tpl
-func Tpl(tpl string, context any) string {
-	var b bytes.Buffer
+func Tpl(dot *Dot, tpl string, context any) string {
+	// gotohelm's tpl implementation is intentionally more restrictive than
+	// helm's. Anything that accesses this function should be a short and
+	// simple user provided template.
+	const recursionLimit = 10
+	recusion := 0
+	maybeRecurse := func() error {
+		recusion++
+		if recusion > recursionLimit {
+			return errors.New("recursion limit reached")
+		}
+		return nil
+	}
 
-	f := sprig.TxtFuncMap()
-	extra := template.FuncMap{
-		// Not yet implemented in sprig.go
-		//"toToml":        toTOML,
-		//"fromYamlArray": fromYAMLArray,
-		//"fromJsonArray": fromJSONArray,
-
+	fns := sprig.TxtFuncMap()
+	maps.Copy(fns, template.FuncMap{
 		"toYaml":   ToYaml,
 		"fromYaml": FromYaml,
 		"toJson":   ToJSON,
 		"fromJson": FromJSON,
 
-		// Not yet implemented in gotohelm
-		"include":  func(string, interface{}) string { return "not implemented" },
-		"tpl":      func(string, interface{}) interface{} { return "not implemented" },
-		"required": func(string, interface{}) (interface{}, error) { return "not implemented", nil },
+		// Any helm function needs to be stubbed out to ensure that parse works
+		// as function calls are checked at parse time and we have to parse the
+		// entire chart. Again, we're intentionally restrictive here.
+		"lookup":        func(...any) error { return errors.New("not implemented") },
+		"toToml":        func(...any) error { return errors.New("not implemented") },
+		"fromYamlArray": func(...any) error { return errors.New("not implemented") },
+		"fromJsonArray": func(...any) error { return errors.New("not implemented") },
 
-		"lookup": func(string, interface{}) string { return "not implemented" },
+		// These need to be lazily bound as they refer to the template instance they're bound to.
+		"include": func(string, any) (string, error) { return "", errors.New("not implemented") },
+		"tpl":     func(string, any) (string, error) { return "", errors.New("not implemented") },
+	})
+
+	// [template.ParseFS] will return an error if any of the provided globs
+	// turn up zero results. As this is a possible and valid case for us, we
+	// loop over our patterns and filter out the error if encountered.
+	tmpl := template.New("").Funcs(fns)
+	patterns := []string{"*.tpl", "*.yaml"}
+	for _, pattern := range patterns {
+		t, err := tmpl.ParseFS(dot.Templates, pattern)
+		if err != nil {
+			if strings.HasPrefix(err.Error(), "template: pattern matches no files:") {
+				continue
+			}
+			panic(err)
+		}
+		tmpl = t
 	}
 
-	for k, v := range extra {
-		f[k] = v
-	}
+	tmpl = template.Must(tmpl.Parse(tpl))
 
-	tmpl := template.Must(template.New("").Funcs(f).Parse(tpl))
+	tmpl.Funcs(template.FuncMap{
+		"include": func(name string, data any) (string, error) {
+			if err := maybeRecurse(); err != nil {
+				return "", err
+			}
+
+			var b strings.Builder
+			if err := tmpl.ExecuteTemplate(&b, name, data); err != nil {
+				return "", err
+			}
+			return b.String(), nil
+		},
+		"tpl": func(text string, data any) (string, error) {
+			if err := maybeRecurse(); err != nil {
+				return "", err
+			}
+
+			t, err := tmpl.Clone()
+			if err != nil {
+				return "", err
+			}
+
+			t, err = t.Parse(text)
+			if err != nil {
+				return "", err
+			}
+
+			var b strings.Builder
+			if err := t.Execute(&b, data); err != nil {
+				return "", err
+			}
+			return b.String(), nil
+		},
+	})
+
+	var b strings.Builder
 	if err := tmpl.Execute(&b, context); err != nil {
 		panic(err)
 	}
@@ -114,7 +183,7 @@ func SafeLookup[T any, PT kube.AddrofObject[T]](dot *Dot, namespace, name string
 
 	obj, err := kube.Get[T, PT](context.Background(), ctl, kube.ObjectKey{Namespace: namespace, Name: name})
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, false, err
 		}
 

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/goutils"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/imdario/mergo"
 	"golang.org/x/exp/maps"
@@ -500,7 +501,10 @@ func NIndent(spaces int, v string) string {
 
 // +gotohelm:builtin=randAlphaNum
 func RandAlphaNum(length int) string {
-	return "4" // Chosen by a fair dice roll.
+	// Implementation taken from sprig, which uses their own helper library.
+	// It is not possible, it appears, to actually generate an error here.
+	r, _ := goutils.CryptoRandomAlphaNumeric(length)
+	return r
 }
 
 // +gotohelm:builtin=replace

--- a/pkg/gotohelm/testdata/src/example/inputs/inputs.go
+++ b/pkg/gotohelm/testdata/src/example/inputs/inputs.go
@@ -51,7 +51,7 @@ func keys(globals *helmette.Dot) []string {
 	// Get the keys in all possible ways but only return the stable ones.
 
 	keys := []string{}
-	for key := range globals.Values {
+	for key := range helmette.SortedMap(globals.Values) {
 		keys = append(keys, key)
 	}
 

--- a/pkg/gotohelm/testdata/src/example/inputs/inputs.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/inputs/inputs.rewritten.go
@@ -52,7 +52,7 @@ func keys(globals *helmette.Dot) []string {
 	// Get the keys in all possible ways but only return the stable ones.
 
 	keys := []string{}
-	for key := range globals.Values {
+	for key := range helmette.SortedMap(globals.Values) {
 		keys = append(keys, key)
 	}
 

--- a/pkg/gotohelm/testdata/src/example/main.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/main.rewritten.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
 	"example.com/example/aaacommon"
 	"example.com/example/astrewrites"
@@ -46,6 +47,10 @@ func main() {
 			panic(err_1)
 		}
 
+		// HACK: Inject an FS into .Templates to test `tpl`. This is done
+		// "lazily" so this FS always contains freshly transpiled templates.
+		dot.Templates = os.DirFS("./" + dot.Chart.Name)
+
 		out, err := runChart(&dot)
 
 		if out == nil {
@@ -67,7 +72,12 @@ func main() {
 }
 
 func runChart(dot *helmette.Dot) (_ map[string]any, err any) {
-	defer func() { err = recover() }()
+	defer func() {
+		r_3 := recover()
+		if r_3 != nil {
+			err = fmt.Errorf("%v\n%s", r_3, debug.Stack())
+		}
+	}()
 
 	switch dot.Chart.Name {
 	case "aaacommon":

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -43,7 +43,7 @@ func Sprig(dot *helmette.Dot) map[string]any {
 		"regexSplit":      regexSplit(),
 		"strings":         stringsFunctions(),
 		"toString":        toString(),
-		"tpl":             tpl(),
+		"tpl":             tpl(dot),
 		"trim":            trim(),
 		"unset":           unset(),
 		"yaml":            yaml(),
@@ -87,11 +87,16 @@ func yaml() any {
 	}
 }
 
-func tpl() []string {
+func tpl(dot *helmette.Dot) []string {
 	return []string{
-		helmette.Tpl(`hello world`, nil),
-		helmette.Tpl(`{{ .Foo }}`, map[string]any{"Foo": "bar"}),
-		helmette.Tpl(`{{ . }}`, 3),
+		helmette.Tpl(dot, `hello world`, nil),
+		helmette.Tpl(dot, `{{ .Foo }}`, map[string]any{"Foo": "bar"}),
+		helmette.Tpl(dot, `{{ . }}`, 3),
+		helmette.Tpl(dot, `{{ . | toJson }}`, 3),
+		// NB: The usage of (dict "a" (list)) here is to appear the test
+		// harness's logging hooks. Failure to do so will result in arcane
+		// errors that seem to come from template execution.
+		helmette.Tpl(dot, `{{ (dict "a" (list))  | include "sprig.trim" }}`, nil),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -44,7 +44,7 @@ func Sprig(dot *helmette.Dot) map[string]any {
 		"regexSplit":      regexSplit(),
 		"strings":         stringsFunctions(),
 		"toString":        toString(),
-		"tpl":             tpl(),
+		"tpl":             tpl(dot),
 		"trim":            trim(),
 		"unset":           unset(),
 		"yaml":            yaml(),
@@ -88,11 +88,16 @@ func yaml() any {
 	}
 }
 
-func tpl() []string {
+func tpl(dot *helmette.Dot) []string {
 	return []string{
-		helmette.Tpl(`hello world`, nil),
-		helmette.Tpl(`{{ .Foo }}`, map[string]any{"Foo": "bar"}),
-		helmette.Tpl(`{{ . }}`, 3),
+		helmette.Tpl(dot, `hello world`, nil),
+		helmette.Tpl(dot, `{{ .Foo }}`, map[string]any{"Foo": "bar"}),
+		helmette.Tpl(dot, `{{ . }}`, 3),
+		helmette.Tpl(dot, `{{ . | toJson }}`, 3),
+		// NB: The usage of (dict "a" (list)) here is to appear the test
+		// harness's logging hooks. Failure to do so will result in arcane
+		// errors that seem to come from template execution.
+		helmette.Tpl(dot, `{{ (dict "a" (list))  | include "sprig.trim" }}`, nil),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -5,7 +5,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (dict "asIntegral" (get (fromJson (include "sprig.asIntegral" (dict "a" (list $dot) ))) "r") "asNumeric" (get (fromJson (include "sprig.asNumeric" (dict "a" (list $dot) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "errTypes" (get (fromJson (include "sprig.errTypes" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "hasPrefix" (get (fromJson (include "sprig.hasPrefix" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "mapIteration" (get (fromJson (include "sprig.mapIteration" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "regexReplaceAll" (get (fromJson (include "sprig.regexReplaceAll" (dict "a" (list ) ))) "r") "regexSplit" (get (fromJson (include "sprig.regexSplit" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "tpl" (get (fromJson (include "sprig.tpl" (dict "a" (list ) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "yaml" (get (fromJson (include "sprig.yaml" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "asIntegral" (get (fromJson (include "sprig.asIntegral" (dict "a" (list $dot) ))) "r") "asNumeric" (get (fromJson (include "sprig.asNumeric" (dict "a" (list $dot) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "errTypes" (get (fromJson (include "sprig.errTypes" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "hasPrefix" (get (fromJson (include "sprig.hasPrefix" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "mapIteration" (get (fromJson (include "sprig.mapIteration" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "regexReplaceAll" (get (fromJson (include "sprig.regexReplaceAll" (dict "a" (list ) ))) "r") "regexSplit" (get (fromJson (include "sprig.regexSplit" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "tpl" (get (fromJson (include "sprig.tpl" (dict "a" (list $dot) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "yaml" (get (fromJson (include "sprig.yaml" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -50,10 +50,11 @@
 {{- end -}}
 
 {{- define "sprig.tpl" -}}
+{{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (tpl `hello world` (coalesce nil)) (tpl `{{ .Foo }}` (dict "Foo" "bar" )) (tpl `{{ . }}` (3 | int)))) | toJson -}}
+{{- (dict "r" (list (tpl `hello world` (coalesce nil)) (tpl `{{ .Foo }}` (dict "Foo" "bar" )) (tpl `{{ . }}` (3 | int)) (tpl `{{ . | toJson }}` (3 | int)) (tpl `{{ (dict "a" (list))  | include "sprig.trim" }}` (coalesce nil)))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -108,15 +109,15 @@
 {{- define "sprig.float" -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_168_f__ := (list (float64 "3.2") nil) -}}
-{{- $f := ((index $_168_f__ 0) | float64) -}}
-{{- $_ := (index $_168_f__ 1) -}}
-{{- $_169_integer__ := (list (float64 "3") nil) -}}
-{{- $integer := ((index $_169_integer__ 0) | float64) -}}
-{{- $_ := (index $_169_integer__ 1) -}}
-{{- $_170_invalidInput_err := (list (float64 "abc") nil) -}}
-{{- $invalidInput := ((index $_170_invalidInput_err 0) | float64) -}}
-{{- $err := (index $_170_invalidInput_err 1) -}}
+{{- $_173_f__ := (list (float64 "3.2") nil) -}}
+{{- $f := ((index $_173_f__ 0) | float64) -}}
+{{- $_ := (index $_173_f__ 1) -}}
+{{- $_174_integer__ := (list (float64 "3") nil) -}}
+{{- $integer := ((index $_174_integer__ 0) | float64) -}}
+{{- $_ := (index $_174_integer__ 1) -}}
+{{- $_175_invalidInput_err := (list (float64 "abc") nil) -}}
+{{- $invalidInput := ((index $_175_invalidInput_err 0) | float64) -}}
+{{- $err := (index $_175_invalidInput_err 1) -}}
 {{- $errorHappen := 0.3 -}}
 {{- if (ne (toJson $err) "null") -}}
 {{- end -}}
@@ -138,15 +139,15 @@
 {{- define "sprig.atoi" -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_193_positive__ := (list (atoi "234") nil) -}}
-{{- $positive := ((index $_193_positive__ 0) | int) -}}
-{{- $_ := (index $_193_positive__ 1) -}}
-{{- $_194_negative__ := (list (atoi "-23") nil) -}}
-{{- $negative := ((index $_194_negative__ 0) | int) -}}
-{{- $_ := (index $_194_negative__ 1) -}}
-{{- $_195_invalidInput_err := (list (atoi "paokwdpo") nil) -}}
-{{- $invalidInput := ((index $_195_invalidInput_err 0) | int) -}}
-{{- $err := (index $_195_invalidInput_err 1) -}}
+{{- $_198_positive__ := (list (atoi "234") nil) -}}
+{{- $positive := ((index $_198_positive__ 0) | int) -}}
+{{- $_ := (index $_198_positive__ 1) -}}
+{{- $_199_negative__ := (list (atoi "-23") nil) -}}
+{{- $negative := ((index $_199_negative__ 0) | int) -}}
+{{- $_ := (index $_199_negative__ 1) -}}
+{{- $_200_invalidInput_err := (list (atoi "paokwdpo") nil) -}}
+{{- $invalidInput := ((index $_200_invalidInput_err 0) | int) -}}
+{{- $err := (index $_200_invalidInput_err 1) -}}
 {{- $errorHappen := (0 | int) -}}
 {{- if (ne (toJson $err) "null") -}}
 {{- end -}}
@@ -226,12 +227,12 @@
 {{- define "sprig.errTypes" -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_297_x1_err1 := (list (atoi "1") nil) -}}
-{{- $x1 := ((index $_297_x1_err1 0) | int) -}}
-{{- $err1 := (index $_297_x1_err1 1) -}}
-{{- $_298_x2_err2 := (list (float64 "1.1") nil) -}}
-{{- $x2 := ((index $_298_x2_err2 0) | float64) -}}
-{{- $err2 := (index $_298_x2_err2 1) -}}
+{{- $_302_x1_err1 := (list (atoi "1") nil) -}}
+{{- $x1 := ((index $_302_x1_err1 0) | int) -}}
+{{- $err1 := (index $_302_x1_err1 1) -}}
+{{- $_303_x2_err2 := (list (float64 "1.1") nil) -}}
+{{- $x2 := ((index $_303_x2_err2 0) | float64) -}}
+{{- $err2 := (index $_303_x2_err2 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (list (list $x1 $err1) (list $x2 $err2))) | toJson -}}
 {{- break -}}

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -232,6 +233,7 @@ func TestTranspile(t *testing.T) {
 							Name:    pkg.Name,
 							Version: "1.2.3",
 						},
+						Templates: os.DirFS(filepath.Join(td, "src", "example", pkg.Name)),
 						Release: helmette.Release{
 							Name:      "release-name",
 							Namespace: "release-namespace",


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda-operator/pull/413

Prior to this commit the `tpl` function was only supported for simple cases.
Attempts to `include` other templates, or functions in the case of gotohelm,
would cause the go rendering process to ungracefully error out.

This commit expands support of `tpl` to be nearly equivalent to that of `helm`.
Notable exceptions being:
- No support for `lookup`, `toToml`, `fromYamlArray`, or `fromJsonArray`.
- Recursion limits are global instead of per template and max out at 10 levels.

Support is added by embedding the entire helm chart into the go code which will
be parsed and executed by `helmette.Tpl`. Provided that gotohelm generated
portions of the chart are up to date at compile time, the vast majority of
usages should function the same.