### PR TITLE
[backport] Fix Redpanda chart default installation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -164,7 +164,7 @@ tasks:
       vars:
         GO_TEST_RUNNER:
           ref: .GO_TEST_RUNNER
-        CLI_ARGS: '{{.CLI_ARGS}} -run "^TestIntegration" -timeout 35m -tags integration'
+        CLI_ARGS: '{{.CLI_ARGS}} -p=1 -run "^TestIntegration" -timeout 35m -tags integration'
 
   test:acceptance:
     desc: "Run all acceptance tests (~90m)"

--- a/charts/redpanda/rbac.go
+++ b/charts/redpanda/rbac.go
@@ -241,10 +241,6 @@ func SidecarControllersClusterRoleBinding(dot *helmette.Dot) *rbacv1.ClusterRole
 func SidecarControllersRole(dot *helmette.Dot) *rbacv1.Role {
 	values := helmette.Unwrap[Values](dot.Values)
 
-	if !values.Statefulset.SideCars.ShouldCreateRBAC() {
-		return nil
-	}
-
 	sidecarControllerName := fmt.Sprintf("%s-sidecar-controllers", Fullname(dot))
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
@@ -259,6 +255,16 @@ func SidecarControllersRole(dot *helmette.Dot) *rbacv1.Role {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
+				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+			},
+			{
+				Verbs:     []string{"create", "patch"},
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+			},
+			{
 				APIGroups: []string{"apps"},
 				Resources: []string{"statefulsets/status"},
 				Verbs:     []string{"patch", "update"},
@@ -271,7 +277,7 @@ func SidecarControllersRole(dot *helmette.Dot) *rbacv1.Role {
 			{
 				APIGroups: []string{"apps"},
 				Resources: []string{"statefulsets"},
-				Verbs:     []string{"get", "patch", "update", "list", "watch"},
+				Verbs:     []string{"get", "list", "patch", "update", "watch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -284,10 +290,6 @@ func SidecarControllersRole(dot *helmette.Dot) *rbacv1.Role {
 
 func SidecarControllersRoleBinding(dot *helmette.Dot) *rbacv1.RoleBinding {
 	values := helmette.Unwrap[Values](dot.Values)
-
-	if !values.Statefulset.SideCars.ShouldCreateRBAC() {
-		return nil
-	}
 
 	sidecarControllerName := fmt.Sprintf("%s-sidecar-controllers", Fullname(dot))
 	return &rbacv1.RoleBinding{

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -217,12 +217,7 @@ func StatefulSetVolumes(dot *helmette.Dot) []corev1.Volume {
 
 	// Volume is used when:
 	// * service account automount is set to false
-	// * one of the below condition:
-	//   * deprecated: sidecars controllers are enabled (decommission, node-watcher) and rbac is enabled
-	//   * rack awareness is enabled
-	//   * either broker decommissioner or pvc unbinder are enabled
-	if !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false) &&
-		(values.Statefulset.SideCars.AdditionalSidecarControllersEnabled() || values.RackAwareness.Enabled) {
+	if !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false) {
 		foundK8STokenVolume := false
 		for _, v := range volumes {
 			if strings.HasPrefix(ServiceAccountVolumeName+"-", v.Name) {
@@ -899,9 +894,7 @@ func statefulSetContainerSidecar(dot *helmette.Dot) *corev1.Container {
 		templateToVolumeMounts(dot, values.Statefulset.SideCars.ConfigWatcher.ExtraVolumeMounts)...,
 	)
 
-	if !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false) &&
-		(values.Statefulset.SideCars.AdditionalSidecarControllersEnabled()) {
-
+	if !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false) {
 		mountName := ServiceAccountVolumeName
 		for _, vol := range StatefulSetVolumes(dot) {
 			if strings.HasPrefix(ServiceAccountVolumeName+"-", vol.Name) {

--- a/charts/redpanda/templates/_rbac.go.tpl
+++ b/charts/redpanda/templates/_rbac.go.tpl
@@ -85,14 +85,9 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- if (not (get (fromJson (include "redpanda.Sidecars.ShouldCreateRBAC" (dict "a" (list $values.statefulset.sideCars) ))) "r")) -}}
-{{- $_is_returning = true -}}
-{{- (dict "r" (coalesce nil)) | toJson -}}
-{{- break -}}
-{{- end -}}
 {{- $sidecarControllerName := (printf "%s-sidecar-controllers" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "rules" (coalesce nil) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "rbac.authorization.k8s.io/v1" "kind" "Role" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" $sidecarControllerName "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "annotations" $values.serviceAccount.annotations )) "rules" (list (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "apps") "resources" (list "statefulsets/status") "verbs" (list "patch" "update") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "") "resources" (list "secrets" "pods") "verbs" (list "get" "list" "watch") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "apps") "resources" (list "statefulsets") "verbs" (list "get" "patch" "update" "list" "watch") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "") "resources" (list "persistentvolumeclaims") "verbs" (list "delete" "get" "list" "patch" "update" "watch") ))) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "rules" (coalesce nil) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "rbac.authorization.k8s.io/v1" "kind" "Role" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" $sidecarControllerName "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "annotations" $values.serviceAccount.annotations )) "rules" (list (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "verbs" (list "create" "delete" "get" "list" "patch" "update" "watch") "apiGroups" (list "coordination.k8s.io") "resources" (list "leases") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "verbs" (list "create" "patch") "apiGroups" (list "") "resources" (list "events") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "apps") "resources" (list "statefulsets/status") "verbs" (list "patch" "update") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "") "resources" (list "secrets" "pods") "verbs" (list "get" "list" "watch") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "apps") "resources" (list "statefulsets") "verbs" (list "get" "list" "patch" "update" "watch") )) (mustMergeOverwrite (dict "verbs" (coalesce nil) ) (dict "apiGroups" (list "") "resources" (list "persistentvolumeclaims") "verbs" (list "delete" "get" "list" "patch" "update" "watch") ))) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -102,11 +97,6 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- if (not (get (fromJson (include "redpanda.Sidecars.ShouldCreateRBAC" (dict "a" (list $values.statefulset.sideCars) ))) "r")) -}}
-{{- $_is_returning = true -}}
-{{- (dict "r" (coalesce nil)) | toJson -}}
-{{- break -}}
-{{- end -}}
 {{- $sidecarControllerName := (printf "%s-sidecar-controllers" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "roleRef" (dict "apiGroup" "" "kind" "" "name" "" ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "rbac.authorization.k8s.io/v1" "kind" "RoleBinding" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" $sidecarControllerName "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "annotations" $values.serviceAccount.annotations )) "roleRef" (mustMergeOverwrite (dict "apiGroup" "" "kind" "" "name" "" ) (dict "apiGroup" "rbac.authorization.k8s.io" "kind" "Role" "name" $sidecarControllerName )) "subjects" (list (mustMergeOverwrite (dict "kind" "" "name" "" ) (dict "kind" "ServiceAccount" "name" (get (fromJson (include "redpanda.ServiceAccountName" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace ))) ))) | toJson -}}

--- a/charts/redpanda/templates/_statefulset.go.tpl
+++ b/charts/redpanda/templates/_statefulset.go.tpl
@@ -101,7 +101,7 @@
 {{- if (ne (toJson $v_6) "null") -}}
 {{- $volumes = (concat (default (list ) $volumes) (list $v_6)) -}}
 {{- end -}}
-{{- if (and (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r")) ((or (get (fromJson (include "redpanda.Sidecars.AdditionalSidecarControllersEnabled" (dict "a" (list $values.statefulset.sideCars) ))) "r") $values.rackAwareness.enabled))) -}}
+{{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r")) -}}
 {{- $foundK8STokenVolume := false -}}
 {{- range $_, $v := $volumes -}}
 {{- if (hasPrefix $v.name (printf "%s%s" "kube-api-access" "-")) -}}
@@ -249,9 +249,9 @@
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $_443_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $dot "set-datadir-ownership") ))) "r") -}}
-{{- $uid := ((index $_443_uid_gid 0) | int64) -}}
-{{- $gid := ((index $_443_uid_gid 1) | int64) -}}
+{{- $_438_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $dot "set-datadir-ownership") ))) "r") -}}
+{{- $uid := ((index $_438_uid_gid 0) | int64) -}}
+{{- $gid := ((index $_438_uid_gid 1) | int64) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict ) ) (dict "name" "set-datadir-ownership" "image" (printf "%s:%s" $values.statefulset.initContainerImage.repository $values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `chown %d:%d -R /var/lib/redpanda/data` $uid $gid)) "volumeMounts" (concat (default (list ) (concat (default (list ) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r")) (default (list ) (get (fromJson (include "redpanda.templateToVolumeMounts" (dict "a" (list $dot $values.statefulset.initContainers.setDataDirOwnership.extraVolumeMounts) ))) "r")))) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" `datadir` "mountPath" `/var/lib/redpanda/data` )))) "resources" $values.statefulset.initContainers.setDataDirOwnership.resources ))) | toJson -}}
 {{- break -}}
@@ -310,9 +310,9 @@
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $_525_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $dot "set-tiered-storage-cache-dir-ownership") ))) "r") -}}
-{{- $uid := ((index $_525_uid_gid 0) | int64) -}}
-{{- $gid := ((index $_525_uid_gid 1) | int64) -}}
+{{- $_520_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $dot "set-tiered-storage-cache-dir-ownership") ))) "r") -}}
+{{- $uid := ((index $_520_uid_gid 0) | int64) -}}
+{{- $gid := ((index $_520_uid_gid 1) | int64) -}}
 {{- $cacheDir := (get (fromJson (include "redpanda.Storage.TieredCacheDirectory" (dict "a" (list $values.storage $dot) ))) "r") -}}
 {{- $mounts := (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r") -}}
 {{- $mounts = (concat (default (list ) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "datadir" "mountPath" "/var/lib/redpanda/data" )))) -}}
@@ -482,7 +482,7 @@
 {{- end -}}
 {{- $volumeMounts := (concat (default (list ) (concat (default (list ) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r")) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "config" "mountPath" "/etc/redpanda" ))))) (default (list ) (get (fromJson (include "redpanda.templateToVolumeMounts" (dict "a" (list $dot $values.statefulset.sideCars.extraVolumeMounts) ))) "r"))) -}}
 {{- $volumeMounts = (concat (default (list ) $volumeMounts) (default (list ) (get (fromJson (include "redpanda.templateToVolumeMounts" (dict "a" (list $dot $values.statefulset.sideCars.configWatcher.extraVolumeMounts) ))) "r"))) -}}
-{{- if (and (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r")) ((get (fromJson (include "redpanda.Sidecars.AdditionalSidecarControllersEnabled" (dict "a" (list $values.statefulset.sideCars) ))) "r"))) -}}
+{{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r")) -}}
 {{- $mountName := "kube-api-access" -}}
 {{- range $_, $vol := (get (fromJson (include "redpanda.StatefulSetVolumes" (dict "a" (list $dot) ))) "r") -}}
 {{- if (hasPrefix $vol.name (printf "%s%s" "kube-api-access" "-")) -}}

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -871,6 +871,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -1004,6 +1007,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -2101,6 +2122,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -2218,6 +2242,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -3185,6 +3227,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -3318,6 +3363,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -4491,6 +4554,9 @@ spec:
           readOnly: true
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -4626,6 +4692,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -5698,6 +5782,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -5849,6 +5936,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -7198,6 +7303,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -8668,6 +8776,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -8809,6 +8920,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -10123,6 +10252,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -10256,6 +10388,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -11527,6 +11677,9 @@ spec:
           name: config
         - mountPath: /fake/lifecycle
           name: test-extra-volume
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -11744,6 +11897,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -12956,6 +13127,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -13089,6 +13263,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -14398,6 +14590,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -14549,6 +14744,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -15778,6 +15991,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -15911,6 +16127,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -17115,6 +17349,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -17248,6 +17485,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -18282,6 +18537,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -18399,6 +18657,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -19433,6 +19709,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -19566,6 +19845,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -21086,6 +21383,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -21219,6 +21519,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -22434,6 +22752,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -22567,6 +22888,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -23779,6 +24118,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -23912,6 +24254,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -25189,6 +25549,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -25337,6 +25700,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -26613,6 +26994,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -26761,6 +27145,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -28035,6 +28437,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -28183,6 +28588,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -29403,6 +29826,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -29551,6 +29977,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -30827,6 +31271,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -30977,6 +31424,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -32270,6 +32735,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -32420,6 +32888,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -33711,6 +34197,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -33861,6 +34350,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -35099,6 +35606,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -35249,6 +35759,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -36541,6 +37069,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -36691,6 +37222,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -37984,6 +38533,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -38134,6 +38686,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -39425,6 +39995,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -39575,6 +40148,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -40813,6 +41404,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -40963,6 +41557,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -42192,6 +42804,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -42325,6 +42940,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -43538,6 +44171,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -43671,6 +44307,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -44883,6 +45537,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -45016,6 +45673,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -46319,6 +46994,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -46452,6 +47130,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -47682,6 +48378,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -47818,6 +48517,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -49306,6 +50023,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -49439,6 +50159,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -50884,6 +51622,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -51060,6 +51801,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -52486,6 +53245,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -52619,6 +53381,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -53831,6 +54611,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -53964,6 +54747,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -55187,6 +55988,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -55321,6 +56125,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -56573,6 +57395,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -56712,6 +57537,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -57952,6 +58795,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -58091,6 +58937,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -59324,6 +60188,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       imagePullSecrets:
       - name: secret-1
       - name: secret-2
@@ -59460,6 +60327,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -60478,6 +61363,9 @@ spec:
           name: redpanda-kafka-internal-0-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -60619,6 +61507,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -61936,6 +62842,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -62069,6 +62978,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -63379,6 +64306,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -63530,6 +64460,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -64816,6 +65764,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -64949,6 +65900,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -66168,6 +67137,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -66301,6 +67273,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -67760,6 +68750,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -67893,6 +68886,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -69156,6 +70167,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -69289,6 +70303,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -70502,6 +71534,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -70635,6 +71670,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -71848,6 +72901,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -71981,6 +73037,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -73290,6 +74364,9 @@ spec:
           name: redpanda-selfsigned-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - args:
         - -c
@@ -73488,6 +74565,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -74853,6 +75948,9 @@ spec:
           name: redpanda-selfsigned-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - args:
         - -c
@@ -75051,6 +76149,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -76326,6 +77442,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -76459,6 +77578,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -77762,6 +78899,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -77913,6 +79053,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -79166,6 +80324,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -79299,6 +80460,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -80565,6 +81744,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -80698,6 +81880,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -81917,6 +83117,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -83295,6 +84498,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -83428,6 +84634,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -84694,6 +85918,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -84827,6 +86054,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -86046,6 +87291,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -87412,6 +88660,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -87545,6 +88796,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -88811,6 +90080,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -88944,6 +90216,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -90163,6 +91453,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -91529,6 +92822,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -91662,6 +92958,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -92928,6 +94242,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -93061,6 +94378,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -94280,6 +95615,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -95647,6 +96985,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -95780,6 +97121,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -97047,6 +98406,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -97180,6 +98542,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -98400,6 +99780,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -99767,6 +101150,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -99900,6 +101286,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -101167,6 +102571,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -101300,6 +102707,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -102520,6 +103945,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -103886,6 +105314,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -104019,6 +105450,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -105043,6 +106492,9 @@ spec:
           name: redpanda-for-internal-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -105176,6 +106628,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -106486,6 +107956,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -106619,6 +108092,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -108134,6 +109625,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -108285,6 +109779,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -109728,6 +111240,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -109861,6 +111376,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -114429,6 +115962,9 @@ spec:
           name: config
         - mountPath: /fake/config-watcher
           name: test-extra-volume
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -114628,6 +116164,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -115930,6 +117484,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -116063,6 +117620,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -117369,6 +118944,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -117502,6 +119080,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -118848,6 +120444,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -119015,6 +120614,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -120246,6 +121863,9 @@ spec:
           name: redpanda-kafka-internal-0-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -120387,6 +122007,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -121727,6 +123365,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -121860,6 +123501,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -123072,6 +124731,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -123205,6 +124867,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -124433,6 +126113,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -124566,6 +126249,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -126143,6 +127844,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -126318,6 +128022,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -127742,6 +129464,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -127875,6 +129600,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -129141,6 +130884,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -129274,6 +131020,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -130493,6 +132257,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -131860,6 +133627,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -131993,6 +133763,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -133260,6 +135048,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -133393,6 +135184,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -134613,6 +136422,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -135996,6 +137808,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -136129,6 +137944,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
@@ -137370,6 +139203,9 @@ spec:
           name: redpanda-external-cert
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       initContainers:
       - command:
         - /bin/bash
@@ -137503,6 +139339,24 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -1116,7 +1116,7 @@ func (s *RedpandaControllerSuite) hasChartReplaceDirectives() bool {
 
 	// Very very course check to see if there's a replace directive for a chart to the local version.
 	// NOTE: This (probably) won't handle go.work correctly.
-	matched, err := regexp.Match(`github.com/redpanda-data/redpanda-operator/charts/.+ => \.\.`, out)
+	matched, err := regexp.Match(`^\s*github.com/redpanda-data/redpanda-operator/charts/.+ => \.\.`, out)
 	s.NoError(err)
 
 	return matched

--- a/operator/internal/decommissioning/statefulset_decommissioner_test.go
+++ b/operator/internal/decommissioning/statefulset_decommissioner_test.go
@@ -63,6 +63,7 @@ type StatefulSetDecommissionerSuite struct {
 var _ suite.SetupAllSuite = (*StatefulSetDecommissionerSuite)(nil)
 
 func (s *StatefulSetDecommissionerSuite) TestDecommission() {
+	s.T().Skip("we currently have issues with the eviction code in this test due to pod disruption budgets")
 	chart := s.installChart("basic", "", map[string]any{
 		"statefulset": map[string]any{
 			"replicas": 5,

--- a/operator/internal/probes/broker_test.go
+++ b/operator/internal/probes/broker_test.go
@@ -64,6 +64,7 @@ type ProberSuite struct {
 var _ suite.SetupAllSuite = (*ProberSuite)(nil)
 
 func (s *ProberSuite) TestProbes() {
+	s.T().Skip("Redpanda now does not allow decommissioning that mimic under-replicated partition")
 	chart := s.installChart("default", "")
 	adminClient := s.adminClientFor(chart)
 	defer adminClient.Close()

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -364,7 +364,7 @@ func TestIntegrationClientFactoryTLSListeners(t *testing.T) {
 	testutil.SkipIfNotIntegration(t)
 
 	ctx := context.Background()
-	cluster, err := k3d.NewCluster(t.Name(), k3d.WithAgents(1))
+	cluster, err := k3d.NewCluster("client-tls-listeners", k3d.WithAgents(1))
 	require.NoError(t, err)
 	t.Logf("created cluster %T %q", cluster, cluster.Name)
 


### PR DESCRIPTION
#### https://github.com/redpanda-data/redpanda-operator/commit/e8e6e4189562d565087a7c5c96902d95c6a90cc3

charts/redpanda: Always mount service account token to sidecar container

The following error was logged by sidecar as token was never mounted
```
{"level":"error","ts":"2025-03-04T13:08:05.597Z","logger":"controller-runtime.client.config","msg":"unable to load in-cluster config","error":"open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"}
{"level":"error","ts":"2025-03-04T13:08:05.597Z","logger":"controller-runtime.client.config","msg":"unable to get kubeconfig","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
```

The PVCUnbinder and broker dommissioner is not enabled by default, that's why
service account token is not mounted.

#### https://github.com/redpanda-data/redpanda-operator/commit/ecbbd22226e2817ac27714a1f4b1267c2fce2173

charts/redpanda: Always create Role for sidecar container

The following error was logged by sidecar as service account did not have enough
permission:
```
{"level":"info","ts":"2025-03-04T13:46:11.329Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2025-03-04T13:46:11.329Z","msg":"starting server","name":"pprof","addr":"[::]:8092"}
{"level":"info","ts":"2025-03-04T13:46:11.329Z","msg":"starting server","name":"health probe","addr":"[::]:8091"}
{"level":"info","ts":"2025-03-04T13:46:11.329Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8090","secure":false}
{"level":"info","ts":"2025-03-04T13:46:11.329Z","logger":"ProbeServer","msg":"running health probe server","address":":8093"}
I0304 13:46:11.329816       1 leaderelection.go:250] attempting to acquire leader lease test-62qxx/redpanda-1741095953.test-62qxx.redpanda...
E0304 13:46:11.379230       1 leaderelection.go:347] error retrieving resource lock test-62qxx/redpanda-1741095953.test-62qxx.redpanda: leases.coordination.k8s.io "redpanda-1741095953.test-62qxx.redpanda" is forbidden: User "system:serviceaccount:test-62qxx:default" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "test-62qxx"
```

and
```
{"level":"info","ts":"2025-03-04T14:10:58.836Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2025-03-04T14:10:58.836Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8090","secure":false}
{"level":"info","ts":"2025-03-04T14:10:58.836Z","msg":"starting server","name":"pprof","addr":"[::]:8092"}
{"level":"info","ts":"2025-03-04T14:10:58.836Z","logger":"ProbeServer","msg":"running health probe server","address":":8093"}
{"level":"info","ts":"2025-03-04T14:10:58.836Z","msg":"starting server","name":"health probe","addr":"[::]:8091"}
I0304 14:10:58.836342       1 leaderelection.go:250] attempting to acquire leader lease test-62qxx/redpanda-1741097440.test-62qxx.redpanda...
I0304 14:10:58.884961       1 leaderelection.go:260] successfully acquired lease test-62qxx/redpanda-1741097440.test-62qxx.redpanda
E0304 14:10:58.898064       1 event.go:359] "Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:test-62qxx:default\" cannot create resource \"events\" in API group \"\" in the namespace \"test-62qxx\"" event="&Event{ObjectMeta:{redpanda-1741097440.test-62qxx.redpanda.18299eea042b736a  test-62qxx    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Lease,Namespace:test-62qxx,Name:redpanda-1741097440.test-62qxx.redpanda,UID:def89912-1e62-4d6f-9eda-0b0b756913f1,APIVersion:coordination.k8s.io/v1,ResourceVersion:10162,FieldPath:,},Reason:LeaderElection,Message:redpanda-1741097440-0_714e6270-47a1-4bdf-85f6-855eeb468578 became leader,Source:EventSource{Component:redpanda-1741097440-0_714e6270-47a1-4bdf-85f6-855eeb468578,Host:,},FirstTimestamp:2025-03-04 14:10:58.88489969 +0000 UTC m=+0.138453377,LastTimestamp:2025-03-04 14:10:58.88489969 +0000 UTC m=+0.138453377,Count:1,Type:Normal,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:redpanda-1741097440-0_714e6270-47a1-4bdf-85f6-855eeb468578,ReportingInstance:,}"
```

Our sidecar uses controller-runtime to corrdinate each instance, so the leases
and events permission needs to be added to service account.

#### https://github.com/redpanda-data/redpanda-operator/commit/e3a00ea54c3fd6605bd15a395a0c4d2b04e73e70

operator: Skip TestProbes test as Redpanda changed decommission condition

Apparently Decommission process now can not finished as 3 node cluster with
topic that have replica factor of 3 will block decommission process.

#### https://github.com/redpanda-data/redpanda-operator/pull/479/commits/275caf899387114201bae6e0124d6c2150eed401

operator: fix integration test k3d cluster name error

At some point the TLS listener client test started failing when booting
up a k3d cluster due to name length requirements. This adds an explicitly
named k3d cluster rather than generating it based off of the test name
so that the name of the cluster is capped in length.