### PR TITLE
Switch integration, acceptance, and kuttl-v1 CI tests to required

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -91,7 +91,7 @@ steps:
           failed: true
         message: ':cloud: Integration Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: true
+    soft_fail: false
     timeout_in_minutes: 90
   - continue_on_failure: true
     wait: null
@@ -133,7 +133,7 @@ steps:
           failed: true
         message: ':cloud: Acceptance Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: true
+    soft_fail: false
     timeout_in_minutes: 60
   - continue_on_failure: true
     wait: null
@@ -175,7 +175,7 @@ steps:
           failed: true
         message: ':cloud: Kuttl-V1 Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: true
+    soft_fail: false
     timeout_in_minutes: 90
   - continue_on_failure: true
     wait: null

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -36,17 +36,17 @@ var suites = []TestSuite{
 	},
 	{
 		Name:     "integration",
-		Required: false,
+		Required: true,
 		Timeout:  30*time.Minute + time.Hour,
 	},
 	{
 		Name:     "acceptance",
-		Required: false,
+		Required: true,
 		Timeout:  time.Hour,
 	},
 	{
 		Name:         "kuttl-v1",
-		Required:     false,
+		Required:     true,
 		Timeout:      30*time.Minute + time.Hour,
 		JUnitPattern: ptr.To("work/operator/tests/_e2e_artifacts/kuttl-report.xml"),
 	},
@@ -57,7 +57,9 @@ var suites = []TestSuite{
 		JUnitPattern: ptr.To("work/operator/tests/_e2e_with_flags_artifacts/kuttl-report.xml"),
 	},
 	{
-		Name:         "kuttl-v2",
+		Name: "kuttl-v2",
+		// swap this over when https://github.com/redpanda-data/redpanda-operator/pull/546
+		// gets backported, released, and the operator ref to the redpanda chart gets rev'd
 		Required:     false,
 		Timeout:      time.Hour,
 		JUnitPattern: ptr.To("work/operator/tests/_e2e_artifacts_v2/kuttl-report.xml"),


### PR DESCRIPTION
This swaps over most of our tests to be required (other than `kuttl-v2` which has a known issue right now: https://github.com/redpanda-data/redpanda-operator/pull/546)