### PR TITLE
Add licenseupdater organization for re-use in OSS licenses

### DIFF
--- a/licenseupdater/config.go
+++ b/licenseupdater/config.go
@@ -23,6 +23,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const defaultOrganization = "Redpanda Data, Inc."
+
 type staticFile struct {
 	Name      string    `yaml:"name"`
 	License   string    `yaml:"license"`
@@ -186,6 +188,7 @@ func (m *match) doMatch(path string) bool {
 
 type config struct {
 	Path             string        `yaml:"path"`
+	Organization     string        `yaml:"organization"`
 	TopLevelLicense  string        `yaml:"top_level_license"`
 	LicenseDirectory string        `yaml:"license_directory"`
 	Licenses         []string      `yaml:"licenses"`
@@ -207,6 +210,13 @@ func loadConfig(path string) (*config, error) {
 
 	if err := c.initializeAndValidate(); err != nil {
 		return nil, err
+	}
+
+	// we just jam the initialization of the template org here
+	// since this is always called
+	licenseTemplateData.Organization = c.Organization
+	if licenseTemplateData.Organization == "" {
+		licenseTemplateData.Organization = defaultOrganization
 	}
 
 	return c, nil

--- a/licenseupdater/config.go
+++ b/licenseupdater/config.go
@@ -214,9 +214,8 @@ func loadConfig(path string) (*config, error) {
 
 	// we just jam the initialization of the template org here
 	// since this is always called
-	licenseTemplateData.Organization = c.Organization
-	if licenseTemplateData.Organization == "" {
-		licenseTemplateData.Organization = defaultOrganization
+	if c.Organization != "" {
+		licenseTemplateData.Organization = c.Organization
 	}
 
 	return c, nil

--- a/licenseupdater/main.go
+++ b/licenseupdater/main.go
@@ -23,7 +23,8 @@ import (
 )
 
 type templateData struct {
-	Year int
+	Organization string
+	Year         int
 }
 
 var (

--- a/licenseupdater/main.go
+++ b/licenseupdater/main.go
@@ -37,7 +37,8 @@ var (
 	licenseTemplates            = map[string]*template.Template{}
 
 	licenseTemplateData = &templateData{
-		Year: time.Now().Year(),
+		Organization: defaultOrganization,
+		Year:         time.Now().Year(),
 	}
 
 	writer *fsWriter

--- a/licenseupdater/main_test.go
+++ b/licenseupdater/main_test.go
@@ -21,7 +21,8 @@ func TestMain(t *testing.T) {
 		differ: diffChecker(),
 	}
 	licenseTemplateData = &templateData{
-		Year: 9999, // pin the year to make sure our tests don't randomly start failing at a year switch
+		Organization: defaultOrganization,
+		Year:         9999, // pin the year to make sure our tests don't randomly start failing at a year switch
 	}
 
 	config := &config{

--- a/licenseupdater/templates/MIT.header.tmpl
+++ b/licenseupdater/templates/MIT.header.tmpl
@@ -1,4 +1,4 @@
-Copyright (c) {{.Year}} Redpanda Data, Inc.
+Copyright (c) {{.Year}} {{.Organization}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/licenseupdater/templates/MIT.md.tmpl
+++ b/licenseupdater/templates/MIT.md.tmpl
@@ -1,4 +1,4 @@
-Copyright (c) {{.Year}} Redpanda Data, Inc.
+Copyright (c) {{.Year}} {{.Organization}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/licenseupdater/templates/MIT.short
+++ b/licenseupdater/templates/MIT.short
@@ -1,2 +1,2 @@
-Copyright (c) Redpanda Data, Inc.
+Copyright (c) {{.Organization}}
 SPDX-License-Identifier: MIT


### PR DESCRIPTION
Just so we can extract this into a more useful standalone at some point.