### PR TITLE
operator: Delete HelmChart custom resource when HelmRelease is suspended

### DIFF
--- a/operator/config/rbac/v2-manager-role/role.yaml
+++ b/operator/config/rbac/v2-manager-role/role.yaml
@@ -189,6 +189,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - helm.toolkit.fluxcd.io
   resources:
   - helmreleases

--- a/operator/internal/controller/redpanda/role.yaml
+++ b/operator/internal/controller/redpanda/role.yaml
@@ -189,6 +189,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - helm.toolkit.fluxcd.io
   resources:
   - helmreleases

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -248,6 +248,7 @@ func (e *Env) shutdown() {
 
 		c := e.client()
 
+		// Namespace deletion proves that there is no resources left after test that has finalizers on them
 		assert.NoError(e.t, c.Delete(ctx, e.namespace, client.PropagationPolicy(metav1.DeletePropagationForeground)))
 
 		// Poll until the namespace is fully deleted.


### PR DESCRIPTION
When Redpanda resource is migrated from using flux to defluxed mode the HelmRelease custom resource is put into suspend mode. That suspend mode can affect deletion process as HelmChart (a child resource that doesn't have ownerReference) is not fully reconciled by helmrelease_controller. Redpanda operator now try to delete HelmChart.

As unrelated problems with RBAC permission in integration test suite arised
RBAC in Redpanda resource is disabled.

Reference
https://github.com/fluxcd/helm-controller/blob/2d335f2aa0e2e0df2a631ebf19394aed07c556f3/internal/reconcile/helmchart_template.go#L163-L166 https://github.com/fluxcd/helm-controller/blob/2d335f2aa0e2e0df2a631ebf19394aed07c556f3/internal/controller/helmrelease_controller.go#L375-L388