### PR TITLE
fix build caching of go binaries

### DIFF
--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -108,4 +108,4 @@ tasks:
     # Negating the output of grep effectively indicates if go thinks a rebuild
     # is required. Command must be encased in "s as the negation operator (!)
     # is otherwise consumed during YAML parsing.
-    - "! go build -C {{ .DIR }} -n -o ../.build/{{ .DIR }} 2>&1 | grep 'mv $WORK'"
+    - "! go build -C {{ .DIR }} -n -o ../.build/{{ .DIR }} {{ .PACKAGE }} 2>&1 | grep 'mv $WORK'"


### PR DESCRIPTION
A recent change added the `{{ .PACKAGE }}` selector to the `go:build` command but neglected to update the command in `status`. This caused `gotohelm` to not be rebuilt as expected leading to exciting new build errors.

This commit updates the status check.