### PR TITLE
operator: Align redpanda helm chart reference before release

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
 	github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250129114027-a89e202aea86
 	github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250129114027-a89e202aea86
-	github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250228163934-c445c9211ec5
+	github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250207141022-1388ec6c6b63
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250206213012-3bb78bb0f17f
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/scalalang2/golang-fifo v1.0.2

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1103,8 +1103,8 @@ github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-202501291140
 github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250129114027-a89e202aea86/go.mod h1:VTE5b2s0AWj/gJ1ygVXbfMaDKd6mmxiIgbw32hD2w94=
 github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250129114027-a89e202aea86 h1:OIMgob/yXf+LmtfBd4D9URQs3ULGZmjnCLwbTb61kb0=
 github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250129114027-a89e202aea86/go.mod h1:uMzbKxddryc+t69uOI6U7yTaXAVqjEtZ6gGH3sszgIk=
-github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250228163934-c445c9211ec5 h1:UJYhZZ8U9U0M/JGv9+3Cs7nQ9b8TgSxbIk+uGzv08eY=
-github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250228163934-c445c9211ec5/go.mod h1:hqkCJt09li/REYBgJ/O32gBxHTUhAaLqCRoVhj0Er+o=
+github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250207141022-1388ec6c6b63 h1:ANC+jxOUwNNNid1+7ni6SX6UhQlB6TkROIyE3vuXqeM=
+github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250207141022-1388ec6c6b63/go.mod h1:hqkCJt09li/REYBgJ/O32gBxHTUhAaLqCRoVhj0Er+o=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250206213012-3bb78bb0f17f h1:JY/VwWH44/wYDbfalLAQeqY5r1xeh1UXXX+d052T54M=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250206213012-3bb78bb0f17f/go.mod h1:jstEIOVRim07DsGZbS3+ljpk+dziWMd0QFF2g4MPRJI=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=


### PR DESCRIPTION
The go depedency points to redpanda helm chart release 5.9.20

Reference
https://github.com/redpanda-data/redpanda-operator/commit/1388ec6c6b63ea2637b6c34c17d9e2c87d41e624