### PR TITLE
formalize new versioning scheme and fix console nightlies

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -3,7 +3,10 @@ unreleasedDir: unreleased
 headerPath: header.tpl.md
 changelogPath: CHANGELOG.md
 versionExt: md
-versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
+# This nasty regex reformats "internal versions" to "external versions" the
+# same way that ./ci/scripts/version.sh does.
+# v$MAJOR.$MINOR.$PATCH-$PREREL+$METADATA -> v$MAJOR.$MINOR-k8s$PATCH-$PREREL+$METADATA
+versionFormat: '## {{regexReplaceAll "^(v\\d+\\.\\d+)\\.(\\d+.*)$" .Version "${1}-k8s${2}"}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '* {{.Body}}'
 body:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,12 +78,15 @@ applying the "no-changelog" label.
 
 To release any project in this repository:
 1. Mint the version and its CHANGELOG.md entry via `changie batch -j <project> <version>`
+    - If minting a pre-release, specify `-k` to keep the unreleased changes in place for the official release.
 2. Run `task test:unit` and `task lint`, they will report additional required actions, if any.
 4. Commit the resultant diff with the commit message `<project>: cut release <version>` and rebase it into master via a Pull Request.
 5. Tag the above commit with as `<project>/v<version>` with `git tag $(changie latest -j <project>) <commit-sha>`.
-    - If the operator is being released, also tag the same commit as `v<version>`.
-6. Push the tag(s).
-7. Create a Github [Release](https://github.com/redpanda-data/redpanda-operator/releases) on the redpanda-operator repo based on the entires in CHANGELOG.md associated with the Operator release tag. 
+6. Push the tags.
+7. Create a [Release on GitHub](https://github.com/redpanda-data/redpanda-operator/releases)
+    - Associate it with the tag pushed in the previous step.
+    - Paste the contents of `.changes/<project>/<version>.md`, excluding the header, into the release notes field.
+    - Use the header of `./changes/<project>/<version>.md` as the release name. e.g. `<project>: v42.8+k8s1`
 
 ## Nightly build
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,13 +37,13 @@ vars:
   # `--always` is a fallback to print out the commit if no tag is found.
   # `sed` is used to trim off the qualifying parts of the tag so we just get the "version".
   OPERATOR_VERSION:
-    sh: git describe --dirty --tags --match 'v*' --match 'operator/v*' | sed 's#^operator/##'
+    sh: '{{.SRC_DIR}}/ci/scripts/version.sh operator'
   OPERATOR_CHART_VERSION:
     # NB: OPERATOR_CHART_VERSION is currently only used for the operator chart's nightly releases.
-    sh: git describe --dirty --tags --match 'charts/operator/v*' --always | sed 's#^charts/operator/##'
+    sh: '{{.SRC_DIR}}/ci/scripts/version.sh charts/operator'
   CONSOLE_CHART_VERSION:
     # NB: CONSOLE_CHART_VERSION is currently only used for the console chart's nightly releases.
-    sh: git describe --dirty --tags --match 'charts/console/v*' --always | sed 's#^charts/console/##'
+    sh: '{{.SRC_DIR}}/ci/scripts/version.sh charts/console -e'
 
 includes:
   build: taskfiles/build.yml

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 version: 0.7.31
 
 # The app version is the version of the Chart application
-appVersion: v3.0.0
+appVersion: v3.0.0-beta.1
 
 kubeVersion: ">= 1.25.0-0"
 

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Console Helm chart.
 ---
 
-![Version: 0.7.31](https://img.shields.io/badge/Version-0.7.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.0](https://img.shields.io/badge/AppVersion-v3.0.0-informational?style=flat-square)
+![Version: 0.7.31](https://img.shields.io/badge/Version-0.7.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.0.0-beta.1](https://img.shields.io/badge/AppVersion-v3.0.0--beta.1-informational?style=flat-square)
 
 This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml).
 Each of the settings is listed and described on this page, along with any default values.

--- a/charts/console/testdata/template-cases.golden.txtar
+++ b/charts/console/testdata/template-cases.golden.txtar
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -62,7 +62,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -77,7 +77,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -102,7 +102,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -135,7 +135,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -198,7 +198,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -233,7 +233,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -258,7 +258,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -272,7 +272,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -324,7 +324,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -349,7 +349,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -382,7 +382,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -445,7 +445,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -499,7 +499,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -513,7 +513,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -550,7 +550,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -623,7 +623,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -686,7 +686,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -715,7 +715,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: HRoLg
   namespace: test-namespace
@@ -756,7 +756,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: hvGoJL
   namespace: test-namespace
@@ -794,7 +794,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: hvGoJL
   namespace: test-namespace
@@ -810,7 +810,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: hvGoJL
   namespace: test-namespace
@@ -837,7 +837,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: hvGoJL
   namespace: test-namespace
@@ -876,7 +876,7 @@ spec:
               key: authentication-jwt-secret
               name: hvGoJL
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1028486626
@@ -946,7 +946,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -971,7 +971,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: T50cZi
   namespace: test-namespace
@@ -985,7 +985,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: T50cZi
   namespace: test-namespace
@@ -1022,7 +1022,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: T50cZi
   namespace: test-namespace
@@ -1037,7 +1037,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: T50cZi
   namespace: test-namespace
@@ -1062,7 +1062,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: T50cZi
   namespace: test-namespace
@@ -1112,7 +1112,7 @@ spec:
               key: authentication-jwt-secret
               name: T50cZi
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: R1Yar8
   namespace: test-namespace
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: xZty
   namespace: test-namespace
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: xZty
   namespace: test-namespace
@@ -1299,7 +1299,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: xZty
   namespace: test-namespace
@@ -1324,7 +1324,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: xZty
   namespace: test-namespace
@@ -1364,7 +1364,7 @@ spec:
           secretRef:
             name: ha
         - prefix: i2E2Jvnc
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1452,7 +1452,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -1480,7 +1480,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 8nE
   namespace: test-namespace
@@ -1494,7 +1494,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 8nE
   namespace: test-namespace
@@ -1528,7 +1528,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 8nE
   namespace: test-namespace
@@ -1553,7 +1553,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 8nE
   namespace: test-namespace
@@ -1590,7 +1590,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -1616,7 +1616,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console-YMl
   namespace: test-namespace
@@ -1631,7 +1631,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console-YMl
   namespace: test-namespace
@@ -1669,7 +1669,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console-YMl
   namespace: test-namespace
@@ -1685,7 +1685,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console-YMl
   namespace: test-namespace
@@ -1711,7 +1711,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console-YMl
   namespace: test-namespace
@@ -1755,7 +1755,7 @@ spec:
               key: authentication-jwt-secret
               name: console-YMl
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1827,7 +1827,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -1852,7 +1852,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: pN
   namespace: test-namespace
@@ -1866,7 +1866,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: pN
   namespace: test-namespace
@@ -1900,7 +1900,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: pN
   namespace: test-namespace
@@ -1925,7 +1925,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: pN
   namespace: test-namespace
@@ -2032,7 +2032,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -2060,7 +2060,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: nd7TSb2mNTS
   namespace: test-namespace
@@ -2074,7 +2074,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: rzd
   namespace: test-namespace
@@ -2111,7 +2111,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: rzd
   namespace: test-namespace
@@ -2126,7 +2126,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: rzd
   namespace: test-namespace
@@ -2151,7 +2151,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: rzd
   namespace: test-namespace
@@ -2284,7 +2284,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HWL
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.31
@@ -2300,7 +2300,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HWL
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.31
@@ -2339,7 +2339,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HWL
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.31
@@ -2356,7 +2356,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HWL
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.31
@@ -2383,7 +2383,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HWL
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.31
@@ -2440,7 +2440,7 @@ spec:
         - configMapRef:
             name: 4xZZ
           prefix: Djbp99U
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1105213631
@@ -2518,7 +2518,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HWL
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.31
@@ -2545,7 +2545,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: YcV5zP8
   namespace: test-namespace
@@ -2563,7 +2563,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GbgHqD
   namespace: test-namespace
@@ -2578,7 +2578,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GbgHqD
   namespace: test-namespace
@@ -2604,7 +2604,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GbgHqD
   namespace: test-namespace
@@ -2636,7 +2636,7 @@ spec:
         command: null
         env: []
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1421249778
@@ -2726,7 +2726,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -2751,7 +2751,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: l1Bnpx
   namespace: test-namespace
@@ -2765,7 +2765,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: l1Bnpx
   namespace: test-namespace
@@ -2800,7 +2800,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: l1Bnpx
   namespace: test-namespace
@@ -2825,7 +2825,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: l1Bnpx
   namespace: test-namespace
@@ -2861,7 +2861,7 @@ spec:
               key: authentication-jwt-secret
               name: l1Bnpx
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -1420734522
@@ -2959,7 +2959,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -2988,7 +2988,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: kIzbDF
   namespace: test-namespace
@@ -3003,7 +3003,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: ivK
   namespace: test-namespace
@@ -3028,7 +3028,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: ivK
   namespace: test-namespace
@@ -3262,7 +3262,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -3288,7 +3288,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     v7E: 1g6JB
   name: hbe
@@ -3304,7 +3304,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     v7E: 1g6JB
   name: hbe
@@ -3343,7 +3343,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     v7E: 1g6JB
   name: hbe
@@ -3363,7 +3363,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     v7E: 1g6JB
   name: hbe
@@ -3391,7 +3391,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     v7E: 1g6JB
   name: hbe
@@ -3608,7 +3608,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     v7E: 1g6JB
   annotations:
@@ -3634,7 +3634,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: tmn2Kt
   namespace: test-namespace
@@ -3648,7 +3648,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: tmn2Kt
   namespace: test-namespace
@@ -3685,7 +3685,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: tmn2Kt
   namespace: test-namespace
@@ -3700,7 +3700,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: tmn2Kt
   namespace: test-namespace
@@ -3726,7 +3726,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: tmn2Kt
   namespace: test-namespace
@@ -3765,7 +3765,7 @@ spec:
               name: tmn2Kt
         envFrom:
         - prefix: RyT9JuZ
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 666524470
@@ -3973,7 +3973,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -3998,7 +3998,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: RttlJN
   namespace: test-namespace
@@ -4012,7 +4012,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: RttlJN
   namespace: test-namespace
@@ -4049,7 +4049,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: RttlJN
   namespace: test-namespace
@@ -4064,7 +4064,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: RttlJN
   namespace: test-namespace
@@ -4089,7 +4089,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: RttlJN
   namespace: test-namespace
@@ -4122,7 +4122,7 @@ spec:
               key: authentication-jwt-secret
               name: RttlJN
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -4273,7 +4273,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -4298,7 +4298,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: h6eHrUr
   namespace: test-namespace
@@ -4312,7 +4312,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: htymHJ
   namespace: test-namespace
@@ -4349,7 +4349,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: htymHJ
   namespace: test-namespace
@@ -4364,7 +4364,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: htymHJ
   namespace: test-namespace
@@ -4389,7 +4389,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -4420,7 +4420,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: zmr
   namespace: test-namespace
@@ -4437,7 +4437,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9RweMGWqBs
   namespace: test-namespace
@@ -4477,7 +4477,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9RweMGWqBs
   namespace: test-namespace
@@ -4495,7 +4495,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9RweMGWqBs
   namespace: test-namespace
@@ -4525,7 +4525,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9RweMGWqBs
   namespace: test-namespace
@@ -4772,7 +4772,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9RweMGWqBs
   namespace: test-namespace
@@ -4811,7 +4811,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -4836,7 +4836,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: DdF7ALq
   namespace: test-namespace
@@ -4850,7 +4850,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 6maz
   namespace: test-namespace
@@ -4887,7 +4887,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 6maz
   namespace: test-namespace
@@ -4902,7 +4902,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 6maz
   namespace: test-namespace
@@ -4927,7 +4927,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 6maz
   namespace: test-namespace
@@ -5211,7 +5211,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -5236,7 +5236,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9XG3SZW
   namespace: test-namespace
@@ -5250,7 +5250,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9XG3SZW
   namespace: test-namespace
@@ -5287,7 +5287,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9XG3SZW
   namespace: test-namespace
@@ -5302,7 +5302,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9XG3SZW
   namespace: test-namespace
@@ -5330,7 +5330,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9XG3SZW
   namespace: test-namespace
@@ -5751,7 +5751,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: uAvlOXf
   namespace: test-namespace
@@ -5765,7 +5765,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: ExFU3
   namespace: test-namespace
@@ -5799,7 +5799,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: ExFU3
   namespace: test-namespace
@@ -5825,7 +5825,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: ExFU3
   namespace: test-namespace
@@ -6107,7 +6107,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -6134,7 +6134,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: NZ7h9
   namespace: test-namespace
@@ -6148,7 +6148,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: NZ7h9
   namespace: test-namespace
@@ -6185,7 +6185,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: NZ7h9
   namespace: test-namespace
@@ -6200,7 +6200,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: NZ7h9
   namespace: test-namespace
@@ -6227,7 +6227,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: NZ7h9
   namespace: test-namespace
@@ -6370,7 +6370,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -6398,7 +6398,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: HMpc
   namespace: test-namespace
@@ -6412,7 +6412,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Om7
   namespace: test-namespace
@@ -6449,7 +6449,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Om7
   namespace: test-namespace
@@ -6464,7 +6464,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Om7
   namespace: test-namespace
@@ -6492,7 +6492,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Om7
   namespace: test-namespace
@@ -6864,7 +6864,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -6895,7 +6895,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: tW
   namespace: test-namespace
@@ -6911,7 +6911,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: PhRk
   namespace: test-namespace
@@ -6950,7 +6950,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: PhRk
   namespace: test-namespace
@@ -6970,7 +6970,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: PhRk
   namespace: test-namespace
@@ -6996,7 +6996,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: PhRk
   namespace: test-namespace
@@ -7033,7 +7033,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -7058,7 +7058,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GVjeLRc
   namespace: test-namespace
@@ -7072,7 +7072,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GVjeLRc
   namespace: test-namespace
@@ -7109,7 +7109,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GVjeLRc
   namespace: test-namespace
@@ -7124,7 +7124,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GVjeLRc
   namespace: test-namespace
@@ -7150,7 +7150,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: GVjeLRc
   namespace: test-namespace
@@ -7659,7 +7659,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -7688,7 +7688,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Pga
   namespace: test-namespace
@@ -7702,7 +7702,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: fXCb
   namespace: test-namespace
@@ -7739,7 +7739,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: fXCb
   namespace: test-namespace
@@ -7764,7 +7764,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: fXCb
   namespace: test-namespace
@@ -7850,7 +7850,7 @@ spec:
               key: authentication-jwt-secret
               name: fXCb
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2110243128
@@ -8040,7 +8040,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: fXCb
   namespace: test-namespace
@@ -8069,7 +8069,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -8094,7 +8094,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Wpq
   namespace: test-namespace
@@ -8112,7 +8112,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Wpq
   namespace: test-namespace
@@ -8127,7 +8127,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Wpq
   namespace: test-namespace
@@ -8152,7 +8152,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -8179,7 +8179,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: H5TDAALUdD
   namespace: test-namespace
@@ -8194,7 +8194,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Uo
   namespace: test-namespace
@@ -8221,7 +8221,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Uo
   namespace: test-namespace
@@ -8733,7 +8733,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -8766,7 +8766,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     kuKPk7: ""
   name: Utu8ZHG2
@@ -8783,7 +8783,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     kuKPk7: ""
   name: qhaD
@@ -8810,7 +8810,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     kuKPk7: ""
   name: qhaD
@@ -8904,7 +8904,7 @@ spec:
         command: null
         env: []
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1372450161
@@ -9018,7 +9018,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     kuKPk7: ""
   name: qhaD
@@ -9083,7 +9083,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 55C9f3
   namespace: test-namespace
@@ -9103,7 +9103,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 61hunk
   namespace: test-namespace
@@ -9132,7 +9132,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 61hunk
   namespace: test-namespace
@@ -9167,7 +9167,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -9193,7 +9193,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: odFI2M4
   namespace: test-namespace
@@ -9231,7 +9231,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: odFI2M4
   namespace: test-namespace
@@ -9247,7 +9247,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: odFI2M4
   namespace: test-namespace
@@ -9274,7 +9274,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: odFI2M4
   namespace: test-namespace
@@ -9529,7 +9529,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -9556,7 +9556,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     xi7L: ibI45
   name: HK
@@ -9595,7 +9595,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     xi7L: ibI45
   name: HK
@@ -9613,7 +9613,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     xi7L: ibI45
   name: HK
@@ -9643,7 +9643,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     xi7L: ibI45
   name: HK
@@ -10151,7 +10151,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     xi7L: ibI45
   annotations:
@@ -10176,7 +10176,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
@@ -10213,7 +10213,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
@@ -10240,7 +10240,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
@@ -10278,7 +10278,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
@@ -10309,7 +10309,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
@@ -10326,7 +10326,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
@@ -10352,7 +10352,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
@@ -10392,7 +10392,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
@@ -10447,7 +10447,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
@@ -10482,7 +10482,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wB
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     e3Cx: MIAO
     helm.sh/chart: console-0.7.31
   name: llK4G
@@ -10500,7 +10500,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wB
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     e3Cx: MIAO
     helm.sh/chart: console-0.7.31
   name: llK4G
@@ -10529,7 +10529,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wB
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     e3Cx: MIAO
     helm.sh/chart: console-0.7.31
   name: llK4G
@@ -11164,7 +11164,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wB
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     e3Cx: MIAO
     helm.sh/chart: console-0.7.31
   name: llK4G
@@ -11204,7 +11204,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wB
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     e3Cx: MIAO
     helm.sh/chart: console-0.7.31
   name: llK4G
@@ -11246,7 +11246,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wB
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     e3Cx: MIAO
     helm.sh/chart: console-0.7.31
   annotations:
@@ -11274,7 +11274,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bCPeYVWao
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     gZ85uw3T: e
     helm.sh/chart: console-0.7.31
     qO: F4dqLo67vKYZ
@@ -11292,7 +11292,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bCPeYVWao
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     gZ85uw3T: e
     helm.sh/chart: console-0.7.31
     qO: F4dqLo67vKYZ
@@ -11319,7 +11319,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bCPeYVWao
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     gZ85uw3T: e
     helm.sh/chart: console-0.7.31
     qO: F4dqLo67vKYZ
@@ -12316,7 +12316,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     blGSa: Hnim0SflkfpF
     helm.sh/chart: console-0.7.31
   name: QxrM
@@ -12336,7 +12336,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     blGSa: Hnim0SflkfpF
     helm.sh/chart: console-0.7.31
   name: l
@@ -12355,7 +12355,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     blGSa: Hnim0SflkfpF
     helm.sh/chart: console-0.7.31
   name: l
@@ -12382,7 +12382,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     blGSa: Hnim0SflkfpF
     helm.sh/chart: console-0.7.31
   annotations:
@@ -12416,7 +12416,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: HMyYp
   namespace: test-namespace
@@ -12437,7 +12437,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Bv0I
   namespace: test-namespace
@@ -12456,7 +12456,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Bv0I
   namespace: test-namespace
@@ -12484,7 +12484,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Bv0I
   namespace: test-namespace
@@ -13403,7 +13403,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Bv0I
   namespace: test-namespace
@@ -13478,7 +13478,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -13507,7 +13507,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: AumW
   namespace: test-namespace
@@ -13544,7 +13544,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: AumW
   namespace: test-namespace
@@ -13575,7 +13575,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: AumW
   namespace: test-namespace
@@ -14450,7 +14450,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     uEVMkDkYRvnn: zvptNai
   name: ItYso
@@ -14471,7 +14471,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
@@ -14489,7 +14489,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
@@ -14518,7 +14518,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
@@ -14584,7 +14584,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     uEVMkDkYRvnn: zvptNai
   annotations:
@@ -14614,7 +14614,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: fP77cJ3T
   namespace: test-namespace
@@ -14632,7 +14632,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: j1dUk8TGy8Np
   namespace: test-namespace
@@ -14647,7 +14647,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: j1dUk8TGy8Np
   namespace: test-namespace
@@ -14672,7 +14672,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -14702,7 +14702,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 8s2qVhKEW
   namespace: test-namespace
@@ -14720,7 +14720,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: bbshm
   namespace: test-namespace
@@ -14738,7 +14738,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: bbshm
   namespace: test-namespace
@@ -14763,7 +14763,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: bbshm
   namespace: test-namespace
@@ -14802,7 +14802,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: KchYZFsbB3
   namespace: test-namespace
@@ -14819,7 +14819,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: KchYZFsbB3
   namespace: test-namespace
@@ -14846,7 +14846,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: KchYZFsbB3
   namespace: test-namespace
@@ -15885,7 +15885,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -15918,7 +15918,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: 0Z71mJNQUx
@@ -15934,7 +15934,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: Wq
@@ -15973,7 +15973,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: Wq
@@ -15991,7 +15991,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: Wq
@@ -16019,7 +16019,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: Wq
@@ -16556,7 +16556,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: Wq
@@ -16595,7 +16595,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: x
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.31
   name: Wq
@@ -16631,7 +16631,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: eHZ
   namespace: test-namespace
@@ -16648,7 +16648,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: eHZ
   namespace: test-namespace
@@ -16678,7 +16678,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: eHZ
   namespace: test-namespace
@@ -17607,7 +17607,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: eHZ
   namespace: test-namespace
@@ -17644,7 +17644,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -17669,7 +17669,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: Gma
   namespace: test-namespace
@@ -17684,7 +17684,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: y0pa6pm83
   namespace: test-namespace
@@ -17712,7 +17712,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: y0pa6pm83
   namespace: test-namespace
@@ -17756,7 +17756,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: W9k
   namespace: test-namespace
@@ -17775,7 +17775,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: resP
   namespace: test-namespace
@@ -17792,7 +17792,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: resP
   namespace: test-namespace
@@ -17821,7 +17821,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: resP
   namespace: test-namespace
@@ -18474,7 +18474,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -18502,7 +18502,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: nX5G
   namespace: test-namespace
@@ -18517,7 +18517,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9gCm5xz
   namespace: test-namespace
@@ -18552,7 +18552,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9gCm5xz
   namespace: test-namespace
@@ -18577,7 +18577,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9gCm5xz
   namespace: test-namespace
@@ -18613,7 +18613,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 9gCm5xz
   namespace: test-namespace
@@ -18660,7 +18660,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -18687,7 +18687,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     rHtDM6k: ZY6Kw
   name: fB6TF
@@ -18724,7 +18724,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     rHtDM6k: ZY6Kw
   name: fB6TF
@@ -18754,7 +18754,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     rHtDM6k: ZY6Kw
   name: fB6TF
@@ -18797,7 +18797,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: DSw7
   namespace: test-namespace
@@ -18815,7 +18815,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: YUi5JpG
   namespace: test-namespace
@@ -18842,7 +18842,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: YUi5JpG
   namespace: test-namespace
@@ -19470,7 +19470,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: YUi5JpG
   namespace: test-namespace
@@ -19510,7 +19510,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: sKa
   namespace: test-namespace
@@ -19531,7 +19531,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 3um
   namespace: test-namespace
@@ -19551,7 +19551,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 3um
   namespace: test-namespace
@@ -19580,7 +19580,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 3um
   namespace: test-namespace
@@ -20400,7 +20400,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: 3um
   namespace: test-namespace
@@ -20442,7 +20442,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     ztm: qegfb80
   name: z12W
@@ -20459,7 +20459,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     ztm: qegfb80
   name: 0BIfuN
@@ -20499,7 +20499,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     ztm: qegfb80
   name: 0BIfuN
@@ -20528,7 +20528,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     ztm: qegfb80
   name: 0BIfuN
@@ -21286,7 +21286,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     ztm: qegfb80
   name: 0BIfuN
@@ -21324,7 +21324,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
     ztm: qegfb80
   annotations:
@@ -21352,7 +21352,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21366,7 +21366,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21404,7 +21404,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21419,7 +21419,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21444,7 +21444,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21477,7 +21477,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -21541,7 +21541,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -21566,7 +21566,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21580,7 +21580,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21618,7 +21618,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21633,7 +21633,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21658,7 +21658,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21691,7 +21691,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -21755,7 +21755,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -21780,7 +21780,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21794,7 +21794,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21841,7 +21841,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21856,7 +21856,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21881,7 +21881,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -21916,7 +21916,7 @@ spec:
         envFrom:
         - secretRef:
             name: my-client-secret-oidc
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -21986,7 +21986,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -22011,7 +22011,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22025,7 +22025,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22071,7 +22071,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22086,7 +22086,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22111,7 +22111,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22144,7 +22144,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -22208,7 +22208,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -22700,7 +22700,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22714,7 +22714,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22751,7 +22751,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22766,7 +22766,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22791,7 +22791,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22888,7 +22888,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -22913,7 +22913,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22927,7 +22927,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22964,7 +22964,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -22979,7 +22979,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23004,7 +23004,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23037,7 +23037,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -23101,7 +23101,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -23126,7 +23126,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23140,7 +23140,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23177,7 +23177,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23192,7 +23192,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23217,7 +23217,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23250,7 +23250,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -23323,7 +23323,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -23348,7 +23348,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23362,7 +23362,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23399,7 +23399,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23414,7 +23414,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23439,7 +23439,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23472,7 +23472,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -23537,7 +23537,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23569,7 +23569,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -23594,7 +23594,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23608,7 +23608,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23645,7 +23645,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23660,7 +23660,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23685,7 +23685,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23718,7 +23718,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: redpandadata/console:v3.0.0
+        image: redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -23782,7 +23782,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -23807,7 +23807,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23821,7 +23821,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23858,7 +23858,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23873,7 +23873,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23898,7 +23898,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -23931,7 +23931,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -24015,7 +24015,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -24256,7 +24256,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24270,7 +24270,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24307,7 +24307,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24322,7 +24322,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24347,7 +24347,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24380,7 +24380,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -24464,7 +24464,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -24489,7 +24489,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24503,7 +24503,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24540,7 +24540,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24555,7 +24555,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24580,7 +24580,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24613,7 +24613,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -24677,7 +24677,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test
@@ -24702,7 +24702,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24716,7 +24716,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24753,7 +24753,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24769,7 +24769,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24795,7 +24795,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   name: console
   namespace: test-namespace
@@ -24828,7 +24828,7 @@ spec:
               key: authentication-jwt-secret
               name: console
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.0.0
+        image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -24892,7 +24892,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.0.0
+    app.kubernetes.io/version: v3.0.0-beta.1
     helm.sh/chart: console-0.7.31
   annotations:
     "helm.sh/hook": test

--- a/ci/scripts/version.sh
+++ b/ci/scripts/version.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# vi: ft=sh
+#
+# This script is responsible for computing the "External Version" from an
+# internal version determined by the output of `git describe`.
+#
+# "Internal Versions" are minted via git tags and are valid semantic versions
+# prefixed with a go module path. e.g. `charts/redpanda/v0.0.0-prerel+metadata`.
+# This is done to ensure compatibility with tooling that expects semantic
+# versions, like go modules. Trust me, there's hell to pay if we diverge.
+#
+# "External Versions" are computed from a corresponding "Internal Version" and
+# come in the form "v0.0-k8s0-prerel+metadata". They are used as the "Version
+# Stamp" of our released software. e.g. Docker image tags, the output of
+# `--version`, and version in Chart.yaml.
+# They exist to help end users easily identify compatibility of our software
+# and Core redpanda release with as little ambiguity as possible. e.g.
+# v25.1+k8s4 is compatible with v25.1.14.
+#
+# `git describe --dirty` can generate 1 of 4 outputs:
+# 1. v0.0.0 - HEAD is tagged as v0.0.0 and no changes are in the index.
+# 2. v0.0.0-dirty - HEAD is tagged as v0.0.0 and there are changes in the index.
+# 3. v0.0.0-<N>-g<commit> - HEAD is at <commit> which is N commits away from v0.0.0; no changes in index.
+# 4. v0.0.0-<N>-g<commit>-dirty - HEAD is at <commit> which is N commits away from v0.0.0; changes in index.
+# `--tags` is required to match tags with `/`'s in them which we have due to go modules' tagging conventions.
+# `--match` is used to target tags that apply to a specific module.
+# `--always` is a fallback to print out the commit if no tag is found.
+#
+# All describe outputs have a corresponding "External Version":
+# 1. v0.0-k8s0 - HEAD is tagged as v0.0.0 and no changes are in the index.
+# 2. v0.0-k8s0-dirty - HEAD is tagged as v0.0.0 and there are changes in the index.
+# 3. v0.0-k8s0-<N>-g<commit> - HEAD is at <commit> which is N commits away from v0.0.0; no changes in index.
+# 4. v0.0-k8s0-<N>-g<commit>-dirty - HEAD is at <commit> which is N commits away from v0.0.0; changes in index.
+
+MODULE=""
+
+# Not all of our versions currently follow the internal vs external versioning scheme.
+# Currently externalizing is opt in.
+# All Post 25.1 versions should be "externalized"
+EXTERNALIZE=false
+
+# --dirty can't be used with a commit-ish in git describe. So rather than
+# defaulting to HEAD, we default to --dirty which then implies HEAD.
+COMMITISH="--dirty"
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		charts/console|charts/redpanda|charts/operator|operator|gotohelm)
+			MODULE="$1"
+			shift 1
+			;;
+		-r|--ref)
+			# For testing purposes, allow passing in a commit.
+			COMMITISH="$2"
+			shift 2
+			;;
+		-d|--debug|-v|--verbose)
+			set -x
+			shift
+			;;
+		-e|--externalize)
+			EXTERNALIZE=true
+			shift
+			;;
+		-*)
+			echo "unhandled argument: $1" 1>&2
+			echo "usage: $0 [-v|--verbose] [-e|--externalize] [-r|--ref <COMMITISH>] <go module>" 1>&2
+			exit 1
+			;;
+		*)
+			echo "unknown module: $1" 1>&2
+			echo "usage: $0 [-v|--verbose] [-e|--externalize] [-r|--ref <COMMITISH>] <go module>" 1>&2
+			exit 1
+			;;
+	esac
+done
+
+# Build a pattern to match git tags against. e.g. charts/redpanda/v*
+PATTERN="$MODULE"'/v*'
+DESC="$(git describe --tags --match "$PATTERN" "$COMMITISH" 2>/dev/null)"
+RES="$?"
+
+# If no such tag is found, git describe will exit non-zero and we'll fallback
+# to --always which will output a commit and a pseudo version of v0.0.0
+if [ $RES -ne 0 ]; then
+	DESC="${MODULE}/v0.0.0-$(git describe --always --tags --match "$PATTERN" "$COMMITISH")"
+fi
+
+# Trim the full description to just the version. charts/redpanda/v1.2.3 -> v1.2.3
+VERSION="${DESC#"$MODULE"/}"
+
+if [[ "$EXTERNALIZE" = false ]]; then
+	echo "$VERSION"
+	exit 0
+fi;
+
+# Extract the patch version, and
+if [[ $DESC =~ (v[0-9]+\.[0-9]+)\.([0-9]+.*)$ ]]; then
+	MAJOR_MINOR="${BASH_REMATCH[1]}"
+	PATCH_ET_AL="${BASH_REMATCH[2]}"
+	echo "${MAJOR_MINOR}-k8s$PATCH_ET_AL"
+else
+	echo "Failed to extract patch version from $DESC" 1>&2
+	exit 1
+fi

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -151,6 +151,7 @@ tasks:
         vars: {REPO: console-unstable, CHART: console, VERSION: "{{ .CONSOLE_CHART_VERSION }}"}
 
   publish:nightly:helm:chart:
+    run: 'always'
     desc: "Packages and pushes a helm chart to redpandadata's dockerhub account as an OCI artifact"
     label: "publish:helm:chart:{{ .CHART }}"
     requires:
@@ -159,6 +160,7 @@ tasks:
       TMP_PATH:
         sh: mktemp --directory --tmpdir "helm-package-XXXXXXXXXX"
     cmds:
+      - 'echo "~~~ :k8s: Building {{ .CHART }} Helm Chart version {{.VERSION}}"'
       - defer: 'rm -r {{.TMP_PATH}}'
       # NB: cp -r/-R is dependent on the implementation (macOS vs Linux).
       # cp -R src/. dest/ <- Same behavior, copy contents of src to dest.
@@ -176,6 +178,7 @@ tasks:
       - helm package {{.TMP_PATH}} --version "{{ .VERSION }}-helm-chart" --destination {{.BUILD_ROOT}} --dependency-update
       - helm registry login registry-1.docker.io -u {{.DOCKERHUB_USER}} --password {{.DOCKERHUB_TOKEN}}
       - defer: 'helm registry logout registry-1.docker.io'
+      - 'echo "~~~ :k8s: Pushing {{ .CHART }} Helm Chart to Dockerhub redpandadata/{{.REPO}}:{{.VERSION}}-helm-chart"'
       # For usage of operator artifact please go to specific reference like the one below
       # https://hub.docker.com/layers/redpandadata/redpanda-operator-nightly/v0.0.0-20250104git4a5a076-helm-chart/images/sha256-ffaea8752b6bd00a26589a168830a87d498106e470f11af0f08267bc13fbd078
       - helm push '{{.BUILD_ROOT}}/{{ .REPO }}-{{.VERSION}}-helm-chart.tgz' oci://registry-1.docker.io/redpandadata


### PR DESCRIPTION
This commit formalizes the new version format of `$MAJOR.$MINOR-k8s$PATCH` for
releases v25.1 and forwards.

Changie has been configured to refer to versions in their semver format but
will replace them with their `-k8s` alternative in the CHANGELOG itself.

Version stamping has been moved to `./ci/script/version.sh` which provides a
variety of options.

```bash
./ci/scripts/version.sh charts/console -e  # v3.0-k8s0-beta.1-1-g760a015f
./ci/scripts/version.sh charts/console     # v3.0.0-beta.1-1-g760a015f
./ci/scripts/version.sh charts/redpanda    # v5.9.20-66-g92c19f4b
./ci/scripts/version.sh charts/redpanda -e # v5.9-k8s20-66-g92c19f4b
```