### PR TITLE
operator v1: support new ghost broker decommissioner

### DIFF
--- a/operator/config/e2e-tests/manager.yaml
+++ b/operator/config/e2e-tests/manager.yaml
@@ -20,7 +20,7 @@ spec:
         - "--configurator-image-pull-policy=Never"
         - "--superusers-prefix=__redpanda_system__"
         - "--log-level=trace"
-        - "--unsafe-decommission-failed-brokers=true"
+        - "--enable-ghost-broker-decommissioner"
         - "--unbind-pvcs-after=5s"
         livenessProbe:
           timeoutSeconds: 10

--- a/operator/pkg/client/cluster.go
+++ b/operator/pkg/client/cluster.go
@@ -10,12 +10,18 @@
 package client
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 
 	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/certmanager"
 )
 
 // redpandaAdminForCluster returns a simple rpadmin.AdminAPI able to communicate with the given cluster specified via a Redpanda cluster.
@@ -38,6 +44,25 @@ func (c *Factory) redpandaAdminForCluster(cluster *redpandav1alpha2.Redpanda) (*
 	}
 
 	return client, nil
+}
+
+func (c *Factory) redpandaAdminForV1Cluster(cluster *vectorizedv1alpha1.Cluster) (*rpadmin.AdminAPI, error) {
+	ctx := context.Background()
+
+	if cluster.AdminAPITLS() != nil {
+		return nil, fmt.Errorf("non-TLS admin API is not supported on V1 CRD")
+	}
+	// Assume no TLS. Practically, we don't need to support it in Operator V1.
+	t := &certmanager.ClusterCertificates{}
+
+	a, err := admin.NewNodePoolInternalAdminAPI(ctx, c.Client, cluster, fmt.Sprintf("%s.%s.svc.cluster.local", cluster.Name, cluster.Namespace), t, c.dialer)
+	if err != nil {
+		return nil, err
+	}
+	// It's weird that the V1 admin factory returns an interface instead of the
+	// rpadmin struct. We'll cast it back; it's ugly but since this is a legacy
+	// code path we don't care too much.
+	return a.(*rpadmin.AdminAPI), nil
 }
 
 // schemaRegistryForCluster returns a simple sr.Client able to communicate with the given cluster specified via a Redpanda cluster.

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -29,6 +29,7 @@ import (
 
 	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/schemas"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/users"
@@ -179,6 +180,10 @@ func (c *Factory) RedpandaAdminClient(ctx context.Context, obj any) (*rpadmin.Ad
 	// if we pass in a Redpanda cluster, just use it
 	if cluster, ok := obj.(*redpandav1alpha2.Redpanda); ok {
 		return c.redpandaAdminForCluster(cluster)
+	}
+
+	if cluster, ok := obj.(*vectorizedv1alpha1.Cluster); ok {
+		return c.redpandaAdminForV1Cluster(cluster)
 	}
 
 	if profile, ok := obj.(*rpkconfig.RpkProfile); ok {

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -20,18 +20,29 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/k3d"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
@@ -81,6 +92,118 @@ func (f *fakeObject) GetKafkaAPISpec() *redpandav1alpha2.KafkaAPISpec {
 
 func (f *fakeObject) DeepCopyObject() runtime.Object {
 	return f
+}
+
+func TestIntegrationFactoryOperatorV1(t *testing.T) {
+	testutil.SkipIfNotIntegration(t)
+
+	scheme := controller.V1Scheme
+
+	env := testenv.New(t, testenv.Options{
+		Scheme: scheme,
+		CRDs:   crds.All(),
+		Logger: testr.New(t),
+	})
+
+	var clientFactory *Factory
+	var r *vectorized.ClusterReconciler
+
+	c := env.Client()
+	err := c.Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: env.Namespace(),
+		},
+	})
+	require.NoError(t, err)
+
+	err = c.Create(context.Background(), &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: env.Namespace(),
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Namespace: env.Namespace(), Name: "test"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	})
+	require.NoError(t, err)
+
+	env.SetupManager("test", func(mgr ctrl.Manager) error {
+		dialer := kube.NewPodDialer(mgr.GetConfig())
+		clientFactory = NewFactory(mgr.GetConfig(), mgr.GetClient()).WithDialer(dialer.DialContext)
+
+		r = &vectorized.ClusterReconciler{
+			Client:                mgr.GetClient(),
+			Log:                   testr.New(t),
+			AdminAPIClientFactory: admin.NewNodePoolInternalAdminAPI,
+			Dialer:                dialer.DialContext,
+			Scheme:                scheme,
+		}
+
+		// TODO: this is not optimal, we're using hardcoded docker image name, tag
+		// only until we have better tooling to use a local image
+		r.WithConfiguratorSettings(resources.ConfiguratorSettings{
+			ImagePullPolicy:       corev1.PullIfNotPresent,
+			ConfiguratorBaseImage: "docker.io/redpandadata/redpanda-operator-nightly",
+			ConfiguratorTag:       "v0.0.0-20250129gita89e202",
+		})
+		r.WithClusterDomain("cluster.local")
+
+		return r.SetupWithManager(mgr)
+	})
+
+	cr := vectorizedv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: vectorizedv1alpha1.ClusterSpec{
+			Image:    "docker.io/redpandadata/redpanda",
+			Version:  "v24.3.5",
+			Replicas: ptr.To(int32(1)),
+			Configuration: vectorizedv1alpha1.RedpandaConfig{
+				RPCServer: vectorizedv1alpha1.SocketAddress{
+					Port: 33145,
+				},
+				KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
+					{
+						Port: 9092,
+					},
+				},
+				AdminAPI: []vectorizedv1alpha1.AdminAPI{
+					{
+						Port: 9644,
+					},
+				},
+				DeveloperMode: true,
+			},
+		},
+	}
+
+	err = env.Client().Create(testutil.Context(t), &cr)
+	require.NoError(t, err)
+
+	require.Eventuallyf(t, func() bool {
+		cluster := vectorizedv1alpha1.Cluster{}
+		if err := env.Client().Get(testutil.Context(t), types.NamespacedName{
+			Name: "test",
+		}, &cluster); err != nil {
+			return false
+		}
+		return cluster.Status.GetConditionStatus(vectorizedv1alpha1.OperatorQuiescentConditionType) == corev1.ConditionTrue
+	}, time.Minute*5, time.Second*5, "didn't work")
+
+	adminClient, err := clientFactory.RedpandaAdminClient(testutil.Context(t), &cr)
+	require.NoError(t, err)
+
+	brokers, err := adminClient.Brokers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, brokers, 1)
+	require.Equal(t, rpadmin.MembershipStatusActive, brokers[0].MembershipStatus)
 }
 
 func TestIntegrationClientFactory(t *testing.T) {


### PR DESCRIPTION
- add flag to enable this new controller (it's previously only available as sidecar)
- update factory to create admin api for v1 clusters
- add log when decommissioning a broker

Questions:

- the controller also does some stuff with PVCs. i don't quite understand what. Can we split/refactor it so we can opt into just the ghost broker parts?
- i had to remove the check for "managed by helm" label. is this safe to do? if no, any suggestions how to do this?