### PR TITLE
Fix acceptance CI step

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -155,10 +155,7 @@ tasks:
       CLI_ARGS: '{{.CLI_ARGS}} -tags=acceptance -run "^TestAcceptance" -timeout 20m -v'
     cmds:
     - task: k8s:build-operator-images
-    - kind delete cluster --name acceptance || true
-    - kind create cluster --name acceptance
-    - defer: kind delete cluster --name acceptance
-    - kind load --name acceptance docker-image localhost/redpanda-operator:dev localhost/configurator:dev
+    - kind load docker-image localhost/redpanda-operator:dev localhost/configurator:dev
     - task: test:unit
       vars:
         GO_TEST_RUNNER:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -155,7 +155,7 @@ tasks:
       CLI_ARGS: '{{.CLI_ARGS}} -tags=acceptance -run "^TestAcceptance" -timeout 20m -v'
     cmds:
     - task: k8s:build-operator-images
-    - kind load docker-image localhost/redpanda-operator:dev localhost/configurator:dev
+    - kind load docker-image localhost/redpanda-operator:dev
     - task: test:unit
       vars:
         GO_TEST_RUNNER:

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -75,7 +75,7 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 					},
 					"additionalCmdFlags": []string{"--additional-controllers=all", "--enable-helm-controllers=false", "--force-defluxed-mode"},
 				},
-			})
+			}, helm.Dependency{Name: "prometheus", Repository: "https://prometheus-community.github.io/helm-charts"})
 			t.Log("Successfully installed Redpanda operator chart")
 		}).
 		RegisterTag("cluster", 1, ClusterTag).

--- a/harpoon/internal/testing/helm.go
+++ b/harpoon/internal/testing/helm.go
@@ -52,6 +52,8 @@ func (t *TestingT) InstallLocalHelmChart(ctx context.Context, path string, optio
 
 	options.CreateNamespace = true
 
+	require.NoError(t, helmClient.DependencyBuild(ctx, path))
+
 	t.Logf("installing chart %q", path)
 	_, err = helmClient.Install(ctx, path, options)
 	require.NoError(t, err)

--- a/harpoon/internal/testing/helm.go
+++ b/harpoon/internal/testing/helm.go
@@ -42,7 +42,7 @@ func (t *TestingT) InstallHelmChart(ctx context.Context, url, repo, chart string
 	})
 }
 
-func (t *TestingT) InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions) {
+func (t *TestingT) InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions, deps ...helm.Dependency) {
 	helmClient, err := helm.New(helm.Options{
 		KubeConfig: rest.CopyConfig(t.restConfig),
 	})
@@ -51,6 +51,10 @@ func (t *TestingT) InstallLocalHelmChart(ctx context.Context, path string, optio
 	require.NotEqual(t, "", options.Name, "name must not be blank")
 
 	options.CreateNamespace = true
+
+	for _, dep := range deps {
+		require.NoError(t, helmClient.RepoAdd(ctx, dep.Name, dep.Repository))
+	}
 
 	require.NoError(t, helmClient.DependencyBuild(ctx, path))
 

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -40,7 +40,7 @@ type TestingT interface {
 	IsolateNamespace(ctx context.Context) string
 
 	InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions)
-	InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions)
+	InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions, deps ...helm.Dependency)
 
 	Namespace() string
 	RestConfig() *rest.Config


### PR DESCRIPTION
#### https://github.com/redpanda-data/redpanda-operator/commit/5f560c1a8c199fc096e740e3ab56a02ca8392fc1

Remove secondary kind cluster

The `task ci:test:acceptance` target is creating kind cluster. The kind cluster
created in `test:acceptance` inside `Taskfile.yml` is redundant.

https://github.com/redpanda-data/redpanda-operator/blob/510c4edb96ffe117dfa78908e4a91a0a8e3571a9/taskfiles/ci.yml#L45

#### https://github.com/redpanda-data/redpanda-operator/commit/d811c4105e37d757a43a9484c424bfc08006e21c

Remove pushing configurator container image as it is not longer build

https://github.com/redpanda-data/redpanda-operator/pull/345