### PR TITLE
operator: Include ClusterRole permission for redpanda controller

### DIFF
--- a/operator/config/rbac/v2-manager-role/role.yaml
+++ b/operator/config/rbac/v2-manager-role/role.yaml
@@ -188,6 +188,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - podmonitors

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -97,6 +97,10 @@ type RedpandaReconciler struct {
 // +kubebuilder:rbac:groups=cluster.redpanda.com,resources=redpandas/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,namespace=default,resources=events,verbs=create;patch
 
+// sidecar resources
+// The leases is used by controller-runtime in sidecar. Operator main reconciliation needs to have leases permissions in order to create role that have the same permissions.
+// +kubebuilder:rbac:groups=coordination.k8s.io,namespace=default,resources=leases,verbs=get;list;watch;create;update;patch;delete
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *RedpandaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	if err := registerHelmReferencedIndex(ctx, mgr, "statefulset", &appsv1.StatefulSet{}); err != nil {

--- a/operator/internal/controller/redpanda/role.yaml
+++ b/operator/internal/controller/redpanda/role.yaml
@@ -188,6 +188,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - podmonitors


### PR DESCRIPTION
In the redpanda package the kubebuilder comment does not have all possible variants of ClusterRole permissions neccessery to handle creation of all Redpanda helm chart resources. During integration test suite execution controller runtime complain about leases permissions missing.

```
error: deploying *v1.Role: \"rp-4bpw0i-sidecar-controllers\":
roles.rbac.authorization.k8s.io \"rp-4bpw0i-sidecar-controllers\" is forbidden:
user \"system:serviceaccount:testenv-wm758:testenv-pzy3ce\"
(groups=[\"system:serviceaccounts\" \"system:serviceaccounts:testenv-wm758\" \"system:authenticated\"])
is attempting to grant RBAC permissions not currently held:
{APIGroups:[\"coordination.k8s.io\"], Resources:[\"leases\"], Verbs:[\"create\" \"delete\" \"get\" \"list\" \"patch\" \"update\" \"watch\"]}"
```

The setup of integration test suite included only permissions defined in redpanda package. Kustomize and Operator helm chart includes those missing permissions.

The failure started from https://github.com/redpanda-data/redpanda-operator/pull/521 PR 