### PR TITLE
Remove availableReplicas check for old DecommissionController

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_decommission_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_decommission_controller.go
@@ -315,13 +315,6 @@ func (r *DecommissionReconciler) reconcileDecommission(ctx context.Context, log 
 		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// This helps avoid decommissioning nodes that are starting up where, say, a node has been removed
-	// and you need to move it and start a new one
-	if availableReplicas != 0 {
-		log.Info("have not reached steady state yet, requeue here")
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
-	}
-
 	valuesMap, err := getHelmValues(ctx, r, log, releaseName, namespace, r.OperatorMode)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not retrieve values, probably not a valid managed helm release: %w", err)


### PR DESCRIPTION
So, this was causing our e2e v2 tests to fail the decommissioning test.

The logic basically says, "make sure I have 0 available replicas before attempting a decommission" -- in other words _every broker must be marked as "not ready" for a decommission to happen_ with the old decommission controller. This isn't the way that the new decommissioner works and I'm amenable to plumbing in the new decommissioner sooner than later, but this is to just get our decommissioning tests to pass as this guard should be unnecessary and never will actually happen with the relaxed health checks (i.e. we'll never be in a state where all nodes are marked unhealthy since they tolerate potential `node_down` states). 