### PR TITLE
[release/v2.3.x] Remove availableReplicas check (#545)

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_decommission_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_decommission_controller.go
@@ -315,13 +315,6 @@ func (r *DecommissionReconciler) reconcileDecommission(ctx context.Context, log 
 		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// This helps avoid decommissioning nodes that are starting up where, say, a node has been removed
-	// and you need to move it and start a new one
-	if availableReplicas != 0 {
-		log.Info("have not reached steady state yet, requeue here")
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
-	}
-
 	valuesMap, err := getHelmValues(ctx, r, log, releaseName, namespace, r.OperatorMode)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not retrieve values, probably not a valid managed helm release: %w", err)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [Remove availableReplicas check (#545)](https://github.com/redpanda-data/redpanda-operator/pull/545)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)