### PR TITLE
add `actionlint` to CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Fail
         if: steps.changed-changelog-files.outputs.any_changed != 'true'
         run: |
-          echo <<EOF
+          cat <<EOF
           No changelog entry detected.
           If this PR has user facing changes, ensure that a change log entry as been added via changie. See CONTRIBUTING.md for details.
           If this PR does not have user facing changes, label the PR with "no-changelog" through GitHub's UI.
-          EOF && exit 1
+          EOF
+          exit 1

--- a/.github/workflows/comment_added.yml
+++ b/.github/workflows/comment_added.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install dependencies
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
-        run: pip install -r ${SCRIPT_DIR}/requirements.txt
+        run: pip install -r "${SCRIPT_DIR}"/requirements.txt
       - name: install pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Add comment to JIRA Issue
@@ -40,4 +40,4 @@ jobs:
           ISSUE_URL: ${{ github.event.issue.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_COMMENT: ${{ github.event.comment.body }}
-        run: python ${SCRIPT_DIR}/jira_helper.py UPDATE_COMMENT --verbose -p K8S
+        run: python "${SCRIPT_DIR}"/jira_helper.py UPDATE_COMMENT --verbose -p K8S

--- a/.github/workflows/jira_issue_manage.yml
+++ b/.github/workflows/jira_issue_manage.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install dependencies
         env:
           SCRIPT_DIR: ${{ github.workspace }}/.github/workflows/scripts
-        run: pip install -r ${SCRIPT_DIR}/requirements.txt
+        run: pip install -r "${SCRIPT_DIR}"/requirements.txt
       - name: install pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Manage JIRA Issue
@@ -49,4 +49,4 @@ jobs:
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name) }}
           ISSUE_STATE: ${{ github.event.issue.state }}
           EVENT_NAME: ${{ github.event.action }}
-        run: python ${SCRIPT_DIR}/jira_helper.py ISSUE --verbose -p K8S
+        run: python "${SCRIPT_DIR}"/jira_helper.py ISSUE --verbose -p K8S

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,6 +60,7 @@ tasks:
           var: MOD
         cmd: cd {{.ITEM}} && golangci-lint run --timeout 28m {{.PKG}} {{.CLI_ARGS}}
       - ct lint --chart-dirs ./charts --check-version-increment=false --all
+      - actionlint
 
   lint-fix:
     desc: "equivalent to task lint -- --fix"

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             # If the version of the installed binary is important make sure to
             # update TestToolVersions.
             packages = [
+              pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               pkgs.applyconfiguration-gen
               pkgs.backport
               pkgs.buildkite-agent
@@ -75,7 +76,6 @@
               pkgs.openssl
               pkgs.setup-envtest # Kubernetes provided test utilities
               pkgs.yq-go
-              # pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               # pkgs.gotools
             ] ++ lib.optionals pkgs.stdenv.isLinux [
               pkgs.sysctl # Used to adjust ulimits on linux systems (Namely, CI).


### PR DESCRIPTION
I previously broke the changelog detection script with an incorrectly formatted heredoc. This commit corrects the issue and adds `actionlint` to our CI checks which would have caught this issue ahead of merge.