### PR TITLE
[backport] replace `goimports` with `gci` in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,23 +4,31 @@ linters:
 
   enable:
   - errcheck
+  - gci
+  - gocritic
   - gofumpt
-  - goimports
   - gosec
   - gosimple
   - govet
   - importas
   - ineffassign
   - misspell
-  - gocritic
   - staticcheck
   - stylecheck
   - unparam
   - unused
 
 linters-settings:
-  goimports:
-    local-prefixes: github.com/redpanda-data/redpanda-operator,github.com/redpanda-data/helm-charts
+  gci:
+    sections:
+    - standard
+    - default
+    - prefix(github.com/redpanda-data/redpanda-operator)
+
+    custom-order: true
+    skip-generated: true
+    no-inline-comments: false
+    no-prefix-comments: false
 
   gosec:
     excludes:
@@ -30,11 +38,24 @@ linters-settings:
       G306: "0644" # Maximum allowed os.WriteFile Permissions
 
   importas:
+    # Disallow not using aliases for all matches of the below alias list.
+    no-unaliased: true
+    # Enforce standard import aliases for k8s type packages of (group)(version)
     alias:
     - pkg: k8s.io/api/(\w+)/(v\d)
       alias: $1$2
     - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       alias: metav1
+    - pkg: k8s.io/client-go/applyconfigurations/(\w+)/(v\w+)
+      alias: apply$1$2
+    - pkg: github.com/redpanda-data/redpanda-operator/operator/api/(\w+)/(v\w+)
+      alias: $1$2
+    - pkg: github.com/cert-manager/cert-manager/pkg/apis/meta/v1
+      alias: cmmetav1
+    - pkg: github.com/cert-manager/cert-manager/pkg/apis/certmanager/(v\w+)
+      alias: certmanager$1
+    - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/(v\w+)
+      alias: monitoring$1
 
   gocritic:
     disable-all: true

--- a/charts/operator/certificates.go
+++ b/charts/operator/certificates.go
@@ -13,21 +13,21 @@ package operator
 import (
 	"fmt"
 
-	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 )
 
-func Certificate(dot *helmette.Dot) *certv1.Certificate {
+func Certificate(dot *helmette.Dot) *certmanagerv1.Certificate {
 	values := helmette.Unwrap[Values](dot.Values)
 
 	if !values.Webhook.Enabled {
 		return nil
 	}
 
-	return &certv1.Certificate{
+	return &certmanagerv1.Certificate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cert-manager.io/v1",
 			Kind:       "Certificate",
@@ -38,17 +38,17 @@ func Certificate(dot *helmette.Dot) *certv1.Certificate {
 			Labels:      Labels(dot),
 			Annotations: values.Annotations,
 		},
-		Spec: certv1.CertificateSpec{
+		Spec: certmanagerv1.CertificateSpec{
 			DNSNames: []string{
 				fmt.Sprintf("%s-webhook-service.%s.svc", RedpandaOperatorName(dot), dot.Release.Namespace),
 				fmt.Sprintf("%s-webhook-service.%s.svc.%s", RedpandaOperatorName(dot), dot.Release.Namespace, values.ClusterDomain),
 			},
-			IssuerRef: cmmeta.ObjectReference{
+			IssuerRef: cmmetav1.ObjectReference{
 				Kind: "Issuer",
 				Name: cleanForK8sWithSuffix(Fullname(dot), "selfsigned-issuer"),
 			},
 			SecretName: values.WebhookSecretName,
-			PrivateKey: &certv1.CertificatePrivateKey{
+			PrivateKey: &certmanagerv1.CertificatePrivateKey{
 				// There is an issue with gotohelm when RotationPolicyNever is used.
 				// The conversion from constant string to helm template is failing.
 				//
@@ -60,14 +60,14 @@ func Certificate(dot *helmette.Dot) *certv1.Certificate {
 	}
 }
 
-func Issuer(dot *helmette.Dot) *certv1.Issuer {
+func Issuer(dot *helmette.Dot) *certmanagerv1.Issuer {
 	values := helmette.Unwrap[Values](dot.Values)
 
 	if !values.Webhook.Enabled {
 		return nil
 	}
 
-	return &certv1.Issuer{
+	return &certmanagerv1.Issuer{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cert-manager.io/v1",
 			Kind:       "Issuer",
@@ -78,9 +78,9 @@ func Issuer(dot *helmette.Dot) *certv1.Issuer {
 			Labels:      Labels(dot),
 			Annotations: values.Annotations,
 		},
-		Spec: certv1.IssuerSpec{
-			IssuerConfig: certv1.IssuerConfig{
-				SelfSigned: &certv1.SelfSignedIssuer{},
+		Spec: certmanagerv1.IssuerSpec{
+			IssuerConfig: certmanagerv1.IssuerConfig{
+				SelfSigned: &certmanagerv1.SelfSignedIssuer{},
 			},
 		},
 	}

--- a/charts/operator/servicemonitor.go
+++ b/charts/operator/servicemonitor.go
@@ -11,21 +11,21 @@
 package operator
 
 import (
-	monitorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 )
 
-func ServiceMonitor(dot *helmette.Dot) *monitorv1.ServiceMonitor {
+func ServiceMonitor(dot *helmette.Dot) *monitoringv1.ServiceMonitor {
 	values := helmette.Unwrap[Values](dot.Values)
 
 	if !values.Monitoring.Enabled {
 		return nil
 	}
 
-	return &monitorv1.ServiceMonitor{
+	return &monitoringv1.ServiceMonitor{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceMonitor",
 			APIVersion: "monitoring.coreos.com/v1",
@@ -36,21 +36,21 @@ func ServiceMonitor(dot *helmette.Dot) *monitorv1.ServiceMonitor {
 			Namespace:   dot.Release.Namespace,
 			Annotations: values.Annotations,
 		},
-		Spec: monitorv1.ServiceMonitorSpec{
-			Endpoints: []monitorv1.Endpoint{
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{
 				{
 					Port:   "https",
 					Path:   "/metrics",
 					Scheme: "https",
-					TLSConfig: &monitorv1.TLSConfig{
-						SafeTLSConfig: monitorv1.SafeTLSConfig{
+					TLSConfig: &monitoringv1.TLSConfig{
+						SafeTLSConfig: monitoringv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(true),
 						},
 					},
 					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 				},
 			},
-			NamespaceSelector: monitorv1.NamespaceSelector{
+			NamespaceSelector: monitoringv1.NamespaceSelector{
 				MatchNames: []string{dot.Release.Namespace},
 			},
 			Selector: metav1.LabelSelector{

--- a/charts/redpanda/cert_issuers.go
+++ b/charts/redpanda/cert_issuers.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -115,7 +115,7 @@ func certIssuersAndCAs(dot *helmette.Dot) ([]*certmanagerv1.Issuer, []*certmanag
 						Algorithm: "ECDSA",
 						Size:      256,
 					},
-					IssuerRef: cmmeta.ObjectReference{
+					IssuerRef: cmmetav1.ObjectReference{
 						Name:  fmt.Sprintf(`%s-%s-selfsigned-issuer`, Fullname(dot), name),
 						Kind:  "Issuer",
 						Group: "cert-manager.io",

--- a/charts/redpanda/certs.go
+++ b/charts/redpanda/certs.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -62,7 +62,7 @@ func ClientCerts(dot *helmette.Dot) []*certmanagerv1.Certificate {
 		}
 
 		duration := helmette.Default("43800h", data.Duration)
-		issuerRef := ptr.Deref(data.IssuerRef, cmmeta.ObjectReference{
+		issuerRef := ptr.Deref(data.IssuerRef, cmmetav1.ObjectReference{
 			Kind:  "Issuer",
 			Group: "cert-manager.io",
 			Name:  fmt.Sprintf("%s-%s-root-issuer", fullname, name),
@@ -103,7 +103,7 @@ func ClientCerts(dot *helmette.Dot) []*certmanagerv1.Certificate {
 		return certs
 	}
 
-	issuerRef := cmmeta.ObjectReference{
+	issuerRef := cmmetav1.ObjectReference{
 		Group: "cert-manager.io",
 		Kind:  "Issuer",
 		Name:  fmt.Sprintf("%s-%s-root-issuer", fullname, name),

--- a/charts/redpanda/client/client.go
+++ b/charts/redpanda/client/client.go
@@ -22,17 +22,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
-
-	"github.com/redpanda-data/common-go/rpadmin"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -13,7 +13,7 @@ package redpanda
 import (
 	"fmt"
 
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/invopop/jsonschema"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	_ "github.com/quasilyte/go-ruleguard/dsl"
@@ -1104,7 +1104,7 @@ type TLSCert struct {
 	CAEnabled             bool                         `json:"caEnabled" jsonschema:"required"`
 	ApplyInternalDNSNames *bool                        `json:"applyInternalDNSNames"`
 	Duration              string                       `json:"duration" jsonschema:"pattern=.*[smh]$"`
-	IssuerRef             *cmmeta.ObjectReference      `json:"issuerRef"`
+	IssuerRef             *cmmetav1.ObjectReference    `json:"issuerRef"`
 	SecretRef             *corev1.LocalObjectReference `json:"secretRef"`
 	ClientSecretRef       *corev1.LocalObjectReference `json:"clientSecretRef"`
 }

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -14,7 +14,7 @@
 package redpanda
 
 import (
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redpanda-data/redpanda-operator/charts/connectors"
 	"github.com/redpanda-data/redpanda-operator/charts/console"
@@ -461,7 +461,7 @@ type PartialTLSCert struct {
 	CAEnabled             *bool                        "json:\"caEnabled,omitempty\" jsonschema:\"required\""
 	ApplyInternalDNSNames *bool                        "json:\"applyInternalDNSNames,omitempty\""
 	Duration              *string                      "json:\"duration,omitempty\" jsonschema:\"pattern=.*[smh]$\""
-	IssuerRef             *cmmeta.ObjectReference      "json:\"issuerRef,omitempty\""
+	IssuerRef             *cmmetav1.ObjectReference    "json:\"issuerRef,omitempty\""
 	SecretRef             *corev1.LocalObjectReference "json:\"secretRef,omitempty\""
 	ClientSecretRef       *corev1.LocalObjectReference "json:\"clientSecretRef,omitempty\""
 }

--- a/harpoon/suite_test.go
+++ b/harpoon/suite_test.go
@@ -14,9 +14,8 @@ import (
 	"sync"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -13,10 +13,9 @@ import (
 	"context"
 
 	"github.com/cucumber/godog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"

--- a/operator/api/redpanda/v1alpha1/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha1/redpanda_types.go
@@ -10,7 +10,7 @@
 package v1alpha1
 
 import (
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 var RedpandaChartRepository = "https://charts.redpanda.com/"
@@ -22,11 +22,11 @@ var RedpandaChartRepository = "https://charts.redpanda.com/"
 // +kubebuilder:resource:shortName=rp
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
-type Redpanda v1alpha2.Redpanda
+type Redpanda redpandav1alpha2.Redpanda
 
 // RedpandaList contains a list of Redpanda objects.
 // +kubebuilder:object:root=true
-type RedpandaList v1alpha2.RedpandaList
+type RedpandaList redpandav1alpha2.RedpandaList
 
 func init() {
 	SchemeBuilder.Register(&Redpanda{}, &RedpandaList{})
@@ -34,10 +34,10 @@ func init() {
 
 // RedpandaReady registers a successful reconciliation of the given HelmRelease.
 func RedpandaReady(rp *Redpanda) *Redpanda {
-	return (*Redpanda)(v1alpha2.RedpandaReady((*v1alpha2.Redpanda)(rp)))
+	return (*Redpanda)(redpandav1alpha2.RedpandaReady((*redpandav1alpha2.Redpanda)(rp)))
 }
 
 // RedpandaNotReady registers a failed reconciliation of the given Redpanda.
 func RedpandaNotReady(rp *Redpanda, reason, message string) *Redpanda {
-	return (*Redpanda)(v1alpha2.RedpandaNotReady((*v1alpha2.Redpanda)(rp), reason, message))
+	return (*Redpanda)(redpandav1alpha2.RedpandaNotReady((*redpandav1alpha2.Redpanda)(rp), reason, message))
 }

--- a/operator/api/redpanda/v1alpha1/topic_types.go
+++ b/operator/api/redpanda/v1alpha1/topic_types.go
@@ -9,13 +9,13 @@
 
 package v1alpha1
 
-import "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+import redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 
 // Topic defines the CRD for Topic resources. See https://docs.redpanda.com/current/manage/kubernetes/manage-topics/.
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-type Topic v1alpha2.Topic
+type Topic redpandav1alpha2.Topic
 
 // TopicList contains a list of Topic objects.
 // +kubebuilder:object:root=true
-type TopicList v1alpha2.TopicList
+type TopicList redpandav1alpha2.TopicList

--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -25,10 +25,9 @@ import (
 	"k8s.io/utils/ptr"
 
 	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
-
-	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
 const (
@@ -94,11 +93,11 @@ type Migration struct {
 	Enabled bool `json:"enabled"`
 	// ClusterRef by default will not be able to reach different namespaces, but it can be
 	// overwritten by adding ClusterRole and ClusterRoleBinding to operator ServiceAccount.
-	ClusterRef v1alpha1.NamespaceNameRef `json:"clusterRef"`
+	ClusterRef vectorizedv1alpha1.NamespaceNameRef `json:"clusterRef"`
 
 	// ConsoleRef by default will not be able to reach different namespaces, but it can be
 	// overwritten by adding ClusterRole and ClusterRoleBinding to operator ServiceAccount.
-	ConsoleRef v1alpha1.NamespaceNameRef `json:"consoleRef"`
+	ConsoleRef vectorizedv1alpha1.NamespaceNameRef `json:"consoleRef"`
 }
 
 // RedpandaStatus defines the observed state of Redpanda

--- a/operator/api/redpanda/v1alpha2/redpanda_types_test.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/charts/console"
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
 	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 )
@@ -113,12 +113,12 @@ func TestRedpanda_ValuesJSON(t *testing.T) {
 
 		t.Logf("%s", rawValue)
 
-		rp := v1alpha2.Redpanda{
-			Spec: v1alpha2.RedpandaSpec{
-				ClusterSpec: &v1alpha2.RedpandaClusterSpec{
-					Storage: &v1alpha2.Storage{
-						Tiered: &v1alpha2.Tiered{
-							Config: &v1alpha2.TieredConfig{
+		rp := redpandav1alpha2.Redpanda{
+			Spec: redpandav1alpha2.RedpandaSpec{
+				ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+					Storage: &redpandav1alpha2.Storage{
+						Tiered: &redpandav1alpha2.Tiered{
+							Config: &redpandav1alpha2.TieredConfig{
 								CloudStorageEnabled: &apiutil.JSONBoolean{Raw: rawValue},
 							},
 						},
@@ -190,7 +190,7 @@ func TestHelmValuesCompat(t *testing.T) {
 	}
 
 	t.Run("clusterSpec", rapid.MakeCheck(func(t *rapid.T) {
-		AssertJSONCompat[redpanda.PartialValues, v1alpha2.RedpandaClusterSpec](t, cfg, func(from *redpanda.PartialValues) {
+		AssertJSONCompat[redpanda.PartialValues, redpandav1alpha2.RedpandaClusterSpec](t, cfg, func(from *redpanda.PartialValues) {
 			if from.Storage != nil && from.Storage.Tiered != nil && from.Storage.Tiered.PersistentVolume != nil {
 				// Incorrect type (should be a *resource.Quantity) on an anonymous struct in Partial Values.
 				from.Storage.Tiered.PersistentVolume.Size = nil
@@ -199,11 +199,11 @@ func TestHelmValuesCompat(t *testing.T) {
 	}))
 
 	t.Run("connectors", rapid.MakeCheck(func(t *rapid.T) {
-		AssertJSONCompat[connectors.PartialValues, v1alpha2.RedpandaConnectors](t, cfg, nil)
+		AssertJSONCompat[connectors.PartialValues, redpandav1alpha2.RedpandaConnectors](t, cfg, nil)
 	}))
 
 	t.Run("console", rapid.MakeCheck(func(t *rapid.T) {
-		AssertJSONCompat[console.PartialValues, v1alpha2.RedpandaConsole](t, cfg, nil)
+		AssertJSONCompat[console.PartialValues, redpandav1alpha2.RedpandaConsole](t, cfg, nil)
 	}))
 }
 
@@ -217,7 +217,7 @@ func TestClusterSpecBackwardsCompat(t *testing.T) {
 	})
 
 	scheme := runtime.NewScheme()
-	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.AddToScheme(scheme))
 
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
@@ -227,7 +227,7 @@ func TestClusterSpecBackwardsCompat(t *testing.T) {
 	cr := unstructured.Unstructured{Object: make(map[string]interface{})}
 	cr.SetNamespace("default")
 	cr.SetName("namespace-selector")
-	cr.SetGroupVersionKind(v1alpha2.GroupVersion.WithKind("Redpanda"))
+	cr.SetGroupVersionKind(redpandav1alpha2.GroupVersion.WithKind("Redpanda"))
 
 	// Create a minimal redpanda CR with an extranious field in the namespace
 	// selector (which was previously mistyped as a map[string]any).

--- a/operator/api/vectorized/v1alpha1/cluster_types.go
+++ b/operator/api/vectorized/v1alpha1/cluster_types.go
@@ -16,7 +16,7 @@ import (
 	"slices"
 	"time"
 
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -762,7 +762,7 @@ type KafkaAPITLS struct {
 	// Typically you want to provide the issuer when a generated self-signed one
 	// is not enough and you need to have a verifiable chain with a proper CA
 	// certificate.
-	IssuerRef *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
+	IssuerRef *cmmetav1.ObjectReference `json:"issuerRef,omitempty"`
 	// If provided, operator uses certificate in this secret instead of
 	// issuing its own node certificate. The secret is expected to provide
 	// the following keys: 'ca.crt', 'tls.key' and 'tls.crt'
@@ -804,7 +804,7 @@ type AdminAPITLS struct {
 	// Typically you want to provide the issuer when a generated self-signed one
 	// is not enough and you need to have a verifiable chain with a proper CA
 	// certificate.
-	IssuerRef *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
+	IssuerRef *cmmetav1.ObjectReference `json:"issuerRef,omitempty"`
 	// If provided, operator uses certificate in this secret instead of
 	// issuing its own node certificate. The secret is expected to provide
 	// the following keys: 'ca.crt', 'tls.key' and 'tls.crt'
@@ -846,7 +846,7 @@ type PandaproxyAPITLS struct {
 	// Typically you want to provide the issuer when a generated self-signed one
 	// is not enough and you need to have a verifiable chain with a proper CA
 	// certificate.
-	IssuerRef *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
+	IssuerRef *cmmetav1.ObjectReference `json:"issuerRef,omitempty"`
 	// If provided, operator uses certificate in this secret instead of
 	// issuing its own node certificate. The secret is expected to provide
 	// the following keys: 'ca.crt', 'tls.key' and 'tls.crt'
@@ -890,7 +890,7 @@ type SchemaRegistryAPITLS struct {
 	// Typically you want to provide the issuer when a generated self-signed one
 	// is not enough and you need to have a verifiable chain with a proper CA
 	// certificate.
-	IssuerRef *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
+	IssuerRef *cmmetav1.ObjectReference `json:"issuerRef,omitempty"`
 	// If provided, operator uses certificate in this secret instead of
 	// issuing its own node certificate. The secret is expected to provide
 	// the following keys: 'ca.crt', 'tls.key' and 'tls.crt'
@@ -1251,10 +1251,10 @@ func (r *Cluster) GetDesiredReplicas() int32 {
 
 // TLSConfig is a generic TLS configuration
 type TLSConfig struct {
-	Enabled           bool                    `json:"enabled,omitempty"`
-	RequireClientAuth bool                    `json:"requireClientAuth,omitempty"`
-	IssuerRef         *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
-	NodeSecretRef     *corev1.ObjectReference `json:"nodeSecretRef,omitempty"`
+	Enabled           bool                      `json:"enabled,omitempty"`
+	RequireClientAuth bool                      `json:"requireClientAuth,omitempty"`
+	IssuerRef         *cmmetav1.ObjectReference `json:"issuerRef,omitempty"`
+	NodeSecretRef     *corev1.ObjectReference   `json:"nodeSecretRef,omitempty"`
 
 	ClientCACertRef *corev1.TypedLocalObjectReference `json:"clientCACertRef,omitempty"`
 }

--- a/operator/api/vectorized/v1alpha1/cluster_types_test.go
+++ b/operator/api/vectorized/v1alpha1/cluster_types_test.go
@@ -18,7 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
 //nolint:funlen // this is ok for a test
@@ -32,8 +32,8 @@ func TestRedpandaResourceRequirements(t *testing.T) {
 		expectedRedpandaCPU resource.Quantity
 		expectedRedpandaMem resource.Quantity
 	}
-	makeResources := func(t test) v1alpha1.RedpandaResourceRequirements {
-		return v1alpha1.RedpandaResourceRequirements{
+	makeResources := func(t test) vectorizedv1alpha1.RedpandaResourceRequirements {
+		return vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: t.setRequestsMem,
@@ -143,11 +143,11 @@ func TestConditions(t *testing.T) {
 
 	t.Run("create a condition", func(t *testing.T) {
 		t.Parallel()
-		cluster := &v1alpha1.Cluster{}
-		assert.True(t, cluster.Status.SetCondition(v1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
+		cluster := &vectorizedv1alpha1.Cluster{}
+		assert.True(t, cluster.Status.SetCondition(vectorizedv1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
 		require.Len(t, cluster.Status.Conditions, 1)
 		cond := cluster.Status.Conditions[0]
-		assert.Equal(t, v1alpha1.ClusterConfiguredConditionType, cond.Type)
+		assert.Equal(t, vectorizedv1alpha1.ClusterConfiguredConditionType, cond.Type)
 		assert.Equal(t, corev1.ConditionTrue, cond.Status)
 		assert.Equal(t, "reason", cond.Reason)
 		assert.Equal(t, "message", cond.Message)
@@ -157,15 +157,15 @@ func TestConditions(t *testing.T) {
 
 	t.Run("update a condition", func(t *testing.T) {
 		t.Parallel()
-		cluster := &v1alpha1.Cluster{}
-		assert.True(t, cluster.Status.SetCondition(v1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
+		cluster := &vectorizedv1alpha1.Cluster{}
+		assert.True(t, cluster.Status.SetCondition(vectorizedv1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
 		require.Len(t, cluster.Status.Conditions, 1)
 		cond := cluster.Status.Conditions[0]
 		condTime := cond.LastTransitionTime
-		assert.True(t, cluster.Status.SetConditionUsingClock(v1alpha1.ClusterConfiguredConditionType, corev1.ConditionFalse, "reason2", "message2", earlyClock))
+		assert.True(t, cluster.Status.SetConditionUsingClock(vectorizedv1alpha1.ClusterConfiguredConditionType, corev1.ConditionFalse, "reason2", "message2", earlyClock))
 		require.Len(t, cluster.Status.Conditions, 1)
 		cond = cluster.Status.Conditions[0]
-		assert.Equal(t, v1alpha1.ClusterConfiguredConditionType, cond.Type)
+		assert.Equal(t, vectorizedv1alpha1.ClusterConfiguredConditionType, cond.Type)
 		assert.Equal(t, corev1.ConditionFalse, cond.Status)
 		assert.Equal(t, "reason2", cond.Reason)
 		assert.Equal(t, "message2", cond.Message)
@@ -175,8 +175,8 @@ func TestConditions(t *testing.T) {
 
 	t.Run("update to one condition does not affect the other", func(t *testing.T) {
 		t.Parallel()
-		cluster := &v1alpha1.Cluster{}
-		assert.True(t, cluster.Status.SetCondition(v1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
+		cluster := &vectorizedv1alpha1.Cluster{}
+		assert.True(t, cluster.Status.SetCondition(vectorizedv1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
 		assert.True(t, cluster.Status.SetCondition("otherType", corev1.ConditionFalse, "reason2", "message2"))
 		require.Len(t, cluster.Status.Conditions, 2)
 		condCluster := cluster.Status.Conditions[0]
@@ -187,7 +187,7 @@ func TestConditions(t *testing.T) {
 		assert.True(t, cluster.Status.SetConditionUsingClock("otherType", corev1.ConditionUnknown, "reason3", "message3", earlyClock))
 		require.Len(t, cluster.Status.Conditions, 2)
 		condCluster = cluster.Status.Conditions[0]
-		assert.Equal(t, v1alpha1.ClusterConfiguredConditionType, condCluster.Type)
+		assert.Equal(t, vectorizedv1alpha1.ClusterConfiguredConditionType, condCluster.Type)
 		assert.Equal(t, corev1.ConditionTrue, condCluster.Status)
 		assert.Equal(t, "reason", condCluster.Reason)
 		assert.Equal(t, "message", condCluster.Message)
@@ -195,7 +195,7 @@ func TestConditions(t *testing.T) {
 		assert.Equal(t, condClusterTime2, condClusterTime)
 
 		condOther = cluster.Status.Conditions[1]
-		assert.Equal(t, v1alpha1.ClusterConditionType("otherType"), condOther.Type)
+		assert.Equal(t, vectorizedv1alpha1.ClusterConditionType("otherType"), condOther.Type)
 		assert.Equal(t, corev1.ConditionUnknown, condOther.Status)
 		assert.Equal(t, "reason3", condOther.Reason)
 		assert.Equal(t, "message3", condOther.Message)
@@ -205,12 +205,12 @@ func TestConditions(t *testing.T) {
 
 	t.Run("updating a condition with itself does not change transition time", func(t *testing.T) {
 		t.Parallel()
-		cluster := &v1alpha1.Cluster{}
-		assert.True(t, cluster.Status.SetCondition(v1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
+		cluster := &vectorizedv1alpha1.Cluster{}
+		assert.True(t, cluster.Status.SetCondition(vectorizedv1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message"))
 		require.Len(t, cluster.Status.Conditions, 1)
 		cond := cluster.Status.Conditions[0]
 		condTime := cond.LastTransitionTime
-		assert.False(t, cluster.Status.SetConditionUsingClock(v1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message", earlyClock))
+		assert.False(t, cluster.Status.SetConditionUsingClock(vectorizedv1alpha1.ClusterConfiguredConditionType, corev1.ConditionTrue, "reason", "message", earlyClock))
 		require.Len(t, cluster.Status.Conditions, 1)
 		cond2 := cluster.Status.Conditions[0]
 		assert.Equal(t, condTime, cond2.LastTransitionTime)

--- a/operator/api/vectorized/v1alpha1/cluster_webhook.go
+++ b/operator/api/vectorized/v1alpha1/cluster_webhook.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"strings"
 
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -950,7 +950,7 @@ func hasDifferentNodeSecret(listener1, listener2 KafkaAPITLS) bool {
 
 func validateListener(
 	tlsEnabled, requireClientAuth bool,
-	issuerRef *cmmeta.ObjectReference,
+	issuerRef *cmmetav1.ObjectReference,
 	nodeSecretRef *corev1.ObjectReference,
 	clientCACertRef *corev1.TypedLocalObjectReference,
 	path *field.Path,
@@ -1034,7 +1034,7 @@ func validateExternalCA(
 		return allErrs
 	}
 
-	crt, found := secret.Data[cmmeta.TLSCAKey]
+	crt, found := secret.Data[cmmetav1.TLSCAKey]
 	if !found {
 		allErrs = append(allErrs,
 			field.Invalid(

--- a/operator/api/vectorized/v1alpha1/cluster_webhook_test.go
+++ b/operator/api/vectorized/v1alpha1/cluster_webhook_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
 var fakeK8sClient = fake.NewClientBuilder().Build()
@@ -63,14 +63,14 @@ func TestDefault(t *testing.T) {
 	for _, tt := range tests {
 		for _, field := range fields {
 			t.Run(tt.name, func(t *testing.T) {
-				redpandaCluster := &v1alpha1.Cluster{
+				redpandaCluster := &vectorizedv1alpha1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "",
 					},
-					Spec: v1alpha1.ClusterSpec{
+					Spec: vectorizedv1alpha1.ClusterSpec{
 						Replicas:      ptr.To(tt.replicas),
-						Configuration: v1alpha1.RedpandaConfig{},
+						Configuration: vectorizedv1alpha1.RedpandaConfig{},
 					},
 				}
 
@@ -89,15 +89,15 @@ func TestDefault(t *testing.T) {
 	}
 
 	t.Run("missing schema registry does not set default port", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{
+			Spec: vectorizedv1alpha1.ClusterSpec{
 				Replicas:      ptr.To(int32(1)),
-				Configuration: v1alpha1.RedpandaConfig{},
-				Resources: v1alpha1.RedpandaResourceRequirements{
+				Configuration: vectorizedv1alpha1.RedpandaConfig{},
+				Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -112,17 +112,17 @@ func TestDefault(t *testing.T) {
 		assert.Nil(t, redpandaCluster.Spec.Configuration.SchemaRegistry)
 	})
 	t.Run("if schema registry exist, but the port is 0 the default is set", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{
+			Spec: vectorizedv1alpha1.ClusterSpec{
 				Replicas: ptr.To(int32(1)),
-				Configuration: v1alpha1.RedpandaConfig{
-					SchemaRegistry: &v1alpha1.SchemaRegistryAPI{},
+				Configuration: vectorizedv1alpha1.RedpandaConfig{
+					SchemaRegistry: &vectorizedv1alpha1.SchemaRegistryAPI{},
 				},
-				Resources: v1alpha1.RedpandaResourceRequirements{
+				Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -137,19 +137,19 @@ func TestDefault(t *testing.T) {
 		assert.Equal(t, 8081, redpandaCluster.Spec.Configuration.SchemaRegistry.Port)
 	})
 	t.Run("if schema registry exist and port have not zero value the default will not be used", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{
+			Spec: vectorizedv1alpha1.ClusterSpec{
 				Replicas: ptr.To(int32(1)),
-				Configuration: v1alpha1.RedpandaConfig{
-					SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
+				Configuration: vectorizedv1alpha1.RedpandaConfig{
+					SchemaRegistry: &vectorizedv1alpha1.SchemaRegistryAPI{
 						Port: 999,
 					},
 				},
-				Resources: v1alpha1.RedpandaResourceRequirements{
+				Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -164,21 +164,21 @@ func TestDefault(t *testing.T) {
 		assert.Equal(t, 999, redpandaCluster.Spec.Configuration.SchemaRegistry.Port)
 	})
 	t.Run("if schema registry is defined as rest of external listeners the default port is used", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{
+			Spec: vectorizedv1alpha1.ClusterSpec{
 				Replicas: ptr.To(int32(1)),
-				Configuration: v1alpha1.RedpandaConfig{
-					SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
-						External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-							ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+				Configuration: vectorizedv1alpha1.RedpandaConfig{
+					SchemaRegistry: &vectorizedv1alpha1.SchemaRegistryAPI{
+						External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+							ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 						},
 					},
 				},
-				Resources: v1alpha1.RedpandaResourceRequirements{
+				Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -193,12 +193,12 @@ func TestDefault(t *testing.T) {
 		assert.Equal(t, 8081, redpandaCluster.Spec.Configuration.SchemaRegistry.Port)
 	})
 	t.Run("pod disruption budget", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{
+			Spec: vectorizedv1alpha1.ClusterSpec{
 				Replicas: ptr.To(int32(1)),
 			},
 		}
@@ -207,30 +207,30 @@ func TestDefault(t *testing.T) {
 		assert.Equal(t, intstr.FromInt(1), *redpandaCluster.Spec.PodDisruptionBudget.MaxUnavailable)
 	})
 	t.Run("cluster license key default is set", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{
+			Spec: vectorizedv1alpha1.ClusterSpec{
 				Replicas: ptr.To(int32(1)),
-				LicenseRef: &v1alpha1.SecretKeyRef{
+				LicenseRef: &vectorizedv1alpha1.SecretKeyRef{
 					Name:      "test",
 					Namespace: "",
 				},
 			},
 		}
 		redpandaCluster.Default()
-		assert.Equal(t, v1alpha1.DefaultLicenseSecretKey, redpandaCluster.Spec.LicenseRef.Key)
+		assert.Equal(t, vectorizedv1alpha1.DefaultLicenseSecretKey, redpandaCluster.Spec.LicenseRef.Key)
 	})
 
 	t.Run("when restart config is nil, set UnderReplicatedPartitionThreshold to 0", func(t *testing.T) {
-		redpandaCluster := &v1alpha1.Cluster{
+		redpandaCluster := &vectorizedv1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "",
 			},
-			Spec: v1alpha1.ClusterSpec{},
+			Spec: vectorizedv1alpha1.ClusterSpec{},
 		}
 		redpandaCluster.Default()
 		assert.NotNil(t, redpandaCluster.Spec.RestartConfig)
@@ -242,15 +242,15 @@ func TestValidateUpdate(t *testing.T) {
 	var replicas0 int32
 	var replicas3 int32 = 3
 
-	redpandaCluster := &v1alpha1.Cluster{
+	redpandaCluster := &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "",
 		},
-		Spec: v1alpha1.ClusterSpec{
+		Spec: vectorizedv1alpha1.ClusterSpec{
 			Replicas:      ptr.To(replicas3),
-			Configuration: v1alpha1.RedpandaConfig{},
-			Resources: v1alpha1.RedpandaResourceRequirements{
+			Configuration: vectorizedv1alpha1.RedpandaConfig{},
+			Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 				ResourceRequirements: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
@@ -264,13 +264,13 @@ func TestValidateUpdate(t *testing.T) {
 
 	updatedCluster := redpandaCluster.DeepCopy()
 	updatedCluster.Spec.Replicas = &replicas0
-	updatedCluster.Spec.Configuration = v1alpha1.RedpandaConfig{
-		KafkaAPI: []v1alpha1.KafkaAPI{
+	updatedCluster.Spec.Configuration = vectorizedv1alpha1.RedpandaConfig{
+		KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 			{
 				Port: 123,
-				TLS: v1alpha1.KafkaAPITLS{
+				TLS: vectorizedv1alpha1.KafkaAPITLS{
 					RequireClientAuth: true,
-					IssuerRef: &cmmeta.ObjectReference{
+					IssuerRef: &cmmetav1.ObjectReference{
 						Name: "test",
 					},
 					NodeSecretRef: &corev1.ObjectReference{
@@ -315,20 +315,20 @@ func TestValidateUpdate(t *testing.T) {
 func TestValidateUpdate_NoError(t *testing.T) {
 	var replicas2 int32 = 2
 
-	redpandaCluster := &v1alpha1.Cluster{
+	redpandaCluster := &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "",
 		},
-		Spec: v1alpha1.ClusterSpec{
-			Configuration: v1alpha1.RedpandaConfig{
-				KafkaAPI:       []v1alpha1.KafkaAPI{{Port: 124, AuthenticationMethod: "none"}},
-				AdminAPI:       []v1alpha1.AdminAPI{{Port: 125}},
-				RPCServer:      v1alpha1.SocketAddress{Port: 126},
-				SchemaRegistry: &v1alpha1.SchemaRegistryAPI{Port: 127},
-				PandaproxyAPI:  []v1alpha1.PandaproxyAPI{{Port: 128}},
+		Spec: vectorizedv1alpha1.ClusterSpec{
+			Configuration: vectorizedv1alpha1.RedpandaConfig{
+				KafkaAPI:       []vectorizedv1alpha1.KafkaAPI{{Port: 124, AuthenticationMethod: "none"}},
+				AdminAPI:       []vectorizedv1alpha1.AdminAPI{{Port: 125}},
+				RPCServer:      vectorizedv1alpha1.SocketAddress{Port: 126},
+				SchemaRegistry: &vectorizedv1alpha1.SchemaRegistryAPI{Port: 127},
+				PandaproxyAPI:  []vectorizedv1alpha1.PandaproxyAPI{{Port: 128}},
 			},
-			Resources: v1alpha1.RedpandaResourceRequirements{
+			Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 				ResourceRequirements: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -337,7 +337,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 				},
 				Redpanda: nil,
 			},
-			NodePools: []v1alpha1.NodePoolSpec{
+			NodePools: []vectorizedv1alpha1.NodePoolSpec{
 				{
 					Name:     "test",
 					Replicas: ptr.To(replicas2),
@@ -381,11 +381,11 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
 		updatePort := redpandaCluster.DeepCopy()
 		updatePort.Spec.Configuration.KafkaAPI = append(updatePort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		updatePort.Spec.Configuration.AdminAPI = append(updatePort.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.AdminAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		updatePort.Spec.Configuration.PandaproxyAPI = append(updatePort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}})
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}})
 
 		_, err := updatePort.ValidateUpdate(redpandaCluster)
 		assert.Error(t, err)
@@ -395,11 +395,11 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		updatePort := redpandaCluster.DeepCopy()
 		updatePort.Spec.Configuration.KafkaAPI[0].Port = 200
 		updatePort.Spec.Configuration.KafkaAPI = append(updatePort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{AuthenticationMethod: "none", External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{AuthenticationMethod: "none", External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		updatePort.Spec.Configuration.PandaproxyAPI = append(updatePort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}})
-		updatePort.Spec.Configuration.SchemaRegistry.External = &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}})
+		updatePort.Spec.Configuration.SchemaRegistry.External = &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 		}
 
 		_, err := updatePort.ValidateUpdate(redpandaCluster)
@@ -409,7 +409,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
 		updatePort := redpandaCluster.DeepCopy()
 		updatePort.Spec.Configuration.KafkaAPI = append(updatePort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		updatePort.Spec.Configuration.KafkaAPI[0].Port = 200
 		updatePort.Spec.Configuration.AdminAPI[0].Port = 300
 		updatePort.Spec.Configuration.RPCServer.Port = 201
@@ -421,7 +421,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
 		updatePort := redpandaCluster.DeepCopy()
 		updatePort.Spec.Configuration.KafkaAPI = append(updatePort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		updatePort.Spec.Configuration.KafkaAPI[0].Port = 200
 		updatePort.Spec.Configuration.AdminAPI[0].Port = 300
 		updatePort.Spec.Configuration.AdminAPI[0].External.Enabled = true
@@ -443,7 +443,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		updatePort := redpandaCluster.DeepCopy()
 		updatePort.Spec.Configuration.AdminAPI[0].External.Enabled = true
 		updatePort.Spec.Configuration.KafkaAPI = append(updatePort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		updatePort.Spec.Configuration.KafkaAPI[0].Port = 201
 		updatePort.Spec.Configuration.AdminAPI[0].Port = 200
 		updatePort.Spec.Configuration.RPCServer.Port = 300
@@ -465,7 +465,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		exPort := redpandaCluster.DeepCopy()
 		exPort.Spec.Configuration.KafkaAPI[0].External.Enabled = true
 		exPort.Spec.Configuration.KafkaAPI = append(exPort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 123, External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{Port: 123, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		_, err := exPort.ValidateUpdate(redpandaCluster)
 
 		assert.Error(t, err)
@@ -474,7 +474,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("multiple internal listeners", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.KafkaAPI = append(multiPort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 123})
+			vectorizedv1alpha1.KafkaAPI{Port: 123})
 		_, err := multiPort.ValidateUpdate(redpandaCluster)
 
 		assert.Error(t, err)
@@ -490,7 +490,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("no admin port", func(t *testing.T) {
 		noPort := redpandaCluster.DeepCopy()
-		noPort.Spec.Configuration.AdminAPI = []v1alpha1.AdminAPI{}
+		noPort.Spec.Configuration.AdminAPI = []vectorizedv1alpha1.AdminAPI{}
 
 		_, err := noPort.ValidateUpdate(redpandaCluster)
 		assert.Error(t, err)
@@ -499,7 +499,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("multiple internal admin listeners", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.AdminAPI = append(multiPort.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{Port: 123})
+			vectorizedv1alpha1.AdminAPI{Port: 123})
 		_, err := multiPort.ValidateUpdate(redpandaCluster)
 
 		assert.Error(t, err)
@@ -509,10 +509,10 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.AdminAPI[0].TLS.Enabled = true
 		multiPort.Spec.Configuration.AdminAPI = append(multiPort.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{
+			vectorizedv1alpha1.AdminAPI{
 				Port:     123,
-				External: v1alpha1.ExternalConnectivityConfig{Enabled: true},
-				TLS:      v1alpha1.AdminAPITLS{Enabled: true},
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
+				TLS:      vectorizedv1alpha1.AdminAPITLS{Enabled: true},
 			})
 		_, err := multiPort.ValidateUpdate(redpandaCluster)
 
@@ -530,10 +530,10 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("proxy subdomain must be the same as kafka subdomain", func(t *testing.T) {
 		withSub := redpandaCluster.DeepCopy()
-		withSub.Spec.Configuration.PandaproxyAPI = []v1alpha1.PandaproxyAPI{
+		withSub.Spec.Configuration.PandaproxyAPI = []vectorizedv1alpha1.PandaproxyAPI{
 			{
 				Port:     145,
-				External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "subdomain"}},
+				External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "subdomain"}},
 			},
 		}
 		_, err := withSub.ValidateUpdate(redpandaCluster)
@@ -544,7 +544,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("cannot have multiple internal proxy listeners", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.PandaproxyAPI = append(multiPort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{Port: 123}, v1alpha1.PandaproxyAPI{Port: 321})
+			vectorizedv1alpha1.PandaproxyAPI{Port: 123}, vectorizedv1alpha1.PandaproxyAPI{Port: 321})
 		_, err := multiPort.ValidateUpdate(redpandaCluster)
 
 		assert.Error(t, err)
@@ -553,7 +553,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	t.Run("cannot have external proxy listener without an internal one", func(t *testing.T) {
 		noInternal := redpandaCluster.DeepCopy()
 		noInternal.Spec.Configuration.PandaproxyAPI = append(noInternal.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123})
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123})
 		_, err := noInternal.ValidateUpdate(redpandaCluster)
 
 		assert.Error(t, err)
@@ -561,15 +561,15 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("pandaproxy tls disabled with client auth enabled", func(t *testing.T) {
 		tls := redpandaCluster.DeepCopy()
-		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
-			External: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
+			External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 			Port:     30092,
 		})
-		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{
-			External: v1alpha1.PandaproxyExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{
+			External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 			},
-			TLS: v1alpha1.PandaproxyAPITLS{Enabled: false, RequireClientAuth: true},
+			TLS: vectorizedv1alpha1.PandaproxyAPITLS{Enabled: false, RequireClientAuth: true},
 		})
 
 		_, err := tls.ValidateUpdate(redpandaCluster)
@@ -578,15 +578,15 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("pandaproxy tls issuerref with secretref is not allowed", func(t *testing.T) {
 		tls := redpandaCluster.DeepCopy()
-		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
-			External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
+			External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
 			Port:     30092,
 		})
-		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{
-			External: v1alpha1.PandaproxyExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{
+			External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
 			},
-			TLS: v1alpha1.PandaproxyAPITLS{Enabled: true, IssuerRef: &cmmeta.ObjectReference{}, NodeSecretRef: &corev1.ObjectReference{}},
+			TLS: vectorizedv1alpha1.PandaproxyAPITLS{Enabled: true, IssuerRef: &cmmetav1.ObjectReference{}, NodeSecretRef: &corev1.ObjectReference{}},
 		})
 
 		_, err := tls.ValidateUpdate(redpandaCluster)
@@ -595,16 +595,16 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("pandaproxy tls can specify issuerref", func(t *testing.T) {
 		tls := redpandaCluster.DeepCopy()
-		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+		tls.Spec.Configuration.KafkaAPI = append(tls.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
 			AuthenticationMethod: "none",
-			External:             v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+			External:             vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
 			Port:                 30092,
 		})
-		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{
-			External: v1alpha1.PandaproxyExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
+		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{
+			External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "cluster.com"},
 			},
-			TLS: v1alpha1.PandaproxyAPITLS{Enabled: true, IssuerRef: &cmmeta.ObjectReference{}},
+			TLS: vectorizedv1alpha1.PandaproxyAPITLS{Enabled: true, IssuerRef: &cmmetav1.ObjectReference{}},
 		})
 
 		_, err := tls.ValidateUpdate(redpandaCluster)
@@ -612,7 +612,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	})
 
 	t.Run("update priority class name", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 		pc := &schedulingv1.PriorityClass{}
 		pcName := "my-priority-class-2"
 		pc.SetName(pcName)
@@ -656,8 +656,8 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("resource limits/requests on rpk status resources", func(t *testing.T) {
 		c := redpandaCluster.DeepCopy()
-		c.Spec.Sidecars = v1alpha1.Sidecars{
-			RpkStatus: &v1alpha1.Sidecar{
+		c.Spec.Sidecars = vectorizedv1alpha1.Sidecars{
+			RpkStatus: &vectorizedv1alpha1.Sidecar{
 				Enabled: true,
 				Resources: &corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -678,7 +678,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 
 	t.Run("cluster can be deleted even if licenseRef not found", func(t *testing.T) {
 		license := redpandaCluster.DeepCopy()
-		license.Spec.LicenseRef = &v1alpha1.SecretKeyRef{Name: "notfound", Namespace: "notfound"}
+		license.Spec.LicenseRef = &vectorizedv1alpha1.SecretKeyRef{Name: "notfound", Namespace: "notfound"}
 
 		// Set cluster to deleting state
 		now := metav1.Now()
@@ -777,11 +777,11 @@ func TestCreation(t *testing.T) {
 		newPort := redpandaCluster.DeepCopy()
 		newPort.Spec.Configuration.AdminAPI[0].Port = newPort.Spec.Configuration.KafkaAPI[0].Port + 1
 		newPort.Spec.Configuration.KafkaAPI = append(newPort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		newPort.Spec.Configuration.AdminAPI = append(newPort.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.AdminAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		newPort.Spec.Configuration.PandaproxyAPI = append(newPort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}})
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}})
 
 		_, err := newPort.ValidateCreate()
 		assert.Error(t, err)
@@ -791,11 +791,11 @@ func TestCreation(t *testing.T) {
 		newPort := redpandaCluster.DeepCopy()
 		newPort.Spec.Configuration.KafkaAPI[0].Port = 200
 		newPort.Spec.Configuration.KafkaAPI = append(newPort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{AuthenticationMethod: "none", External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{AuthenticationMethod: "none", External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		newPort.Spec.Configuration.PandaproxyAPI = append(newPort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}})
-		newPort.Spec.Configuration.SchemaRegistry.External = &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}})
+		newPort.Spec.Configuration.SchemaRegistry.External = &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 		}
 
 		_, err := newPort.ValidateCreate()
@@ -812,7 +812,7 @@ func TestCreation(t *testing.T) {
 
 	t.Run("no kafka port", func(t *testing.T) {
 		noPort := redpandaCluster.DeepCopy()
-		noPort.Spec.Configuration.KafkaAPI = []v1alpha1.KafkaAPI{}
+		noPort.Spec.Configuration.KafkaAPI = []vectorizedv1alpha1.KafkaAPI{}
 
 		_, err := noPort.ValidateCreate()
 		assert.Error(t, err)
@@ -820,7 +820,7 @@ func TestCreation(t *testing.T) {
 
 	t.Run("no admin port", func(t *testing.T) {
 		noPort := redpandaCluster.DeepCopy()
-		noPort.Spec.Configuration.AdminAPI = []v1alpha1.AdminAPI{}
+		noPort.Spec.Configuration.AdminAPI = []vectorizedv1alpha1.AdminAPI{}
 
 		_, err := noPort.ValidateCreate()
 		assert.Error(t, err)
@@ -829,7 +829,7 @@ func TestCreation(t *testing.T) {
 	t.Run("multiple internal admin listeners", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.AdminAPI = append(multiPort.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{Port: 123})
+			vectorizedv1alpha1.AdminAPI{Port: 123})
 		_, err := multiPort.ValidateCreate()
 
 		assert.Error(t, err)
@@ -837,7 +837,7 @@ func TestCreation(t *testing.T) {
 
 	t.Run("incorrect memory (need 2GB per core)", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
-		memory.Spec.Resources = v1alpha1.RedpandaResourceRequirements{
+		memory.Spec.Resources = vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -853,7 +853,7 @@ func TestCreation(t *testing.T) {
 
 	t.Run("no 2GB per core required when in developer mode", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
-		memory.Spec.Resources = v1alpha1.RedpandaResourceRequirements{
+		memory.Spec.Resources = vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -870,7 +870,7 @@ func TestCreation(t *testing.T) {
 
 	t.Run("incorrect redpanda memory (need <= request)", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
-		memory.Spec.Resources = v1alpha1.RedpandaResourceRequirements{
+		memory.Spec.Resources = vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -890,7 +890,7 @@ func TestCreation(t *testing.T) {
 	//nolint:dupl // the values are different
 	t.Run("incorrect redpanda memory (need <= limit)", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
-		memory.Spec.Resources = v1alpha1.RedpandaResourceRequirements{
+		memory.Spec.Resources = vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -914,7 +914,7 @@ func TestCreation(t *testing.T) {
 	//nolint:dupl // the values are different
 	t.Run("correct redpanda memory", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
-		memory.Spec.Resources = v1alpha1.RedpandaResourceRequirements{
+		memory.Spec.Resources = vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2.223Gi"),
@@ -938,7 +938,7 @@ func TestCreation(t *testing.T) {
 	//nolint:dupl // the values are different
 	t.Run("correct redpanda memory (boundary check)", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
-		memory.Spec.Resources = v1alpha1.RedpandaResourceRequirements{
+		memory.Spec.Resources = vectorizedv1alpha1.RedpandaResourceRequirements{
 			ResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -981,7 +981,7 @@ func TestCreation(t *testing.T) {
 		exPort := redpandaCluster.DeepCopy()
 		exPort.Spec.Configuration.KafkaAPI[0].External.Enabled = true
 		exPort.Spec.Configuration.KafkaAPI = append(exPort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 123, External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+			vectorizedv1alpha1.KafkaAPI{Port: 123, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 		_, err := exPort.ValidateCreate()
 
 		assert.Error(t, err)
@@ -990,7 +990,7 @@ func TestCreation(t *testing.T) {
 	t.Run("multiple internal listeners", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.KafkaAPI = append(multiPort.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 123})
+			vectorizedv1alpha1.KafkaAPI{Port: 123})
 		_, err := multiPort.ValidateCreate()
 
 		assert.Error(t, err)
@@ -1008,10 +1008,10 @@ func TestCreation(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.AdminAPI[0].TLS.Enabled = true
 		multiPort.Spec.Configuration.AdminAPI = append(multiPort.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{
+			vectorizedv1alpha1.AdminAPI{
 				Port:     123,
-				External: v1alpha1.ExternalConnectivityConfig{Enabled: true},
-				TLS:      v1alpha1.AdminAPITLS{Enabled: true},
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
+				TLS:      vectorizedv1alpha1.AdminAPITLS{Enabled: true},
 			})
 		_, err := multiPort.ValidateCreate()
 
@@ -1029,10 +1029,10 @@ func TestCreation(t *testing.T) {
 
 	t.Run("proxy subdomain must be the same as kafka subdomain", func(t *testing.T) {
 		withSub := redpandaCluster.DeepCopy()
-		withSub.Spec.Configuration.PandaproxyAPI = []v1alpha1.PandaproxyAPI{
+		withSub.Spec.Configuration.PandaproxyAPI = []vectorizedv1alpha1.PandaproxyAPI{
 			{
 				Port:     145,
-				External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "subdomain"}},
+				External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "subdomain"}},
 			},
 		}
 		_, err := withSub.ValidateCreate()
@@ -1043,7 +1043,7 @@ func TestCreation(t *testing.T) {
 	t.Run("cannot have multiple internal proxy listeners", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.PandaproxyAPI = append(multiPort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{Port: 123}, v1alpha1.PandaproxyAPI{Port: 321})
+			vectorizedv1alpha1.PandaproxyAPI{Port: 123}, vectorizedv1alpha1.PandaproxyAPI{Port: 321})
 		_, err := multiPort.ValidateCreate()
 
 		assert.Error(t, err)
@@ -1052,7 +1052,7 @@ func TestCreation(t *testing.T) {
 	t.Run("cannot have external proxy listener without an internal one", func(t *testing.T) {
 		noInternal := redpandaCluster.DeepCopy()
 		noInternal.Spec.Configuration.PandaproxyAPI = append(noInternal.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123})
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123})
 		_, err := noInternal.ValidateCreate()
 
 		assert.Error(t, err)
@@ -1061,8 +1061,8 @@ func TestCreation(t *testing.T) {
 	t.Run("external proxy listener cannot have port specified", func(t *testing.T) {
 		multiPort := redpandaCluster.DeepCopy()
 		multiPort.Spec.Configuration.PandaproxyAPI = append(multiPort.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123},
-			v1alpha1.PandaproxyAPI{Port: 321})
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}}, Port: 123},
+			vectorizedv1alpha1.PandaproxyAPI{Port: 321})
 		_, err := multiPort.ValidateCreate()
 
 		assert.Error(t, err)
@@ -1071,14 +1071,14 @@ func TestCreation(t *testing.T) {
 	t.Run("pandaproxy tls disabled but client auth enabled", func(t *testing.T) {
 		tls := redpandaCluster.DeepCopy()
 		tls.Spec.Configuration.PandaproxyAPI = append(tls.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{TLS: v1alpha1.PandaproxyAPITLS{Enabled: false, RequireClientAuth: true}})
+			vectorizedv1alpha1.PandaproxyAPI{TLS: vectorizedv1alpha1.PandaproxyAPITLS{Enabled: false, RequireClientAuth: true}})
 
 		_, err := tls.ValidateCreate()
 		assert.Error(t, err)
 	})
 
 	t.Run("priority class name is set: success", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 
 		pc := &schedulingv1.PriorityClass{}
 		pcName := "my-priority-class-1"
@@ -1094,7 +1094,7 @@ func TestCreation(t *testing.T) {
 	})
 
 	t.Run("specified priority class name does not exist: failure", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 
 		cluster := redpandaCluster.DeepCopy()
 		cluster.Spec.PriorityClassName = "my-priority-class-not-exist"
@@ -1103,7 +1103,7 @@ func TestCreation(t *testing.T) {
 	})
 
 	t.Run("pandaproxy mtls with external ca set by clientCACertRef: success", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 
 		caCertSecret := &corev1.Secret{}
 		caCertName := "pandaproxy-client-valid-ca-cert"
@@ -1117,10 +1117,10 @@ func TestCreation(t *testing.T) {
 		assert.NoError(t, err)
 
 		tls := redpandaCluster.DeepCopy()
-		tls.Spec.Configuration.PandaproxyAPI = []v1alpha1.PandaproxyAPI{
+		tls.Spec.Configuration.PandaproxyAPI = []vectorizedv1alpha1.PandaproxyAPI{
 			{
 				Port: 1234,
-				TLS: v1alpha1.PandaproxyAPITLS{
+				TLS: vectorizedv1alpha1.PandaproxyAPITLS{
 					Enabled:           true,
 					RequireClientAuth: true,
 					ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1136,7 +1136,7 @@ func TestCreation(t *testing.T) {
 
 	// More failure test cases are covered by those for Schema Registry since the common validation function is called.
 	t.Run("pandaproxy mtls with external ca set by clientCACertRef: invalid certificate", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 
 		caCertSecret := &corev1.Secret{}
 		caCertName := "pandaproxy-client-not-ca-cert"
@@ -1147,10 +1147,10 @@ func TestCreation(t *testing.T) {
 		assert.NoError(t, err)
 
 		tls := redpandaCluster.DeepCopy()
-		tls.Spec.Configuration.PandaproxyAPI = []v1alpha1.PandaproxyAPI{
+		tls.Spec.Configuration.PandaproxyAPI = []vectorizedv1alpha1.PandaproxyAPI{
 			{
 				Port: 1234,
-				TLS: v1alpha1.PandaproxyAPITLS{
+				TLS: vectorizedv1alpha1.PandaproxyAPITLS{
 					Enabled:           true,
 					RequireClientAuth: true,
 					ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1168,7 +1168,7 @@ func TestCreation(t *testing.T) {
 	t.Run("kafka external subdomain is provided along with preferred address type", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 123, External: v1alpha1.ExternalConnectivityConfig{Enabled: true, PreferredAddressType: "preferred", Subdomain: "subdomain"}})
+			vectorizedv1alpha1.KafkaAPI{Port: 123, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, PreferredAddressType: "preferred", Subdomain: "subdomain"}})
 		_, err := rp.ValidateCreate()
 		assert.Error(t, err)
 	})
@@ -1176,11 +1176,11 @@ func TestCreation(t *testing.T) {
 	t.Run("kafka TLS for external listener without a subdomain", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{
-				TLS: v1alpha1.KafkaAPITLS{
+			vectorizedv1alpha1.KafkaAPI{
+				TLS: vectorizedv1alpha1.KafkaAPITLS{
 					Enabled: true,
 				},
-				Port: 123, External: v1alpha1.ExternalConnectivityConfig{Enabled: true, PreferredAddressType: "InternalIP"},
+				Port: 123, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, PreferredAddressType: "InternalIP"},
 			})
 		_, err := rp.ValidateCreate()
 		assert.Error(t, err)
@@ -1188,14 +1188,14 @@ func TestCreation(t *testing.T) {
 	t.Run("bootstrap loadbalancer for kafka api needs a port", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Bootstrap: &v1alpha1.LoadBalancerConfig{}}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Bootstrap: &vectorizedv1alpha1.LoadBalancerConfig{}}})
 		_, err := rp.ValidateCreate()
 		assert.Error(t, err)
 	})
 	t.Run("bootstrap loadbalancer not allowed for admin", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		rp.Spec.Configuration.AdminAPI = append(rp.Spec.Configuration.AdminAPI,
-			v1alpha1.AdminAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Bootstrap: &v1alpha1.LoadBalancerConfig{
+			vectorizedv1alpha1.AdminAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Bootstrap: &vectorizedv1alpha1.LoadBalancerConfig{
 				Port: 123,
 			}}})
 		_, err := rp.ValidateCreate()
@@ -1204,7 +1204,7 @@ func TestCreation(t *testing.T) {
 	t.Run("bootstrap loadbalancer not allowed for pandaproxy", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI,
-			v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Bootstrap: &v1alpha1.LoadBalancerConfig{
+			vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Bootstrap: &vectorizedv1alpha1.LoadBalancerConfig{
 				Port: 123,
 			}}}})
 		_, err := rp.ValidateCreate()
@@ -1212,9 +1212,9 @@ func TestCreation(t *testing.T) {
 	})
 	t.Run("bootstrap loadbalancer not allowed for schemaregistry", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
-		rp.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
-				Enabled: true, Bootstrap: &v1alpha1.LoadBalancerConfig{
+		rp.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
+				Enabled: true, Bootstrap: &vectorizedv1alpha1.LoadBalancerConfig{
 					Port: 123,
 				},
 			},
@@ -1227,12 +1227,12 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		const commonDomain = "company.org"
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:   true,
 			Subdomain: commonDomain,
 		}})
-		rp.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:          true,
 				Subdomain:        commonDomain,
 				EndpointTemplate: "xxx",
@@ -1245,15 +1245,15 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		const commonDomain = "company.org"
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
 			AuthenticationMethod: "none",
-			External: v1alpha1.ExternalConnectivityConfig{
+			External: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:   true,
 				Subdomain: commonDomain,
 			},
 		})
-		rp.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:   true,
 				Subdomain: commonDomain,
 			},
@@ -1267,12 +1267,12 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		const commonDomain = "company.org"
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:   true,
 			Subdomain: commonDomain,
 		}})
-		rp.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:   true,
 				Subdomain: commonDomain,
 			},
@@ -1285,11 +1285,11 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 		const commonDomain = "company.org"
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:   true,
 			Subdomain: commonDomain,
 		}})
-		rp.Spec.Configuration.AdminAPI = append(rp.Spec.Configuration.AdminAPI, v1alpha1.AdminAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.AdminAPI = append(rp.Spec.Configuration.AdminAPI, vectorizedv1alpha1.AdminAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:          true,
 			Subdomain:        commonDomain,
 			EndpointTemplate: "xxx",
@@ -1300,7 +1300,7 @@ func TestCreation(t *testing.T) {
 	t.Run("endpoint template without subdomain is not allowed in kafka API", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:          true,
 			EndpointTemplate: "xxx",
 		}})
@@ -1310,10 +1310,10 @@ func TestCreation(t *testing.T) {
 	t.Run("endpoint template without subdomain is not allowed in pandaproxy API", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled: true,
 		}})
-		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:          true,
 			EndpointTemplate: "xxx",
 		}}})
@@ -1323,7 +1323,7 @@ func TestCreation(t *testing.T) {
 	t.Run("invalid endpoint template in kafka API", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:          true,
 			Subdomain:        "example.com",
 			EndpointTemplate: "{{.Inexistent}}",
@@ -1334,9 +1334,9 @@ func TestCreation(t *testing.T) {
 	t.Run("valid endpoint template in kafka API", func(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
 			AuthenticationMethod: "none",
-			External: v1alpha1.ExternalConnectivityConfig{
+			External: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:          true,
 				Subdomain:        "example.com",
 				EndpointTemplate: "{{.Index}}-broker",
@@ -1349,11 +1349,11 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
 		const commonDomain = "mydomain"
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:   true,
 			Subdomain: commonDomain,
 		}})
-		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:          true,
 			Subdomain:        commonDomain,
 			EndpointTemplate: "{{.Index | nonexistent }}",
@@ -1365,14 +1365,14 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
 		const commonDomain = "mydomain"
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
 			AuthenticationMethod: "none",
-			External: v1alpha1.ExternalConnectivityConfig{
+			External: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:   true,
 				Subdomain: commonDomain,
 			},
 		})
-		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 			Enabled:          true,
 			Subdomain:        commonDomain,
 			EndpointTemplate: "{{.Index}}-pp",
@@ -1384,19 +1384,19 @@ func TestCreation(t *testing.T) {
 		rp := redpandaCluster.DeepCopy()
 
 		const commonDomain = "mydomain"
-		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{
+		rp.Spec.Configuration.KafkaAPI = append(rp.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{
 			AuthenticationMethod: "none",
-			External: v1alpha1.ExternalConnectivityConfig{
+			External: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:   true,
 				Subdomain: commonDomain,
 			},
 		})
-		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{External: v1alpha1.PandaproxyExternalConnectivityConfig{
-			ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+		rp.Spec.Configuration.PandaproxyAPI = append(rp.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{
+			ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 				Enabled:   true,
 				Subdomain: commonDomain,
 			},
-			Ingress: &v1alpha1.IngressConfig{},
+			Ingress: &vectorizedv1alpha1.IngressConfig{},
 		}})
 
 		cases := []struct {
@@ -1435,9 +1435,9 @@ func TestSchemaRegistryValidations(t *testing.T) {
 
 	t.Run("if schema registry externally available, kafka external listener is required", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 			},
 		}
 		schemaReg.Spec.Configuration.KafkaAPI[0].External.Enabled = false
@@ -1447,13 +1447,13 @@ func TestSchemaRegistryValidations(t *testing.T) {
 	})
 	t.Run("schema registry externally available is valid when it has the same subdomain as kafka external listener", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"},
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"},
 			},
 		}
 		schemaReg.Spec.Configuration.KafkaAPI = append(schemaReg.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{AuthenticationMethod: "none", External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"}})
+			vectorizedv1alpha1.KafkaAPI{AuthenticationMethod: "none", External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"}})
 
 		_, err := schemaReg.ValidateCreate()
 		assert.NoError(t, err)
@@ -1461,13 +1461,13 @@ func TestSchemaRegistryValidations(t *testing.T) {
 	//nolint:dupl // the tests are not duplicates
 	t.Run("if schema registry externally available, it should have same subdomain as kafka external listener", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"},
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"},
 			},
 		}
 		schemaReg.Spec.Configuration.KafkaAPI = append(schemaReg.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "other.com"}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "other.com"}})
 
 		_, err := schemaReg.ValidateCreate()
 		assert.Error(t, err)
@@ -1475,13 +1475,13 @@ func TestSchemaRegistryValidations(t *testing.T) {
 	//nolint:dupl // the tests are not duplicates
 	t.Run("if schema registry externally available, kafka external listener should not be empty", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-				ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"},
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+				ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "test.com"},
 			},
 		}
 		schemaReg.Spec.Configuration.KafkaAPI = append(schemaReg.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: ""}})
+			vectorizedv1alpha1.KafkaAPI{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: ""}})
 
 		_, err := schemaReg.ValidateCreate()
 		assert.Error(t, err)
@@ -1489,8 +1489,8 @@ func TestSchemaRegistryValidations(t *testing.T) {
 
 	t.Run("schema registry mTLS enabled and TLS enabled is valid", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 			},
@@ -1502,8 +1502,8 @@ func TestSchemaRegistryValidations(t *testing.T) {
 
 	t.Run("if schema registry mTLS enabled, TLS should also be enabled", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           false,
 				RequireClientAuth: true,
 			},
@@ -1519,8 +1519,8 @@ func TestSchemaRegistryTLSExternalCAConfigValidations(t *testing.T) {
 
 	t.Run("if schema registry mTLS enabled and clientCACertRef is set, name must be provided in clientCACertRef", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef:   &corev1.TypedLocalObjectReference{},
@@ -1535,8 +1535,8 @@ func TestSchemaRegistryTLSExternalCAConfigValidations(t *testing.T) {
 
 	t.Run("if schema registry mTLS enabled and clientCACertRef is set, kind must be set to secret in clientCACertRef", func(t *testing.T) {
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1553,10 +1553,10 @@ func TestSchemaRegistryTLSExternalCAConfigValidations(t *testing.T) {
 	})
 
 	t.Run("if schema registry mTLS enabled and clientCACertRef is set, the CA certificate secret must exist", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1573,12 +1573,12 @@ func TestSchemaRegistryTLSExternalCAConfigValidations(t *testing.T) {
 	})
 
 	t.Run("if schema registry mTLS enabled, clientCACertRef is set and cluster is being deleted, skip update validation", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 		schemaReg := redpandaCluster.DeepCopy()
 		deleteTime := metav1.Now()
 		schemaReg.DeletionTimestamp = &deleteTime
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1597,7 +1597,7 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 	redpandaCluster := validRedpandaCluster()
 
 	t.Run("if schema registry mTLS enabled and clientCACertRef is set, the CA certificate secret must provide ca.crt", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 		caCertSecret := &corev1.Secret{}
 		caCertName := "schema-registry-client-ca-cert-no-ca-crt"
 		caCertSecret.SetName(caCertName)
@@ -1607,8 +1607,8 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 		assert.NoError(t, err)
 
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1624,7 +1624,7 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 	})
 
 	t.Run("if schema registry mTLS enabled and clientCACertRef is set, the CA certificate secret must be in PEM", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 		caCertSecret := &corev1.Secret{}
 		caCertName := "schema-registry-client-ca-cert-invalid-pem"
 		caCertSecret.SetName(caCertName)
@@ -1634,8 +1634,8 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 		assert.NoError(t, err)
 
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1652,7 +1652,7 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 	})
 
 	t.Run("if schema registry mTLS enabled and clientCACertRef is set, the certificate secret must be valid x509 certificate", func(t *testing.T) {
-		v1alpha1.SetK8sClient(fakeK8sClient)
+		vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 
 		caCertSecret := &corev1.Secret{}
 		caCertName := "schema-registry-client-ca-cert-not-ca-cert"
@@ -1666,8 +1666,8 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 		assert.NoError(t, err)
 
 		schemaReg := redpandaCluster.DeepCopy()
-		schemaReg.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{
-			TLS: &v1alpha1.SchemaRegistryAPITLS{
+		schemaReg.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{
+			TLS: &vectorizedv1alpha1.SchemaRegistryAPITLS{
 				Enabled:           true,
 				RequireClientAuth: true,
 				ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1687,8 +1687,8 @@ func TestSchemaRegistryTLSExternalCACertValidations(t *testing.T) {
 func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing related tests together
 	cases := []struct {
 		name        string
-		adminAPI    []v1alpha1.AdminAPI
-		clusterFn   func(cluster *v1alpha1.Cluster)
+		adminAPI    []vectorizedv1alpha1.AdminAPI
+		clusterFn   func(cluster *vectorizedv1alpha1.Cluster)
 		secret      *corev1.Secret
 		skipCreate  bool
 		createError bool
@@ -1696,10 +1696,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 	}{
 		{
 			name: "if admin API mTLS enabled and clientCACertRef is set, name must be provided in clientCACertRef",
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef:   &corev1.TypedLocalObjectReference{},
@@ -1711,10 +1711,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 		},
 		{
 			name: "if admin API mTLS enabled and clientCACertRef is set, the CA certificate secret must exist",
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1729,10 +1729,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 		},
 		{
 			name: "if admin API mTLS enabled, clientCACertRef is set and cluster is being deleted, skip update validation",
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1742,7 +1742,7 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 					},
 				},
 			},
-			clusterFn: func(c *v1alpha1.Cluster) {
+			clusterFn: func(c *vectorizedv1alpha1.Cluster) {
 				deleteTime := metav1.Now()
 				c.DeletionTimestamp = &deleteTime
 			},
@@ -1757,10 +1757,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 				},
 				Data: map[string][]byte{"no.ca.crt": []byte("no.ca.crt")},
 			},
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1781,10 +1781,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 				},
 				Data: map[string][]byte{"ca.crt": []byte("not-in-pem")},
 			},
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1805,10 +1805,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 				},
 				Data: map[string][]byte{"ca.crt": readFile(t, "./testdata/not.ca.crt.pem")},
 			},
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1829,24 +1829,24 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 				},
 				Data: map[string][]byte{"ca.crt": readFile(t, "./testdata/ca.crt.pem")},
 			},
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
 				},
 				{
 					Port: 30644,
-					External: v1alpha1.ExternalConnectivityConfig{
+					External: vectorizedv1alpha1.ExternalConnectivityConfig{
 						Enabled:   true,
 						Subdomain: "panda.dev",
 					},
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
 							Name: "admin-api-client-ca-cert-in",
 							Kind: "Secret",
 						},
 						RequireClientAuth: true,
-						IssuerRef: &cmmeta.ObjectReference{
+						IssuerRef: &cmmetav1.ObjectReference{
 							Kind: "ClusterIssuer",
 							Name: "letsencrypt",
 						},
@@ -1869,10 +1869,10 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 				},
 				Data: map[string][]byte{"ca.crt": readFile(t, "./testdata/ca.crt.pem")},
 			},
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1893,17 +1893,17 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 				},
 				Data: map[string][]byte{"ca.crt": readFile(t, "./testdata/ca.crt.pem")},
 			},
-			adminAPI: []v1alpha1.AdminAPI{
+			adminAPI: []vectorizedv1alpha1.AdminAPI{
 				{
 					Port: 9644,
 				},
 				{
 					Port: 30644,
-					External: v1alpha1.ExternalConnectivityConfig{
+					External: vectorizedv1alpha1.ExternalConnectivityConfig{
 						Enabled:   true,
 						Subdomain: "panda.dev",
 					},
-					TLS: v1alpha1.AdminAPITLS{
+					TLS: vectorizedv1alpha1.AdminAPITLS{
 						Enabled:           true,
 						RequireClientAuth: true,
 						ClientCACertRef: &corev1.TypedLocalObjectReference{
@@ -1919,7 +1919,7 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v1alpha1.SetK8sClient(fakeK8sClient)
+			vectorizedv1alpha1.SetK8sClient(fakeK8sClient)
 			adminCluster := validRedpandaCluster()
 			if tc.secret != nil {
 				if tc.secret.Namespace == "" {
@@ -1950,28 +1950,28 @@ func TestAdminAPITLSExternalCA(t *testing.T) { //nolint:funlen // better packing
 	}
 }
 
-func validRedpandaCluster() *v1alpha1.Cluster {
-	return &v1alpha1.Cluster{
+func validRedpandaCluster() *vectorizedv1alpha1.Cluster {
+	return &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "",
 		},
-		Spec: v1alpha1.ClusterSpec{
-			NodePools: []v1alpha1.NodePoolSpec{
+		Spec: vectorizedv1alpha1.ClusterSpec{
+			NodePools: []vectorizedv1alpha1.NodePoolSpec{
 				{
 					Name:     "test",
 					Replicas: ptr.To(int32(3)),
 				},
 			},
 			Replicas: ptr.To(int32(1)),
-			Configuration: v1alpha1.RedpandaConfig{
-				KafkaAPI:       []v1alpha1.KafkaAPI{{Port: 124, AuthenticationMethod: "none"}},
-				AdminAPI:       []v1alpha1.AdminAPI{{Port: 126}},
-				RPCServer:      v1alpha1.SocketAddress{Port: 128},
-				SchemaRegistry: &v1alpha1.SchemaRegistryAPI{Port: 130},
-				PandaproxyAPI:  []v1alpha1.PandaproxyAPI{{Port: 132}},
+			Configuration: vectorizedv1alpha1.RedpandaConfig{
+				KafkaAPI:       []vectorizedv1alpha1.KafkaAPI{{Port: 124, AuthenticationMethod: "none"}},
+				AdminAPI:       []vectorizedv1alpha1.AdminAPI{{Port: 126}},
+				RPCServer:      vectorizedv1alpha1.SocketAddress{Port: 128},
+				SchemaRegistry: &vectorizedv1alpha1.SchemaRegistryAPI{Port: 130},
+				PandaproxyAPI:  []vectorizedv1alpha1.PandaproxyAPI{{Port: 132}},
 			},
-			Resources: v1alpha1.RedpandaResourceRequirements{
+			Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 				ResourceRequirements: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -1990,7 +1990,7 @@ func TestPodDisruptionBudget(t *testing.T) {
 
 	t.Run("pdb not enabled is valid", func(t *testing.T) {
 		rpc := rpCluster.DeepCopy()
-		rpc.Spec.PodDisruptionBudget = &v1alpha1.PDBConfig{
+		rpc.Spec.PodDisruptionBudget = &vectorizedv1alpha1.PDBConfig{
 			Enabled: false,
 		}
 
@@ -2000,7 +2000,7 @@ func TestPodDisruptionBudget(t *testing.T) {
 
 	t.Run("pdb with only maxunavailable is valid", func(t *testing.T) {
 		rpc := rpCluster.DeepCopy()
-		rpc.Spec.PodDisruptionBudget = &v1alpha1.PDBConfig{
+		rpc.Spec.PodDisruptionBudget = &vectorizedv1alpha1.PDBConfig{
 			Enabled:        true,
 			MaxUnavailable: &value,
 		}
@@ -2011,7 +2011,7 @@ func TestPodDisruptionBudget(t *testing.T) {
 
 	t.Run("pdb with only minavailable is valid", func(t *testing.T) {
 		rpc := rpCluster.DeepCopy()
-		rpc.Spec.PodDisruptionBudget = &v1alpha1.PDBConfig{
+		rpc.Spec.PodDisruptionBudget = &vectorizedv1alpha1.PDBConfig{
 			Enabled:      true,
 			MinAvailable: &value,
 		}
@@ -2022,7 +2022,7 @@ func TestPodDisruptionBudget(t *testing.T) {
 
 	t.Run("pdb with both minavailable and maxunavailable is invalid", func(t *testing.T) {
 		rpc := rpCluster.DeepCopy()
-		rpc.Spec.PodDisruptionBudget = &v1alpha1.PDBConfig{
+		rpc.Spec.PodDisruptionBudget = &vectorizedv1alpha1.PDBConfig{
 			Enabled:        true,
 			MinAvailable:   &value,
 			MaxUnavailable: &value,
@@ -2034,7 +2034,7 @@ func TestPodDisruptionBudget(t *testing.T) {
 
 	t.Run("pdb with minavailable but enabled=false is invalid", func(t *testing.T) {
 		rpc := rpCluster.DeepCopy()
-		rpc.Spec.PodDisruptionBudget = &v1alpha1.PDBConfig{
+		rpc.Spec.PodDisruptionBudget = &vectorizedv1alpha1.PDBConfig{
 			Enabled:      false,
 			MinAvailable: &value,
 		}
@@ -2158,36 +2158,36 @@ func TestRangesAndCollisions(t *testing.T) {
 			rpCluster := validRedpandaCluster()
 			c := rpCluster.DeepCopy()
 
-			c.Spec.Configuration.KafkaAPI = []v1alpha1.KafkaAPI{}
-			c.Spec.Configuration.AdminAPI = []v1alpha1.AdminAPI{}
-			c.Spec.Configuration.PandaproxyAPI = []v1alpha1.PandaproxyAPI{}
+			c.Spec.Configuration.KafkaAPI = []vectorizedv1alpha1.KafkaAPI{}
+			c.Spec.Configuration.AdminAPI = []vectorizedv1alpha1.AdminAPI{}
+			c.Spec.Configuration.PandaproxyAPI = []vectorizedv1alpha1.PandaproxyAPI{}
 			c.Spec.Configuration.SchemaRegistry = nil
 
 			if tc.kafkaInternal != 0 {
-				c.Spec.Configuration.KafkaAPI = append(c.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{AuthenticationMethod: "none", Port: tc.kafkaInternal})
+				c.Spec.Configuration.KafkaAPI = append(c.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{AuthenticationMethod: "none", Port: tc.kafkaInternal})
 			}
 			if tc.kafkaExternal != 0 {
-				c.Spec.Configuration.KafkaAPI = append(c.Spec.Configuration.KafkaAPI, v1alpha1.KafkaAPI{AuthenticationMethod: "none", Port: tc.kafkaExternal, External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+				c.Spec.Configuration.KafkaAPI = append(c.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{AuthenticationMethod: "none", Port: tc.kafkaExternal, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 			}
 			if tc.adminAPIInternal != 0 {
-				c.Spec.Configuration.AdminAPI = append(c.Spec.Configuration.AdminAPI, v1alpha1.AdminAPI{Port: tc.adminAPIInternal})
+				c.Spec.Configuration.AdminAPI = append(c.Spec.Configuration.AdminAPI, vectorizedv1alpha1.AdminAPI{Port: tc.adminAPIInternal})
 			}
 			if tc.adminAPIExternal != 0 {
-				c.Spec.Configuration.AdminAPI = append(c.Spec.Configuration.AdminAPI, v1alpha1.AdminAPI{Port: tc.adminAPIExternal, External: v1alpha1.ExternalConnectivityConfig{Enabled: true}})
+				c.Spec.Configuration.AdminAPI = append(c.Spec.Configuration.AdminAPI, vectorizedv1alpha1.AdminAPI{Port: tc.adminAPIExternal, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}})
 			}
 			if tc.pandaproxyAPIInternal != 0 {
-				c.Spec.Configuration.PandaproxyAPI = append(c.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{Port: tc.pandaproxyAPIInternal})
+				c.Spec.Configuration.PandaproxyAPI = append(c.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{Port: tc.pandaproxyAPIInternal})
 			}
 			if tc.pandaproxyAPIExternal != 0 {
-				c.Spec.Configuration.PandaproxyAPI = append(c.Spec.Configuration.PandaproxyAPI, v1alpha1.PandaproxyAPI{Port: tc.pandaproxyAPIExternal, External: v1alpha1.PandaproxyExternalConnectivityConfig{
-					ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+				c.Spec.Configuration.PandaproxyAPI = append(c.Spec.Configuration.PandaproxyAPI, vectorizedv1alpha1.PandaproxyAPI{Port: tc.pandaproxyAPIExternal, External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{
+					ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 				}})
 			}
 			if tc.schemaRegistryPort != 0 && !tc.schemaRegistryExternal {
-				c.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{Port: tc.schemaRegistryPort}
+				c.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{Port: tc.schemaRegistryPort}
 			} else if tc.schemaRegistryPort != 0 && tc.schemaRegistryExternal {
-				c.Spec.Configuration.SchemaRegistry = &v1alpha1.SchemaRegistryAPI{Port: tc.schemaRegistryPort, External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-					ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{Enabled: true},
+				c.Spec.Configuration.SchemaRegistry = &vectorizedv1alpha1.SchemaRegistryAPI{Port: tc.schemaRegistryPort, External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+					ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true},
 					StaticNodePort:             tc.schemaRegistryStatic,
 				}}
 			}
@@ -2209,17 +2209,17 @@ func TestKafkaTLSRules(t *testing.T) {
 	//nolint:dupl // the tests are not duplicates
 	t.Run("different issuer for two tls listeners", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
-		newRp.Spec.Configuration.KafkaAPI[0].TLS = v1alpha1.KafkaAPITLS{
+		newRp.Spec.Configuration.KafkaAPI[0].TLS = vectorizedv1alpha1.KafkaAPITLS{
 			Enabled: true,
-			IssuerRef: &cmmeta.ObjectReference{
+			IssuerRef: &cmmetav1.ObjectReference{
 				Name: "issuer",
 				Kind: "ClusterIssuer",
 			},
 		}
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 30001, External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "redpanda.com"}, TLS: v1alpha1.KafkaAPITLS{
+			vectorizedv1alpha1.KafkaAPI{Port: 30001, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "redpanda.com"}, TLS: vectorizedv1alpha1.KafkaAPITLS{
 				Enabled: true,
-				IssuerRef: &cmmeta.ObjectReference{
+				IssuerRef: &cmmetav1.ObjectReference{
 					Name: "other",
 					Kind: "ClusterIssuer",
 				},
@@ -2231,22 +2231,22 @@ func TestKafkaTLSRules(t *testing.T) {
 
 	t.Run("same issuer for two tls listeners is allowed", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
-		newRp.Spec.Configuration.KafkaAPI[0].TLS = v1alpha1.KafkaAPITLS{
+		newRp.Spec.Configuration.KafkaAPI[0].TLS = vectorizedv1alpha1.KafkaAPITLS{
 			Enabled: true,
-			IssuerRef: &cmmeta.ObjectReference{
+			IssuerRef: &cmmetav1.ObjectReference{
 				Name: "issuer",
 				Kind: "ClusterIssuer",
 			},
 		}
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{
+			vectorizedv1alpha1.KafkaAPI{
 				AuthenticationMethod: "none",
 				Port:                 30001,
-				External: v1alpha1.ExternalConnectivityConfig{
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{
 					Enabled: true, Subdomain: "redpanda.com",
-				}, TLS: v1alpha1.KafkaAPITLS{
+				}, TLS: vectorizedv1alpha1.KafkaAPITLS{
 					Enabled: true,
-					IssuerRef: &cmmeta.ObjectReference{
+					IssuerRef: &cmmetav1.ObjectReference{
 						Name: "issuer",
 						Kind: "ClusterIssuer",
 					},
@@ -2260,7 +2260,7 @@ func TestKafkaTLSRules(t *testing.T) {
 	//nolint:dupl // the tests are not duplicates
 	t.Run("different nodeSecretRef for two tls listeners", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
-		newRp.Spec.Configuration.KafkaAPI[0].TLS = v1alpha1.KafkaAPITLS{
+		newRp.Spec.Configuration.KafkaAPI[0].TLS = vectorizedv1alpha1.KafkaAPITLS{
 			Enabled: true,
 			NodeSecretRef: &corev1.ObjectReference{
 				Name:      "node",
@@ -2268,7 +2268,7 @@ func TestKafkaTLSRules(t *testing.T) {
 			},
 		}
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{Port: 30001, External: v1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "redpanda.com"}, TLS: v1alpha1.KafkaAPITLS{
+			vectorizedv1alpha1.KafkaAPI{Port: 30001, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true, Subdomain: "redpanda.com"}, TLS: vectorizedv1alpha1.KafkaAPITLS{
 				Enabled: true,
 				NodeSecretRef: &corev1.ObjectReference{
 					Name:      "other-node",
@@ -2282,7 +2282,7 @@ func TestKafkaTLSRules(t *testing.T) {
 
 	t.Run("same nodesecretref for two tls listeners is allowed", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
-		newRp.Spec.Configuration.KafkaAPI[0].TLS = v1alpha1.KafkaAPITLS{
+		newRp.Spec.Configuration.KafkaAPI[0].TLS = vectorizedv1alpha1.KafkaAPITLS{
 			Enabled: true,
 			NodeSecretRef: &corev1.ObjectReference{
 				Name:      "node",
@@ -2290,14 +2290,14 @@ func TestKafkaTLSRules(t *testing.T) {
 			},
 		}
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{
+			vectorizedv1alpha1.KafkaAPI{
 				AuthenticationMethod: "none",
 				Port:                 30001,
-				External: v1alpha1.ExternalConnectivityConfig{
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{
 					Enabled:   true,
 					Subdomain: "redpanda.com",
 				},
-				TLS: v1alpha1.KafkaAPITLS{
+				TLS: vectorizedv1alpha1.KafkaAPITLS{
 					Enabled: true,
 					NodeSecretRef: &corev1.ObjectReference{
 						Name:      "node",
@@ -2317,10 +2317,10 @@ func TestKafkaAuthenticationMethod(t *testing.T) {
 	t.Run("no authentication method provided", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{
+			vectorizedv1alpha1.KafkaAPI{
 				AuthenticationMethod: "",
 				Port:                 30001,
-				External: v1alpha1.ExternalConnectivityConfig{
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{
 					Enabled:   true,
 					Subdomain: "redpanda.com",
 				},
@@ -2336,10 +2336,10 @@ func TestKafkaAuthenticationMethod(t *testing.T) {
 	t.Run("sasl authentication method provided", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{
+			vectorizedv1alpha1.KafkaAPI{
 				AuthenticationMethod: "sasl",
 				Port:                 30001,
-				External: v1alpha1.ExternalConnectivityConfig{
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{
 					Enabled:   true,
 					Subdomain: "redpanda.com",
 				},
@@ -2355,10 +2355,10 @@ func TestKafkaAuthenticationMethod(t *testing.T) {
 	t.Run("mtls_identity authentication method provided", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
 		newRp.Spec.Configuration.KafkaAPI = append(newRp.Spec.Configuration.KafkaAPI,
-			v1alpha1.KafkaAPI{
+			vectorizedv1alpha1.KafkaAPI{
 				AuthenticationMethod: "mtls_identity",
 				Port:                 30001,
-				External: v1alpha1.ExternalConnectivityConfig{
+				External: vectorizedv1alpha1.ExternalConnectivityConfig{
 					Enabled:   true,
 					Subdomain: "redpanda.com",
 				},
@@ -2411,7 +2411,7 @@ func TestCloudStorage(t *testing.T) {
 	t.Run("invalid cloud storage with config file (no secret)", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
 		newRp.Spec.CloudStorage.Enabled = true
-		newRp.Spec.CloudStorage.CredentialsSource = v1alpha1.CredentialsSourceConfigFile
+		newRp.Spec.CloudStorage.CredentialsSource = vectorizedv1alpha1.CredentialsSourceConfigFile
 		newRp.Spec.CloudStorage.Bucket = bucket
 		newRp.Spec.CloudStorage.Region = region
 		newRp.Spec.CloudStorage.AccessKey = accessKey
@@ -2423,7 +2423,7 @@ func TestCloudStorage(t *testing.T) {
 	t.Run("valid cloud storage with sts", func(t *testing.T) {
 		newRp := rpCluster.DeepCopy()
 		newRp.Spec.CloudStorage.Enabled = true
-		newRp.Spec.CloudStorage.CredentialsSource = v1alpha1.CredentialsSource("sts")
+		newRp.Spec.CloudStorage.CredentialsSource = vectorizedv1alpha1.CredentialsSource("sts")
 		newRp.Spec.CloudStorage.Bucket = bucket
 		newRp.Spec.CloudStorage.Region = region
 

--- a/operator/api/vectorized/v1alpha1/webhook_suite_test.go
+++ b/operator/api/vectorized/v1alpha1/webhook_suite_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
-
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/operator/cmd/configurator/configurator.go
+++ b/operator/cmd/configurator/configurator.go
@@ -25,14 +25,13 @@ import (
 	"strings"
 
 	"github.com/moby/sys/mountinfo"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"

--- a/operator/cmd/ready/ready.go
+++ b/operator/cmd/ready/ready.go
@@ -14,13 +14,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
-
-	"github.com/spf13/cobra"
-
 	"github.com/redpanda-data/redpanda-operator/operator/internal/probes"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 )
 
 func Command() *cobra.Command {

--- a/operator/internal/controller/redpanda/redpanda_controller_utils.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_utils.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 const (
@@ -64,7 +64,7 @@ func isValidReleaseName(releaseName string, redpandaNameList []string) bool {
 
 func getHelmValues(ctx context.Context, c client.Client, log logr.Logger, releaseName, namespace string, operatorMode bool) (map[string]interface{}, error) {
 	if operatorMode {
-		rp := v1alpha2.Redpanda{}
+		rp := redpandav1alpha2.Redpanda{}
 		err := c.Get(ctx, client.ObjectKey{Name: releaseName, Namespace: namespace}, &rp)
 		if err != nil {
 			return nil, fmt.Errorf("getting Redpanda customer resource: %w", err)

--- a/operator/internal/controller/redpanda/redpanda_decommission_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_decommission_controller.go
@@ -30,7 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
+	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
 )
 
@@ -180,7 +180,7 @@ func (r *DecommissionReconciler) verifyIfNeedDecommission(ctx context.Context, s
 	redpandaNameList := make([]string, 0)
 	if r.OperatorMode {
 		opts := &client.ListOptions{Namespace: namespace}
-		redpandaList := &v1alpha1.RedpandaList{}
+		redpandaList := &redpandav1alpha1.RedpandaList{}
 		if errGET := r.Client.List(ctx, redpandaList, opts); errGET != nil {
 			return ctrl.Result{}, fmt.Errorf("could not GET list of Redpandas in namespace: %w", errGET)
 		}

--- a/operator/internal/controller/redpanda/redpanda_node_pvc_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_node_pvc_controller.go
@@ -22,7 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
+	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups=cluster.redpanda.com,resources=redpandas,verbs=get;list;watch;
@@ -74,7 +74,7 @@ func (r *RedpandaNodePVCReconciler) reconcile(ctx context.Context, req ctrl.Requ
 	redpandaNameList := make([]string, 0)
 	if r.OperatorMode {
 		opts := &client.ListOptions{Namespace: req.Namespace}
-		redpandaList := &v1alpha1.RedpandaList{}
+		redpandaList := &redpandav1alpha1.RedpandaList{}
 		if errList := r.Client.List(ctx, redpandaList, opts); errList != nil {
 			return ctrl.Result{}, fmt.Errorf("could not GET list of Redpandas in namespace: %w", errList)
 		}

--- a/operator/internal/controller/scheme.go
+++ b/operator/internal/controller/scheme.go
@@ -10,7 +10,7 @@
 package controller
 
 import (
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	helmControllerAPIv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
 	helmControllerAPIv2beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
 	sourceControllerAPIv1 "github.com/fluxcd/source-controller/api/v1"
@@ -28,12 +28,12 @@ import (
 var (
 	v1SchemeFns = []func(s *runtime.Scheme) error{
 		clientgoscheme.AddToScheme,
-		cmapiv1.AddToScheme,
+		certmanagerv1.AddToScheme,
 		vectorizedv1alpha1.AddToScheme,
 	}
 	v2SchemeFns = []func(s *runtime.Scheme) error{
 		clientgoscheme.AddToScheme,
-		cmapiv1.AddToScheme,
+		certmanagerv1.AddToScheme,
 		helmControllerAPIv2beta1.AddToScheme,
 		helmControllerAPIv2beta2.AddToScheme,
 		redpandav1alpha1.AddToScheme,

--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,9 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/redpanda-data/common-go/rpadmin"
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/internal/controller/vectorized/cluster_controller_configuration.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration.go
@@ -17,9 +17,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/redpanda-data/common-go/rpadmin"
+	corev1 "k8s.io/api/core/v1"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/rpadmin"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,8 +25,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-
-	"github.com/redpanda-data/common-go/rpadmin"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/internal/controller/vectorized/test/cluster_controller_common_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_common_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	podutils "github.com/redpanda-data/redpanda-operator/operator/internal/util/pod"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 )
@@ -59,13 +59,13 @@ func annotationGetter(
 
 func clusterConfiguredConditionGetter(
 	key client.ObjectKey,
-) func() *v1alpha1.ClusterCondition {
-	return func() *v1alpha1.ClusterCondition {
-		var cluster v1alpha1.Cluster
+) func() *vectorizedv1alpha1.ClusterCondition {
+	return func() *vectorizedv1alpha1.ClusterCondition {
+		var cluster vectorizedv1alpha1.Cluster
 		if err := k8sClient.Get(context.Background(), key, &cluster); err != nil {
 			return nil
 		}
-		return cluster.Status.GetCondition(v1alpha1.ClusterConfiguredConditionType)
+		return cluster.Status.GetCondition(vectorizedv1alpha1.ClusterConfiguredConditionType)
 	}
 }
 
@@ -77,10 +77,10 @@ func clusterConfiguredConditionStatusGetter(key client.ObjectKey) func() bool {
 }
 
 func clusterUpdater(
-	clusterNamespacedName types.NamespacedName, upd func(*v1alpha1.Cluster),
+	clusterNamespacedName types.NamespacedName, upd func(*vectorizedv1alpha1.Cluster),
 ) func() error {
 	return func() error {
-		cl := &v1alpha1.Cluster{}
+		cl := &vectorizedv1alpha1.Cluster{}
 		if err := k8sClient.Get(context.Background(), clusterNamespacedName, cl); err != nil {
 			return err
 		}
@@ -91,10 +91,10 @@ func clusterUpdater(
 }
 
 func consoleUpdater(
-	consoleNamespacedName types.NamespacedName, upd func(*v1alpha1.Console),
+	consoleNamespacedName types.NamespacedName, upd func(*vectorizedv1alpha1.Console),
 ) func() error {
 	return func() error {
-		con := &v1alpha1.Console{}
+		con := &vectorizedv1alpha1.Console{}
 		if err := k8sClient.Get(context.Background(), consoleNamespacedName, con); err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func consoleUpdater(
 }
 
 func statefulSetReplicasReconciler(
-	log logr.Logger, key types.NamespacedName, cluster *v1alpha1.Cluster,
+	log logr.Logger, key types.NamespacedName, cluster *vectorizedv1alpha1.Cluster,
 ) func() error {
 	return func() error {
 		var sts appsv1.StatefulSet

--- a/operator/internal/controller/vectorized/test/cluster_controller_scale_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_scale_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/common-go/rpadmin"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-
-	"github.com/redpanda-data/common-go/rpadmin"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"

--- a/operator/internal/controller/vectorized/test/cluster_controller_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_test.go
@@ -31,9 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
-
-	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	res "github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 )
@@ -92,7 +91,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "redpanda-init-configurator",
 				Namespace: "",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
@@ -100,37 +99,37 @@ var _ = Describe("RedPandaCluster controller", func() {
 						"app": "redpanda",
 					},
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{Port: kafkaPort},
-							{External: v1alpha1.ExternalConnectivityConfig{Enabled: true}},
+							{External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{
 							{Port: adminPort},
-							{External: v1alpha1.ExternalConnectivityConfig{
+							{External: vectorizedv1alpha1.ExternalConnectivityConfig{
 								Enabled: true,
 							}},
 						},
-						PandaproxyAPI: []v1alpha1.PandaproxyAPI{
+						PandaproxyAPI: []vectorizedv1alpha1.PandaproxyAPI{
 							{Port: pandaProxyPort},
-							{External: v1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+							{External: vectorizedv1alpha1.PandaproxyExternalConnectivityConfig{ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 								Enabled: true,
 							}}},
 						},
-						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
+						SchemaRegistry: &vectorizedv1alpha1.SchemaRegistryAPI{
 							Port: schemaRegistryPort,
-							External: &v1alpha1.SchemaRegistryExternalConnectivityConfig{
-								ExternalConnectivityConfig: v1alpha1.ExternalConnectivityConfig{
+							External: &vectorizedv1alpha1.SchemaRegistryExternalConnectivityConfig{
+								ExternalConnectivityConfig: vectorizedv1alpha1.ExternalConnectivityConfig{
 									Enabled: true,
 								},
 							},
 						},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resourceLimits,
 							Requests: resourceRequests,
@@ -268,7 +267,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			Expect(sts.Spec.Template.Spec.Containers[0].Env).Should(ContainElement(corev1.EnvVar{Name: "REDPANDA_ENVIRONMENT", Value: "kubernetes"}))
 
 			By("Reporting nodes internal and external")
-			var rc v1alpha1.Cluster
+			var rc vectorizedv1alpha1.Cluster
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), key, &rc)
 				return err == nil &&
@@ -291,25 +290,25 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "redpanda-test-tls",
 				Namespace: "default",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{
 								Port: kafkaPort,
-								TLS:  v1alpha1.KafkaAPITLS{Enabled: true, RequireClientAuth: true},
+								TLS:  vectorizedv1alpha1.KafkaAPITLS{Enabled: true, RequireClientAuth: true},
 							},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{{Port: adminPort}},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resources,
 							Requests: resources,
@@ -393,24 +392,24 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "internal-redpanda",
 				Namespace: "default",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{
 								Port: kafkaPort,
 							},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{{Port: adminPort}},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resources,
 							Requests: resources,
@@ -452,7 +451,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("report only internal address")
-			var cluster v1alpha1.Cluster
+			var cluster vectorizedv1alpha1.Cluster
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), key, &cluster)
 				return err == nil &&
@@ -471,31 +470,31 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "external-fixed-redpanda",
 				Namespace: "default",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{
 								Port: kafkaPort,
 							},
 							{
 								Port: 31111,
-								External: v1alpha1.ExternalConnectivityConfig{
+								External: vectorizedv1alpha1.ExternalConnectivityConfig{
 									Enabled:   true,
 									Subdomain: "vectorized.io",
 								},
 							},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{{Port: adminPort}},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resources,
 							Requests: resources,
@@ -545,30 +544,30 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "preferred-address-redpanda",
 				Namespace: "default",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{
 								Port: kafkaPort,
 							},
 							{
-								External: v1alpha1.ExternalConnectivityConfig{
+								External: vectorizedv1alpha1.ExternalConnectivityConfig{
 									Enabled:              true,
 									PreferredAddressType: "InternalIP",
 								},
 							},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{{Port: adminPort}},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resources,
 							Requests: resources,
@@ -622,7 +621,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Reporting external connectivity through InternalIP")
-			var rc v1alpha1.Cluster
+			var rc vectorizedv1alpha1.Cluster
 			nodeport := svc.Spec.Ports[0].NodePort
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), key, &rc)
@@ -640,24 +639,24 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "bootstrap-redpanda",
 				Namespace: "default",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{
 								Port: kafkaPort,
 							},
 							{
-								External: v1alpha1.ExternalConnectivityConfig{
+								External: vectorizedv1alpha1.ExternalConnectivityConfig{
 									Enabled: true,
-									Bootstrap: &v1alpha1.LoadBalancerConfig{
+									Bootstrap: &vectorizedv1alpha1.LoadBalancerConfig{
 										Annotations: map[string]string{
 											"key": "val",
 										},
@@ -666,9 +665,9 @@ var _ = Describe("RedPandaCluster controller", func() {
 								},
 							},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{{Port: adminPort}},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resources,
 							Requests: resources,
@@ -722,7 +721,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Reporting external connectivity bootstrap load balancer")
-			var rc v1alpha1.Cluster
+			var rc vectorizedv1alpha1.Cluster
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), key, &rc)
 				return err == nil &&
@@ -740,24 +739,24 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:      "redpanda-no-restart",
 				Namespace: "default",
 			}
-			redpandaCluster := &v1alpha1.Cluster{
+			redpandaCluster := &vectorizedv1alpha1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
 				},
-				Spec: v1alpha1.ClusterSpec{
+				Spec: vectorizedv1alpha1.ClusterSpec{
 					Image:    redpandaContainerImage,
 					Version:  redpandaContainerTag,
 					Replicas: ptr.To(int32(replicas)),
-					Configuration: v1alpha1.RedpandaConfig{
-						KafkaAPI: []v1alpha1.KafkaAPI{
+					Configuration: vectorizedv1alpha1.RedpandaConfig{
+						KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 							{
 								Port: kafkaPort,
 							},
 						},
-						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+						AdminAPI: []vectorizedv1alpha1.AdminAPI{{Port: adminPort}},
 					},
-					Resources: v1alpha1.RedpandaResourceRequirements{
+					Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
 						ResourceRequirements: corev1.ResourceRequirements{
 							Limits:   resources,
 							Requests: resources,
@@ -779,7 +778,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			// configmap annotation should not change when scaling out cluster replicas
 			// to avoid an unnecessary rolling restart
 			configMapHash := sts.Annotations[res.ConfigMapHashAnnotationKey]
-			var existingCluster v1alpha1.Cluster
+			var existingCluster vectorizedv1alpha1.Cluster
 			Expect(k8sClient.Get(context.Background(), key, &existingCluster)).Should(Succeed())
 			latest := existingCluster.DeepCopy()
 			var newReplicas int32 = replicas + 2
@@ -804,13 +803,13 @@ var _ = Describe("RedPandaCluster controller", func() {
 					Namespace: licenseNamespace,
 					Name:      licenseName,
 				},
-				StringData: map[string]string{v1alpha1.DefaultLicenseSecretKey: "fake-license"},
+				StringData: map[string]string{vectorizedv1alpha1.DefaultLicenseSecretKey: "fake-license"},
 			}
 			Expect(k8sClient.Create(context.Background(), licenseSecret)).Should(Succeed())
 
 			By("Creating a Cluster")
 			key, _, redpandaCluster, namespace := getInitialTestCluster(clusterNameWithLicense)
-			redpandaCluster.Spec.LicenseRef = &v1alpha1.SecretKeyRef{Namespace: licenseNamespace, Name: licenseName}
+			redpandaCluster.Spec.LicenseRef = &vectorizedv1alpha1.SecretKeyRef{Namespace: licenseNamespace, Name: licenseName}
 			Expect(k8sClient.Create(context.Background(), namespace)).Should(Succeed())
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
 			Eventually(clusterConfiguredConditionStatusGetter(key), timeout, interval).Should(BeTrue())
@@ -855,7 +854,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 			Expect(err).To(Succeed())
 			By("Reporting the existence of cluster")
-			var rc v1alpha1.Cluster
+			var rc vectorizedv1alpha1.Cluster
 			Eventually(func() bool {
 				err := fc.Get(context.Background(), key, &rc)
 				return err == nil
@@ -884,7 +883,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 			Expect(err).To(Succeed())
 			By("Reporting the existence of cluster and allowed version status")
-			var rc v1alpha1.Cluster
+			var rc vectorizedv1alpha1.Cluster
 			Eventually(func() bool {
 				err := fc.Get(context.Background(), key, &rc)
 				return err == nil && rc.Status.Version == allowedVersion
@@ -920,7 +919,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 		Entry("Random image pull policy", "asdvasd", Not(Succeed())))
 })
 
-func readyPodsForCluster(cluster *v1alpha1.Cluster) []*corev1.Pod {
+func readyPodsForCluster(cluster *vectorizedv1alpha1.Cluster) []*corev1.Pod {
 	var result []*corev1.Pod
 	for i := 0; i < int(*cluster.Spec.Replicas); i++ {
 		pod := &corev1.Pod{
@@ -950,18 +949,18 @@ func readyPodsForCluster(cluster *v1alpha1.Cluster) []*corev1.Pod {
 
 func getVersionedRedpanda(
 	name string, version string,
-) (key types.NamespacedName, cluster *v1alpha1.Cluster) {
+) (key types.NamespacedName, cluster *vectorizedv1alpha1.Cluster) {
 	key = types.NamespacedName{
 		Name:      name,
 		Namespace: "default",
 	}
-	config := v1alpha1.RedpandaConfig{
-		KafkaAPI: []v1alpha1.KafkaAPI{
+	config := vectorizedv1alpha1.RedpandaConfig{
+		KafkaAPI: []vectorizedv1alpha1.KafkaAPI{
 			{
 				Port: 9644,
 			},
 		},
-		AdminAPI: []v1alpha1.AdminAPI{
+		AdminAPI: []vectorizedv1alpha1.AdminAPI{
 			{
 				Port: 9092,
 			},
@@ -971,19 +970,19 @@ func getVersionedRedpanda(
 		corev1.ResourceCPU:    resource.MustParse("1"),
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
 	}
-	rpresources := v1alpha1.RedpandaResourceRequirements{
+	rpresources := vectorizedv1alpha1.RedpandaResourceRequirements{
 		ResourceRequirements: corev1.ResourceRequirements{
 			Limits:   resources,
 			Requests: resources,
 		},
 		Redpanda: nil,
 	}
-	redpandaCluster := &v1alpha1.Cluster{
+	redpandaCluster := &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.Name,
 			Namespace: key.Namespace,
 		},
-		Spec: v1alpha1.ClusterSpec{
+		Spec: vectorizedv1alpha1.ClusterSpec{
 			Image:         "vectorized/redpanda",
 			Version:       version,
 			Replicas:      ptr.To(int32(1)),
@@ -1004,7 +1003,7 @@ func findPort(ports []corev1.ServicePort, name string) int32 {
 }
 
 func validOwner(
-	cluster *v1alpha1.Cluster, owners []metav1.OwnerReference,
+	cluster *vectorizedv1alpha1.Cluster, owners []metav1.OwnerReference,
 ) bool {
 	if len(owners) != 1 {
 		return false

--- a/operator/internal/controller/vectorized/test/redpanda_controller_test.go
+++ b/operator/internal/controller/vectorized/test/redpanda_controller_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 var _ = Describe("Redpanda Controller", func() {
@@ -48,12 +48,12 @@ var _ = Describe("Redpanda Controller", func() {
 			Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())
 
 			// check if redpanda cluster exists, create it if not
-			RedpandaObj := &v1alpha2.Redpanda{}
+			RedpandaObj := &redpandav1alpha2.Redpanda{}
 			if err := k8sClient.Get(ctx, key, RedpandaObj); err != nil {
 				if !apierrors.IsNotFound(err) {
 					Expect(err).To(Equal(nil))
 				}
-				RedpandaObj = &v1alpha2.Redpanda{
+				RedpandaObj = &redpandav1alpha2.Redpanda{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "cluster.redpanda.com/v1alpha1",
 						Kind:       "Redpanda",
@@ -62,12 +62,12 @@ var _ = Describe("Redpanda Controller", func() {
 						Name:      RedpandaClusterName,
 						Namespace: RedpandaNamespace,
 					},
-					Spec: v1alpha2.RedpandaSpec{
-						ChartRef: v1alpha2.ChartRef{
+					Spec: redpandav1alpha2.RedpandaSpec{
+						ChartRef: redpandav1alpha2.ChartRef{
 							ChartVersion:       "5.x.x",
 							HelmRepositoryName: HelmRepositoryName,
 						},
-						ClusterSpec: &v1alpha2.RedpandaClusterSpec{},
+						ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{},
 					},
 				}
 

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	helmControllerAPIV2Beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
 	helmControllerAPIV2Beta2 "github.com/fluxcd/helm-controller/api/v2beta2"
 	fluxclient "github.com/fluxcd/pkg/runtime/client"
@@ -38,9 +38,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
-	"github.com/redpanda-data/redpanda-operator/pkg/kube"
-
 	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
@@ -49,10 +46,11 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	consolepkg "github.com/redpanda-data/redpanda-operator/operator/pkg/console"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
-	//+kubebuilder:scaffold:imports
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -110,7 +108,7 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	Expect(err).NotTo(HaveOccurred())
 	err = redpandav1alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
-	err = cmapiv1.AddToScheme(scheme.Scheme)
+	err = certmanagerv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = helmControllerAPIV2Beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/operator/internal/decommissioning/statefulset_decomissioner.go
+++ b/operator/internal/decommissioning/statefulset_decomissioner.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -359,8 +359,8 @@ func (s *StatefulSetDecomissioner) Decommission(ctx context.Context, set *appsv1
 			}
 
 			// ensure that the PV has a retain policy
-			if err := s.client.Patch(ctx, volume, kubernetes.ApplyPatch(corev1ac.PersistentVolume(volume.Name).WithSpec(
-				corev1ac.PersistentVolumeSpec().WithPersistentVolumeReclaimPolicy(corev1.PersistentVolumeReclaimRetain),
+			if err := s.client.Patch(ctx, volume, kubernetes.ApplyPatch(applycorev1.PersistentVolume(volume.Name).WithSpec(
+				applycorev1.PersistentVolumeSpec().WithPersistentVolumeReclaimPolicy(corev1.PersistentVolumeReclaimRetain),
 			)), client.ForceOwnership, client.FieldOwner("owner")); err != nil {
 				log.Error(err, "error patching PersistentVolume spec")
 				return err

--- a/operator/pkg/client/acls/syncer_test.go
+++ b/operator/pkg/client/acls/syncer_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"k8s.io/utils/ptr"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 func TestSyncer(t *testing.T) {
@@ -49,7 +49,7 @@ func TestSyncer(t *testing.T) {
 	syncer := NewSyncer(kafkaClient)
 	defer syncer.Close()
 
-	sortACLs := func(acls []v1alpha2.ACLRule) {
+	sortACLs := func(acls []redpandav1alpha2.ACLRule) {
 		sort.SliceStable(acls, func(i, j int) bool {
 			return acls[i].Resource.Type < acls[j].Resource.Type
 		})
@@ -58,7 +58,7 @@ func TestSyncer(t *testing.T) {
 	principalOne := "User:testuser"
 	principalTwo := "User:testuser2"
 
-	expectACLsMatch := func(t *testing.T, principal string, acls []v1alpha2.ACLRule) {
+	expectACLsMatch := func(t *testing.T, principal string, acls []redpandav1alpha2.ACLRule) {
 		actual, err := syncer.ListACLs(ctx, principal)
 		require.NoError(t, err)
 
@@ -72,7 +72,7 @@ func TestSyncer(t *testing.T) {
 		}
 	}
 
-	expectACLUpdate := func(t *testing.T, principal string, acls []v1alpha2.ACLRule, expectCreated, expectDeleted int) {
+	expectACLUpdate := func(t *testing.T, principal string, acls []redpandav1alpha2.ACLRule, expectCreated, expectDeleted int) {
 		t.Helper()
 
 		created, deleted, err := syncer.sync(ctx, principal, acls)
@@ -84,22 +84,22 @@ func TestSyncer(t *testing.T) {
 		expectACLsMatch(t, principal, acls)
 	}
 
-	initialACLS := []v1alpha2.ACLRule{{
-		Type: v1alpha2.ACLTypeAllow,
-		Resource: v1alpha2.ACLResourceSpec{
-			Type: v1alpha2.ResourceTypeTopic,
+	initialACLS := []redpandav1alpha2.ACLRule{{
+		Type: redpandav1alpha2.ACLTypeAllow,
+		Resource: redpandav1alpha2.ACLResourceSpec{
+			Type: redpandav1alpha2.ResourceTypeTopic,
 			Name: "1",
 		},
-		Operations: []v1alpha2.ACLOperation{
-			v1alpha2.ACLOperationRead,
+		Operations: []redpandav1alpha2.ACLOperation{
+			redpandav1alpha2.ACLOperationRead,
 		},
 	}, {
-		Type: v1alpha2.ACLTypeAllow,
-		Resource: v1alpha2.ACLResourceSpec{
-			Type: v1alpha2.ResourceTypeCluster,
+		Type: redpandav1alpha2.ACLTypeAllow,
+		Resource: redpandav1alpha2.ACLResourceSpec{
+			Type: redpandav1alpha2.ResourceTypeCluster,
 		},
-		Operations: []v1alpha2.ACLOperation{
-			v1alpha2.ACLOperationRead,
+		Operations: []redpandav1alpha2.ACLOperation{
+			redpandav1alpha2.ACLOperationRead,
 		},
 	}}
 
@@ -107,47 +107,47 @@ func TestSyncer(t *testing.T) {
 	expectACLUpdate(t, principalOne, initialACLS, 2, 0)
 
 	// remove 1 acl
-	expectACLUpdate(t, principalOne, []v1alpha2.ACLRule{{
-		Type: v1alpha2.ACLTypeAllow,
+	expectACLUpdate(t, principalOne, []redpandav1alpha2.ACLRule{{
+		Type: redpandav1alpha2.ACLTypeAllow,
 		Host: ptr.To("*"),
-		Resource: v1alpha2.ACLResourceSpec{
-			Type: v1alpha2.ResourceTypeCluster,
+		Resource: redpandav1alpha2.ACLResourceSpec{
+			Type: redpandav1alpha2.ResourceTypeCluster,
 		},
-		Operations: []v1alpha2.ACLOperation{
-			v1alpha2.ACLOperationRead,
+		Operations: []redpandav1alpha2.ACLOperation{
+			redpandav1alpha2.ACLOperationRead,
 		},
 	}}, 0, 1)
 
 	// update acl
-	expectACLUpdate(t, principalOne, []v1alpha2.ACLRule{{
-		Type: v1alpha2.ACLTypeAllow,
+	expectACLUpdate(t, principalOne, []redpandav1alpha2.ACLRule{{
+		Type: redpandav1alpha2.ACLTypeAllow,
 		Host: ptr.To("*"),
-		Resource: v1alpha2.ACLResourceSpec{
-			Type:        v1alpha2.ResourceTypeTopic,
+		Resource: redpandav1alpha2.ACLResourceSpec{
+			Type:        redpandav1alpha2.ResourceTypeTopic,
 			Name:        "mytopic",
-			PatternType: ptr.To(v1alpha2.PatternTypePrefixed),
+			PatternType: ptr.To(redpandav1alpha2.PatternTypePrefixed),
 		},
-		Operations: []v1alpha2.ACLOperation{
-			v1alpha2.ACLOperationRead,
+		Operations: []redpandav1alpha2.ACLOperation{
+			redpandav1alpha2.ACLOperationRead,
 		},
 	}}, 1, 1)
 
 	// update acl again
-	expectACLUpdate(t, principalOne, []v1alpha2.ACLRule{{
-		Type: v1alpha2.ACLTypeAllow,
+	expectACLUpdate(t, principalOne, []redpandav1alpha2.ACLRule{{
+		Type: redpandav1alpha2.ACLTypeAllow,
 		Host: ptr.To("*"),
-		Resource: v1alpha2.ACLResourceSpec{
-			Type:        v1alpha2.ResourceTypeTopic,
+		Resource: redpandav1alpha2.ACLResourceSpec{
+			Type:        redpandav1alpha2.ResourceTypeTopic,
 			Name:        "mytopic2",
-			PatternType: ptr.To(v1alpha2.PatternTypePrefixed),
+			PatternType: ptr.To(redpandav1alpha2.PatternTypePrefixed),
 		},
-		Operations: []v1alpha2.ACLOperation{
-			v1alpha2.ACLOperationRead,
+		Operations: []redpandav1alpha2.ACLOperation{
+			redpandav1alpha2.ACLOperationRead,
 		},
 	}}, 1, 1)
 
 	// delete all acls
-	expectACLUpdate(t, principalOne, []v1alpha2.ACLRule{}, 0, 1)
+	expectACLUpdate(t, principalOne, []redpandav1alpha2.ACLRule{}, 0, 1)
 
 	// check de-duplication of ACLs
 	created, deleted, err := syncer.sync(ctx, principalOne, append(initialACLS, initialACLS[0]))
@@ -157,7 +157,7 @@ func TestSyncer(t *testing.T) {
 	expectACLsMatch(t, principalOne, initialACLS)
 
 	// make sure we have separation based on principals
-	aclsTwo := []v1alpha2.ACLRule{initialACLS[0]}
+	aclsTwo := []redpandav1alpha2.ACLRule{initialACLS[0]}
 	created, deleted, err = syncer.sync(ctx, principalTwo, aclsTwo)
 	require.NoError(t, err)
 	require.Equal(t, created, 1)
@@ -168,8 +168,8 @@ func TestSyncer(t *testing.T) {
 	// clear all
 	err = syncer.deleteAll(ctx, principalOne)
 	require.NoError(t, err)
-	expectACLsMatch(t, principalOne, []v1alpha2.ACLRule{})
+	expectACLsMatch(t, principalOne, []redpandav1alpha2.ACLRule{})
 	err = syncer.deleteAll(ctx, principalTwo)
 	require.NoError(t, err)
-	expectACLsMatch(t, principalTwo, []v1alpha2.ACLRule{})
+	expectACLsMatch(t, principalTwo, []redpandav1alpha2.ACLRule{})
 }

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/console/backend/pkg/config"
+	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -25,8 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
 	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -274,22 +274,22 @@ func TestIntegrationClientFactoryTLSListeners(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = kubeClient.Create(ctx, &cmapiv1.Certificate{
+	err = kubeClient.Create(ctx, &certmanagerv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kafka-internal-0",
 			Namespace: name,
 		},
-		Spec: cmapiv1.CertificateSpec{
+		Spec: certmanagerv1.CertificateSpec{
 			EmailAddresses: []string{
 				"test@domain.com",
 			},
 			Duration: ptr.To(metav1.Duration{Duration: 43800 * time.Hour}),
-			IssuerRef: cmetav1.ObjectReference{
+			IssuerRef: cmmetav1.ObjectReference{
 				Name:  "cluster-tls-kafka-internal-0-root-issuer",
 				Kind:  "Issuer",
 				Group: "cert-manager.io",
 			},
-			PrivateKey: &cmapiv1.CertificatePrivateKey{
+			PrivateKey: &certmanagerv1.CertificatePrivateKey{
 				Algorithm: "ECDSA",
 				Size:      256,
 			},

--- a/operator/pkg/client/rpk.go
+++ b/operator/pkg/client/rpk.go
@@ -18,12 +18,11 @@ import (
 
 	commonnet "github.com/redpanda-data/common-go/net"
 	"github.com/redpanda-data/common-go/rpadmin"
+	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
-
-	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 )
 
 // this roughly implements https://github.com/redpanda-data/redpanda/blob/f5a7a13f7fca3f69a4380f0bbfa8fbc3e7f899d6/src/go/rpk/pkg/adminapi/admin.go#L46

--- a/operator/pkg/client/schemas/syncer_test.go
+++ b/operator/pkg/client/schemas/syncer_test.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 
 const (
@@ -54,7 +54,7 @@ const (
 }`
 )
 
-func normalizeSchema(t *testing.T, ctx context.Context, syncer *Syncer, schema *v1alpha2.Schema) {
+func normalizeSchema(t *testing.T, ctx context.Context, syncer *Syncer, schema *redpandav1alpha2.Schema) {
 	actualSchema, err := syncer.getLatest(ctx, schema)
 	require.NoError(t, err)
 	schema.Spec.Text = actualSchema.Schema
@@ -63,7 +63,7 @@ func normalizeSchema(t *testing.T, ctx context.Context, syncer *Syncer, schema *
 	schema.Status.SchemaHash = hash
 }
 
-func expectSchemasMatch(t *testing.T, ctx context.Context, syncer *Syncer, schema *v1alpha2.Schema) {
+func expectSchemasMatch(t *testing.T, ctx context.Context, syncer *Syncer, schema *redpandav1alpha2.Schema) {
 	normalizeSchema(t, ctx, syncer, schema)
 
 	expectedSchema, err := schemaFromV1Alpha2Schema(schema)
@@ -77,7 +77,7 @@ func expectSchemasMatch(t *testing.T, ctx context.Context, syncer *Syncer, schem
 	require.True(t, expectedSchema.SchemaEquals(actualSchema), "Schemas not equal %+v != %+v", actualSchema, expectedSchema)
 }
 
-func expectSchemaUpdate(t *testing.T, ctx context.Context, syncer *Syncer, schema *v1alpha2.Schema, update bool) {
+func expectSchemaUpdate(t *testing.T, ctx context.Context, syncer *Syncer, schema *redpandav1alpha2.Schema, update bool) {
 	t.Helper()
 
 	_, versions, err := syncer.Sync(ctx, schema)
@@ -120,26 +120,26 @@ func TestSyncer(t *testing.T) {
 
 	syncer := NewSyncer(schemaRegistryClient)
 
-	for schemaType, schemaText := range map[v1alpha2.SchemaType]string{
-		v1alpha2.SchemaTypeAvro: validAvroSchema,
-		v1alpha2.SchemaTypeJSON: validJSONSchema,
+	for schemaType, schemaText := range map[redpandav1alpha2.SchemaType]string{
+		redpandav1alpha2.SchemaTypeAvro: validAvroSchema,
+		redpandav1alpha2.SchemaTypeJSON: validJSONSchema,
 	} {
 		t.Run(string(schemaType), func(t *testing.T) {
-			schema := &v1alpha2.Schema{
+			schema := &redpandav1alpha2.Schema{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "schema-" + string(schemaType),
 				},
-				Spec: v1alpha2.SchemaSpec{
+				Spec: redpandav1alpha2.SchemaSpec{
 					Type: ptr.To(schemaType),
 					Text: schemaText,
 				},
 			}
 
-			reference := &v1alpha2.Schema{
+			reference := &redpandav1alpha2.Schema{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "reference" + string(schemaType),
 				},
-				Spec: v1alpha2.SchemaSpec{
+				Spec: redpandav1alpha2.SchemaSpec{
 					Type: ptr.To(schemaType),
 					Text: schemaText,
 				},
@@ -150,7 +150,7 @@ func TestSyncer(t *testing.T) {
 			expectSchemaUpdate(t, ctx, syncer, reference, true)
 
 			// update references
-			schema.Spec.References = []v1alpha2.SchemaReference{
+			schema.Spec.References = []redpandav1alpha2.SchemaReference{
 				{
 					Subject: reference.Name,
 					Name:    "test",
@@ -160,7 +160,7 @@ func TestSyncer(t *testing.T) {
 			expectSchemaUpdate(t, ctx, syncer, schema, true)
 
 			// update compatibility level
-			schema.Spec.CompatibilityLevel = ptr.To(v1alpha2.CompatabilityLevelFull)
+			schema.Spec.CompatibilityLevel = ptr.To(redpandav1alpha2.CompatabilityLevelFull)
 			expectSchemaUpdate(t, ctx, syncer, schema, false)
 
 			// TODO: Request from core support for the following

--- a/operator/pkg/client/users/client_test.go
+++ b/operator/pkg/client/users/client_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 )
 
@@ -41,7 +41,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	err = v1alpha2.AddToScheme(scheme.Scheme)
+	err = redpandav1alpha2.AddToScheme(scheme.Scheme)
 	require.NoError(t, err)
 
 	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -115,7 +115,7 @@ func TestClientPasswordCreation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	err = v1alpha2.AddToScheme(scheme.Scheme)
+	err = redpandav1alpha2.AddToScheme(scheme.Scheme)
 	require.NoError(t, err)
 
 	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -161,22 +161,22 @@ func TestClientPasswordCreation(t *testing.T) {
 			"test": "label",
 		}
 
-		user := &v1alpha2.User{
+		user := &redpandav1alpha2.User{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      username,
 				Namespace: metav1.NamespaceDefault,
 			},
-			Spec: v1alpha2.UserSpec{
-				ClusterSource: &v1alpha2.ClusterSource{
-					ClusterRef: &v1alpha2.ClusterRef{
+			Spec: redpandav1alpha2.UserSpec{
+				ClusterSource: &redpandav1alpha2.ClusterSource{
+					ClusterRef: &redpandav1alpha2.ClusterRef{
 						Name: "bogus",
 					},
 				},
-				Authentication: &v1alpha2.UserAuthenticationSpec{
-					Type: ptr.To(v1alpha2.SASLMechanismScramSHA512),
-					Password: v1alpha2.Password{
+				Authentication: &redpandav1alpha2.UserAuthenticationSpec{
+					Type: ptr.To(redpandav1alpha2.SASLMechanismScramSHA512),
+					Password: redpandav1alpha2.Password{
 						Value: password,
-						ValueFrom: &v1alpha2.PasswordSource{
+						ValueFrom: &redpandav1alpha2.PasswordSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{
 									Name: secret,
@@ -186,9 +186,9 @@ func TestClientPasswordCreation(t *testing.T) {
 						},
 					},
 				},
-				Template: &v1alpha2.UserTemplateSpec{
-					Secret: &v1alpha2.ResourceTemplate{
-						Metadata: v1alpha2.MetadataTemplate{
+				Template: &redpandav1alpha2.UserTemplateSpec{
+					Secret: &redpandav1alpha2.ResourceTemplate{
+						Metadata: redpandav1alpha2.MetadataTemplate{
 							Labels:      labels,
 							Annotations: annotations,
 						},

--- a/operator/pkg/console/deployment_internal_test.go
+++ b/operator/pkg/console/deployment_internal_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"

--- a/operator/pkg/resources/certmanager/ca_certificate_bundle_test.go
+++ b/operator/pkg/resources/certmanager/ca_certificate_bundle_test.go
@@ -23,14 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
-
-	"github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/certmanager"
-
 	"k8s.io/client-go/kubernetes/scheme"
-
+	"k8s.io/utils/ptr"
 	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/certmanager"
 )
 
 var errNotSecret = errors.New("not secret")
@@ -43,20 +41,20 @@ const (
 
 func init() {
 	fakeK8sClient := fake.NewClientBuilder().Build()
-	_ = v1alpha1.AddToScheme(fakeK8sClient.Scheme())
+	_ = vectorizedv1alpha1.AddToScheme(fakeK8sClient.Scheme())
 }
 
 func TestCreateCACertBundle(t *testing.T) {
 	fakeK8sClient := fake.NewClientBuilder().Build()
 	nsPrefix := "test-ns"
 
-	pandaCluster := &v1alpha1.Cluster{
+	pandaCluster := &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName,
 		},
-		Spec: v1alpha1.ClusterSpec{
+		Spec: vectorizedv1alpha1.ClusterSpec{
 			Replicas:      ptr.To(int32(1)),
-			Configuration: v1alpha1.RedpandaConfig{},
+			Configuration: vectorizedv1alpha1.RedpandaConfig{},
 		},
 	}
 
@@ -122,15 +120,15 @@ func TestCreateCACertBundle(t *testing.T) {
 func TestUpdateCACertBundle(t *testing.T) {
 	fakeK8sClient := fake.NewClientBuilder().Build()
 
-	pandaCluster := &v1alpha1.Cluster{
+	pandaCluster := &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: ns,
 			UID:       "ff2770aa-c919-43f0-8b4a-30cb7cfdaf79",
 		},
-		Spec: v1alpha1.ClusterSpec{
+		Spec: vectorizedv1alpha1.ClusterSpec{
 			Replicas:      ptr.To(int32(1)),
-			Configuration: v1alpha1.RedpandaConfig{},
+			Configuration: vectorizedv1alpha1.RedpandaConfig{},
 		},
 	}
 
@@ -182,15 +180,15 @@ func TestUpdateCACertBundle(t *testing.T) {
 func TestCACertBundleFailures(t *testing.T) {
 	fakeK8sClient := fake.NewClientBuilder().Build()
 
-	pandaCluster := &v1alpha1.Cluster{
+	pandaCluster := &vectorizedv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: ns,
 			UID:       "ff2770aa-c919-43f0-8b4a-30cb7cfdaf79",
 		},
-		Spec: v1alpha1.ClusterSpec{
+		Spec: vectorizedv1alpha1.ClusterSpec{
 			Replicas:      ptr.To(int32(1)),
-			Configuration: v1alpha1.RedpandaConfig{},
+			Configuration: vectorizedv1alpha1.RedpandaConfig{},
 		},
 	}
 

--- a/operator/pkg/resources/certmanager/certificate.go
+++ b/operator/pkg/resources/certmanager/certificate.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,7 +48,7 @@ type CertificateResource struct {
 	scheme         *runtime.Scheme
 	pandaCluster   *vectorizedv1alpha1.Cluster
 	key            types.NamespacedName
-	issuerRef      *cmetav1.ObjectReference
+	issuerRef      *cmmetav1.ObjectReference
 	fqdn           []string
 	commonName     CommonName
 	isCA           bool
@@ -62,7 +62,7 @@ func NewCACertificate(
 	scheme *runtime.Scheme,
 	pandaCluster *vectorizedv1alpha1.Cluster,
 	key types.NamespacedName,
-	issuerRef *cmetav1.ObjectReference,
+	issuerRef *cmmetav1.ObjectReference,
 	commonName CommonName,
 	keystoreSecret *types.NamespacedName,
 	logger logr.Logger,
@@ -87,7 +87,7 @@ func NewNodeCertificate(
 	scheme *runtime.Scheme,
 	pandaCluster *vectorizedv1alpha1.Cluster,
 	key types.NamespacedName,
-	issuerRef *cmetav1.ObjectReference,
+	issuerRef *cmmetav1.ObjectReference,
 	fqdn []string,
 	commonName CommonName,
 	keystoreSecret *types.NamespacedName,
@@ -113,7 +113,7 @@ func NewCertificate(
 	scheme *runtime.Scheme,
 	pandaCluster *vectorizedv1alpha1.Cluster,
 	key types.NamespacedName,
-	issuerRef *cmetav1.ObjectReference,
+	issuerRef *cmmetav1.ObjectReference,
 	commonName CommonName,
 	isCA bool,
 	keystoreSecret *types.NamespacedName,
@@ -147,7 +147,7 @@ func (r *CertificateResource) Ensure(ctx context.Context) error {
 // obj returns resource managed client.Object
 func (r *CertificateResource) obj() (k8sclient.Object, error) {
 	objLabels := labels.ForCluster(r.pandaCluster)
-	cert := &cmapiv1.Certificate{
+	cert := &certmanagerv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Key().Name,
 			Namespace: r.Key().Namespace,
@@ -157,7 +157,7 @@ func (r *CertificateResource) obj() (k8sclient.Object, error) {
 			Kind:       "Certificate",
 			APIVersion: "cert-manager.io/v1",
 		},
-		Spec: cmapiv1.CertificateSpec{
+		Spec: certmanagerv1.CertificateSpec{
 			SecretName:  r.Key().Name,
 			IssuerRef:   *r.issuerRef,
 			IsCA:        r.isCA,
@@ -182,25 +182,25 @@ func (r *CertificateResource) obj() (k8sclient.Object, error) {
 	return cert, nil
 }
 
-func (r *CertificateResource) createKeystores() *cmapiv1.CertificateKeystores {
+func (r *CertificateResource) createKeystores() *certmanagerv1.CertificateKeystores {
 	if r.keystoreSecret == nil {
 		return nil
 	}
 
-	return &cmapiv1.CertificateKeystores{
-		JKS: &cmapiv1.JKSKeystore{
+	return &certmanagerv1.CertificateKeystores{
+		JKS: &certmanagerv1.JKSKeystore{
 			Create: true,
-			PasswordSecretRef: cmetav1.SecretKeySelector{
-				LocalObjectReference: cmetav1.LocalObjectReference{
+			PasswordSecretRef: cmmetav1.SecretKeySelector{
+				LocalObjectReference: cmmetav1.LocalObjectReference{
 					Name: r.keystoreSecret.Name,
 				},
 				Key: passwordKey,
 			},
 		},
-		PKCS12: &cmapiv1.PKCS12Keystore{
+		PKCS12: &certmanagerv1.PKCS12Keystore{
 			Create: true,
-			PasswordSecretRef: cmetav1.SecretKeySelector{
-				LocalObjectReference: cmetav1.LocalObjectReference{
+			PasswordSecretRef: cmmetav1.SecretKeySelector{
+				LocalObjectReference: cmmetav1.LocalObjectReference{
 					Name: r.keystoreSecret.Name,
 				},
 				Key: passwordKey,
@@ -216,6 +216,6 @@ func (r *CertificateResource) Key() types.NamespacedName {
 }
 
 func certificateKind() string {
-	var obj cmapiv1.Certificate
+	var obj certmanagerv1.Certificate
 	return obj.Kind
 }

--- a/operator/pkg/resources/certmanager/issuer.go
+++ b/operator/pkg/resources/certmanager/issuer.go
@@ -13,8 +13,8 @@ import (
 	"context"
 	"fmt"
 
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,24 +74,24 @@ func (r *IssuerResource) obj() (k8sclient.Object, error) {
 		Labels:    objLabels,
 	}
 
-	var spec cmapiv1.IssuerSpec
+	var spec certmanagerv1.IssuerSpec
 	if r.secretName == "" {
-		spec = cmapiv1.IssuerSpec{
-			IssuerConfig: cmapiv1.IssuerConfig{
-				SelfSigned: &cmapiv1.SelfSignedIssuer{},
+		spec = certmanagerv1.IssuerSpec{
+			IssuerConfig: certmanagerv1.IssuerConfig{
+				SelfSigned: &certmanagerv1.SelfSignedIssuer{},
 			},
 		}
 	} else {
-		spec = cmapiv1.IssuerSpec{
-			IssuerConfig: cmapiv1.IssuerConfig{
-				CA: &cmapiv1.CAIssuer{
+		spec = certmanagerv1.IssuerSpec{
+			IssuerConfig: certmanagerv1.IssuerConfig{
+				CA: &certmanagerv1.CAIssuer{
 					SecretName: r.secretName,
 				},
 			},
 		}
 	}
 
-	issuer := &cmapiv1.Issuer{
+	issuer := &certmanagerv1.Issuer{
 		ObjectMeta: objectMeta,
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Issuer",
@@ -115,14 +115,14 @@ func (r *IssuerResource) Key() types.NamespacedName {
 }
 
 // objRef returns the issuer's object reference
-func (r *IssuerResource) objRef() *cmetav1.ObjectReference {
-	return &cmetav1.ObjectReference{
+func (r *IssuerResource) objRef() *cmmetav1.ObjectReference {
+	return &cmmetav1.ObjectReference{
 		Name: r.Key().Name,
 		Kind: issuerKind(),
 	}
 }
 
 func issuerKind() string {
-	var issuer cmapiv1.Issuer
+	var issuer certmanagerv1.Issuer
 	return issuer.Kind
 }

--- a/operator/pkg/resources/certmanager/pki_test.go
+++ b/operator/pkg/resources/certmanager/pki_test.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"testing"
 
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,7 +30,7 @@ import (
 
 func TestKafkaAPIWithMultipleTLSListeners(t *testing.T) {
 	require.NoError(t, vectorizedv1alpha1.AddToScheme(scheme.Scheme))
-	require.NoError(t, cmapiv1.AddToScheme(scheme.Scheme))
+	require.NoError(t, certmanagerv1.AddToScheme(scheme.Scheme))
 	clusterWithMultipleTLS := pandaCluster().DeepCopy()
 	clusterWithMultipleTLS.Spec.Configuration.KafkaAPI[0].TLS = vectorizedv1alpha1.KafkaAPITLS{Enabled: true, RequireClientAuth: true}
 	clusterWithMultipleTLS.Spec.Configuration.KafkaAPI = append(clusterWithMultipleTLS.Spec.Configuration.KafkaAPI, vectorizedv1alpha1.KafkaAPI{Port: 30001, External: vectorizedv1alpha1.ExternalConnectivityConfig{Enabled: true}, TLS: vectorizedv1alpha1.KafkaAPITLS{Enabled: true}})
@@ -61,7 +61,7 @@ func TestKafkaAPIWithMultipleTLSListeners(t *testing.T) {
 			require.NoError(t, pkiRes.Ensure(context.TODO()))
 
 			for _, cert := range tc.expectedCertificates {
-				actual := &cmapiv1.Certificate{}
+				actual := &certmanagerv1.Certificate{}
 				err := c.Get(context.Background(), types.NamespacedName{Name: cert, Namespace: pandaCluster().Namespace}, actual)
 				require.NoError(t, err)
 			}

--- a/operator/pkg/resources/certmanager/type_helpers.go
+++ b/operator/pkg/resources/certmanager/type_helpers.go
@@ -16,17 +16,16 @@ import (
 	"errors"
 	"fmt"
 
-	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
@@ -362,17 +361,17 @@ func isSelfSigned(ctx context.Context, nodeSecretRef *corev1.ObjectReference, ex
 		return ok, nil // if the ca key exists, it means it's self-signed
 	}
 	if externalIssuerRef != nil {
-		var issuerSpec cmapiv1.IssuerSpec
+		var issuerSpec certmanagerv1.IssuerSpec
 		switch externalIssuerRef.Kind {
 		case "Issuer":
-			var issuer cmapiv1.Issuer
+			var issuer certmanagerv1.Issuer
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: externalIssuerRef.Name, Namespace: clusterNamespace}, &issuer)
 			if err != nil {
 				return false, err
 			}
 			issuerSpec = issuer.Spec
 		case "ClusterIssuer":
-			var issuer cmapiv1.ClusterIssuer
+			var issuer certmanagerv1.ClusterIssuer
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: externalIssuerRef.Name, Namespace: clusterNamespace}, &issuer)
 			if err != nil {
 				return false, err

--- a/operator/pkg/resources/configmap.go
+++ b/operator/pkg/resources/configmap.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"strconv"
 
-	cmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +29,6 @@ import (
 	"k8s.io/utils/ptr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
@@ -285,7 +284,7 @@ func (r *ConfigMapResource) CreateConfiguration(
 			RequireClientAuth: kl[i].TLS.RequireClientAuth,
 		}
 		if kl[i].TLS.RequireClientAuth {
-			tls.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.KafkaAPI.ClientCAMountDir, cmetav1.TLSCAKey)
+			tls.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.KafkaAPI.ClientCAMountDir, cmmetav1.TLSCAKey)
 		}
 		cr.KafkaAPITLS = append(cr.KafkaAPITLS, tls)
 	}
@@ -305,7 +304,7 @@ func (r *ConfigMapResource) CreateConfiguration(
 			RequireClientAuth: adminAPITLSListener.TLS.RequireClientAuth,
 		}
 		if adminAPITLSListener.TLS.RequireClientAuth {
-			adminTLS.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.AdminAPI.ClientCAMountDir, cmetav1.TLSCAKey)
+			adminTLS.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.AdminAPI.ClientCAMountDir, cmmetav1.TLSCAKey)
 		}
 		cr.AdminAPITLS = append(cr.AdminAPITLS, adminTLS)
 	}
@@ -622,7 +621,7 @@ func (r *ConfigMapResource) preparePandaproxyTLS(
 			RequireClientAuth: tlsListener.TLS.RequireClientAuth,
 		}
 		if tlsListener.TLS.RequireClientAuth {
-			tls.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.PandaProxyAPI.ClientCAMountDir, cmetav1.TLSCAKey)
+			tls.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.PandaProxyAPI.ClientCAMountDir, cmmetav1.TLSCAKey)
 		}
 		cfgRpk.Pandaproxy.PandaproxyAPITLS = []config.ServerTLS{tls}
 	}
@@ -643,7 +642,7 @@ func (r *ConfigMapResource) prepareSchemaRegistryTLS(
 			RequireClientAuth: r.pandaCluster.Spec.Configuration.SchemaRegistry.TLS.RequireClientAuth,
 		}
 		if r.pandaCluster.Spec.Configuration.SchemaRegistry.TLS.RequireClientAuth {
-			tls.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.SchemaRegistryAPI.ClientCAMountDir, cmetav1.TLSCAKey)
+			tls.TruststoreFile = fmt.Sprintf("%s/%s", mountPoints.SchemaRegistryAPI.ClientCAMountDir, cmmetav1.TLSCAKey)
 		}
 		cfgRpk.SchemaRegistry.SchemaRegistryAPITLS = []config.ServerTLS{tls}
 	}

--- a/operator/pkg/resources/configmap_test.go
+++ b/operator/pkg/resources/configmap_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -27,12 +28,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	resourcetypes "github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
-
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
-
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
+	resourcetypes "github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
 )
 
 func TestEnsureConfigMap(t *testing.T) {

--- a/operator/pkg/resources/configuration/patch.go
+++ b/operator/pkg/resources/configuration/patch.go
@@ -19,9 +19,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"gopkg.in/yaml.v3"
-
 	"github.com/redpanda-data/common-go/rpadmin"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,8 +34,6 @@ import (
 	"k8s.io/utils/ptr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/pkg/resources/statefulset_scale.go
+++ b/operator/pkg/resources/statefulset_scale.go
@@ -28,7 +28,6 @@ import (
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
-
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/patch"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/featuregates"
 )

--- a/operator/pkg/resources/statefulset_update.go
+++ b/operator/pkg/resources/statefulset_update.go
@@ -26,14 +26,13 @@ import (
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/common/expfmt"
+	"github.com/redpanda-data/common-go/rpadmin"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/redpanda-data/common-go/rpadmin"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"

--- a/operator/pkg/resources/statefulset_update_test.go
+++ b/operator/pkg/resources/statefulset_update_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,8 +30,6 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/redpanda-data/common-go/rpadmin"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/pkg/utils/conditions.go
+++ b/operator/pkg/utils/conditions.go
@@ -12,15 +12,15 @@ package utils
 import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // StatusConditionConfigs takes a set of existing conditions and conditions of a
 // desired state and merges them idempotently to create a series of ConditionApplyConfiguration
 // values that can be used in a server-side apply.
-func StatusConditionConfigs(existing []metav1.Condition, generation int64, conditions []metav1.Condition) []*metav1ac.ConditionApplyConfiguration {
+func StatusConditionConfigs(existing []metav1.Condition, generation int64, conditions []metav1.Condition) []*applymetav1.ConditionApplyConfiguration {
 	now := metav1.Now()
-	configurations := []*metav1ac.ConditionApplyConfiguration{}
+	configurations := []*applymetav1.ConditionApplyConfiguration{}
 
 	for _, condition := range conditions {
 		existingCondition := apimeta.FindStatusCondition(existing, condition.Type)
@@ -55,8 +55,8 @@ func StatusConditionConfigs(existing []metav1.Condition, generation int64, condi
 	return configurations
 }
 
-func conditionToConfig(generation int64, now metav1.Time, condition metav1.Condition) *metav1ac.ConditionApplyConfiguration { //nolint:gocritic // passing a Condition without a pointer reference is fine here
-	return metav1ac.Condition().
+func conditionToConfig(generation int64, now metav1.Time, condition metav1.Condition) *applymetav1.ConditionApplyConfiguration { //nolint:gocritic // passing a Condition without a pointer reference is fine here
+	return applymetav1.Condition().
 		WithType(condition.Type).
 		WithStatus(condition.Status).
 		WithReason(condition.Reason).

--- a/pkg/gotohelm/rewrite.go
+++ b/pkg/gotohelm/rewrite.go
@@ -17,7 +17,6 @@ import (
 	"go/types"
 
 	"github.com/cockroachdb/errors"
-
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/packages"
 )


### PR DESCRIPTION
backport of https://github.com/redpanda-data/redpanda-operator/pull/448

This commit drops `goimports` in favor of `gci` as goimports fails to reformat import blocks with extraneous `\n`s.

For example, goimports considers this block valid.

```go
import (
	"net"

	"net/http"
)
```

`gci`, will reformat it to:

```go
import (
	"net"
	"net/http"
)
```

Additionally, this commit updates the `importas` linter with naming requirements for commonly used k8s packages.