### PR TITLE
Add dialer injection to v1 admin client initialization

### DIFF
--- a/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
+++ b/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
@@ -423,6 +423,7 @@ func (a *attachedResources) statefulSet() error {
 			a.reconciler.configuratorSettings,
 			cm.GetNodeConfigHash,
 			a.reconciler.AdminAPIClientFactory,
+			a.reconciler.Dialer,
 			a.reconciler.DecommissionWaitInterval,
 			a.log,
 			a.reconciler.MetricsTimeout,

--- a/operator/internal/controller/vectorized/cluster_controller_configuration.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration.go
@@ -68,7 +68,7 @@ func (r *ClusterReconciler) reconcileConfiguration(
 		return errorWithContext(err, "could not load the last applied configuration")
 	}
 
-	adminAPI, err := r.AdminAPIClientFactory(ctx, r, redpandaCluster, fqdn, pki.AdminAPIConfigProvider())
+	adminAPI, err := r.AdminAPIClientFactory(ctx, r, redpandaCluster, fqdn, pki.AdminAPIConfigProvider(), r.Dialer)
 	if err != nil {
 		return errorWithContext(err, "error creating the admin API client")
 	}

--- a/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/redpanda-data/common-go/rpadmin"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"
@@ -49,6 +50,7 @@ type ClusterConfigurationDriftReconciler struct {
 	DriftCheckPeriod          *time.Duration
 	AdminAPIClientFactory     adminutils.NodePoolAdminAPIClientFactory
 	RestrictToRedpandaVersion string
+	Dialer                    redpanda.DialContextFunc
 }
 
 // Reconcile detects drift in configuration for clusters and schedules a patch.
@@ -141,7 +143,7 @@ func (r *ClusterConfigurationDriftReconciler) Reconcile(
 		return ctrl.Result{RequeueAfter: r.getDriftCheckPeriod()}, nil
 	}
 
-	adminAPI, err := r.AdminAPIClientFactory(ctx, r, &redpandaCluster, headlessSvc.HeadlessServiceFQDN(r.clusterDomain), pki.AdminAPIConfigProvider())
+	adminAPI, err := r.AdminAPIClientFactory(ctx, r, &redpandaCluster, headlessSvc.HeadlessServiceFQDN(r.clusterDomain), pki.AdminAPIConfigProvider(), r.Dialer)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not get admin API to check drifts on the cluster: %w", err)
 	}

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -40,11 +40,12 @@ import (
 
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/flux"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
+	redpandacontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
@@ -146,6 +147,7 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 		_ *vectorizedv1alpha1.Cluster,
 		_ string,
 		_ types.AdminTLSConfigProvider,
+		_ redpanda.DialContextFunc,
 		pods ...string,
 	) (adminutils.AdminAPIClient, error) {
 		if len(pods) == 1 {
@@ -198,7 +200,7 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Redpanda Reconciler
-	err = (&redpanda.RedpandaReconciler{
+	err = (&redpandacontrollers.RedpandaReconciler{
 		Client:            k8sManager.GetClient(),
 		ClientFactory:     internalclient.NewFactory(k8sManager.GetConfig(), k8sManager.GetClient()),
 		Scheme:            k8sManager.GetScheme(),
@@ -207,19 +209,19 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&redpanda.DecommissionReconciler{
+	err = (&redpandacontrollers.DecommissionReconciler{
 		Client:       k8sManager.GetClient(),
 		OperatorMode: false,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&redpanda.RedpandaNodePVCReconciler{
+	err = (&redpandacontrollers.RedpandaNodePVCReconciler{
 		Client:       k8sManager.GetClient(),
 		OperatorMode: false,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&redpanda.ManagedDecommissionReconciler{
+	err = (&redpandacontrollers.ManagedDecommissionReconciler{
 		Client: k8sManager.GetClient(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/operator/pkg/admin/admin.go
+++ b/operator/pkg/admin/admin.go
@@ -18,12 +18,12 @@ import (
 	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	"github.com/scalalang2/golang-fifo/sieve"
 	fifotypes "github.com/scalalang2/golang-fifo/types"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"

--- a/operator/pkg/console/admin.go
+++ b/operator/pkg/console/admin.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
@@ -38,6 +39,7 @@ func NewAdminAPI(
 	cluster *vectorizedv1alpha1.Cluster,
 	clusterDomain string,
 	adminAPI adminutils.NodePoolAdminAPIClientFactory,
+	dialer redpanda.DialContextFunc,
 	log logr.Logger,
 ) (adminutils.AdminAPIClient, error) {
 	headlessSvc := resources.NewHeadlessService(cl, cluster, scheme, nil, log)
@@ -61,6 +63,7 @@ func NewAdminAPI(
 		cluster,
 		headlessSvc.HeadlessServiceFQDN(clusterDomain),
 		adminTLSConfigProvider,
+		dialer,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating AdminAPIClient: %w", err)

--- a/operator/pkg/console/sasl.go
+++ b/operator/pkg/console/sasl.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
@@ -40,6 +41,7 @@ type KafkaSA struct {
 	adminAPI           adminutils.NodePoolAdminAPIClientFactory
 	superUsersResource *resources.SuperUsersResource
 	log                logr.Logger
+	dialer             redpanda.DialContextFunc
 }
 
 // NewKafkaSA instantiates a new KafkaSA
@@ -115,7 +117,7 @@ func (k *KafkaSA) Ensure(ctx context.Context) error {
 	username := string(secret.Data[corev1.BasicAuthUsernameKey])
 	password := string(secret.Data[corev1.BasicAuthPasswordKey])
 
-	adminAPI, err := NewAdminAPI(ctx, k.Client, k.scheme, k.clusterobj, k.clusterDomain, k.adminAPI, k.log)
+	adminAPI, err := NewAdminAPI(ctx, k.Client, k.scheme, k.clusterobj, k.clusterDomain, k.adminAPI, k.dialer, k.log)
 	if err != nil {
 		return err
 	}
@@ -161,7 +163,7 @@ func (k *KafkaSA) Cleanup(ctx context.Context) error {
 		return k.Update(ctx, k.consoleobj)
 	}
 
-	adminAPI, err := NewAdminAPI(ctx, k.Client, k.scheme, k.clusterobj, k.clusterDomain, k.adminAPI, k.log)
+	adminAPI, err := NewAdminAPI(ctx, k.Client, k.scheme, k.clusterobj, k.clusterDomain, k.adminAPI, k.dialer, k.log)
 	if err != nil {
 		return err
 	}

--- a/operator/pkg/resources/resource_integration_test.go
+++ b/operator/pkg/resources/resource_integration_test.go
@@ -99,6 +99,7 @@ func TestEnsure_StatefulSet(t *testing.T) {
 		},
 		func(ctx context.Context) (string, error) { return hash, nil },
 		adminutils.NewNodePoolInternalAdminAPI,
+		nil,
 		time.Second,
 		ctrl.Log.WithName("test"),
 		0,

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
@@ -121,6 +122,7 @@ type StatefulSetResource struct {
 	nodePool          vectorizedv1alpha1.NodePoolSpecWithDeleted
 
 	autoDeletePVCs bool
+	dialer         redpanda.DialContextFunc
 }
 
 func (r *StatefulSetResource) GetNodePool() *vectorizedv1alpha1.NodePoolSpecWithDeleted {

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -34,8 +34,6 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-
 	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
@@ -43,6 +41,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"
 	resourcetypes "github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 )
 
 var _ Resource = &StatefulSetResource{}
@@ -143,6 +142,7 @@ func NewStatefulSet(
 	configuratorSettings ConfiguratorSettings,
 	nodeConfigMapHashGetter func(context.Context) (string, error),
 	adminAPIClientFactory adminutils.NodePoolAdminAPIClientFactory,
+	dialer redpanda.DialContextFunc,
 	decommissionWaitInterval time.Duration,
 	logger logr.Logger,
 	metricsTimeout time.Duration,
@@ -163,6 +163,7 @@ func NewStatefulSet(
 		configuratorSettings:     configuratorSettings,
 		nodeConfigMapHashGetter:  nodeConfigMapHashGetter,
 		adminAPIClientFactory:    adminAPIClientFactory,
+		dialer:                   dialer,
 		decommissionWaitInterval: decommissionWaitInterval,
 		logger:                   logger.WithName("StatefulSetResource"),
 		metricsTimeout:           defaultAdminAPITimeout,

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,7 +42,6 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"
 	resourcetypes "github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/utils"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 )
 
 var _ Resource = &StatefulSetResource{}

--- a/operator/pkg/resources/statefulset_scale.go
+++ b/operator/pkg/resources/statefulset_scale.go
@@ -403,7 +403,7 @@ func (r *StatefulSetResource) handleRecommission(ctx context.Context) error {
 func (r *StatefulSetResource) getAdminAPIClient(
 	ctx context.Context, pods ...string,
 ) (adminutils.AdminAPIClient, error) {
-	return r.adminAPIClientFactory(ctx, r, r.pandaCluster, r.serviceFQDN, r.adminTLSConfigProvider, pods...)
+	return r.adminAPIClientFactory(ctx, r, r.pandaCluster, r.serviceFQDN, r.adminTLSConfigProvider, r.dialer, pods...)
 }
 
 // disableMaintenanceModeOnDecommissionedNodes can be used to put a cluster in a consistent state, disabling maintenance mode on

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -175,6 +175,7 @@ func TestEnsure(t *testing.T) {
 					adminAPI.SetClusterHealth(health)
 					return adminAPI, nil
 				},
+				nil,
 				time.Second,
 				ctrl.Log.WithName("test"),
 				0,
@@ -650,6 +651,7 @@ func TestCurrentVersion(t *testing.T) {
 				func(ctx context.Context, k8sClient client.Reader, redpandaCluster *vectorizedv1alpha1.Cluster, fqdn string, adminTLSProvider resourcetypes.AdminTLSConfigProvider, dialer redpanda.DialContextFunc, pods ...string) (adminutils.AdminAPIClient, error) {
 					return nil, nil
 				},
+				nil,
 				time.Second,
 				ctrl.Log.WithName("test"),
 				0,
@@ -905,7 +907,7 @@ func TestStatefulSetResource_IsManagedDecommission(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := resources.NewStatefulSet(nil,
 				tt.fields.pandaCluster,
-				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, time.Hour,
+				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, nil, time.Hour,
 				tt.fields.logger,
 				time.Hour,
 				vectorizedv1alpha1.NodePoolSpecWithDeleted{NodePoolSpec: vectorizedv1alpha1.NodePoolSpec{Replicas: ptr.To(int32(0))}},
@@ -1030,7 +1032,7 @@ func TestStatefulSetPorts_AdditionalListeners(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := resources.NewStatefulSet(nil,
 				tt.pandaCluster,
-				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, time.Hour,
+				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, nil, time.Hour,
 				logger,
 				time.Hour,
 				vectorizedv1alpha1.NodePoolSpecWithDeleted{NodePoolSpec: tt.pandaCluster.Spec.NodePools[0]},
@@ -1122,7 +1124,7 @@ func TestStatefulSetEnv_AdditionalListeners(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := resources.NewStatefulSet(nil,
 				tt.pandaCluster,
-				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, time.Hour,
+				nil, "", "", types.NamespacedName{}, nil, nil, "", resources.ConfiguratorSettings{}, nil, nil, nil, time.Hour,
 				logger,
 				time.Hour,
 				vectorizedv1alpha1.NodePoolSpecWithDeleted{NodePoolSpec: tt.pandaCluster.Spec.NodePools[0]},

--- a/operator/pkg/resources/statefulset_update_test.go
+++ b/operator/pkg/resources/statefulset_update_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/redpanda-data/common-go/rpadmin"
 
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
@@ -237,6 +238,7 @@ func TestPutInMaintenanceMode(t *testing.T) {
 					redpandaCluster *vectorizedv1alpha1.Cluster,
 					fqdn string,
 					adminTLSProvider types.AdminTLSConfigProvider,
+					_ redpanda.DialContextFunc,
 					pods ...string,
 				) (adminutils.AdminAPIClient, error) {
 					return &adminutils.MockAdminAPI{


### PR DESCRIPTION
@birdayz this is a bit of a dirty hack where I just pass in a dialer function to the admin client initialization function closure, but I think this is pretty much what we'd need at minimum to support injecting a port-forwarding/hole-punching dialer into the admin client initialization code that runs through `operator/pkg/admin/NewNodePoolInternalAdminAPI`.