### PR TITLE
Trigger CRD docs automation on new releases rather than pushes to main

### DIFF
--- a/.github/workflows/dispatch-crd-docs.yml
+++ b/.github/workflows/dispatch-crd-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            sdlc/prod/github/actions_bot_token
+            ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
       - name: Trigger generate-crd-docs event
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/dispatch-crd-docs.yml
+++ b/.github/workflows/dispatch-crd-docs.yml
@@ -1,13 +1,12 @@
 ---
 # This workflow triggers the action in redpanda-data/docs that
 # publishes the CRD specifications to the Redpanda documentation.
+# https://github.com/redpanda-data/docs/blob/main/.github/workflows/generate-crd.yml
 
 name: Trigger CRD docs
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'operator/api/**'
+  release:
+    types: [published]
 jobs:
   dispatch:
     runs-on: ubuntu-latest
@@ -22,11 +21,11 @@ jobs:
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            ,sdlc/prod/github/actions_bot_token
+            sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
       - name: Trigger generate-crd-docs event
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/docs
           event-type: generate-crd-docs

--- a/.github/workflows/dispatch-crd-docs.yml
+++ b/.github/workflows/dispatch-crd-docs.yml
@@ -1,9 +1,9 @@
 ---
 # This workflow triggers the action in redpanda-data/docs that
-# publishes the CRD specifications to the Redpanda documentation.
+# publishes the CRD and Helm chart specifications to the Redpanda documentation.
 # https://github.com/redpanda-data/docs/blob/main/.github/workflows/generate-crd.yml
 
-name: Trigger CRD docs
+name: Trigger Kubernetes reference docs
 on:
   release:
     types: [published]
@@ -26,6 +26,6 @@ jobs:
       - name: Trigger generate-crd-docs event
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/docs
           event-type: generate-crd-docs


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/dispatch-crd-docs.yml` file to change the workflow trigger so that docs are updated upon each release.

Changes to workflow trigger:

* Updated the trigger from a push to the main branch to a release event of the type 'published'. This change ensures the workflow runs when a new release is published instead of on every push to the main branch.

Related PR: https://github.com/redpanda-data/docs/pull/1024