### PR TITLE
task: fix caching of go builds, mod tidy, and 3rd party licenses

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,6 +44,12 @@ tasks:
           CLI_ARGS: "--fix"
 
   mod:tidy:
+    # This isn't the most accurate check as any new imports in go files may
+    # require go mod tidy to get re-run. Builds will fail and CI will always
+    # re-run this task, so some false negatives are acceptable.
+    sources:
+    - ./**/go.mod
+    - ./**/go.sum
     cmds:
     - for:
         var: MOD
@@ -76,11 +82,12 @@ tasks:
 
   generate:third-party-licenses-list:
     dir: operator
+    method: checksum
     generates:
-    - licenses/third_party.md
+    - ../licenses/third_party.md
     sources:
-    - ./operator/go.mod
-    - ./operator/go.sum
+    - ./go.mod
+    - ./go.sum
     cmds:
     # Our own packages should not be reported as third party license
     # The example.com/example depedency is ignored as it's part of the

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -1,21 +1,40 @@
 version: '3'
 
-# NB: Task's globbing appears to be a bit finicky WRT it's recursion. We'll
-# instead rely on go build's caching as it's quite good and eliminates false
-# negatives.
-
 tasks:
+
   gen:
-    dir: ./gen
     cmds:
-    - go build -o ../.build/gen main.go
+      - task: go:build
+        vars: { DIR: gen }
 
   gotohelm:
-    dir: gotohelm
     cmds:
-    - go build -o ../.build/gotohelm .
+      - task: go:build
+        vars: { DIR: gotohelm }
 
   licenseupdater:
-    dir: licenseupdater
     cmds:
-    - go build -o ../.build/licenseupdater .
+      - task: go:build
+        vars: { DIR: licenseupdater }
+
+  go:build:
+    internal: true
+    run: when_changed
+    label: "go:build:{{ .DIR }}"
+    var:
+      DIR: ""
+    requires:
+      vars: [DIR]
+    cmds:
+    - go build -C {{ .DIR }} -o ../.build/{{ .DIR }} .
+    status:
+    # NB: Task's globbing is finicky and tracking all possible go files is
+    # prone to error. Instead, rely on go build's caching. Cache status must be
+    # reflected through `status` in order to not re-fire dependent tasks (e.g.
+    # gotohelm invocations)
+    # `go build -n` reports all commands to build without running them. When a
+    # rebuild is required, the final lines will contain: 'mv $WORK/<somepath> < -o flag >'.
+    # Negating the output of grep effectively indicates if go thinks a rebuild
+    # is required. Command must be encased in "s as the negation operator (!)
+    # is otherwise consumed during YAML parsing.
+    - "! go build -C {{ .DIR }} -n -o ../.build/{{ .DIR }} 2>&1 | grep 'mv $WORK'"


### PR DESCRIPTION
Prior to this change, `task generate` would consistently run the majority of tasks despite there being no changes. This was due to incorrectly configured sources (3rd party licenses), missing sources (mod tidy), and no caching configured on go builds (all chart tasks).

This change corrects any misconfiguration and adds a `status` check to go build tasks to inform task of go's cache status.