### PR TITLE
[main] operator: Align Redpanda helm chart go module to match 5.9.21 release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   - gci
   - gocritic
   - gofumpt
+  - gomodguard
   - gosec
   - gosimple
   - govet
@@ -29,6 +30,15 @@ linters-settings:
     skip-generated: true
     no-inline-comments: false
     no-prefix-comments: false
+
+  gomodguard:
+    blocked:
+      modules:
+        - "github.com/redpanda-data/redpanda-operator/charts/redpanda":
+            reason: "The redpanda chart must be imported from a versioned module"
+            recommendations:
+              - github.com/redpanda-data/redpanda-operator/charts/redpanda/v5
+
 
   gosec:
     excludes:

--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 
-	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
@@ -58,7 +58,7 @@ type ChartRef struct {
 	// This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other
 	// ChartRef fields to be ignored.
 	//
-	// Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.20` or the corresponding
+	// Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding
 	// version of the Redpanda chart.
 	//
 	// Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is

--- a/operator/api/redpanda/v1alpha2/redpanda_types_test.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/redpanda-data/redpanda-operator/charts/connectors"
 	"github.com/redpanda-data/redpanda-operator/charts/console"
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
@@ -128,13 +128,14 @@ func TestRedpanda_ValuesJSON(t *testing.T) {
 func TestHelmValuesCompat(t *testing.T) {
 	cfg := rapid.MakeConfig{
 		Types: map[reflect.Type]*rapid.Generator[any]{
-			reflect.TypeFor[intstr.IntOrString](): IntOrString.AsAny(),
-			reflect.TypeFor[*resource.Quantity](): Quantity.AsAny(),
-			reflect.TypeFor[metav1.Duration]():    Duration.AsAny(),
-			reflect.TypeFor[metav1.Time]():        Time.AsAny(),
-			reflect.TypeFor[any]():                rapid.Just[any](nil), // Return nil for all untyped (any, interface{}) fields.
-			reflect.TypeFor[*metav1.FieldsV1]():   rapid.Just[any](nil), // Return nil for K8s accounting fields.
-			reflect.TypeFor[corev1.Probe]():       Probe.AsAny(),        // We use the Probe type to simplify typing but it's serialization isn't fully "partial" which is acceptable.
+			reflect.TypeFor[intstr.IntOrString]():        IntOrString.AsAny(),
+			reflect.TypeFor[*resource.Quantity]():        Quantity.AsAny(),
+			reflect.TypeFor[metav1.Duration]():           Duration.AsAny(),
+			reflect.TypeFor[metav1.Time]():               Time.AsAny(),
+			reflect.TypeFor[any]():                       rapid.Just[any](nil), // Return nil for all untyped (any, interface{}) fields.
+			reflect.TypeFor[*metav1.FieldsV1]():          rapid.Just[any](nil), // Return nil for K8s accounting fields.
+			reflect.TypeFor[corev1.Probe]():              Probe.AsAny(),        // We use the Probe type to simplify typing but it's serialization isn't fully "partial" which is acceptable.
+			reflect.TypeFor[*redpanda.PartialSidecars](): rapid.Just[any](nil), // Intentionally not included in the operator as the operator handles this itself.
 		},
 		Fields: map[reflect.Type]map[string]*rapid.Generator[any]{
 			reflect.TypeFor[redpanda.PartialValues](): {

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -402,7 +402,7 @@ This ties the operator to a specific version of the Go-based Redpanda Helm chart
 ChartRef fields to be ignored. +
 
 
-Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.20` or the corresponding +
+Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding +
 version of the Redpanda chart. +
 
 

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -78,7 +78,7 @@ spec:
                       This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other
                       ChartRef fields to be ignored.
 
-                      Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.20` or the corresponding
+                      Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding
                       version of the Redpanda chart.
 
                       Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is
@@ -20303,7 +20303,7 @@ spec:
                       This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other
                       ChartRef fields to be ignored.
 
-                      Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.20` or the corresponding
+                      Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding
                       version of the Redpanda chart.
 
                       Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
 	github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250129114027-a89e202aea86
 	github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250129114027-a89e202aea86
-	github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-00010101000000-000000000000
+	github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.9.21
 	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250206213012-3bb78bb0f17f
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8
 	github.com/scalalang2/golang-fifo v1.0.2
@@ -301,7 +301,7 @@ replace (
 
 	// Roughly equivalent to redpanda chart version v5.9.19. pkg, connectors, and console are inherited from redpanda.
 	// TODO it may behoove us to split gotohelm into it's own module out of pkg so the operator doesn't have to follow redpanda.
-	github.com/redpanda-data/redpanda-operator/charts/redpanda => github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250207141022-1388ec6c6b63
+	// github.com/redpanda-data/redpanda-operator/charts/redpanda => ../charts/redpanda
 
 	// NB: Due to our older version of sigs.k8s.io/controller-runtime. We have
 	// to pin to otel/sdk and cel-go to 1.28.0 and 0.17.8, respectively.

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -667,8 +667,8 @@ github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-202501291140
 github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250129114027-a89e202aea86/go.mod h1:VTE5b2s0AWj/gJ1ygVXbfMaDKd6mmxiIgbw32hD2w94=
 github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250129114027-a89e202aea86 h1:OIMgob/yXf+LmtfBd4D9URQs3ULGZmjnCLwbTb61kb0=
 github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250129114027-a89e202aea86/go.mod h1:uMzbKxddryc+t69uOI6U7yTaXAVqjEtZ6gGH3sszgIk=
-github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250207141022-1388ec6c6b63 h1:ANC+jxOUwNNNid1+7ni6SX6UhQlB6TkROIyE3vuXqeM=
-github.com/redpanda-data/redpanda-operator/charts/redpanda v0.0.0-20250207141022-1388ec6c6b63/go.mod h1:hqkCJt09li/REYBgJ/O32gBxHTUhAaLqCRoVhj0Er+o=
+github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.9.21 h1:81YaoI/WHrrrdC6+o00O1LQJ5GZZw5Bp+YkOTmBKE6U=
+github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.9.21/go.mod h1:ddEPHeeGL8bgxSVjPsu2djVaM7imOruuAbmIl9CTPh0=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250206213012-3bb78bb0f17f h1:JY/VwWH44/wYDbfalLAQeqY5r1xeh1UXXX+d052T54M=
 github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250206213012-3bb78bb0f17f/go.mod h1:jstEIOVRim07DsGZbS3+ljpk+dziWMd0QFF2g4MPRJI=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20240827155712-244863ea0ae8 h1:uTQKqF8UPNxYxKBJ11VlG6Vt2l9ctkkeXsmmjHUSUG4=

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/yaml"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -37,7 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda"
+	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"

--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"

--- a/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration_drift.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -33,7 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	redpandav1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha1"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"

--- a/operator/pkg/admin/admin.go
+++ b/operator/pkg/admin/admin.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"

--- a/operator/pkg/client/cluster.go
+++ b/operator/pkg/client/cluster.go
@@ -17,7 +17,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"

--- a/operator/pkg/client/spec_tls.go
+++ b/operator/pkg/client/spec_tls.go
@@ -19,7 +19,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
 

--- a/operator/pkg/console/admin.go
+++ b/operator/pkg/console/admin.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"

--- a/operator/pkg/console/sasl.go
+++ b/operator/pkg/console/sasl.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -35,7 +35,7 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"

--- a/operator/pkg/resources/statefulset_update_test.go
+++ b/operator/pkg/resources/statefulset_update_test.go
@@ -31,7 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"

--- a/operator/webhooks/redpanda/validate_enterprise_test.go
+++ b/operator/webhooks/redpanda/validate_enterprise_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	vectorizedcontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/v2.3.x` to `main`:
 - [operator: Align Redpanda helm chart go module to match 5.9.21 release](https://github.com/redpanda-data/redpanda-operator/pull/492)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)