### PR TITLE
Explicitly always set mechanism in users.txt

### DIFF
--- a/charts/redpanda/secrets.go
+++ b/charts/redpanda/secrets.go
@@ -172,13 +172,19 @@ func SecretSASLUsers(dot *helmette.Dot) *corev1.Secret {
 			StringData: map[string]string{},
 		}
 		usersTxt := []string{}
+
+		defaultMechanism := DefaultSASLMechanism
+		if values.Auth.SASL.Mechanism != "" {
+			defaultMechanism = values.Auth.SASL.Mechanism
+		}
+
 		// Working around lack of support for += or strings.Join at the moment
 		for _, user := range values.Auth.SASL.Users {
-			if helmette.Empty(user.Mechanism) {
-				usersTxt = append(usersTxt, fmt.Sprintf("%s:%s", user.Name, user.Password))
-			} else {
-				usersTxt = append(usersTxt, fmt.Sprintf("%s:%s:%s", user.Name, user.Password, user.Mechanism))
+			mechanism := defaultMechanism
+			if !helmette.Empty(user.Mechanism) {
+				mechanism = user.Mechanism
 			}
+			usersTxt = append(usersTxt, fmt.Sprintf("%s:%s:%s", user.Name, user.Password, mechanism))
 		}
 		secret.StringData["users.txt"] = helmette.Join("\n", usersTxt)
 		return secret

--- a/charts/redpanda/templates/_secrets.go.tpl
+++ b/charts/redpanda/templates/_secrets.go.tpl
@@ -57,12 +57,16 @@
 {{- if (and (and (ne $values.auth.sasl.secretRef "") $values.auth.sasl.enabled) (gt ((get (fromJson (include "_shims.len" (dict "a" (list $values.auth.sasl.users) ))) "r") | int) (0 | int))) -}}
 {{- $secret := (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Secret" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" $values.auth.sasl.secretRef "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "type" "Opaque" "stringData" (dict ) )) -}}
 {{- $usersTxt := (list ) -}}
-{{- range $_, $user := $values.auth.sasl.users -}}
-{{- if (empty $user.mechanism) -}}
-{{- $usersTxt = (concat (default (list ) $usersTxt) (list (printf "%s:%s" $user.name $user.password))) -}}
-{{- else -}}
-{{- $usersTxt = (concat (default (list ) $usersTxt) (list (printf "%s:%s:%s" $user.name $user.password $user.mechanism))) -}}
+{{- $defaultMechanism := "SCRAM-SHA-512" -}}
+{{- if (ne $values.auth.sasl.mechanism "") -}}
+{{- $defaultMechanism = $values.auth.sasl.mechanism -}}
 {{- end -}}
+{{- range $_, $user := $values.auth.sasl.users -}}
+{{- $mechanism := $defaultMechanism -}}
+{{- if (not (empty $user.mechanism)) -}}
+{{- $mechanism = $user.mechanism -}}
+{{- end -}}
+{{- $usersTxt = (concat (default (list ) $usersTxt) (list (printf "%s:%s:%s" $user.name $user.password $mechanism))) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}
@@ -93,9 +97,9 @@
 {{- break -}}
 {{- end -}}
 {{- $secretName := (printf "%s-bootstrap-user" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) -}}
-{{- $_203_existing_4_ok_5 := (get (fromJson (include "_shims.lookup" (dict "a" (list "v1" "Secret" $dot.Release.Namespace $secretName) ))) "r") -}}
-{{- $existing_4 := (index $_203_existing_4_ok_5 0) -}}
-{{- $ok_5 := (index $_203_existing_4_ok_5 1) -}}
+{{- $_209_existing_4_ok_5 := (get (fromJson (include "_shims.lookup" (dict "a" (list "v1" "Secret" $dot.Release.Namespace $secretName) ))) "r") -}}
+{{- $existing_4 := (index $_209_existing_4_ok_5 0) -}}
+{{- $ok_5 := (index $_209_existing_4_ok_5 1) -}}
 {{- if $ok_5 -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $existing_4) | toJson -}}


### PR DESCRIPTION
So, we're currently having some issues with Console failing to start up by default when a SASL auth mechanism isn't specified by a user. This is because Console uses the default `SCRAM-SHA-512` as an auth mechanism if it's unspecified, whereas the new sidecar container that synchronizes users mistakenly was defaulting to what Redpanda itself defaults to `SCRAM-SHA-256`. You can see that [here](https://github.com/redpanda-data/redpanda-operator/blob/c68d839a3f0c874cb31ea218d7dda59948608bce/charts/redpanda/notes.go#L182) and [here](https://github.com/redpanda-data/redpanda-operator/blob/c68d839a3f0c874cb31ea218d7dda59948608bce/operator/internal/configwatcher/configwatcher.go#L194) where the first function is the helper leveraged by Console [in its defaulting behavior](https://github.com/redpanda-data/redpanda-operator/blob/c68d839a3f0c874cb31ea218d7dda59948608bce/charts/redpanda/console.tpl.go#L61).

What that means, is that if a SASL mechanism isn't explicitly specified for the user, then Console will fail to initialize because it'll use the wrong auth mechanism for connecting to the Kafka API. This fixes that by simply _always_ specifying the auth mechanism for the user so that it's both created properly by the sidecar and leveraged properly by Console. It does that by:

1. defaulting to the constant `DefaultSASLMechanism` (previously defined as `SCRAM-SHA-512`)
2. if `auth.sasl.mechanism` is specified, using that
3. if a mechanism is specified on an individual user, using that