### PR TITLE
redpanda: Point redpanda chart to nightly console helm chart during tests

### DIFF
--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -22,6 +22,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	golang.org/x/tools v0.29.0
+	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
@@ -199,7 +200,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.14.4 // indirect
 	k8s.io/apiextensions-apiserver v0.30.3 // indirect
 	k8s.io/apiserver v0.30.3 // indirect
 	k8s.io/cli-runtime v0.30.3 // indirect


### PR DESCRIPTION
As Redpanda chart go module import new unreleased version of console the tests are failing to start up Console. This is due the fact that without this change latest Console helm chart is taken as a helm depedency and downloaded to charts folder. Latest (unreleased) version bring breaking changes, so the test setup changes the Chart.yaml depedency definition to download Console helm chart nightly build.