### PR TITLE
Add actions for notifying of pending prs, closing stale prs and switch user for auto-backports

### DIFF
--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -1,0 +1,1 @@
+active: ["main", "release/v2.3.x"]

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -3,5 +3,7 @@ labels:
     color: "ededed"
   "no-changelog":
     color: "8f1402"
+  "stale":
+    color: "8f1402"
   "v2.3.9":
     color: "ededed"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.5.1
         with:
-          # TODO: exchange this token with a PAT of a user like our build bot
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ACTIONS_BOT_TOKEN }}
 
       - name: Info log
         if: ${{ success() }}

--- a/.github/workflows/pending-prs.yml
+++ b/.github/workflows/pending-prs.yml
@@ -1,0 +1,26 @@
+name: 'Notify of Pending PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate Pending PRs list
+        id: generate-prs
+        run: |
+          ./.github/workflows/scripts/pending-prs slack redpanda-data/redpanda-operator > payload.json
+          echo "has-prs=$(cat payload.json | wc -l)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Post message to Slack channel
+        uses: slackapi/slack-github-action@v2.0.0
+        if: steps.generate-prs.outputs.has-prs != '0'
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload-file-path: "./payload.json"

--- a/.github/workflows/scripts/pending-prs
+++ b/.github/workflows/scripts/pending-prs
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+export BROWSER=echo
+current_directory=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+format="$1"
+repo="$2"
+branches_file="$current_directory/../../branches.yml"
+
+readarray activeBranches < <(yq e -o=j -I=0 '.active[]' "$branches_file")
+
+get_url() {
+    local repo=$1
+    local branch=$2
+    gh search prs --repo=$repo --state=open --base $branch -w | awk '{print substr($0, 1, length($0)-12)}' 2> /dev/null
+}
+
+terminal_bold() {
+  local text=$1
+  echo "\033[1m$text\033[22m"
+}
+
+markdown_bold() {
+  local text=$1
+  echo "*$text*"
+}
+
+terminal_url() {
+  local url=$1
+  local text=$2
+  echo "\033]8;;$url\033\\\\$text\033]8;;\033\\\\"
+}
+
+markdown_url() {
+  local url=$1
+  local text=$2
+  echo "<$url|$text>"
+}
+
+format_header() {
+    local branch=$1
+    local url=$2
+    local format=$3
+    case $format in
+        terminal)
+            text=$(echo "PRs open for $(terminal_url $url $branch):")
+            echo "$(terminal_bold "$text")"
+            ;;
+        *)
+            text=$(echo "PRs open for $(markdown_url $url $branch):")
+            echo "$(markdown_bold "$text")"
+            ;;
+    esac  
+}
+
+get_and_format_prs() {
+    local repo=$1
+    local branch=$2
+    local format=$3
+    case $format in
+        terminal)
+            gh search prs --repo=$repo --state=open --json url,number,title,updatedAt --template '{{range .}}{{(printf "- %s | Last Updated: %s\\n" (hyperlink .url (printf "#%v: %q" .number .title)) (timeago .updatedAt))}}{{end}}' --base $branch | cat
+            ;;
+        *)
+            gh search prs --repo=$repo --state=open --json url,number,title,updatedAt --template '{{range .}}{{(printf "• <%s|#%v>: %q | *Last Updated: %s*\\n" .url .number .title (timeago .updatedAt))}}{{end}}' --base $branch | cat
+            ;;
+    esac
+}
+
+echo_terminal() {
+    local text=$1
+    echo -e "$text"
+}
+
+echo_json() {
+    local text=$1
+    echo "$text" | jq -Rc '{type: "mrkdwn", text: .}' | awk '{gsub(/\\\\n/, "\\n"); print}'
+}
+
+message=""
+for activeBranch in "${activeBranches[@]}"; do
+    branch=$(echo "$activeBranch" | yq -r)
+    url=$(get_url "$repo" "$branch")
+    header="$(format_header "$branch" "$url" "$format")"
+    prs="$(get_and_format_prs "$repo" "$branch" "$format")"
+    if [ -n "$prs" ]; then
+        message+="$header\n$prs\n"
+    fi
+done
+
+if [ -n "$message" ]; then
+    # chomp off the last two newlines
+    message="${message::-4}"
+
+    case $format in
+        terminal|testing)
+            echo_terminal "$message"
+            ;;
+        *)
+            echo_json "$message"
+            ;;
+    esac
+fi

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,20 @@
+name: 'Close stale PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 5 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          days-before-pr-stale: 5
+          days-before-pr-close: 5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -179,3 +179,9 @@ tasks:
         GO_TEST_RUNNER:
           ref: .GO_TEST_RUNNER
         CLI_ARGS: '{{.CLI_ARGS}} -run "^TestAcceptance" -timeout 35m -tags acceptance'
+
+  pending-prs:
+    desc: "Get all pending PRs for watched branches"
+    silent: true
+    cmds:
+      - ./.github/workflows/scripts/pending-prs terminal redpanda-data/redpanda-operator

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
               pkgs.docker-client
               pkgs.docker-tag-list
               pkgs.gawk # GNU awk, used by some build scripts.
+              pkgs.gh
               pkgs.gnused # Stream Editor, used by some build scripts.
               pkgs.go-licenses
               pkgs.go-task


### PR DESCRIPTION
Title says pretty much what all of this is. The added task has some hackery to print out what essentially gets sent to Slack (when we set up a webhook for it asking infra folks). The bash script to generate it is all pretty gnarly, but figure 🤷 it's probably good enough for now.

### Here's the terminal output (with clickable links!):

<img width="792" alt="Screenshot 2025-03-07 at 4 19 05 PM" src="https://github.com/user-attachments/assets/3b7d9907-f903-48cb-bd5b-84af41a9fff3" />

### Here's what the output looks like in Slack (using my test Slack workspace):

<img width="812" alt="Screenshot 2025-03-07 at 4 21 28 PM" src="https://github.com/user-attachments/assets/595de07b-3288-4515-b127-60c3fbadb2aa" />
