### PR TITLE
[release/v2.3.x] Add backport action (#495)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,4 +1,6 @@
 {
+  "fork": false,
+  "autoMerge": true,
   "repoOwner": "redpanda-data",
   "repoName": "redpanda-operator",
   "targetBranchChoices": ["release/v2.3.x"],

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,7 @@
+labels:
+  "backport":
+    color: "ededed"
+  "no-changelog":
+    color: "8f1402"
+  "v2.3.9":
+    color: "ededed"

--- a/.github/workflows/auto-approve-backport.yml
+++ b/.github/workflows/auto-approve-backport.yml
@@ -1,0 +1,16 @@
+name: Auto-Approve Backport
+
+on:
+  pull_request_target:
+    branches-ignore:
+      - main
+
+jobs:
+  approve:
+    name: Auto-approve backport
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'backport/') && (github.actor == 'vbotbuildovich')
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,25 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.5.1
+        with:
+          # TODO: exchange this token with a PAT of a user like our build bot
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+        
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: ["labeled", "unlabeled", "opened", "synchronize"]
+    branches:
+      # only check for changelog entries going into main 
+      - main
+
+jobs:
+  changed_files:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    runs-on: ubuntu-latest
+    name: Check for changelog entry
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get all changed changelog files
+        id: changed-changelog-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            .changes/unreleased/**.yaml
+
+      - name: Pass
+        if: steps.changed-changelog-files.outputs.any_changed == 'true'
+        run: |
+          echo "Found changelog entry"
+
+      - name: Fail
+        if: steps.changed-changelog-files.outputs.any_changed != 'true'
+        run: |
+          echo "No changelog entry detected." && exit 1

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,23 @@
+name: Manage Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+  workflow_dispatch:
+
+concurrency: manage-labels
+
+jobs:
+  manage-labels:
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oliversalzburg/action-label-manager@v0.0.9
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [Add backport action (#495)](https://github.com/redpanda-data/redpanda-operator/pull/495)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)