### PR TITLE
gotohelm: use `rest.Config` to support custom dialers

### DIFF
--- a/pkg/gotohelm/helmette/helm.go
+++ b/pkg/gotohelm/helmette/helm.go
@@ -35,12 +35,11 @@ type Dot struct {
 	// Capabilities
 
 	// KubeConfig is a hacked in value to allow `Lookup` to not rely on global
-	// values. It's a kube.Config to support JSON marshalling and allow easy
-	// transport into the `go run` test runner.
+	// values.
 	// It is a pointer to explicitly allow null values, similar to how `helm
 	// template` provides a mock Kubernetes client.
 	// WARNING: DO NOT USE OR REFERENCE IN HELM CHARTS. IT WILL NOT WORK.
-	KubeConfig *kube.Config
+	KubeConfig *kube.RESTConfig
 
 	// Templates, similar to KubeConfig, is a hacked in value to support `tpl`.
 	// It is an FS containing the contents of the charts template/ directory.
@@ -186,7 +185,7 @@ func SafeLookup[T any, PT kube.AddrofObject[T]](dot *Dot, namespace, name string
 		return nil, false, nil
 	}
 
-	ctl, err := kube.FromConfig(*dot.KubeConfig)
+	ctl, err := kube.FromRESTConfig(dot.KubeConfig)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/gotohelm/testdata/src/example/main.go
+++ b/pkg/gotohelm/testdata/src/example/main.go
@@ -31,9 +31,20 @@ import (
 	"example.com/example/typing"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 
 func main() {
+	// Attempt to load a Kubernetes client config from KUBECONFIG. We ignore
+	// any errors as failures will surface in a different way and doing so
+	// preserves the ability to run this binary directly for debugging
+	// purposes.
+	var kubeConfig *kube.RESTConfig
+	ctl, err := kube.FromEnv()
+	if err == nil {
+		kubeConfig = ctl.RestConfig()
+	}
+
 	enc := json.NewEncoder(os.Stdout)
 	dec := json.NewDecoder(os.Stdin)
 
@@ -49,6 +60,9 @@ func main() {
 		// HACK: Inject an FS into .Templates to test `tpl`. This is done
 		// "lazily" so this FS always contains freshly transpiled templates.
 		dot.Templates = os.DirFS("./" + dot.Chart.Name)
+
+		// HACK: Inject the kube rest client we've picked up from KUBECONFIG.
+		dot.KubeConfig = kubeConfig
 
 		out, err := runChart(&dot)
 


### PR DESCRIPTION
Prior to this commit, gotohelm's Dot type contained a KUBECONFIG style struct as this allowed easy serialization for testing.

Doing so prevents gotohelm's GoCharts from respecting customizations, such as Dialers, when connecting to the Kube API Server.

This commit swaps the type to a `rest.Config` to allow such customizations and updates the gorunner in tests to load a kubeconfig from an environment variable as a workound for the lack of serialization support.