### PR TITLE
ci: Allow scheduling test run from buildkite UI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,11 +32,11 @@ steps:
       queue: pipeline-uploader
     # Run for:
     # - all pull requests that aren't from forks
-    # - nightly test schedule
+    # - nightly test schedule or nightly triggered from buildkite ui
     # - changes to main or release/* branches (webhooks are from github)
     if: |
       (build.pull_request.id != null && !build.pull_request.repository.fork) ||
-      (build.source == "schedule" && build.env("K8S_NIGHTLY") == "1") ||
+      ((build.source == "schedule" || build.source == "ui") && build.env("K8S_NIGHTLY") == "1") ||
       ((build.branch == "main" || build.branch =~ /^release\//) && build.source == "webhook")
     command: buildkite-agent pipeline upload .buildkite/testsuite.yml
 


### PR DESCRIPTION
The BUILDKITE_SOURCE is set to `ui` when someone click in the buildkite webpage `Run Now`. To allow engineers schedule ad-hoc runs the check is extended to allow `ui` source.

Example noop build triggered from buildkite webpage (`Run Now`) https://buildkite.com/redpanda/redpanda-operator/builds/4619#019560f0-b162-40d7-bb6e-cd1e674e6c7c

(cherry picked from commit f745a08e014f60ecba4dca5f091fa1079012d70d)