### PR TITLE
gotohelm: allow `Dot.KubeConfig` to be `nil`

### DIFF
--- a/pkg/gotohelm/gochart.go
+++ b/pkg/gotohelm/gochart.go
@@ -206,7 +206,7 @@ func mergeRootValueWithDependency(rootValues helmette.Values, dependencyValues h
 
 // Dot constructs a [helmette.Dot] for this chart and any dependencies it has,
 // taking into consideration the dependencies' condition.
-func (c *GoChart) Dot(cfg kube.Config, release helmette.Release, values any) (*helmette.Dot, error) {
+func (c *GoChart) Dot(cfg *kube.Config, release helmette.Release, values any) (*helmette.Dot, error) {
 	subcharts := map[string]*helmette.Dot{}
 
 	loaded, err := c.LoadValues(values)
@@ -276,7 +276,10 @@ func (c *GoChart) Dot(cfg kube.Config, release helmette.Release, values any) (*h
 //
 // Helm hooks are included in the returned slice, it's up to the caller
 // to filter them.
-func (c *GoChart) Render(cfg kube.Config, release helmette.Release, values any) ([]kube.Object, error) {
+//
+// If cfg is null, the chart will be rendered "offline" causing functions like
+// [helmette.Lookup] to always return false.
+func (c *GoChart) Render(cfg *kube.Config, release helmette.Release, values any) ([]kube.Object, error) {
 	dot, err := c.Dot(cfg, release, values)
 	if err != nil {
 		return nil, err

--- a/pkg/gotohelm/gochart_test.go
+++ b/pkg/gotohelm/gochart_test.go
@@ -125,7 +125,7 @@ func TestDependencyChainRender(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	actual, err := root.Render(kube.Config{}, helmette.Release{}, inputValues)
+	actual, err := root.Render(nil, helmette.Release{}, inputValues)
 	require.NoError(t, err)
 
 	actualByte := convertToString(actual)

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -238,7 +238,7 @@ func TestTranspile(t *testing.T) {
 							Name:      "release-name",
 							Namespace: "release-namespace",
 						},
-						KubeConfig: kube.RestToConfig(ctl.RestConfig()),
+						KubeConfig: ptr.To(kube.RestToConfig(ctl.RestConfig())),
 					}
 
 					// MUST round trip values through JSON marshalling to


### PR DESCRIPTION
Previously, `Dot.KubeConfig` was a struct which required it to be always present, albeit possibly zero valued. This and the inability to reasonably detect whether or not a `kube.Config` is of zero value prevented gothelm GoCharts from being executed offline akin to `helm template`.

This commit changes KubeConfig to a pointer and updates `Lookup` to short circuit when it is nil, matching `helm template`'s behavior.