### PR TITLE
Remove installation of fluxcd CRD from acceptance test suite setup

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -57,7 +57,6 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 			},
 		}).
 		WithCRDDirectory("../operator/config/crd/bases").
-		WithCRDDirectory("../operator/config/crd/bases/toolkit.fluxcd.io").
 		OnFeature(func(ctx context.Context, t framework.TestingT) {
 			t.Log("Installing Redpanda operator chart")
 			t.InstallLocalHelmChart(ctx, "../charts/operator", helm.InstallOptions{


### PR DESCRIPTION
In the https://github.com/redpanda-data/redpanda-operator/commit/be5d30b8 the fluxcd custom resource definition was removed from the repo. This change removes a step that references removed CRDs.

In the CI the following error is reported:
```
setting up test suite: error: the path "../operator/config/crd/bases/toolkit.fluxcd.io" does not exist
: exit status 1
WARNING: error uninstalling crds: error: the path "../operator/config/crd/bases/toolkit.fluxcd.io" does not exist
: exit status 1
```

Reference
https://github.com/redpanda-data/redpanda-operator/pull/434 https://buildkite.com/redpanda/redpanda-operator/builds/4574#01955bf6-7083-4cd4-8265-405d960391f4/219-603