### PR TITLE
[release/v2.3.x] workflows: improve changelog GHA error message

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,4 +30,8 @@ jobs:
       - name: Fail
         if: steps.changed-changelog-files.outputs.any_changed != 'true'
         run: |
-          echo "No changelog entry detected." && exit 1
+          echo <<EOF
+          No changelog entry detected.
+          If this PR has user facing changes, ensure that a change log entry as been added via changie. See CONTRIBUTING.md for details.
+          If this PR does not have user facing changes, label the PR with "no-changelog" through GitHub's UI.
+          EOF && exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ Whenever a user facing change is made, a change log entry should be added via `c
 The `changie merge` command will regenerate all CHANGELOG.mds and should be run upon every commit.
 (This is automatically handled by `task generate`).
 
+### CHANGELOG GHA Check
+
+As it's easy to accidentally forget to add changelog entries, a [GitHub Action](.github/workflows/changelog.yml)
+checks that PRs contain a diff to the `.changes/unreleased` directory.
+
+If a PR does not contain any user facing changes, the check can be disabled by
+applying the "no-changelog" label.
+
 ## Releasing
 
 To release any project in this repository:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [workflows: improve changelog GHA error message](https://github.com/redpanda-data/redpanda-operator/pull/515)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)