### PR TITLE
Add Gene Redpanda to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @RafalKorepta @chrisseto @andrewstucki
+* @RafalKorepta @chrisseto @andrewstucki @gene-redpanda


### PR DESCRIPTION
Any PR that was opened in release branch did not include Gene as reviewer. Now it should be fixed on `main` and `release/v2.3.x`.

(cherry picked from commit d00af754390191d7fbb7dbed5d1dc771822dd377)