### PR TITLE
Fix integration tests suite

### DIFF
--- a/operator/config/rbac/bases/operator/role.yaml
+++ b/operator/config/rbac/bases/operator/role.yaml
@@ -19,6 +19,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - limitranges
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   - secrets
   - serviceaccounts

--- a/operator/config/rbac/v2-manager-role/role.yaml
+++ b/operator/config/rbac/v2-manager-role/role.yaml
@@ -17,6 +17,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - delete

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -140,6 +140,10 @@ type RedpandaReconciler struct {
 // The leases is used by controller-runtime in sidecar. Operator main reconciliation needs to have leases permissions in order to create role that have the same permissions.
 // +kubebuilder:rbac:groups=coordination.k8s.io,namespace=default,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
+// rpk bundle additional rbac permissions
+// When Redpanda chart values has set `rbac.enabled = true`, then operator needs to have elevated permissions to create ClusterRole
+// +kubebuilder:rbac:groups=core,resources=endpoints;events;limitranges;persistentvolumeclaims;pods;pods/log;replicationcontrollers;resourcequotas;serviceaccounts;services,verbs=get;list
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *RedpandaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if err := registerHelmReferencedIndex(ctx, mgr, "statefulset", &appsv1.StatefulSet{}); err != nil {

--- a/operator/internal/controller/redpanda/role.yaml
+++ b/operator/internal/controller/redpanda/role.yaml
@@ -17,6 +17,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - delete


### PR DESCRIPTION
### Based on https://github.com/redpanda-data/redpanda-operator/pull/539

## operator: Include ClusterRole permission for redpanda controller

In the redpanda package the kubebuilder comment does not have all possible
variants of ClusterRole permissions neccessery to handle creation of all
Redpanda helm chart resources. When rpk bundle ClusterRole was included to
the Redpanda helm chart deployment, then the integration test suite failed with
flux reporting the following:
```
creation of clusterroles.rbac.authorization.k8s.io "rp-9gd31r-rpk-bundle" is forbidden:
user "system:serviceaccount:testenv-g5jfk:testenv-pzy3ce"
(groups=["system:serviceaccounts" "system:serviceaccounts:testenv-g5jfk" "system:authenticated"])
is attempting to grant RBAC permissions not currently held:

{APIGroups:[""], Resources:["endpoints"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["events"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["limitranges"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["persistentvolumeclaims"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["pods"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["pods/log"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["replicationcontrollers"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["resourcequotas"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["serviceaccounts"], Verbs:["get" "list"]}
{APIGroups:[""], Resources:["services"], Verbs:["get" "list"]}
```

The setup of integration test suite included only permissions defined in redpanda package.
Kustomize and Operator helm chart includes those missing permissions.

### Reference

https://redpandadata.atlassian.net/browse/K8S-425