### PR TITLE
Testing: one MockAdminAPI per cluster

### DIFF
--- a/operator/internal/controller/vectorized/test/cluster_controller_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_test.go
@@ -808,7 +808,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			Expect(k8sClient.Create(context.Background(), licenseSecret)).Should(Succeed())
 
 			By("Creating a Cluster")
-			key, _, redpandaCluster, namespace := getInitialTestCluster(clusterNameWithLicense)
+			key, _, redpandaCluster, namespace, _ := getInitialTestCluster(clusterNameWithLicense)
 			redpandaCluster.Spec.LicenseRef = &vectorizedv1alpha1.SecretKeyRef{Namespace: licenseNamespace, Name: licenseName}
 			Expect(k8sClient.Create(context.Background(), namespace)).Should(Succeed())
 			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())

--- a/operator/internal/controller/vectorized/test/console_controller_test.go
+++ b/operator/internal/controller/vectorized/test/console_controller_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Console controller", func() {
 	BeforeEach(func() {
 		ctx := context.Background()
 		if redpandaCluster == nil {
-			key, _, redpandaCluster, namespace = getInitialTestCluster(ClusterName)
+			key, _, redpandaCluster, namespace, _ = getInitialTestCluster(ClusterName)
 			ConsoleNamespace = key.Namespace
 		}
 		if err := k8sClient.Get(ctx, key, &vectorizedv1alpha1.Cluster{}); err != nil {
@@ -205,7 +205,7 @@ var _ = Describe("Console controller", func() {
 	Context("When deleting Console", func() {
 		It("Should delete console if cluster is not configured", func() {
 			ctx := context.Background()
-			brokenKey, _, brokenCluster, ns := getInitialTestCluster(ClusterName)
+			brokenKey, _, brokenCluster, ns, _ := getInitialTestCluster(ClusterName)
 			brokenCluster.Spec.Image = "nonexistentimage"
 			var replicas1 int32 = 1
 			brokenCluster.Spec.Replicas = &replicas1

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -12,10 +12,12 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,7 +57,7 @@ var (
 	k8sClient             client.Client
 	testEnv               *testutils.RedpandaTestEnv
 	cfg                   *rest.Config
-	testAdminAPI          *adminutils.MockAdminAPI
+	testAdminAPI          func(string) *adminutils.MockAdminAPI
 	testAdminAPIFactory   adminutils.NodePoolAdminAPIClientFactory
 	testStore             *consolepkg.Store
 	testKafkaAdmin        *mockKafkaAdmin
@@ -119,23 +121,52 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	ctx = ctrl.SetupSignalHandler()
 	ctx, controllerCancel = context.WithCancel(ctx)
 
-	testAdminAPI = &adminutils.MockAdminAPI{Log: l.WithName("testAdminAPI").WithName("mockAdminAPI")}
+	testAdminAPIs := make(map[string]*adminutils.MockAdminAPI)
+	var mu sync.Mutex
+	testAdminAPI = func(clusterName string) *adminutils.MockAdminAPI {
+		mu.Lock()
+		defer mu.Unlock()
+		api, found := testAdminAPIs[clusterName]
+		if !found {
+			api = &adminutils.MockAdminAPI{Log: l.WithName("testAdminAPI").WithName("mockAdminAPI").WithName(clusterName)}
+
+			api.Clear()
+
+			// Register some known properties for all tests
+			api.RegisterPropertySchema("auto_create_topics_enabled", rpadmin.ConfigPropertyMetadata{NeedsRestart: false, Type: "boolean"})
+			api.RegisterPropertySchema("cloud_storage_segment_max_upload_interval_sec", rpadmin.ConfigPropertyMetadata{NeedsRestart: true, Type: "integer"})
+			api.RegisterPropertySchema("log_segment_size", rpadmin.ConfigPropertyMetadata{NeedsRestart: true, Type: "integer"})
+			api.RegisterPropertySchema("enable_rack_awareness", rpadmin.ConfigPropertyMetadata{NeedsRestart: false, Type: "boolean"})
+
+			// By default we set the following properties and they'll be loaded by redpanda from the .bootstrap.yaml
+			// So we initialize the test admin API with those
+			api.SetProperty("auto_create_topics_enabled", false)
+			api.SetProperty("cloud_storage_segment_max_upload_interval_sec", 1800)
+			api.SetProperty("log_segment_size", 536870912)
+			api.SetProperty("enable_rack_awareness", true)
+
+			testAdminAPIs[clusterName] = api
+		}
+		return api
+	}
+
 	testAdminAPIFactory = func(
 		_ context.Context,
 		_ client.Reader,
-		_ *vectorizedv1alpha1.Cluster,
+		cluster *vectorizedv1alpha1.Cluster,
 		_ string,
 		_ types.AdminTLSConfigProvider,
 		_ redpanda.DialContextFunc,
 		pods ...string,
 	) (adminutils.AdminAPIClient, error) {
+		api := testAdminAPI(fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name))
 		if len(pods) == 1 {
 			return &adminutils.NodePoolScopedMockAdminAPI{
-				MockAdminAPI: testAdminAPI,
+				MockAdminAPI: api,
 				Pod:          pods[0],
 			}, nil
 		}
-		return testAdminAPI, nil
+		return api, nil
 	}
 
 	testStore = consolepkg.NewStore(k8sManager.GetClient(), k8sManager.GetScheme())
@@ -214,23 +245,6 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
 }, NodeTimeout(20*time.Second))
-
-var _ = BeforeEach(func() {
-	By("Cleaning the admin API")
-	testAdminAPI.Clear()
-	// Register some known properties for all tests
-	testAdminAPI.RegisterPropertySchema("auto_create_topics_enabled", rpadmin.ConfigPropertyMetadata{NeedsRestart: false, Type: "boolean"})
-	testAdminAPI.RegisterPropertySchema("cloud_storage_segment_max_upload_interval_sec", rpadmin.ConfigPropertyMetadata{NeedsRestart: true, Type: "integer"})
-	testAdminAPI.RegisterPropertySchema("log_segment_size", rpadmin.ConfigPropertyMetadata{NeedsRestart: true, Type: "integer"})
-	testAdminAPI.RegisterPropertySchema("enable_rack_awareness", rpadmin.ConfigPropertyMetadata{NeedsRestart: false, Type: "boolean"})
-
-	// By default we set the following properties and they'll be loaded by redpanda from the .bootstrap.yaml
-	// So we initialize the test admin API with those
-	testAdminAPI.SetProperty("auto_create_topics_enabled", false)
-	testAdminAPI.SetProperty("cloud_storage_segment_max_upload_interval_sec", 1800)
-	testAdminAPI.SetProperty("log_segment_size", 536870912)
-	testAdminAPI.SetProperty("enable_rack_awareness", true)
-})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")


### PR DESCRIPTION
Given the desire to merge the drift controller with the general cluster reconciler, we need to track the mock admin api state on a per-cluster basis - otherwise the rapid reassertion of state will cause flapping as the mock API is poked on behalf of multiple clusters.