### PR TITLE
[release/v2.3.x] charts/redpadna: Align go module path to include v5 version of the helm chart

### DIFF
--- a/charts/redpanda/chart_template_test.go
+++ b/charts/redpanda/chart_template_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/yaml"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -39,7 +39,7 @@ import (
 
 	"github.com/redpanda-data/redpanda-operator/charts/connectors"
 	"github.com/redpanda-data/redpanda-operator/charts/console"
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm/helmtest"

--- a/charts/redpanda/client/client.go
+++ b/charts/redpanda/client/client.go
@@ -29,7 +29,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 )
 

--- a/charts/redpanda/client/client_test.go
+++ b/charts/redpanda/client/client_test.go
@@ -17,7 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 )
 

--- a/charts/redpanda/client_test.go
+++ b/charts/redpanda/client_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"sigs.k8s.io/yaml"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,4 +1,4 @@
-module github.com/redpanda-data/redpanda-operator/charts/redpanda
+module github.com/redpanda-data/redpanda-operator/charts/redpanda/v5
 
 go 1.23.2
 

--- a/charts/redpanda/helpers_test.go
+++ b/charts/redpanda/helpers_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/utils/ptr"
 	"pgregory.net/rapid"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/pkg/rapidutil"
 )
 

--- a/charts/redpanda/values_partial_test.go
+++ b/charts/redpanda/values_partial_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 )
 
 // TestPartialValuesRoundTrip asserts that any .yaml file in ./ci/ can be round


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [charts/redpadna: Align go module path to include v5 version of the helm chart](https://github.com/redpanda-data/redpanda-operator/pull/498)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)