### PR TITLE
gotohelm: support struct embedding in `helmette.Unwrap`

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/Masterminds/goutils v1.1.1
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/cockroachdb/errors v1.11.3
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/gonvenience/ytbx v1.4.4
 	github.com/homeport/dyff v1.7.1
 	github.com/imdario/mergo v0.3.16
 	github.com/invopop/jsonschema v0.12.0
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.10.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -157,6 +157,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobuffalo/logger v1.0.6 h1:nnZNpxYo0zx+Aj9RfMPBm+x9zAU2OayFh/xrAWi34HU=
 github.com/gobuffalo/logger v1.0.6/go.mod h1:J31TBEHR1QLV2683OXTAItYIg8pv2JMHnF/quuAbMjs=
 github.com/gobuffalo/packd v1.0.1 h1:U2wXfRr4E9DH8IdsDLlRFwTZTK7hLfq9qT/QHXGVe/0=
@@ -314,8 +316,6 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
 github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/pkg/gotohelm/helmette/shims.go
+++ b/pkg/gotohelm/helmette/shims.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,8 +102,10 @@ func Unwrap[T any](from Values) T {
 	// a zero value of the struct?
 	var out T
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "json",
-		Result:  &out,
+		TagName:         "json",
+		Result:          &out,
+		Squash:          true,
+		SquashTagOption: "inline",
 		DecodeHook: mapstructure.DecodeHookFuncType(func(from, to reflect.Type, val interface{}) (interface{}, error) {
 			switch reflect.New(to).Interface().(type) {
 			case *resource.Quantity:

--- a/pkg/gotohelm/testdata/src/example/go.mod
+++ b/pkg/gotohelm/testdata/src/example/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
@@ -46,7 +47,6 @@ require (
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/gotohelm/testdata/src/example/go.sum
+++ b/pkg/gotohelm/testdata/src/example/go.sum
@@ -78,6 +78,8 @@ github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -124,8 +126,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/pkg/gotohelm/testdata/src/example/typing/embedding.go
+++ b/pkg/gotohelm/testdata/src/example/typing/embedding.go
@@ -1,0 +1,58 @@
+package typing
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
+)
+
+type EmbedValues struct {
+	Jack *Dog
+	June *Cat
+}
+
+func embedding(dot *helmette.Dot) []any {
+	values := helmette.Unwrap[EmbedValues](dot.Values)
+
+	// The typings package has a lot of test cases and I won't want
+	// to update all of them. If our inputs aren't present, noop this
+	// test case.
+	if values.June == nil || values.Jack == nil {
+		return nil
+	}
+
+	ashe := &Cat{
+		Pet: Pet{
+			Name: "Ashe",
+		},
+	}
+
+	return []any{
+		ashe.Greet(),
+		ashe.Pet.Greet(),
+
+		values.June.Greet(),
+		values.June.Pet.Greet(),
+
+		values.Jack.Greet(),
+		values.Jack.Pet.Greet(),
+	}
+}
+
+type Pet struct {
+	Name string `json:"name"`
+}
+
+func (p *Pet) Greet() string {
+	return fmt.Sprintf("Hello, %s!", p.Name)
+}
+
+type Cat struct {
+	Pet          `json:",inline"`
+	IsLongHaired bool
+}
+
+type Dog struct {
+	Pet   `json:",inline"`
+	Breed string
+}

--- a/pkg/gotohelm/testdata/src/example/typing/embedding.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/typing/embedding.rewritten.go
@@ -1,0 +1,59 @@
+//go:build rewrites
+package typing
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
+)
+
+type EmbedValues struct {
+	Jack *Dog
+	June *Cat
+}
+
+func embedding(dot *helmette.Dot) []any {
+	values := helmette.Unwrap[EmbedValues](dot.Values)
+
+	// The typings package has a lot of test cases and I won't want
+	// to update all of them. If our inputs aren't present, noop this
+	// test case.
+	if values.June == nil || values.Jack == nil {
+		return nil
+	}
+
+	ashe := &Cat{
+		Pet: Pet{
+			Name: "Ashe",
+		},
+	}
+
+	return []any{
+		ashe.Greet(),
+		ashe.Pet.Greet(),
+
+		values.June.Greet(),
+		values.June.Pet.Greet(),
+
+		values.Jack.Greet(),
+		values.Jack.Pet.Greet(),
+	}
+}
+
+type Pet struct {
+	Name string `json:"name"`
+}
+
+func (p *Pet) Greet() string {
+	return fmt.Sprintf("Hello, %s!", p.Name)
+}
+
+type Cat struct {
+	Pet          `json:",inline"`
+	IsLongHaired bool
+}
+
+type Dog struct {
+	Pet   `json:",inline"`
+	Breed string
+}

--- a/pkg/gotohelm/testdata/src/example/typing/embedding.yaml
+++ b/pkg/gotohelm/testdata/src/example/typing/embedding.yaml
@@ -1,0 +1,29 @@
+{{- /* Generated from "embedding.go" */ -}}
+
+{{- define "typing.embedding" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- if (or (eq (toJson $values.June) "null") (eq (toJson $values.Jack) "null")) -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (coalesce nil)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $ashe := (mustMergeOverwrite (dict "IsLongHaired" false "name" "" ) (mustMergeOverwrite (dict "name" "" ) (dict "name" "Ashe" )) (dict )) -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (list (get (fromJson (include "typing.Pet.Greet" (dict "a" (list $ashe) ))) "r") (get (fromJson (include "typing.Pet.Greet" (dict "a" (list $ashe) ))) "r") (get (fromJson (include "typing.Pet.Greet" (dict "a" (list $values.June) ))) "r") (get (fromJson (include "typing.Pet.Greet" (dict "a" (list $values.June) ))) "r") (get (fromJson (include "typing.Pet.Greet" (dict "a" (list $values.Jack) ))) "r") (get (fromJson (include "typing.Pet.Greet" (dict "a" (list $values.Jack) ))) "r"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "typing.Pet.Greet" -}}
+{{- $p := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (printf "Hello, %s!" $p.name)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/typing/typing.go
+++ b/pkg/gotohelm/testdata/src/example/typing/typing.go
@@ -16,9 +16,9 @@ import (
 
 func Typing(dot *helmette.Dot) map[string]any {
 	return map[string]any{
-		"zeros":   zeros(),
-		"numbers": numbers(),
-		// "settingFields":     settingFields(),
+		"zeros":             zeros(),
+		"numbers":           numbers(),
+		"embedding":         embedding(dot),
 		"compileMe":         compileMe(),
 		"typeTesting":       typeTesting(dot),
 		"typeAssertions":    typeSwitching(dot),

--- a/pkg/gotohelm/testdata/src/example/typing/typing.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/typing/typing.rewritten.go
@@ -17,9 +17,9 @@ import (
 
 func Typing(dot *helmette.Dot) map[string]any {
 	return map[string]any{
-		"zeros":   zeros(),
-		"numbers": numbers(),
-		// "settingFields":     settingFields(),
+		"zeros":             zeros(),
+		"numbers":           numbers(),
+		"embedding":         embedding(dot),
 		"compileMe":         compileMe(),
 		"typeTesting":       typeTesting(dot),
 		"typeAssertions":    typeSwitching(dot),

--- a/pkg/gotohelm/testdata/src/example/typing/typing.yaml
+++ b/pkg/gotohelm/testdata/src/example/typing/typing.yaml
@@ -5,7 +5,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (dict "zeros" (get (fromJson (include "typing.zeros" (dict "a" (list ) ))) "r") "numbers" (get (fromJson (include "typing.numbers" (dict "a" (list ) ))) "r") "compileMe" (get (fromJson (include "typing.compileMe" (dict "a" (list ) ))) "r") "typeTesting" (get (fromJson (include "typing.typeTesting" (dict "a" (list $dot) ))) "r") "typeAssertions" (get (fromJson (include "typing.typeSwitching" (dict "a" (list $dot) ))) "r") "typeSwitching" (get (fromJson (include "typing.typeSwitching" (dict "a" (list $dot) ))) "r") "nestedFieldAccess" (get (fromJson (include "typing.nestedFieldAccess" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "zeros" (get (fromJson (include "typing.zeros" (dict "a" (list ) ))) "r") "numbers" (get (fromJson (include "typing.numbers" (dict "a" (list ) ))) "r") "embedding" (get (fromJson (include "typing.embedding" (dict "a" (list $dot) ))) "r") "compileMe" (get (fromJson (include "typing.compileMe" (dict "a" (list ) ))) "r") "typeTesting" (get (fromJson (include "typing.typeTesting" (dict "a" (list $dot) ))) "r") "typeAssertions" (get (fromJson (include "typing.typeSwitching" (dict "a" (list $dot) ))) "r") "typeSwitching" (get (fromJson (include "typing.typeSwitching" (dict "a" (list $dot) ))) "r") "nestedFieldAccess" (get (fromJson (include "typing.nestedFieldAccess" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -143,6 +143,10 @@ var testSpecs = map[string]TestSpec{
 			{"t": float64(1)},
 			{"t": true},
 			{"t": "a string"},
+			{
+				"Jack": map[string]any{"name": "Jack", "Breed": "Mutt"},
+				"June": map[string]any{"name": "June", "IsLongHaired": true},
+			},
 		},
 	},
 }


### PR DESCRIPTION
Prior to this commit, `helmette.Unwrap` would incorrectly handle embedded structs when run from go. Our usage of the `mapstructure` library was not configured to respect struct embeddings and the previously used version wasn't actually able to manage them in a useful way.

This commit updates `mapstructure` to the blessed fork from go-viper and configures it to respect struct embeddings with unofficial `json:",inline"` tag which matches the behavior of gotohelm in helm mode.