### PR TITLE
Fix actionlint complaints of `pending-prs.yml`

### DIFF
--- a/.github/workflows/pending-prs.yml
+++ b/.github/workflows/pending-prs.yml
@@ -14,7 +14,7 @@ jobs:
         id: generate-prs
         run: |
           ./.github/workflows/scripts/pending-prs slack redpanda-data/redpanda-operator > payload.json
-          echo "has-prs=$(cat payload.json | wc -l)" >> $GITHUB_OUTPUT
+          echo "has-prs=$(wc -l < payload.json | xargs)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Post message to Slack channel


### PR DESCRIPTION
Merge skew resulted in this action not being subject to linters at the time of merge.