### PR TITLE
charts: bump gotohelm to fix tpl

### DIFF
--- a/charts/connectors/chart.go
+++ b/charts/connectors/chart.go
@@ -11,7 +11,7 @@
 package connectors
 
 import (
-	_ "embed"
+	"embed"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,13 +28,12 @@ var (
 	Scheme = runtime.NewScheme()
 
 	//go:embed Chart.yaml
-	chartYAML []byte
-
 	//go:embed values.yaml
-	defaultValuesYAML []byte
+	//go:embed templates/*
+	chartFiles embed.FS
 
 	// ChartLabel is the go version of the console helm chart.
-	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render)
+	Chart = gotohelm.MustLoad(chartFiles, render)
 )
 
 // +gotohelm:ignore=true

--- a/charts/console/chart.go
+++ b/charts/console/chart.go
@@ -11,7 +11,7 @@
 package console
 
 import (
-	_ "embed"
+	"embed"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -27,13 +27,13 @@ var (
 	Scheme = runtime.NewScheme()
 
 	//go:embed Chart.yaml
-	chartYAML []byte
-
+	//go:embed templates/*
+	//go:embed values.schema.json
 	//go:embed values.yaml
-	defaultValuesYAML []byte
+	chartFiles embed.FS
 
 	// ChartLabel is the go version of the console helm chart.
-	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render)
+	Chart = gotohelm.MustLoad(chartFiles, render)
 )
 
 // +gotohelm:ignore=true

--- a/charts/console/chart_test.go
+++ b/charts/console/chart_test.go
@@ -229,9 +229,6 @@ func TestGoHelmEquivalence(t *testing.T) {
 		return strings.Compare(aStr, bStr)
 	})
 
-	// resource.Quantity is a special object. To Ensure they compare correctly,
-	// we'll round trip it through JSON so the internal representations will
-	// match (assuming the values are actually equal).
 	assert.Equal(t, len(helmObjs), len(goObjs))
 
 	// Iterate and compare instead of a single comparison for better error

--- a/charts/console/configmap.go
+++ b/charts/console/configmap.go
@@ -27,17 +27,17 @@ func ConfigMap(dot *helmette.Dot) *corev1.ConfigMap {
 	}
 
 	data := map[string]string{
-		"config.yaml": fmt.Sprintf("# from .Values.console.config\n%s\n", helmette.Tpl(helmette.ToYaml(values.Console.Config), dot)),
+		"config.yaml": fmt.Sprintf("# from .Values.console.config\n%s\n", helmette.Tpl(dot, helmette.ToYaml(values.Console.Config), dot)),
 	}
 
 	if len(values.Console.Roles) > 0 {
-		data["roles.yaml"] = helmette.Tpl(helmette.ToYaml(map[string]any{
+		data["roles.yaml"] = helmette.Tpl(dot, helmette.ToYaml(map[string]any{
 			"roles": values.Console.Roles,
 		}), dot)
 	}
 
 	if len(values.Console.RoleBindings) > 0 {
-		data["role-bindings.yaml"] = helmette.Tpl(helmette.ToYaml(map[string]any{
+		data["role-bindings.yaml"] = helmette.Tpl(dot, helmette.ToYaml(map[string]any{
 			"roleBindings": values.Console.RoleBindings,
 		}), dot)
 	}

--- a/charts/console/deployment.go
+++ b/charts/console/deployment.go
@@ -55,7 +55,7 @@ func Deployment(dot *helmette.Dot) *appsv1.Deployment {
 
 	var initContainers []corev1.Container
 	if !helmette.Empty(values.InitContainers.ExtraInitContainers) {
-		initContainers = helmette.UnmarshalYamlArray[corev1.Container](helmette.Tpl(*values.InitContainers.ExtraInitContainers, dot))
+		initContainers = helmette.UnmarshalYamlArray[corev1.Container](helmette.Tpl(dot, *values.InitContainers.ExtraInitContainers, dot))
 	}
 
 	volumeMounts := []corev1.VolumeMount{

--- a/charts/console/ingress.go
+++ b/charts/console/ingress.go
@@ -28,7 +28,7 @@ func Ingress(dot *helmette.Dot) *networkingv1.Ingress {
 	for _, t := range values.Ingress.TLS {
 		var hosts []string
 		for _, host := range t.Hosts {
-			hosts = append(hosts, helmette.Tpl(host, dot))
+			hosts = append(hosts, helmette.Tpl(dot, host, dot))
 		}
 		tls = append(tls, networkingv1.IngressTLS{
 			SecretName: t.SecretName,
@@ -55,7 +55,7 @@ func Ingress(dot *helmette.Dot) *networkingv1.Ingress {
 		}
 
 		rules = append(rules, networkingv1.IngressRule{
-			Host: helmette.Tpl(host.Host, dot),
+			Host: helmette.Tpl(dot, host.Host, dot),
 			IngressRuleValue: networkingv1.IngressRuleValue{
 				HTTP: &networkingv1.HTTPIngressRuleValue{
 					Paths: paths,

--- a/charts/go.mod
+++ b/charts/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
-	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74
+	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250124085449-058118a82f50
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.10.0

--- a/charts/go.sum
+++ b/charts/go.sum
@@ -440,8 +440,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95 h1:TmbXxlIHlKEF2wO5z82sQz98Su/WSgs+bC0k8s26Lsg=
 github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
-github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74 h1:kUQfTikTwGpspksa78MyeC5LoqlRTY0XCeBId0VGAyU=
-github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74/go.mod h1:RLmeTQHyGNaTMZLzf+wPD7hFjkDMQMKz5gSG8X4Gp58=
+github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250124085449-058118a82f50 h1:rmgno9TNZCX2c81zJGrv2CZjiPURWevNeQ7Lo8fVszk=
+github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250124085449-058118a82f50/go.mod h1:b/GBKIBr3nLE+LAtb8P4b2KrOwL3SGXAF4l65UcF71c=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8/go.mod h1:97qkjcMI3gDL+y+aY/w5o0xF2qGHFof6rCXIYjnTalM=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/charts/operator/helpers.go
+++ b/charts/operator/helpers.go
@@ -173,7 +173,7 @@ func StrategicMergePatch(overrides *corev1.PodTemplateSpec, original corev1.PodT
 			}
 			newVolumes = append(newVolumes, vol)
 		}
-		for _, vol := range overrideVolumes {
+		for _, vol := range helmette.SortedMap(overrideVolumes) {
 			newVolumes = append(newVolumes, vol)
 		}
 		original.Spec.Volumes = newVolumes

--- a/charts/redpanda/certs.go
+++ b/charts/redpanda/certs.go
@@ -57,8 +57,8 @@ func ClientCerts(dot *helmette.Dot) []*certmanagerv1.Certificate {
 		}
 
 		if values.External.Domain != nil {
-			names = append(names, helmette.Tpl(*values.External.Domain, dot))
-			names = append(names, fmt.Sprintf("*.%s", helmette.Tpl(*values.External.Domain, dot)))
+			names = append(names, helmette.Tpl(dot, *values.External.Domain, dot))
+			names = append(names, fmt.Sprintf("*.%s", helmette.Tpl(dot, *values.External.Domain, dot)))
 		}
 
 		duration := helmette.Default("43800h", data.Duration)

--- a/charts/redpanda/chart.go
+++ b/charts/redpanda/chart.go
@@ -11,7 +11,7 @@
 package redpanda
 
 import (
-	_ "embed"
+	"embed"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -37,14 +37,15 @@ var (
 	// objects produced by the redpanda chart.
 	Scheme = runtime.NewScheme()
 
+	//go:embed Chart.lock
 	//go:embed Chart.yaml
-	chartYAML []byte
-
+	//go:embed templates/*
+	//go:embed values.schema.json
 	//go:embed values.yaml
-	defaultValuesYAML []byte
+	ChartFiles embed.FS
 
 	// Chart is the go version of the redpanda helm chart.
-	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render, console.Chart, connectors.Chart)
+	Chart = gotohelm.MustLoad(ChartFiles, render, console.Chart, connectors.Chart)
 )
 
 // Types returns a slice containing the set of all [kube.Object] types that

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -298,7 +298,7 @@ func advertisedHost(dot *helmette.Dot, i int32) string {
 
 	address := fmt.Sprintf("%s-%d", Fullname(dot), int(i))
 	if ptr.Deref(values.External.Domain, "") != "" {
-		address = fmt.Sprintf("%s.%s", address, helmette.Tpl(*values.External.Domain, dot))
+		address = fmt.Sprintf("%s.%s", address, helmette.Tpl(dot, *values.External.Domain, dot))
 	}
 
 	if len(values.External.Addresses) <= 0 {
@@ -312,7 +312,7 @@ func advertisedHost(dot *helmette.Dot, i int32) string {
 	}
 
 	if ptr.Deref(values.External.Domain, "") != "" {
-		address = fmt.Sprintf("%s.%s", address, helmette.Tpl(*values.External.Domain, dot))
+		address = fmt.Sprintf("%s.%s", address, helmette.Tpl(dot, *values.External.Domain, dot))
 	}
 
 	return address

--- a/charts/redpanda/secrets.go
+++ b/charts/redpanda/secrets.go
@@ -542,7 +542,7 @@ func secretConfiguratorKafkaConfig(dot *helmette.Dot) []string {
 	)
 	if len(values.Listeners.Kafka.External) > 0 {
 		externalCounter := 0
-		for externalName, externalVals := range values.Listeners.Kafka.External {
+		for externalName, externalVals := range helmette.SortedMap(values.Listeners.Kafka.External) {
 			externalCounter = externalCounter + 1
 			snippet = append(snippet,
 				``,
@@ -619,7 +619,7 @@ func secretConfiguratorHTTPConfig(dot *helmette.Dot) []string {
 	)
 	if len(values.Listeners.HTTP.External) > 0 {
 		externalCounter := 0
-		for externalName, externalVals := range values.Listeners.HTTP.External {
+		for externalName, externalVals := range helmette.SortedMap(values.Listeners.HTTP.External) {
 			externalCounter = externalCounter + 1
 			snippet = append(snippet,
 				``,
@@ -695,7 +695,7 @@ func externalAdvertiseAddress(dot *helmette.Dot) string {
 
 	eaa := "${SERVICE_NAME}"
 	externalDomainTemplate := ptr.Deref(values.External.Domain, "")
-	expanded := helmette.Tpl(externalDomainTemplate, dot)
+	expanded := helmette.Tpl(dot, externalDomainTemplate, dot)
 	if !helmette.Empty(expanded) {
 		eaa = fmt.Sprintf("%s.%s", "${SERVICE_NAME}", expanded)
 	}
@@ -721,7 +721,7 @@ func advertisedHostJSON(dot *helmette.Dot, externalName string, port int32, repl
 		if domain := ptr.Deref(values.External.Domain, ""); domain != "" {
 			host = map[string]any{
 				"name":    externalName,
-				"address": fmt.Sprintf("%s.%s", address, helmette.Tpl(domain, dot)),
+				"address": fmt.Sprintf("%s.%s", address, helmette.Tpl(dot, domain, dot)),
 				"port":    port,
 			}
 		} else {

--- a/charts/redpanda/service.loadbalancer.go
+++ b/charts/redpanda/service.loadbalancer.go
@@ -66,7 +66,7 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 				}
 			}
 
-			address := fmt.Sprintf("%s.%s", prefix, helmette.Tpl(*values.External.Domain, dot))
+			address := fmt.Sprintf("%s.%s", prefix, helmette.Tpl(dot, *values.External.Domain, dot))
 
 			annotations["external-dns.alpha.kubernetes.io/hostname"] = address
 		}
@@ -80,8 +80,11 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 
 		podSelector["statefulset.kubernetes.io/pod-name"] = podname
 
+		// Divergences pop up here due to iterating over a map. This isn't okay
+		// in helm. TODO setup a linter that barks about this? Also a helper
+		// for getting the sorted keys of a map?
 		var ports []corev1.ServicePort
-		for name, listener := range values.Listeners.Admin.External {
+		for name, listener := range helmette.SortedMap(values.Listeners.Admin.External) {
 			if !ptr.Deref(listener.Enabled, values.External.Enabled) {
 				continue
 			}
@@ -96,7 +99,7 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 			})
 		}
 
-		for name, listener := range values.Listeners.Kafka.External {
+		for name, listener := range helmette.SortedMap(values.Listeners.Kafka.External) {
 			if !ptr.Deref(listener.Enabled, values.External.Enabled) {
 				continue
 			}
@@ -111,7 +114,7 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 			})
 		}
 
-		for name, listener := range values.Listeners.HTTP.External {
+		for name, listener := range helmette.SortedMap(values.Listeners.HTTP.External) {
 			if !ptr.Deref(listener.Enabled, values.External.Enabled) {
 				continue
 			}
@@ -126,7 +129,7 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 			})
 		}
 
-		for name, listener := range values.Listeners.SchemaRegistry.External {
+		for name, listener := range helmette.SortedMap(values.Listeners.SchemaRegistry.External) {
 			if !ptr.Deref(listener.Enabled, values.External.Enabled) {
 				continue
 			}

--- a/charts/redpanda/service.nodeport.go
+++ b/charts/redpanda/service.nodeport.go
@@ -49,7 +49,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 		})
 	}
 
-	for name, listener := range values.Listeners.Kafka.External {
+	for name, listener := range helmette.SortedMap(values.Listeners.Kafka.External) {
 		if !listener.IsEnabled() {
 			continue
 		}
@@ -67,7 +67,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 		})
 	}
 
-	for name, listener := range values.Listeners.HTTP.External {
+	for name, listener := range helmette.SortedMap(values.Listeners.HTTP.External) {
 		if !listener.IsEnabled() {
 			continue
 		}
@@ -85,7 +85,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 		})
 	}
 
-	for name, listener := range values.Listeners.SchemaRegistry.External {
+	for name, listener := range helmette.SortedMap(values.Listeners.SchemaRegistry.External) {
 		if !listener.IsEnabled() {
 			continue
 		}

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -793,7 +793,7 @@ func statefulSetContainerRedpanda(dot *helmette.Dot) corev1.Container {
 		Name:          "admin",
 		ContainerPort: values.Listeners.Admin.Port,
 	})
-	for externalName, external := range values.Listeners.Admin.External {
+	for externalName, external := range helmette.SortedMap(values.Listeners.Admin.External) {
 		if external.IsEnabled() {
 			// The original template used
 			// $external.port > 0 &&
@@ -811,7 +811,7 @@ func statefulSetContainerRedpanda(dot *helmette.Dot) corev1.Container {
 		Name:          "http",
 		ContainerPort: values.Listeners.HTTP.Port,
 	})
-	for externalName, external := range values.Listeners.HTTP.External {
+	for externalName, external := range helmette.SortedMap(values.Listeners.HTTP.External) {
 		if external.IsEnabled() {
 			container.Ports = append(container.Ports, corev1.ContainerPort{
 				Name:          fmt.Sprintf("http-%.8s", helmette.Lower(externalName)),
@@ -823,7 +823,7 @@ func statefulSetContainerRedpanda(dot *helmette.Dot) corev1.Container {
 		Name:          "kafka",
 		ContainerPort: values.Listeners.Kafka.Port,
 	})
-	for externalName, external := range values.Listeners.Kafka.External {
+	for externalName, external := range helmette.SortedMap(values.Listeners.Kafka.External) {
 		if external.IsEnabled() {
 			container.Ports = append(container.Ports, corev1.ContainerPort{
 				Name:          fmt.Sprintf("kafka-%.8s", helmette.Lower(externalName)),
@@ -839,7 +839,7 @@ func statefulSetContainerRedpanda(dot *helmette.Dot) corev1.Container {
 		Name:          "schemaregistry",
 		ContainerPort: values.Listeners.SchemaRegistry.Port,
 	})
-	for externalName, external := range values.Listeners.SchemaRegistry.External {
+	for externalName, external := range helmette.SortedMap(values.Listeners.SchemaRegistry.External) {
 		if external.IsEnabled() {
 			container.Ports = append(container.Ports, corev1.ContainerPort{
 				Name:          fmt.Sprintf("schema-%.8s", helmette.Lower(externalName)),
@@ -988,17 +988,17 @@ func bootstrapEnvVars(dot *helmette.Dot, envVars []corev1.EnvVar) []corev1.EnvVa
 }
 
 func templateToVolumeMounts(dot *helmette.Dot, template string) []corev1.VolumeMount {
-	result := helmette.Tpl(template, dot)
+	result := helmette.Tpl(dot, template, dot)
 	return helmette.UnmarshalYamlArray[corev1.VolumeMount](result)
 }
 
 func templateToVolumes(dot *helmette.Dot, template string) []corev1.Volume {
-	result := helmette.Tpl(template, dot)
+	result := helmette.Tpl(dot, template, dot)
 	return helmette.UnmarshalYamlArray[corev1.Volume](result)
 }
 
 func templateToContainers(dot *helmette.Dot, template string) []corev1.Container {
-	result := helmette.Tpl(template, dot)
+	result := helmette.Tpl(dot, template, dot)
 	return helmette.UnmarshalYamlArray[corev1.Container](result)
 }
 

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -1068,8 +1068,7 @@
 {{- if (and (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $l.tls $tls) ))) "r") (ne (toJson $l.tls.trustStore) "null")) -}}
 {{- $tss = (concat (default (list ) $tss) (list $l.tls.trustStore)) -}}
 {{- end -}}
-{{- range $_, $key := (sortAlpha (keys $l.external)) -}}
-{{- $lis := (ternary (index $l.external $key) (dict "enabled" (coalesce nil) "advertisedPorts" (coalesce nil) "port" 0 "nodePort" (coalesce nil) "authenticationMethod" (coalesce nil) "prefixTemplate" (coalesce nil) "tls" (coalesce nil) ) (hasKey $l.external $key)) -}}
+{{- range $_, $lis := $l.external -}}
 {{- if (or (or (not (get (fromJson (include "redpanda.HTTPExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) (eq (toJson $lis.tls.trustStore) "null")) -}}
 {{- continue -}}
 {{- end -}}
@@ -1313,8 +1312,7 @@
 {{- if (and (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $l.tls $tls) ))) "r") (ne (toJson $l.tls.trustStore) "null")) -}}
 {{- $tss = (concat (default (list ) $tss) (list $l.tls.trustStore)) -}}
 {{- end -}}
-{{- range $_, $key := (sortAlpha (keys $l.external)) -}}
-{{- $lis := (ternary (index $l.external $key) (dict "enabled" (coalesce nil) "advertisedPorts" (coalesce nil) "port" 0 "nodePort" (coalesce nil) "authenticationMethod" (coalesce nil) "tls" (coalesce nil) ) (hasKey $l.external $key)) -}}
+{{- range $_, $lis := $l.external -}}
 {{- if (or (or (not (get (fromJson (include "redpanda.SchemaRegistryExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) (eq (toJson $lis.tls.trustStore) "null")) -}}
 {{- continue -}}
 {{- end -}}
@@ -1400,9 +1398,9 @@
 {{- $result := (dict ) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_1961___ok_18 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r") -}}
-{{- $_ := ((index $_1961___ok_18 0) | float64) -}}
-{{- $ok_18 := (index $_1961___ok_18 1) -}}
+{{- $_1959___ok_18 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r") -}}
+{{- $_ := ((index $_1959___ok_18 0) | float64) -}}
+{{- $ok_18 := (index $_1959___ok_18 1) -}}
 {{- if $ok_18 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
@@ -1428,9 +1426,9 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict ) -}}
 {{- range $k, $v := $c -}}
-{{- $_1981_b_19_ok_20 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r") -}}
-{{- $b_19 := (index $_1981_b_19_ok_20 0) -}}
-{{- $ok_20 := (index $_1981_b_19_ok_20 1) -}}
+{{- $_1979_b_19_ok_20 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r") -}}
+{{- $b_19 := (index $_1979_b_19_ok_20 0) -}}
+{{- $ok_20 := (index $_1979_b_19_ok_20 1) -}}
 {{- if $ok_20 -}}
 {{- $_ := (set $result $k $b_19) -}}
 {{- continue -}}
@@ -1473,15 +1471,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_2026___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil)) ))) "r") -}}
-{{- $_ := (index $_2026___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_2026___hasAccessKey 1) -}}
-{{- $_2027___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil)) ))) "r") -}}
-{{- $_ := (index $_2027___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_2027___hasSecretKey 1) -}}
-{{- $_2028___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil)) ))) "r") -}}
-{{- $_ := (index $_2028___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_2028___hasSharedKey 1) -}}
+{{- $_2024___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil)) ))) "r") -}}
+{{- $_ := (index $_2024___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_2024___hasAccessKey 1) -}}
+{{- $_2025___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil)) ))) "r") -}}
+{{- $_ := (index $_2025___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_2025___hasSecretKey 1) -}}
+{{- $_2026___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil)) ))) "r") -}}
+{{- $_ := (index $_2026___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_2026___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey) ))) "r")) -}}
 {{- $envvars = (concat (default (list ) $envvars) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey) ))) "r") )))) -}}
@@ -1504,12 +1502,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_2064___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil)) ))) "r") -}}
-{{- $_ := (index $_2064___containerExists 0) -}}
-{{- $containerExists := (index $_2064___containerExists 1) -}}
-{{- $_2065___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil)) ))) "r") -}}
-{{- $_ := (index $_2065___accountExists 0) -}}
-{{- $accountExists := (index $_2065___accountExists 1) -}}
+{{- $_2062___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil)) ))) "r") -}}
+{{- $_ := (index $_2062___containerExists 0) -}}
+{{- $containerExists := (index $_2062___containerExists 1) -}}
+{{- $_2063___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil)) ))) "r") -}}
+{{- $_ := (index $_2063___accountExists 0) -}}
+{{- $accountExists := (index $_2063___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1520,9 +1518,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_2070_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil)) ))) "r") -}}
-{{- $value := (index $_2070_value_ok 0) -}}
-{{- $ok := (index $_2070_value_ok 1) -}}
+{{- $_2068_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil)) ))) "r") -}}
+{{- $value := (index $_2068_value_ok 0) -}}
+{{- $ok := (index $_2068_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -1392,7 +1392,7 @@ func (l *AdminListeners) Listeners() []map[string]any {
 		createInternalListenerCfg(l.Port),
 	}
 
-	for k, lis := range l.External {
+	for k, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() {
 			continue
 		}
@@ -1414,7 +1414,7 @@ func (l *AdminListeners) ListenersTLS(tls *TLS) []map[string]any {
 		admin = append(admin, internal)
 	}
 
-	for k, lis := range l.External {
+	for k, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() || !lis.TLS.IsEnabled(&l.TLS, tls) {
 			continue
 		}
@@ -1497,7 +1497,7 @@ func (l *HTTPListeners) Listeners(saslEnabled bool) []map[string]any {
 		internal,
 	}
 
-	for k, l := range l.External {
+	for k, l := range helmette.SortedMap(l.External) {
 		if !l.IsEnabled() {
 			continue
 		}
@@ -1530,7 +1530,7 @@ func (l *HTTPListeners) ListenersTLS(tls *TLS) []map[string]any {
 		pp = append(pp, internal)
 	}
 
-	for k, lis := range l.External {
+	for k, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() || !lis.TLS.IsEnabled(&l.TLS, tls) {
 			continue
 		}
@@ -1558,8 +1558,7 @@ func (l *HTTPListeners) TrustStores(tls *TLS) []*TrustStore {
 		tss = append(tss, l.TLS.TrustStore)
 	}
 
-	for _, key := range helmette.SortedKeys(l.External) {
-		lis := l.External[key]
+	for _, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() || !lis.TLS.IsEnabled(&l.TLS, tls) || lis.TLS.TrustStore == nil {
 			continue
 		}
@@ -1624,7 +1623,7 @@ func (l *KafkaListeners) Listeners(auth *Auth) []map[string]any {
 		internal,
 	}
 
-	for k, l := range l.External {
+	for k, l := range helmette.SortedMap(l.External) {
 		if !l.IsEnabled() {
 			continue
 		}
@@ -1659,7 +1658,7 @@ func (l *KafkaListeners) ListenersTLS(tls *TLS) []map[string]any {
 		kafka = append(kafka, internal)
 	}
 
-	for k, lis := range l.External {
+	for k, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() || !lis.TLS.IsEnabled(&l.TLS, tls) {
 			continue
 		}
@@ -1795,7 +1794,7 @@ func (l *SchemaRegistryListeners) Listeners(saslEnabled bool) []map[string]any {
 		internal,
 	}
 
-	for k, l := range l.External {
+	for k, l := range helmette.SortedMap(l.External) {
 		if !l.IsEnabled() {
 			continue
 		}
@@ -1828,7 +1827,7 @@ func (l *SchemaRegistryListeners) ListenersTLS(tls *TLS) []map[string]any {
 		listeners = append(listeners, internal)
 	}
 
-	for k, lis := range l.External {
+	for k, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() || !lis.TLS.IsEnabled(&l.TLS, tls) {
 			continue
 		}
@@ -1856,8 +1855,7 @@ func (l *SchemaRegistryListeners) TrustStores(tls *TLS) []*TrustStore {
 		tss = append(tss, l.TLS.TrustStore)
 	}
 
-	for _, key := range helmette.SortedKeys(l.External) {
-		lis := l.External[key]
+	for _, lis := range helmette.SortedMap(l.External) {
 		if !lis.IsEnabled() || !lis.TLS.IsEnabled(&l.TLS, tls) || lis.TLS.TrustStore == nil {
 			continue
 		}

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 require (
 	github.com/cockroachdb/errors v1.11.3
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
-	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74
+	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250124085449-058118a82f50
 	golang.org/x/tools v0.27.0
 )
 

--- a/gotohelm/go.sum
+++ b/gotohelm/go.sum
@@ -389,8 +389,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
-github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74 h1:kUQfTikTwGpspksa78MyeC5LoqlRTY0XCeBId0VGAyU=
-github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250123101329-b89e4b888a74/go.mod h1:RLmeTQHyGNaTMZLzf+wPD7hFjkDMQMKz5gSG8X4Gp58=
+github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250124085449-058118a82f50 h1:rmgno9TNZCX2c81zJGrv2CZjiPURWevNeQ7Lo8fVszk=
+github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250124085449-058118a82f50/go.mod h1:b/GBKIBr3nLE+LAtb8P4b2KrOwL3SGXAF4l65UcF71c=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda-operator/pull/414

This commit bumps the gotohelm (pkg) to the latest version which contains fixes
for interoperating with `tpl`. As a side effect, many of the shenanigans of
needing to copy the charts in tests are now replaced with `Chart.Write`.

Fixes K8S-468.