### PR TITLE
upgrade to go 1.24

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,5 +1,5 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.23.2
+go 1.24.0
 
 require github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/operator/go.mod
+++ b/charts/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/operator
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "lastModified": 1735644329,
+        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {
@@ -55,14 +55,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
               pkgs.go-licenses
               pkgs.go-task
               pkgs.go-tools
-              pkgs.go_1_23
+              pkgs.go_1_24
               pkgs.gofumpt
               pkgs.golangci-lint
               pkgs.goreleaser

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.23.2
+go 1.24.0
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/licenseupdater/go.mod
+++ b/licenseupdater/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licenseupdater
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.23.2
+go 1.24.0
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/gotohelm/testdata/src/example/go.mod
+++ b/pkg/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -11,7 +11,7 @@ License:	 Apache 2.0
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.23.2
+go version go1.24.0
 
 -- goreleaser --
 # goreleaser --version | awk 'NR>2 {print last} {last=$0}'
@@ -19,21 +19,21 @@ go version go1.23.2
 | |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
 | |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
  \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
-goreleaser: Deliver Go Binaries as fast and easily as possible
+goreleaser: Release engineering, simplified.
 https://goreleaser.com
 
-GitVersion:    2.3.2
+GitVersion:    2.7.0
 GitCommit:     unknown
 GitTreeState:  unknown
 BuildDate:     unknown
 BuiltBy:       nixpkgs
-GoVersion:     go1.23.2
+GoVersion:     go1.23.5
 Compiler:      gc
 ModuleSum:     unknown
 
 -- helm --
 # helm version
-version.BuildInfo{Version:"v3.16.2", GitCommit:"v3.16.2", GitTreeState:"", GoVersion:"go1.23.2"}
+version.BuildInfo{Version:"v3.17.1", GitCommit:"v3.17.1", GitTreeState:"", GoVersion:"go1.23.5"}
 
 -- helm-docs --
 # helm-docs -v
@@ -41,21 +41,21 @@ helm-docs version 1.14.2
 
 -- k3d --
 # k3d version
-k3d version v5.7.4
+k3d version v5.8.2
 k3s version v1.21.7-k3s1 (default)
 
 -- kind --
 # kind version | cut -d ' ' -f 1-3
-kind v0.24.0 go1.23.2
+kind v0.27.0 go1.23.5
 
 -- kubectl --
 # kubectl version --client=true
-Client Version: v1.31.2
-Kustomize Version: v5.4.2
+Client Version: v1.32.2
+Kustomize Version: v5.5.0
 
 -- kustomize --
 # kustomize version
-5.5.0
+5.6.0
 
 -- kuttl --
 # kuttl version | cut -d ' ' -f 1-7
@@ -63,9 +63,9 @@ KUTTL Version: version.Info{GitVersion:"0.19.0", GitCommit:"733ad16", BuildDate:
 
 -- task --
 # task --version
-Task version: 3.39.2 ()
+Task version: 3.41.0 ()
 
 -- yq --
 # yq --version
-yq (https://github.com/mikefarah/yq/) version v4.44.3
+yq (https://github.com/mikefarah/yq/) version v4.45.1
 


### PR DESCRIPTION
This commit bumps all flake inputs and upgrades to go 1.24.