### PR TITLE
operator: Reset resource version to empty string

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -779,6 +779,7 @@ func (s *RedpandaControllerSuite) applyAndWaitFor(cond func(client.Object, error
 		s.NoError(err)
 
 		obj.SetManagedFields(nil)
+		obj.SetResourceVersion("")
 		obj.GetObjectKind().SetGroupVersionKind(gvk)
 
 		s.Require().NoError(s.client.Patch(s.ctx, obj, client.Apply, client.ForceOwnership, client.FieldOwner("tests")))


### PR DESCRIPTION
The following error show up in few of our CI run
```
        	Error Trace:	/work/operator/internal/controller/redpanda/redpanda_controller_test.go:784
        	            				/work/operator/internal/controller/redpanda/redpanda_controller_test.go:754
        	            				/work/operator/internal/controller/redpanda/redpanda_controller_test.go:133
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on redpandas.cluster.redpanda.com "rp-99llrr": the object has been modified; please apply your changes to the latest version and try again
```

https://buildkite.com/redpanda/redpanda-operator/builds/4673#01956b05-b782-4cdd-8c15-95b5f1405448/219-689