### PR TITLE
tests: Bump integration timeout to 40 minutes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -164,7 +164,7 @@ tasks:
       vars:
         GO_TEST_RUNNER:
           ref: .GO_TEST_RUNNER
-        CLI_ARGS: '{{.CLI_ARGS}} -p=1 -run "^TestIntegration" -timeout 35m -tags integration'
+        CLI_ARGS: '{{.CLI_ARGS}} -p=1 -run "^TestIntegration" -timeout 40m -tags integration'
 
   test:acceptance:
     desc: "Run all acceptance tests (~90m)"

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -104,7 +104,7 @@ func SkipIfNotIntegration(t *testing.T) {
 	} else if testing.Short() {
 		t.Skipf("-short specified; skipping integration test")
 	} else {
-		RequireTimeout(t, 20*time.Minute)
+		RequireTimeout(t, 40*time.Minute)
 	}
 }
 


### PR DESCRIPTION
Many buildkite run fail at 35 minut mark.
https://buildkite.com/redpanda/redpanda-operator/builds/4912#0195a7c5-98db-45df-91e9-af24acbe124f/219-699
https://buildkite.com/redpanda/redpanda-operator/builds/4910#0195a7b3-500e-4f60-bdf9-e4b487eec329/219-699
https://buildkite.com/redpanda/redpanda-operator/builds/4908#0195a7a0-e709-47d8-9447-eb4e450c28a8/219-699