### PR TITLE
Add `--mode` to syncer; default to additive

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -604,7 +604,7 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, rp *v1a
 		return err
 	}
 
-	syncer := syncclusterconfig.Syncer{Client: client}
+	syncer := syncclusterconfig.Syncer{Client: client, Mode: syncclusterconfig.SyncerModeAdditive}
 
 	if err := syncer.Sync(ctx, config, usersTXT); err != nil {
 		return err


### PR DESCRIPTION
This change should be a no-op thus far; it needs a follow-up to make v1 default to declarative and v2 default to additive.