### PR TITLE
Basic Lifecycle Management Interfaces + v2 Concrete Implementations

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -47,6 +47,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	golang.org/x/sync v0.10.0
+	golang.org/x/tools v0.29.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.4
@@ -296,7 +297,6 @@ require (
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
-	golang.org/x/tools v0.29.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/api v0.203.0 // indirect
 	google.golang.org/genproto v0.0.0-20241015192408-796eee8c2d53 // indirect

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -1,0 +1,382 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Cluster is a generic interface for a pointer to a Kubernetes object
+// that represents a cluster.
+type Cluster[T any] interface {
+	client.Object
+	*T
+}
+
+// NewClusterObject creates a new instance of a typed cluster object.
+func NewClusterObject[T any, U Cluster[T]]() U {
+	var t T
+	return U(&t)
+}
+
+// NewResourceClient creates a new instance of a ResourceClient for managing resources.
+func NewResourceClient[T any, U Cluster[T]](mgr ctrl.Manager, resourcesFn ResourceManagerFactory[T, U]) *ResourceClient[T, U] {
+	ownershipResolver, statusUpdater, nodePoolRenderer, simpleResourceRenderer := resourcesFn(mgr)
+	return &ResourceClient[T, U]{
+		client:                 mgr.GetClient(),
+		scheme:                 mgr.GetScheme(),
+		mapper:                 mgr.GetRESTMapper(),
+		ownershipResolver:      ownershipResolver,
+		statusUpdater:          statusUpdater,
+		nodePoolRenderer:       nodePoolRenderer,
+		simpleResourceRenderer: simpleResourceRenderer,
+	}
+}
+
+// ResourceClient is a client used to manage dependent resources,
+// both simple and node pools, for a given cluster type.
+type ResourceClient[T any, U Cluster[T]] struct {
+	client                 client.Client
+	scheme                 *runtime.Scheme
+	mapper                 meta.RESTMapper
+	ownershipResolver      OwnershipResolver[T, U]
+	statusUpdater          ClusterStatusUpdater[T, U]
+	nodePoolRenderer       NodePoolRenderer[T, U]
+	simpleResourceRenderer SimpleResourceRenderer[T, U]
+}
+
+// PatchNodePoolSet updates a StatefulSet for a specific node pool.
+func (r *ResourceClient[T, U]) PatchNodePoolSet(ctx context.Context, owner U, set *appsv1.StatefulSet) error {
+	return r.patchOwnedResource(ctx, owner, set)
+}
+
+// SetClusterStatus sets the status of the given cluster.
+func (r *ResourceClient[T, U]) SetClusterStatus(cluster U, status ClusterStatus) bool {
+	return r.statusUpdater.Update(cluster, status)
+}
+
+type gvkObject struct {
+	gvk schema.GroupVersionKind
+	nn  types.NamespacedName
+}
+
+// SyncAll synchronizes the simple resources associated with the given cluster,
+// cleaning up any resources that should no longer exist.
+func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
+	// we don't sync node pools here
+	resources, err := r.listAllOwnedResources(ctx, owner, false)
+	if err != nil {
+		return err
+	}
+	toDelete := map[gvkObject]client.Object{}
+	for _, resource := range resources {
+		toDelete[gvkObject{
+			gvk: resource.GetObjectKind().GroupVersionKind(),
+			nn:  client.ObjectKeyFromObject(resource),
+		}] = resource
+	}
+
+	toSync, err := r.simpleResourceRenderer.Render(ctx, owner)
+	if err != nil {
+		return err
+	}
+
+	// attempt to create as many resources in one pass as we can
+	errs := []error{}
+
+	for _, resource := range toSync {
+		if err := r.patchOwnedResource(ctx, owner, resource); err != nil {
+			errs = append(errs, err)
+		}
+		delete(toDelete, gvkObject{
+			gvk: resource.GetObjectKind().GroupVersionKind(),
+			nn:  client.ObjectKeyFromObject(resource),
+		})
+	}
+
+	for _, resource := range toDelete {
+		if err := r.client.Delete(ctx, resource); err != nil {
+			if !k8sapierrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// FetchExistingAndDesiredPools fetches the existing and desired node pools for a given cluster, returning
+// a tracker that can be used for determining necessary operations on the pools.
+func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context, cluster U) (*PoolTracker, error) {
+	pools := NewPoolTracker(cluster.GetGeneration())
+
+	existingPools, err := r.fetchExistingPools(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("fetching existing pools: %w", err)
+	}
+
+	desired, err := r.nodePoolRenderer.Render(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("constructing desired pools: %w", err)
+	}
+
+	pools.addExisting(existingPools...)
+	pools.addDesired(desired...)
+
+	return pools, nil
+}
+
+// Builder is an interface for our used methods of *sigs.k8s.io/controller-runtime/pkg/builder.Builder
+type Builder interface {
+	For(object client.Object, opts ...builder.ForOption) *builder.Builder
+	Owns(object client.Object, opts ...builder.OwnsOption) *builder.Builder
+	Watches(object client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *builder.Builder
+}
+
+// WatchResources configures resource watching for the given cluster, including StatefulSets and other resources.
+func (r *ResourceClient[T, U]) WatchResources(builder Builder, cluster U) error {
+	// set that this is for the cluster
+	builder.For(cluster)
+
+	// set an Owns on node pool statefulsets
+	builder.Owns(&appsv1.StatefulSet{})
+
+	for _, resourceType := range r.simpleResourceRenderer.WatchedResourceTypes() {
+		mapping, err := getResourceScope(r.mapper, r.scheme, resourceType)
+		if err != nil {
+			return err
+		}
+
+		if mapping.Name() == meta.RESTScopeNamespace.Name() {
+			// we're working with a namespace scoped resource, so we can work with ownership
+			builder.Owns(resourceType)
+			continue
+		}
+
+		// since resources are cluster-scoped we need to call a Watch on them with some
+		// custom mappings
+		builder.Watches(resourceType, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+			if owner := r.ownershipResolver.OwnerForObject(o); owner != nil {
+				return []reconcile.Request{{
+					NamespacedName: *owner,
+				}}
+			}
+			return nil
+		}))
+
+	}
+
+	return nil
+}
+
+// DeleteAll deletes all resources owned by the given cluster, including node pools.
+func (r *ResourceClient[T, U]) DeleteAll(ctx context.Context, owner U) (bool, error) {
+	// since this is a widespread deletion, we can delete even stateful sets
+	resources, err := r.listAllOwnedResources(ctx, owner, true)
+	if err != nil {
+		return false, err
+	}
+
+	alive := []client.Object{}
+	for _, o := range resources {
+		if o.GetDeletionTimestamp() == nil {
+			alive = append(alive, o)
+		}
+	}
+
+	// attempt to delete as many resources in one pass as we can
+	errs := []error{}
+	for _, resource := range alive {
+		if err := r.client.Delete(ctx, resource); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return len(alive) > 0, errors.Join(errs...)
+}
+
+// listResources lists resources of a specific type and object, returning them as an array.
+func (r *ResourceClient[T, U]) listResources(ctx context.Context, object client.Object, opts ...client.ListOption) ([]client.Object, error) {
+	kind, err := getGroupVersionKind(r.client.Scheme(), object)
+	if err != nil {
+		return nil, err
+	}
+
+	olist, err := r.client.Scheme().New(schema.GroupVersionKind{
+		Group:   kind.Group,
+		Version: kind.Version,
+		Kind:    kind.Kind + "List",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initializing list: %w", err)
+	}
+	list, ok := olist.(client.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("invalid object list type: %T", object)
+	}
+
+	if err := r.client.List(ctx, list, opts...); err != nil {
+		return nil, fmt.Errorf("listing resources: %w", err)
+	}
+
+	converted := []client.Object{}
+	items := reflect.ValueOf(list).Elem().FieldByName("Items")
+	for i := 0; i < items.Len(); i++ {
+		item := items.Index(i).Addr().Interface().(client.Object)
+		item.GetObjectKind().SetGroupVersionKind(*kind)
+		converted = append(converted, item)
+	}
+
+	return sortCreation(converted), nil
+}
+
+// listAllOwnedResources lists all resources owned by a given cluster, optionally including node pools.
+func (r *ResourceClient[T, U]) listAllOwnedResources(ctx context.Context, owner U, includeNodePools bool) ([]client.Object, error) {
+	resources := []client.Object{}
+	for _, resourceType := range append(r.simpleResourceRenderer.WatchedResourceTypes(), &appsv1.StatefulSet{}) {
+		matching, err := r.listResources(ctx, resourceType, client.MatchingLabels(r.ownershipResolver.GetOwnerLabels(owner)))
+		if err != nil {
+			return nil, err
+		}
+		filtered := []client.Object{}
+		for i := range matching {
+			// special case the node pools
+			if includeNodePools || !r.nodePoolRenderer.IsNodePool(matching[i]) {
+				filtered = append(filtered, matching[i])
+			}
+		}
+		resources = append(resources, filtered...)
+	}
+	return resources, nil
+}
+
+// patchOwnedResource applies a patch to a resource owned by the cluster.
+func (r *ResourceClient[T, U]) patchOwnedResource(ctx context.Context, owner U, object client.Object, extraLabels ...map[string]string) error {
+	if err := r.normalize(object, owner, extraLabels...); err != nil {
+		return err
+	}
+	return r.client.Patch(ctx, object, client.Apply, defaultFieldOwner, client.ForceOwnership)
+}
+
+// normalize normalizes an object by setting its labels and owner references.
+func (r *ResourceClient[T, U]) normalize(object client.Object, owner U, extraLabels ...map[string]string) error {
+	kind, err := getGroupVersionKind(r.scheme, object)
+	if err != nil {
+		return err
+	}
+	mapping, err := getResourceScope(r.mapper, r.scheme, object)
+	if err != nil {
+		return err
+	}
+
+	object.GetObjectKind().SetGroupVersionKind(*kind)
+
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	for name, value := range r.ownershipResolver.AddLabels(owner) {
+		labels[name] = value
+	}
+
+	for _, extra := range extraLabels {
+		for name, value := range extra {
+			labels[name] = value
+		}
+	}
+
+	object.SetLabels(labels)
+
+	if mapping.Name() == meta.RESTScopeNamespace.Name() {
+		object.SetOwnerReferences([]metav1.OwnerReference{*metav1.NewControllerRef(owner, owner.GetObjectKind().GroupVersionKind())})
+	}
+
+	return nil
+}
+
+// fetchExistingPools fetches the existing pools (StatefulSets) for a given cluster.
+func (r *ResourceClient[T, U]) fetchExistingPools(ctx context.Context, cluster U) ([]*poolWithOrdinals, error) {
+	sets, err := r.listResources(ctx, &appsv1.StatefulSet{}, client.MatchingLabels(r.ownershipResolver.GetOwnerLabels(cluster)))
+	if err != nil {
+		return nil, fmt.Errorf("listing StatefulSets: %w", err)
+	}
+
+	existing := []*poolWithOrdinals{}
+	for _, set := range sets {
+		statefulSet := set.(*appsv1.StatefulSet)
+
+		if !r.nodePoolRenderer.IsNodePool(statefulSet) {
+			continue
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(statefulSet.Spec.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("constructing label selector: %w", err)
+		}
+
+		revisions, err := r.listResources(ctx, &appsv1.ControllerRevision{}, client.MatchingLabelsSelector{
+			Selector: selector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing ControllerRevisions: %w", err)
+		}
+		ownedRevisions := []*appsv1.ControllerRevision{}
+		for i := range revisions {
+			ref := metav1.GetControllerOfNoCopy(revisions[i])
+			if ref == nil || ref.UID == set.GetUID() {
+				ownedRevisions = append(ownedRevisions, revisions[i].(*appsv1.ControllerRevision))
+			}
+
+		}
+
+		pods, err := r.listResources(ctx, &corev1.Pod{}, client.MatchingLabelsSelector{
+			Selector: selector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing Pods: %w", err)
+		}
+
+		ownedPods := []*corev1.Pod{}
+		for i := range pods {
+			ownedPods = append(ownedPods, pods[i].(*corev1.Pod))
+		}
+
+		withOrdinals, err := sortPodsByOrdinal(ownedPods...)
+		if err != nil {
+			return nil, fmt.Errorf("sorting Pods by ordinal: %w", err)
+		}
+
+		existing = append(existing, &poolWithOrdinals{
+			set:       statefulSet,
+			revisions: sortRevisions(ownedRevisions),
+			pods:      withOrdinals,
+		})
+	}
+
+	return existing, nil
+}

--- a/operator/internal/lifecycle/client_test.go
+++ b/operator/internal/lifecycle/client_test.go
@@ -379,7 +379,7 @@ func TestClientWatchResources(t *testing.T) {
 			builder := NewMockBuilder(instances.manager)
 
 			require.NoError(t, instances.resourceClient.WatchResources(builder, &MockCluster{}))
-			require.Equal(t, "*resources.MockCluster", builder.Base())
+			require.Equal(t, "*lifecycle.MockCluster", builder.Base())
 			require.ElementsMatch(t, tt.ownedResources, builder.Owned())
 			require.ElementsMatch(t, tt.watchedResources, builder.Watched())
 		})

--- a/operator/internal/lifecycle/client_test.go
+++ b/operator/internal/lifecycle/client_test.go
@@ -1,0 +1,571 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var parentCtx = ctrl.SetupSignalHandler()
+
+func setupContext() (context.Context, context.CancelFunc) {
+	log.SetLogger(logr.Discard())
+
+	return context.WithTimeout(parentCtx, 2*time.Minute)
+}
+
+func (tt *clientTest) setupManager(ctx context.Context, t *testing.T) ctrl.Manager {
+	t.Helper()
+
+	server := &envtest.APIServer{}
+	etcd := &envtest.Etcd{}
+
+	environment := &envtest.Environment{
+		ControlPlane: envtest.ControlPlane{
+			APIServer: server,
+			Etcd:      etcd,
+		},
+	}
+	config, err := environment.Start()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := environment.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	require.NoError(t, scheme.AddToScheme(scheme.Scheme))
+	require.NoError(t, AddToScheme(scheme.Scheme))
+
+	opts := []zap.Opts{
+		zap.UseDevMode(true), zap.Level(zapcore.DebugLevel),
+	}
+
+	if !testing.Verbose() {
+		opts = append(opts, zap.WriteTo(io.Discard))
+	}
+
+	logger := zap.New(opts...)
+
+	manager, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Logger: logger,
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: append(append(tt.additionalObjects, &appsv1.StatefulSet{}), tt.resources...),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	go func() {
+		if err := manager.Start(ctx); err != nil {
+			panic(err)
+		}
+	}()
+
+	client := manager.GetClient()
+
+	require.NoError(t, InstallCRDs(ctx, client))
+
+	return manager
+}
+
+type clientTest struct {
+	watchedResources     []client.Object
+	resources            []client.Object
+	resourcesRenderError error
+	nodePools            []*appsv1.StatefulSet
+	nodePoolsRenderError error
+	additionalObjects    []client.Object
+}
+
+type clientTestInstances struct {
+	resolver         *MockOwnershipResolver
+	updater          *MockClusterStatusUpdater
+	nodeRenderer     *MockNodePoolRenderer
+	resourceRenderer *MockSimpleResourceRenderer
+	resourceClient   *ResourceClient[MockCluster, *MockCluster]
+	manager          ctrl.Manager
+	k8sClient        client.Client
+}
+
+func (i *clientTestInstances) checkObject(ctx context.Context, t *testing.T, o client.Object) error {
+	t.Helper()
+
+	kind, err := getGroupVersionKind(i.k8sClient.Scheme(), o)
+	require.NoError(t, err)
+	initialized, err := i.k8sClient.Scheme().New(*kind)
+	require.NoError(t, err)
+	initializedO := initialized.(client.Object)
+
+	return i.k8sClient.Get(ctx, client.ObjectKeyFromObject(o), initializedO)
+}
+
+func (tt *clientTest) setupClient(ctx context.Context, t *testing.T) (*clientTestInstances, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	manager := tt.setupManager(ctx, t)
+
+	resolver, updater, nodeRenderer, resourceRenderer, factory := MockResourceManagersSetup()
+	resourceClient := NewResourceClient[MockCluster, *MockCluster](manager, factory)
+
+	return &clientTestInstances{
+		resolver:         resolver,
+		updater:          updater,
+		nodeRenderer:     nodeRenderer,
+		resourceRenderer: resourceRenderer,
+		resourceClient:   resourceClient,
+		manager:          manager,
+		k8sClient:        manager.GetClient(),
+	}, cancel
+}
+
+func (tt *clientTest) HasDeleteableResources() bool {
+	if tt.resourcesRenderError != nil || tt.nodePoolsRenderError != nil {
+		return false
+	}
+	return len(tt.resources) != 0 || len(tt.nodePools) != 0
+}
+
+func (tt *clientTest) AdditionalResources() []client.Object {
+	return tt.additionalObjects
+}
+
+func (tt *clientTest) InitialResources() []client.Object {
+	initialResources := []client.Object{}
+
+	if tt.resourcesRenderError == nil {
+		initialResources = append(initialResources, tt.resources...)
+	}
+
+	if tt.nodePoolsRenderError == nil {
+		for _, pool := range tt.nodePools {
+			initialResources = append(initialResources, pool)
+		}
+	}
+
+	return initialResources
+}
+
+func (tt *clientTest) Run(ctx context.Context, t *testing.T, name string, fn func(t *testing.T, instances *clientTestInstances, cluster *MockCluster)) {
+	t.Helper()
+
+	t.Run(name, func(t *testing.T) {
+		i, cancel := tt.setupClient(ctx, t)
+		defer cancel()
+
+		cluster := &MockCluster{}
+		cluster.Name = name
+		cluster.Namespace = metav1.NamespaceDefault
+
+		require.NoError(t, i.k8sClient.Create(ctx, cluster))
+
+		require.NoError(t, i.k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster))
+
+		i.resolver.AddOwner(cluster, map[string]string{
+			"cluster-name": name,
+		})
+
+		if tt.nodePoolsRenderError != nil {
+			i.nodeRenderer.SetError(cluster, tt.nodePoolsRenderError)
+		} else {
+			for _, resource := range tt.nodePools {
+				resource.SetLabels(map[string]string{
+					"cluster-name": name,
+				})
+			}
+			i.nodeRenderer.SetPools(cluster, tt.nodePools)
+		}
+
+		i.resourceRenderer.SetWatchedResources(tt.watchedResources)
+		if tt.resourcesRenderError != nil {
+			i.resourceRenderer.SetError(cluster, tt.resourcesRenderError)
+		} else {
+			for _, resource := range tt.resources {
+				resource.SetLabels(map[string]string{
+					"cluster-name": name,
+				})
+			}
+			i.resourceRenderer.SetResources(cluster, tt.resources)
+		}
+
+		for _, resource := range tt.additionalObjects {
+			require.NoError(t, i.k8sClient.Create(ctx, resource))
+		}
+
+		fn(t, i, cluster)
+
+		for _, resource := range tt.additionalObjects {
+			require.NoError(t, i.k8sClient.Get(ctx, client.ObjectKeyFromObject(resource), resource))
+			require.Nil(t, resource.GetDeletionTimestamp())
+		}
+	})
+}
+
+func TestClientDeleteAll(t *testing.T) {
+	ctx, cancel := setupContext()
+	defer cancel()
+
+	for name, tt := range map[string]*clientTest{
+		"no-op": {},
+		"overlapping-resources": {
+			watchedResources: []client.Object{
+				&corev1.ConfigMap{},
+				&corev1.Secret{},
+			},
+			resources: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overlapping-resources-resource",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "overlapping-resources-resource",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+		},
+		"resources-with-finalizer": {
+			watchedResources: []client.Object{
+				&corev1.ConfigMap{},
+			},
+			resources: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "resources-with-finalizer",
+						Namespace:  metav1.NamespaceDefault,
+						Finalizers: []string{"cluster.test/test-finalizer"},
+					},
+				},
+			},
+		},
+		"resources-and-pools": {
+			watchedResources: []client.Object{
+				&corev1.ConfigMap{},
+			},
+			resources: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "resources-and-pools-resource",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			additionalObjects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "resources-and-pools-other",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			nodePools: []*appsv1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "resources-and-pools-pool",
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"label": "label"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"label": "label"},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		tt.Run(ctx, t, name, func(t *testing.T, instances *clientTestInstances, cluster *MockCluster) {
+			for _, resource := range tt.InitialResources() {
+				require.NoError(t, instances.k8sClient.Create(ctx, resource))
+			}
+
+			deleted, err := instances.resourceClient.DeleteAll(ctx, cluster)
+			require.NoError(t, err)
+			require.Equal(t, tt.HasDeleteableResources(), deleted)
+
+			deleted, err = instances.resourceClient.DeleteAll(ctx, cluster)
+			require.NoError(t, err)
+			require.False(t, deleted, "found stray resource")
+
+			for _, pool := range tt.nodePools {
+				if err := instances.k8sClient.Get(ctx, client.ObjectKeyFromObject(pool), pool); err != nil {
+					require.True(t, k8sapierrors.IsNotFound(err))
+				} else {
+					require.NotNil(t, pool.GetDeletionTimestamp())
+				}
+			}
+			for _, resource := range tt.resources {
+				if err := instances.k8sClient.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
+					require.True(t, k8sapierrors.IsNotFound(err))
+				} else {
+					require.NotNil(t, resource.GetDeletionTimestamp())
+				}
+			}
+		})
+	}
+}
+
+func TestClientWatchResources(t *testing.T) {
+	ctx, cancel := setupContext()
+	defer cancel()
+
+	for name, tt := range map[string]struct {
+		watchedResources []string
+		ownedResources   []string
+		testParams       clientTest
+	}{
+		"base": {
+			ownedResources: []string{"*v1.StatefulSet"},
+		},
+		"cluster-scoped-resources": {
+			ownedResources:   []string{"*v1.StatefulSet"},
+			watchedResources: []string{"*v1.PersistentVolume"},
+			testParams: clientTest{
+				watchedResources: []client.Object{
+					&corev1.PersistentVolume{},
+				},
+			},
+		},
+		"namespace-and-cluster-scoped-resources": {
+			ownedResources:   []string{"*v1.StatefulSet", "*v1.PersistentVolumeClaim", "*v1.Pod", "*v1.Secret", "*v1.ConfigMap"},
+			watchedResources: []string{"*v1.PersistentVolume"},
+			testParams: clientTest{
+				watchedResources: []client.Object{
+					&corev1.PersistentVolume{},
+					&corev1.PersistentVolumeClaim{},
+					&corev1.Pod{},
+					&corev1.Secret{},
+					&corev1.ConfigMap{},
+				},
+			},
+		},
+	} {
+		tt.testParams.Run(ctx, t, name, func(t *testing.T, instances *clientTestInstances, cluster *MockCluster) {
+			builder := NewMockBuilder(instances.manager)
+
+			require.NoError(t, instances.resourceClient.WatchResources(builder, &MockCluster{}))
+			require.Equal(t, "*resources.MockCluster", builder.Base())
+			require.ElementsMatch(t, tt.ownedResources, builder.Owned())
+			require.ElementsMatch(t, tt.watchedResources, builder.Watched())
+		})
+	}
+}
+
+func TestClientSyncAll(t *testing.T) {
+	ctx, cancel := setupContext()
+	defer cancel()
+
+	for name, tt := range map[string]struct {
+		renderLoops [][]client.Object
+		testParams  clientTest
+	}{
+		"no-op": {},
+		"render-error": {
+			testParams: clientTest{
+				resourcesRenderError: errors.New("render"),
+			},
+		},
+		"overlapping-resource-names": {
+			renderLoops: [][]client.Object{
+				{
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "overlapping-resources-resource",
+							Namespace: metav1.NamespaceDefault,
+						},
+					},
+				},
+			},
+			testParams: clientTest{
+				watchedResources: []client.Object{
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+					&rbacv1.ClusterRole{},
+				},
+				resources: []client.Object{
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "overlapping-resources-resource",
+							Namespace: metav1.NamespaceDefault,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "overlapping-resources-resource",
+							Namespace: metav1.NamespaceDefault,
+						},
+					},
+					&rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "overlapping-resources-resource",
+							Namespace: metav1.NamespaceDefault,
+						},
+					},
+				},
+			},
+		},
+	} {
+		tt.testParams.Run(ctx, t, name, func(t *testing.T, instances *clientTestInstances, cluster *MockCluster) {
+			ensureSynced := func(resources []client.Object) {
+				objects, err := instances.resourceClient.listAllOwnedResources(ctx, cluster, false)
+				require.NoError(t, err)
+				require.Len(t, objects, len(resources))
+			}
+
+			for _, resource := range tt.testParams.resources {
+				err := instances.checkObject(ctx, t, resource)
+				require.Error(t, err)
+				require.True(t, k8sapierrors.IsNotFound(err))
+			}
+
+			err := instances.resourceClient.SyncAll(ctx, cluster)
+			if tt.testParams.resourcesRenderError != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.testParams.resourcesRenderError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			ensureSynced(tt.testParams.resources)
+
+			for _, resources := range tt.renderLoops {
+				instances.resourceRenderer.SetResources(cluster, resources)
+
+				require.NoError(t, instances.resourceClient.SyncAll(ctx, cluster))
+				ensureSynced(resources)
+			}
+		})
+	}
+}
+
+func TestClientFetchExistingAndDesiredPools(t *testing.T) {
+	ctx, cancel := setupContext()
+	defer cancel()
+
+	for name, tt := range map[string]*clientTest{
+		"no-op": {},
+		"render-error": {
+			nodePoolsRenderError: errors.New("render"),
+		},
+		"single-pool": {
+			nodePools: []*appsv1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pool-1",
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"label": "label"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"label": "label"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"multiple-pools": {
+			nodePools: []*appsv1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-pool-1",
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"label": "label"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"label": "label"},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-pool-2",
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"label": "label"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"label": "label"},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		tt.Run(ctx, t, name, func(t *testing.T, instances *clientTestInstances, cluster *MockCluster) {
+			tracker, err := instances.resourceClient.FetchExistingAndDesiredPools(ctx, cluster)
+			if tt.nodePoolsRenderError != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.nodePoolsRenderError)
+				return
+			}
+
+			pools := []string{}
+			for _, pool := range tt.nodePools {
+				pools = append(pools, client.ObjectKeyFromObject(pool).String())
+			}
+
+			require.NoError(t, err)
+			require.Len(t, tracker.ExistingStatefulSets(), 0)
+			require.ElementsMatch(t, pools, tracker.DesiredStatefulSets())
+
+			for _, pool := range tt.nodePools {
+				require.NoError(t, instances.resourceClient.PatchNodePoolSet(ctx, cluster, pool))
+				require.NoError(t, instances.checkObject(ctx, t, pool))
+			}
+
+			tracker, err = instances.resourceClient.FetchExistingAndDesiredPools(ctx, cluster)
+			require.NoError(t, err)
+			require.ElementsMatch(t, pools, tracker.ExistingStatefulSets())
+			require.ElementsMatch(t, pools, tracker.DesiredStatefulSets())
+		})
+	}
+}

--- a/operator/internal/lifecycle/constants.go
+++ b/operator/internal/lifecycle/constants.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+const (
+	defaultFieldOwner     = client.FieldOwner("cluster.redpanda.com/operator")
+	defaultNamespaceLabel = "cluster.redpanda.com/namespace"
+	defaultOperatorLabel  = "cluster.redpanda.com/operator"
+	defaultOwnerLabel     = "cluster.redpanda.com/owner"
+	generationLabel       = "cluster.redpanda.com/generation"
+	componentLabel        = "app.kubernetes.io/component"
+	instanceLabel         = "app.kubernetes.io/instance"
+	fluxNameLabel         = "helm.toolkit.fluxcd.io/name"
+	fluxNamespaceLabel    = "helm.toolkit.fluxcd.io/namespace"
+)

--- a/operator/internal/lifecycle/helpers.go
+++ b/operator/internal/lifecycle/helpers.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func isStatefulSet(object client.Object) bool {
+	gvk := object.GetObjectKind().GroupVersionKind()
+	return gvk.Group == appsv1.SchemeGroupVersion.Group &&
+		gvk.Version == appsv1.SchemeGroupVersion.Version &&
+		gvk.Kind == "StatefulSet"
+}
+
+// getGroupVersionKind gets a GVK for an object based on all
+// GVKs registered with a runtime scheme.
+func getGroupVersionKind(scheme *runtime.Scheme, object client.Object) (*schema.GroupVersionKind, error) {
+	kinds, _, err := scheme.ObjectKinds(object)
+	if err != nil {
+		return nil, fmt.Errorf("fetching object kind: %w", err)
+	}
+	if len(kinds) == 0 {
+		return nil, fmt.Errorf("unable to determine object kind")
+	}
+
+	gvk := kinds[0]
+	return &schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}, nil
+}
+
+// sortCreation sorts a list of objects by their creation timestamp
+func sortCreation[T client.Object](objects []T) []T {
+	sort.SliceStable(objects, func(i, j int) bool {
+		a, b := objects[i], objects[j]
+		aTimestamp, bTimestamp := ptr.To(a.GetCreationTimestamp()), ptr.To(b.GetCreationTimestamp())
+		if aTimestamp.Equal(bTimestamp) {
+			return a.GetName() < b.GetName()
+		}
+		return aTimestamp.Before(bTimestamp)
+	})
+	return objects
+}
+
+// getResourceScope can be used to determine whether an object is namespace-scoped or cluster-scoped
+// (and hence whether or not object ownership can be set on it)
+func getResourceScope(mapper meta.RESTMapper, scheme *runtime.Scheme, object client.Object) (meta.RESTScope, error) {
+	gvk, err := getGroupVersionKind(scheme, object)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get REST mapping: %w", err)
+	}
+
+	return mapping.Scope, nil
+}
+
+// sortRevisions sorts a statefulset's controlerRevisions by revision number
+func sortRevisions(controllerRevisions []*appsv1.ControllerRevision) []*appsv1.ControllerRevision {
+	// from https://github.com/kubernetes/kubernetes/blob/dd25c6a6cb4ea0be1e304de35de45adeef78b264/pkg/controller/history/controller_history.go#L158
+	sort.SliceStable(controllerRevisions, func(i, j int) bool {
+		if controllerRevisions[i].Revision == controllerRevisions[j].Revision {
+			if controllerRevisions[j].CreationTimestamp.Equal(&controllerRevisions[i].CreationTimestamp) {
+				return controllerRevisions[i].Name < controllerRevisions[j].Name
+			}
+			return controllerRevisions[j].CreationTimestamp.After(controllerRevisions[i].CreationTimestamp.Time)
+		}
+		return controllerRevisions[i].Revision < controllerRevisions[j].Revision
+	})
+
+	return controllerRevisions
+}
+
+// sortPodsByOrdinal sorts a list of pods by their ordinals, wrapping them
+// in a helper container to easily fetch the ordinal subsequently.
+func sortPodsByOrdinal(pods ...*corev1.Pod) ([]*podsWithOrdinals, error) {
+	withOrdinals := []*podsWithOrdinals{}
+	for _, pod := range pods {
+		ordinal, err := extractOrdinal(pod.GetName())
+		if err != nil {
+			return nil, err
+		}
+		withOrdinals = append(withOrdinals, &podsWithOrdinals{
+			ordinal: ordinal,
+			pod:     pod.DeepCopy(),
+		})
+	}
+
+	sort.SliceStable(withOrdinals, func(i, j int) bool {
+		return withOrdinals[i].ordinal < withOrdinals[j].ordinal
+	})
+
+	return withOrdinals, nil
+}
+
+// sortByName sorts a generic list of client.Objects by the combination
+// of their namespace/name.
+func sortByName[T client.Object](objs []T) []T {
+	slices.SortStableFunc(objs, func(a, b T) int {
+		return strings.Compare(client.ObjectKeyFromObject(a).String(), client.ObjectKeyFromObject(b).String())
+	})
+
+	return objs
+}
+
+// extractOrdinal extracts an ordinal from the pod name by parsing the last
+// value after a "-" in the pod name
+func extractOrdinal(name string) (int, error) {
+	resourceTokens := strings.Split(name, "-")
+	if len(resourceTokens) < 2 {
+		return 0, fmt.Errorf("invalid resource name for ordinal fetching: %s", name)
+	}
+
+	// grab the last item after the "-"" which should be the ordinal and parse it
+	ordinal, err := strconv.Atoi(resourceTokens[len(resourceTokens)-1])
+	if err != nil {
+		return 0, fmt.Errorf("parsing resource name %q: %w", name, err)
+	}
+
+	return ordinal, nil
+}

--- a/operator/internal/lifecycle/helpers_test.go
+++ b/operator/internal/lifecycle/helpers_test.go
@@ -1,0 +1,418 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type gvkClientObject struct {
+	gvk schema.GroupVersionKind
+	o   client.Object
+}
+
+type scopedGVKClientObject struct {
+	scope meta.RESTScope
+	gvk   schema.GroupVersionKind
+	o     client.Object
+}
+
+func TestGetGVK(t *testing.T) {
+	for name, tt := range map[string]struct {
+		registeredObjects []gvkClientObject
+		found             []gvkClientObject
+		notFound          []client.Object
+	}{
+		"no-op": {},
+		"none-registered": {
+			notFound: []client.Object{&corev1.Pod{}},
+		},
+		"not-found": {
+			registeredObjects: []gvkClientObject{{
+				gvk: corev1.SchemeGroupVersion.WithKind("Pod"),
+				o:   &corev1.Pod{},
+			}},
+			found: []gvkClientObject{{
+				gvk: corev1.SchemeGroupVersion.WithKind("Pod"),
+				o:   &corev1.Pod{},
+			}},
+			notFound: []client.Object{&corev1.PersistentVolume{}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+
+			for _, register := range tt.registeredObjects {
+				scheme.AddKnownTypeWithName(register.gvk, register.o)
+			}
+
+			for _, o := range tt.found {
+				gvk, err := getGroupVersionKind(scheme, o.o)
+				require.NoError(t, err)
+				require.Equal(t, o.gvk, *gvk)
+			}
+
+			for _, o := range tt.notFound {
+				_, err := getGroupVersionKind(scheme, o)
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSortCreation(t *testing.T) {
+	now := metav1.Now()
+	for name, tt := range map[string]struct {
+		items    []client.Object
+		expected []string
+	}{
+		"no-op": {
+			expected: []string{},
+		},
+		"ordered": {
+			expected: []string{"pod-1", "pod-2", "pod-3"},
+			items: []client.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod-1",
+					CreationTimestamp: now,
+				}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod-2",
+					CreationTimestamp: now,
+				}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod-3",
+					CreationTimestamp: metav1.NewTime(now.Add(time.Hour)),
+				}},
+			},
+		},
+		"unordered": {
+			expected: []string{"pod-1", "pod-2", "pod-3"},
+			items: []client.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod-2",
+					CreationTimestamp: now,
+				}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod-3",
+					CreationTimestamp: metav1.NewTime(now.Add(time.Hour)),
+				}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod-1",
+					CreationTimestamp: now,
+				}},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := objectNames(sortCreation(tt.items))
+			require.EqualValues(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSortByName(t *testing.T) {
+	for name, tt := range map[string]struct {
+		items    []*corev1.Pod
+		expected []string
+	}{
+		"no-op": {
+			expected: []string{},
+		},
+		"ordered": {
+			expected: []string{"namespace-1/pod-1", "namespace-1/pod-2", "namespace-2/pod-1", "namespace-2/pod-2"},
+			items: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "namespace-1",
+				}},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-2",
+					Namespace: "namespace-1",
+				}},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "namespace-2",
+				}},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-2",
+					Namespace: "namespace-2",
+				}},
+			},
+		},
+		"unordered": {
+			expected: []string{"namespace-1/pod-1", "namespace-1/pod-2", "namespace-2/pod-1", "namespace-2/pod-2"},
+			items: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-2",
+					Namespace: "namespace-2",
+				}},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-2",
+					Namespace: "namespace-1",
+				}},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "namespace-1",
+				}},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "namespace-2",
+				}},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := objectNamespaceNames(sortByName(tt.items))
+			require.EqualValues(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSortRevisions(t *testing.T) {
+	now := metav1.Now()
+	for name, tt := range map[string]struct {
+		items    []*appsv1.ControllerRevision
+		expected []string
+	}{
+		"no-op": {
+			expected: []string{},
+		},
+		"ordered": {
+			expected: []string{"revision-1-1", "revision-1-2", "revision-1-3", "revision-2"},
+			items: []*appsv1.ControllerRevision{
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-1-1",
+					CreationTimestamp: now,
+				}, Revision: 1},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-1-2",
+					CreationTimestamp: now,
+				}, Revision: 1},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-1-3",
+					CreationTimestamp: metav1.NewTime(now.Add(time.Minute)),
+				}, Revision: 1},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-2",
+					CreationTimestamp: now,
+				}, Revision: 2},
+			},
+		},
+		"unordered": {
+			expected: []string{"revision-1-1", "revision-1-2", "revision-1-3", "revision-2"},
+			items: []*appsv1.ControllerRevision{
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-1-3",
+					CreationTimestamp: metav1.NewTime(now.Add(time.Minute)),
+				}, Revision: 1},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-2",
+					CreationTimestamp: now,
+				}, Revision: 2},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-1-2",
+					CreationTimestamp: now,
+				}, Revision: 1},
+				{ObjectMeta: metav1.ObjectMeta{
+					Name:              "revision-1-1",
+					CreationTimestamp: now,
+				}, Revision: 1},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := objectNames(sortRevisions(tt.items))
+			require.EqualValues(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestExtractOrdinal(t *testing.T) {
+	for _, tt := range []struct {
+		pod     string
+		ordinal int
+		err     error
+	}{{
+		pod:     "pod-1",
+		ordinal: 1,
+	}, {
+		pod:     "lots-of-dashes-100",
+		ordinal: 100,
+	}, {
+		pod: "nodashes",
+		err: errors.New("invalid resource name for ordinal fetching"),
+	}, {
+		pod: "no-ordinals-here",
+		err: errors.New("parsing resource name"),
+	}} {
+		t.Run(tt.pod, func(t *testing.T) {
+			t.Parallel()
+
+			actualOrdinal, actualErr := extractOrdinal(tt.pod)
+			if tt.err != nil {
+				require.Error(t, actualErr)
+				require.ErrorContains(t, actualErr, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, actualErr)
+			require.Equal(t, tt.ordinal, actualOrdinal)
+		})
+	}
+}
+
+func TestSortPodsByOrdinal(t *testing.T) {
+	for name, tt := range map[string]struct {
+		items    []*corev1.Pod
+		expected []int
+		err      error
+	}{
+		"ordered": {
+			expected: []int{1, 2, 3, 8, 9, 10},
+			items: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-8"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-9"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-10"}},
+			},
+		},
+		"unordered": {
+			expected: []int{1, 2, 3, 8, 9, 10},
+			items: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-9"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-10"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-8"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}},
+			},
+		},
+		"error": {
+			items: []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod-10"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "pod"}},
+			},
+			err: errors.New("invalid resource name for ordinal fetching"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			pods, err := sortPodsByOrdinal(tt.items...)
+
+			if tt.err != nil {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+
+			ordinals := []int{}
+			for _, p := range pods {
+				ordinals = append(ordinals, p.ordinal)
+			}
+
+			require.EqualValues(t, tt.expected, ordinals)
+		})
+	}
+}
+
+func TestGetResourceScope(t *testing.T) {
+	for name, tt := range map[string]struct {
+		registeredObjects []scopedGVKClientObject
+		resource          client.Object
+		scope             meta.RESTScope
+		err               error
+	}{
+		"not-registered": {
+			registeredObjects: []scopedGVKClientObject{{
+				scope: meta.RESTScopeNamespace,
+				gvk:   corev1.SchemeGroupVersion.WithKind("Pod"),
+				o:     &corev1.Pod{},
+			}, {
+				scope: meta.RESTScopeRoot,
+				gvk:   corev1.SchemeGroupVersion.WithKind("PersistentVolume"),
+				o:     &corev1.PersistentVolume{},
+			}},
+			resource: &corev1.PersistentVolumeClaim{},
+			err:      errors.New("no kind is registered for the type v1.PersistentVolumeClaim"),
+		},
+		"namespace-scoped": {
+			registeredObjects: []scopedGVKClientObject{{
+				scope: meta.RESTScopeNamespace,
+				gvk:   corev1.SchemeGroupVersion.WithKind("Pod"),
+				o:     &corev1.Pod{},
+			}, {
+				scope: meta.RESTScopeRoot,
+				gvk:   corev1.SchemeGroupVersion.WithKind("PersistentVolume"),
+				o:     &corev1.PersistentVolume{},
+			}},
+			resource: &corev1.Pod{},
+			scope:    meta.RESTScopeNamespace,
+		},
+		"cluster-scoped": {
+			registeredObjects: []scopedGVKClientObject{{
+				scope: meta.RESTScopeNamespace,
+				gvk:   corev1.SchemeGroupVersion.WithKind("Pod"),
+				o:     &corev1.Pod{},
+			}, {
+				scope: meta.RESTScopeRoot,
+				gvk:   corev1.SchemeGroupVersion.WithKind("PersistentVolume"),
+				o:     &corev1.PersistentVolume{},
+			}},
+			resource: &corev1.PersistentVolume{},
+			scope:    meta.RESTScopeRoot,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := meta.NewDefaultRESTMapper(nil)
+			scheme := runtime.NewScheme()
+
+			for _, register := range tt.registeredObjects {
+				scheme.AddKnownTypeWithName(register.gvk, register.o)
+				mapper.Add(register.gvk, register.scope)
+			}
+
+			actualScope, actualErr := getResourceScope(mapper, scheme, tt.resource)
+			if tt.err != nil {
+				require.Error(t, actualErr)
+				require.ErrorContains(t, actualErr, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, actualErr)
+			require.Equal(t, tt.scope, actualScope)
+		})
+	}
+}

--- a/operator/internal/lifecycle/interfaces.go
+++ b/operator/internal/lifecycle/interfaces.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClusterStatus represents a generic status of a cluster
+// based on its desired and actual state as well as whether
+// it has reached a finalized reconciliation state.
+type ClusterStatus struct {
+	// Replicas is the number of actual replicas currently across
+	// the cluster. This differs from DesiredReplicas during
+	// a scaling operation, but should be the same once the cluster
+	// has quiesced.
+	Replicas int
+	// DesiredReplicas is the number of replicas that ought to be
+	// run for the cluster. It combines the desired replicas across
+	// all node pools.
+	DesiredReplicas int
+	// OutOfDateReplicas is the number of replicas that don't currently
+	// match their node pool definitions. If OutOfDateReplicas is not 0
+	// it should mean that the operator will soon roll this many pods.
+	OutOfDateReplicas int
+	// UpToDateReplicas is the number of replicas that currently match
+	// their node pool definitions.
+	UpToDateReplicas int
+	// CondemnedReplicas is the number of replicas that will be decommissioned
+	// as part of a scaling down operation.
+	CondemnedReplicas int
+	// ReadyReplicas is the number of replicas whose readiness probes are
+	// currently passing.
+	ReadyReplicas int
+	// RunningReplicas is the number of replicas that are actively in a running
+	// state.
+	RunningReplicas int
+	// Quiesced indicates that no more reconciliation will occur for the given
+	// cluster unless Kubernetes state changes. Reconciliation is done for the
+	// current iteration of a cluster.
+	Quiesced bool
+}
+
+// OwnershipResolver is responsible for determining what
+// labels get placed on every resource, including both
+// node pools and simple resources, as well as mapping
+// an object back to the particular cluster that it was
+// created by. Rather than purely using owner references,
+// the labels allow us to "own" both cluster and namespace
+// scoped resources.
+type OwnershipResolver[T any, U Cluster[T]] interface {
+	// GetOwnerLabels returns the minimal set of labels that
+	// can identify ownership of an object.
+	GetOwnerLabels(cluster U) map[string]string
+	// AddLabels returns the labels to be applied
+	// to every resource created by the cluster.
+	AddLabels(cluster U) map[string]string
+	// OwnerForObject maps an "owned" object back to a
+	// particular cluster. If the object does not map
+	// to a cluster, return nil.
+	OwnerForObject(object client.Object) *types.NamespacedName
+}
+
+// SimpleResourceRenderer handles compilation of all desired
+// resources to be created by a cluster. These resources should
+// be "simple" in nature in that we don't need to manually control
+// their lifecycles and can easily create/update/delete them as
+// necessary.
+type SimpleResourceRenderer[T any, U Cluster[T]] interface {
+	// Render returns the list of all simple resources to create
+	// for a given cluster.
+	Render(ctx context.Context, cluster U) ([]client.Object, error)
+	// WatchedResourceTypes returns a list of all resources that
+	// our controller should watch for changes to trigger reconciliation.
+	WatchedResourceTypes() []client.Object
+}
+
+// NodePoolRender handles returning the node pools for a given cluster.
+// These are handled separately from "simple" resources because we need
+// to manage their lifecycle, decommissioning broker nodes and scaling
+// clusters up and down as necessary.
+type NodePoolRenderer[T any, U Cluster[T]] interface {
+	// Render returns the list of node pools to create for a given cluster.
+	Render(ctx context.Context, cluster U) ([]*appsv1.StatefulSet, error)
+	// IsNodePool allows us to distinguish owned resources that are StatefulSets
+	// but not node pools from resources that are. This is important if we
+	// create StatefulSets that we don't need to consider part of a cluster's
+	// node pools.
+	IsNodePool(object client.Object) bool
+}
+
+// ClusterStatusUpdater handles back propagating the unified ClusterStatus onto
+// the given cluster.
+type ClusterStatusUpdater[T any, U Cluster[T]] interface {
+	// Update updates the internal cluster's status based on the ClusterStatus it
+	// is given. If any fields are updated it should return `true` so that the
+	// status of the cluster can be synced.
+	Update(cluster U, status ClusterStatus) bool
+}
+
+// ResourceManagerFactory bundles together concrete implementations of OwnershipResolver
+// ClusterStatusUpdater, NodePoolRenderer, and SimpleResourceRenderer for our various
+// cluster versions.
+type ResourceManagerFactory[T any, U Cluster[T]] func(mgr ctrl.Manager) (OwnershipResolver[T, U], ClusterStatusUpdater[T, U], NodePoolRenderer[T, U], SimpleResourceRenderer[T, U])

--- a/operator/internal/lifecycle/interfaces_test.go
+++ b/operator/internal/lifecycle/interfaces_test.go
@@ -1,0 +1,415 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+const (
+	testGroup   = "cluster.test.domain"
+	testVersion = "v1"
+)
+
+var (
+	groupVersion  = schema.GroupVersion{Group: testGroup, Version: testVersion}
+	schemeBuilder = &scheme.Builder{GroupVersion: groupVersion}
+	AddToScheme   = schemeBuilder.AddToScheme
+)
+
+func init() {
+	schemeBuilder.Register(&MockCluster{}, &MockClusterList{})
+}
+
+type MockBuilder struct {
+	*builder.Builder
+	base    string
+	watches []string
+	owns    []string
+}
+
+func NewMockBuilder(manager ctrl.Manager) *MockBuilder {
+	return &MockBuilder{
+		Builder: ctrl.NewControllerManagedBy(manager),
+	}
+}
+
+func (b *MockBuilder) Base() string {
+	return b.base
+}
+
+func (b *MockBuilder) Owned() []string {
+	return b.owns
+}
+
+func (b *MockBuilder) Watched() []string {
+	return b.watches
+}
+
+func (b *MockBuilder) For(object client.Object, opts ...builder.ForOption) *builder.Builder {
+	b.base = fmt.Sprintf("%T", object)
+	return b.Builder.For(object, opts...)
+}
+
+func (b *MockBuilder) Owns(object client.Object, opts ...builder.OwnsOption) *builder.Builder {
+	b.owns = append(b.owns, fmt.Sprintf("%T", object))
+	return b.Builder.Owns(object, opts...)
+}
+
+func (b *MockBuilder) Watches(object client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *builder.Builder {
+	b.watches = append(b.watches, fmt.Sprintf("%T", object))
+	return b.Builder.Watches(object, eventHandler, opts...)
+}
+
+type MockCluster struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Status            MockClusterStatus `json:"status,omitempty"`
+}
+
+func (in *MockCluster) DeepCopyInto(out *MockCluster) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *MockCluster) DeepCopy() *MockCluster {
+	if in == nil {
+		return nil
+	}
+	out := new(MockCluster)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *MockCluster) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+type MockClusterStatus struct{}
+
+func (in *MockClusterStatus) DeepCopyInto(out *MockClusterStatus) {
+	*out = *in
+}
+
+type MockClusterList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []MockCluster `json:"items"`
+}
+
+func (in *MockClusterList) DeepCopyInto(out *MockClusterList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]MockCluster, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *MockClusterList) DeepCopy() *MockClusterList {
+	if in == nil {
+		return nil
+	}
+	out := new(MockClusterList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *MockClusterList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func mockClusterCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "clusters." + testGroup,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: testGroup,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    testVersion,
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"status": {
+									Type:                   "object",
+									XPreserveUnknownFields: ptr.To(true),
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+				},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "clusters",
+				Singular: "cluster",
+				ListKind: "MockClusterList",
+				Kind:     "MockCluster",
+			},
+		},
+	}
+}
+
+func installCRD(ctx context.Context, cl client.Client, crd *apiextensionsv1.CustomResourceDefinition) error {
+	if err := cl.Create(ctx, crd); err != nil {
+		return err
+	}
+
+	return wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: 1 * time.Second,
+		Steps:    10,
+		Cap:      10 * time.Second,
+	}, func(ctx context.Context) (bool, error) {
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+			return false, nil
+		}
+		for _, condition := range crd.Status.Conditions {
+			if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func InstallCRDs(ctx context.Context, cl client.Client) error {
+	for _, crd := range []*apiextensionsv1.CustomResourceDefinition{
+		mockClusterCRD(),
+	} {
+		if err := installCRD(ctx, cl, crd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type MockOwnershipResolver struct {
+	ownerMappings map[types.NamespacedName]map[string]string
+}
+
+var _ OwnershipResolver[MockCluster, *MockCluster] = (*MockOwnershipResolver)(nil)
+
+func NewMockOwnershipResolver() *MockOwnershipResolver {
+	return &MockOwnershipResolver{
+		ownerMappings: make(map[types.NamespacedName]map[string]string),
+	}
+}
+
+func (r *MockOwnershipResolver) AddOwner(cluster *MockCluster, labels map[string]string) {
+	nn := client.ObjectKeyFromObject(cluster)
+
+	r.ownerMappings[nn] = labels
+}
+
+func (r *MockOwnershipResolver) GetOwnerLabels(cluster *MockCluster) map[string]string {
+	nn := client.ObjectKeyFromObject(cluster)
+
+	if labels, ok := r.ownerMappings[nn]; ok {
+		return labels
+	}
+
+	return nil
+}
+
+func (r *MockOwnershipResolver) AddLabels(cluster *MockCluster) map[string]string {
+	return r.GetOwnerLabels(cluster)
+}
+
+func (r *MockOwnershipResolver) OwnerForObject(object client.Object) *types.NamespacedName {
+	for owner, labels := range r.ownerMappings {
+		objectLabels := object.GetLabels()
+
+		matched := true
+		for key, value := range labels {
+			if objectValue, ok := objectLabels[key]; !ok || objectValue != value {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return &owner
+		}
+	}
+
+	return nil
+}
+
+type MockSimpleResourceRenderer struct {
+	watchedResources []client.Object
+	resourceMappings map[types.NamespacedName][]client.Object
+	errorMappings    map[types.NamespacedName]error
+}
+
+var _ SimpleResourceRenderer[MockCluster, *MockCluster] = (*MockSimpleResourceRenderer)(nil)
+
+func NewMockSimpleResourceRenderer() *MockSimpleResourceRenderer {
+	return &MockSimpleResourceRenderer{
+		resourceMappings: make(map[types.NamespacedName][]client.Object),
+		errorMappings:    make(map[types.NamespacedName]error),
+	}
+}
+
+func (r *MockSimpleResourceRenderer) SetResources(cluster *MockCluster, resources []client.Object) {
+	nn := client.ObjectKeyFromObject(cluster)
+	r.resourceMappings[nn] = resources
+}
+
+func (r *MockSimpleResourceRenderer) SetError(cluster *MockCluster, err error) {
+	nn := client.ObjectKeyFromObject(cluster)
+	r.errorMappings[nn] = err
+}
+
+func (r *MockSimpleResourceRenderer) SetWatchedResources(resources []client.Object) {
+	r.watchedResources = resources
+}
+
+func (r *MockSimpleResourceRenderer) Render(ctx context.Context, cluster *MockCluster) ([]client.Object, error) {
+	nn := client.ObjectKeyFromObject(cluster)
+
+	if err, ok := r.errorMappings[nn]; ok {
+		return nil, err
+	}
+
+	if resources, ok := r.resourceMappings[nn]; ok {
+		return resources, nil
+	}
+
+	return nil, nil
+}
+
+func (r *MockSimpleResourceRenderer) WatchedResourceTypes() []client.Object {
+	return r.watchedResources
+}
+
+type MockNodePoolRenderer struct {
+	poolMappings  map[types.NamespacedName][]*appsv1.StatefulSet
+	errorMappings map[types.NamespacedName]error
+}
+
+var _ NodePoolRenderer[MockCluster, *MockCluster] = (*MockNodePoolRenderer)(nil)
+
+func NewMockNodePoolRenderer() *MockNodePoolRenderer {
+	return &MockNodePoolRenderer{
+		poolMappings:  make(map[types.NamespacedName][]*appsv1.StatefulSet),
+		errorMappings: make(map[types.NamespacedName]error),
+	}
+}
+
+func (r *MockNodePoolRenderer) SetPools(cluster *MockCluster, pools []*appsv1.StatefulSet) {
+	nn := client.ObjectKeyFromObject(cluster)
+	r.poolMappings[nn] = pools
+}
+
+func (r *MockNodePoolRenderer) SetError(cluster *MockCluster, err error) {
+	nn := client.ObjectKeyFromObject(cluster)
+	r.errorMappings[nn] = err
+}
+
+func (r *MockNodePoolRenderer) Render(ctx context.Context, cluster *MockCluster) ([]*appsv1.StatefulSet, error) {
+	nn := client.ObjectKeyFromObject(cluster)
+
+	if err, ok := r.errorMappings[nn]; ok {
+		return nil, err
+	}
+
+	if pools, ok := r.poolMappings[nn]; ok {
+		return pools, nil
+	}
+
+	return nil, nil
+}
+
+func (r *MockNodePoolRenderer) IsNodePool(object client.Object) bool {
+	gvk := object.GetObjectKind().GroupVersionKind()
+	if gvk.Group != appsv1.SchemeGroupVersion.Group ||
+		gvk.Version != appsv1.SchemeGroupVersion.Version ||
+		gvk.Kind != "StatefulSet" {
+		return false
+	}
+
+	nn := client.ObjectKeyFromObject(object)
+
+	for _, pools := range r.poolMappings {
+		for _, pool := range pools {
+			if nn == client.ObjectKeyFromObject(pool) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+type MockClusterStatusUpdater struct{}
+
+var _ ClusterStatusUpdater[MockCluster, *MockCluster] = (*MockClusterStatusUpdater)(nil)
+
+func NewMockClusterStatusUpdater() *MockClusterStatusUpdater {
+	return &MockClusterStatusUpdater{}
+}
+
+func (u *MockClusterStatusUpdater) Update(cluster *MockCluster, status ClusterStatus) bool {
+	return false
+}
+
+func MockResourceManagersSetup() (
+	*MockOwnershipResolver,
+	*MockClusterStatusUpdater,
+	*MockNodePoolRenderer,
+	*MockSimpleResourceRenderer,
+	func(mgr ctrl.Manager) (
+		OwnershipResolver[MockCluster, *MockCluster],
+		ClusterStatusUpdater[MockCluster, *MockCluster],
+		NodePoolRenderer[MockCluster, *MockCluster],
+		SimpleResourceRenderer[MockCluster, *MockCluster],
+	),
+) {
+	resolver, updater, nodeRenderer, resourceRenderer := NewMockOwnershipResolver(), NewMockClusterStatusUpdater(), NewMockNodePoolRenderer(), NewMockSimpleResourceRenderer()
+	return resolver, updater, nodeRenderer, resourceRenderer, func(mgr ctrl.Manager) (OwnershipResolver[MockCluster, *MockCluster], ClusterStatusUpdater[MockCluster, *MockCluster], NodePoolRenderer[MockCluster, *MockCluster], SimpleResourceRenderer[MockCluster, *MockCluster]) {
+		return resolver, updater, nodeRenderer, resourceRenderer
+	}
+}

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -1,0 +1,292 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"sort"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// podWithOrdinals is a container for sorting pods
+// by their ordinals
+type podsWithOrdinals struct {
+	ordinal int
+	pod     *corev1.Pod
+}
+
+// poolWithOrdinals is a container for all of the information
+// we need to figure out how to manipulate a given node pool
+type poolWithOrdinals struct {
+	pods      []*podsWithOrdinals
+	set       *appsv1.StatefulSet
+	revisions []*appsv1.ControllerRevision
+}
+
+// ScaleDownSet holds a reference to a pod in need of decommissioning
+// (the last ordinal in a StatefulSet), as well as the StatefulSet
+// it is associated with.
+type ScaleDownSet struct {
+	LastPod     *corev1.Pod
+	StatefulSet *appsv1.StatefulSet
+}
+
+// PoolTracker tracks the existing and desired node pool state
+// for a cluster.
+type PoolTracker struct {
+	// latestGeneration is the generation of the cluster used
+	// to determine whether or not a StatefulSet's definition is
+	// out-of-date
+	latestGeneration int64
+	existingPools    map[types.NamespacedName]*poolWithOrdinals
+	desiredPools     map[types.NamespacedName]*poolWithOrdinals
+}
+
+// NewPoolTracker creates a new PoolTracker with the given cluster generation.
+func NewPoolTracker(generation int64) *PoolTracker {
+	return &PoolTracker{
+		latestGeneration: generation,
+		existingPools:    make(map[types.NamespacedName]*poolWithOrdinals),
+		desiredPools:     make(map[types.NamespacedName]*poolWithOrdinals),
+	}
+}
+
+// ExistingStatefulSets returns a list of the names of the existing StatefulSets tracked by the PoolTracker.
+func (p *PoolTracker) ExistingStatefulSets() []string {
+	sets := []string{}
+	for nn := range p.existingPools {
+		sets = append(sets, nn.String())
+	}
+	return sets
+}
+
+// DesiredStatefulSets returns a list of the names of the desired StatefulSets tracked by the PoolTracker.
+func (p *PoolTracker) DesiredStatefulSets() []string {
+	sets := []string{}
+	for nn := range p.desiredPools {
+		sets = append(sets, nn.String())
+	}
+	return sets
+}
+
+// CheckScale checks if scaling operations can proceed based on the current state of pools.
+// It returns true if scaling is allowed (i.e. no scaling operation is currently in progress).
+func (p *PoolTracker) CheckScale() bool {
+	// if we have no existing pools
+	if len(p.existingPools) == 0 {
+		return true
+	}
+
+	for _, pool := range p.existingPools {
+		replicas := ptr.Deref(pool.set.Spec.Replicas, 0)
+		if replicas != pool.set.Status.Replicas || int(replicas) != len(pool.pods) {
+			// we're potentially in the middle of a scaling operation
+			return false
+		}
+	}
+
+	return true
+}
+
+// ToCreate returns a list of StatefulSets that need to be created.
+func (p *PoolTracker) ToCreate() []*appsv1.StatefulSet {
+	sets := []*appsv1.StatefulSet{}
+
+	generation := strconv.FormatInt(p.latestGeneration, 10)
+
+	for nn := range p.desiredPools {
+		if _, ok := p.existingPools[nn]; !ok {
+			set := p.desiredPools[nn].set.DeepCopy()
+			if set.Labels == nil {
+				set.Labels = map[string]string{}
+			}
+			set.Labels[generationLabel] = generation
+			sets = append(sets, set)
+		}
+	}
+
+	return sortByName(sets)
+}
+
+// ToScaleUp returns a list of StatefulSets that need to be scaled up
+// (i.e. existing replicas are less than desired replicas).
+func (p *PoolTracker) ToScaleUp() []*appsv1.StatefulSet {
+	sets := []*appsv1.StatefulSet{}
+
+	generation := strconv.FormatInt(p.latestGeneration, 10)
+
+	for nn, existing := range p.existingPools {
+		if desired, ok := p.desiredPools[nn]; ok {
+			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
+			desiredReplicas := ptr.Deref(desired.set.Spec.Replicas, 0)
+
+			if existingReplicas < desiredReplicas {
+				set := desired.set.DeepCopy()
+				if set.Labels == nil {
+					set.Labels = map[string]string{}
+				}
+				set.Labels[generationLabel] = generation
+				sets = append(sets, set)
+			}
+		}
+	}
+
+	return sortByName(sets)
+}
+
+// RequiresUpdate returns a list of StatefulSets that require an update
+// because they have not yet been updated since the last time the owning cluster
+// was updated.
+func (p *PoolTracker) RequiresUpdate() []*appsv1.StatefulSet {
+	sets := []*appsv1.StatefulSet{}
+
+	generation := strconv.FormatInt(p.latestGeneration, 10)
+
+	for nn, existing := range p.existingPools {
+		labels := existing.set.Labels
+		if labels == nil {
+			continue
+		}
+		if desired, ok := p.desiredPools[nn]; ok && labels[generationLabel] != generation {
+			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
+			desiredReplicas := ptr.Deref(desired.set.Spec.Replicas, 0)
+
+			// we only return sets in which we already have matched replicas
+			// since the scale operations handle patching the other statefulsets
+			if existingReplicas == desiredReplicas {
+				set := desired.set.DeepCopy()
+				if set.Labels == nil {
+					set.Labels = map[string]string{}
+				}
+				set.Labels[generationLabel] = generation
+				sets = append(sets, set)
+			}
+		}
+	}
+
+	return sortByName(sets)
+}
+
+// ToScaleDown returns a list of ScaleDownSets for StatefulSets
+// that need to be scaled down. Each also contains the pod with
+// the highest ordinal in the set so it can be decommissioned.
+func (p *PoolTracker) ToScaleDown() []*ScaleDownSet {
+	sets := []*ScaleDownSet{}
+
+	generation := strconv.FormatInt(p.latestGeneration, 10)
+
+	for nn := range p.existingPools {
+		if _, ok := p.desiredPools[nn]; !ok {
+			existing := p.existingPools[nn]
+			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
+
+			if existingReplicas != 0 && len(existing.pods) != 0 {
+				set := existing.set.DeepCopy()
+				if set.Labels == nil {
+					set.Labels = map[string]string{}
+				}
+				set.Labels[generationLabel] = generation
+				lastPod := existing.pods[len(existing.pods)-1]
+
+				set.Spec.Replicas = ptr.To(existingReplicas - 1)
+				sets = append(sets, &ScaleDownSet{
+					StatefulSet: set,
+					LastPod:     lastPod.pod.DeepCopy(),
+				})
+			}
+		} else {
+			existing, desired := p.existingPools[nn], p.desiredPools[nn]
+			existingReplicas, desiredReplicas := ptr.Deref(existing.set.Spec.Replicas, 0), ptr.Deref(desired.set.Spec.Replicas, 0)
+
+			if existingReplicas > desiredReplicas {
+				// we use the desired set spec here
+				set := desired.set.DeepCopy()
+				if set.Labels == nil {
+					set.Labels = map[string]string{}
+				}
+				set.Labels[generationLabel] = generation
+				lastPod := existing.pods[len(existing.pods)-1]
+
+				set.Spec.Replicas = ptr.To(existingReplicas - 1)
+				sets = append(sets, &ScaleDownSet{
+					StatefulSet: set,
+					LastPod:     lastPod.pod.DeepCopy(),
+				})
+			}
+		}
+	}
+
+	sort.SliceStable(sets, func(i, j int) bool {
+		return client.ObjectKeyFromObject(sets[i].StatefulSet).String() < client.ObjectKeyFromObject(sets[j].StatefulSet).String()
+	})
+
+	return sets
+}
+
+// ToDelete returns a list of StatefulSets that need to be deleted.
+func (p *PoolTracker) ToDelete() []*appsv1.StatefulSet {
+	sets := []*appsv1.StatefulSet{}
+
+	for nn, existing := range p.existingPools {
+		if _, ok := p.desiredPools[nn]; !ok {
+			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
+			// extra guard to make sure we don't accidentally delete a
+			// statefulset whose pods still need to be decommissioned
+			if existingReplicas == 0 && existing.set.Status.Replicas == 0 {
+				sets = append(sets, p.existingPools[nn].set.DeepCopy())
+			}
+		}
+	}
+
+	return sortByName(sets)
+}
+
+// PodsToRoll returns a list of pods that need to be rolled
+// because their association ControllerRevision does not match
+// the latest applied to the StatefulSet.
+func (p *PoolTracker) PodsToRoll() []*corev1.Pod {
+	pods := []*corev1.Pod{}
+
+	for _, existing := range p.existingPools {
+		for _, withOrdinals := range existing.pods {
+			// the CurrentRevision on the StatefulSet can't be used here due to leveraging onDelete
+			if len(existing.revisions) == 0 {
+				// we have no revisions, just assume this needs to be rolled
+				pods = append(pods, withOrdinals.pod.DeepCopy())
+			} else {
+				lastRevision := existing.revisions[len(existing.revisions)-1]
+				if withOrdinals.pod.Labels[appsv1.StatefulSetRevisionLabel] != lastRevision.Name {
+					pods = append(pods, withOrdinals.pod.DeepCopy())
+				}
+			}
+		}
+	}
+
+	return pods
+}
+
+// addExisting poolWithOrdinals to the tracker
+func (p *PoolTracker) addExisting(pools ...*poolWithOrdinals) {
+	for i := range pools {
+		p.existingPools[client.ObjectKeyFromObject(pools[i].set)] = pools[i]
+	}
+}
+
+// addDesired statefulsets to the tracker
+func (p *PoolTracker) addDesired(sets ...*appsv1.StatefulSet) {
+	for _, set := range sets {
+		p.desiredPools[client.ObjectKeyFromObject(set)] = &poolWithOrdinals{set: set.DeepCopy()}
+	}
+}

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -1,0 +1,828 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func objectNames[T client.Object](list []T) []string {
+	ids := []string{}
+	for _, o := range list {
+		ids = append(ids, o.GetName())
+	}
+	return ids
+}
+
+func objectNamespaceNames[T client.Object](list []T) []string {
+	ids := []string{}
+	for _, o := range list {
+		ids = append(ids, client.ObjectKeyFromObject(o).String())
+	}
+	return ids
+}
+
+func TestPoolTrackerCheckScale(t *testing.T) {
+	for name, tt := range map[string]struct {
+		existingPools []*poolWithOrdinals
+		canScale      bool
+	}{
+		"no-pools": {
+			canScale: true,
+		},
+		"replica-pod-mismatch": {
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}},
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+					Status:     appsv1.StatefulSetStatus{Replicas: 2},
+				},
+			}},
+			canScale: false,
+		},
+		"scale-down": {
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}},
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(0))},
+					Status:     appsv1.StatefulSetStatus{Replicas: 1},
+				},
+			}},
+			canScale: false,
+		},
+		"scale-up": {
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}},
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+					Status:     appsv1.StatefulSetStatus{Replicas: 2},
+				},
+			}},
+			canScale: false,
+		},
+		"stable": {
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+					},
+				}},
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+					Status:     appsv1.StatefulSetStatus{Replicas: 2},
+				},
+			}},
+			canScale: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(0)
+			tracker.addExisting(tt.existingPools...)
+			require.Equal(t, tt.canScale, tracker.CheckScale())
+		})
+	}
+}
+
+func TestPoolTrackerToCreate(t *testing.T) {
+	for name, tt := range map[string]struct {
+		existingPools        []*appsv1.StatefulSet
+		desiredPools         []*appsv1.StatefulSet
+		expectedSetsToCreate []string
+	}{
+		"no-op": {},
+		"no-creations": {
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}},
+		},
+		"excess-existing": {
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-3",
+				},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}},
+		},
+		"no-existing": {
+			expectedSetsToCreate: []string{"pool-1", "pool-2"},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}},
+		},
+		"some-existing": {
+			expectedSetsToCreate: []string{"pool-2"},
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(0)
+
+			pools := []*poolWithOrdinals{}
+			for _, set := range tt.existingPools {
+				pools = append(pools, &poolWithOrdinals{
+					set: set.DeepCopy(),
+				})
+			}
+
+			tracker.addExisting(pools...)
+			tracker.addDesired(tt.desiredPools...)
+
+			actual := objectNames(tracker.ToCreate())
+			require.ElementsMatch(t, tt.expectedSetsToCreate, actual)
+		})
+	}
+}
+
+func TestPoolTrackerToScaleUp(t *testing.T) {
+	for name, tt := range map[string]struct {
+		existingPools         []*appsv1.StatefulSet
+		desiredPools          []*appsv1.StatefulSet
+		expectedSetsToScaleUp []string
+	}{
+		"no-op": {},
+		"no-scale-ups": {
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+		},
+		"all-scale-ups": {
+			expectedSetsToScaleUp: []string{"pool-1"},
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+		},
+		"some-scale-ups": {
+			expectedSetsToScaleUp: []string{"pool-1"},
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+		},
+		"scale-down": {
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(0)
+
+			pools := []*poolWithOrdinals{}
+			for _, set := range tt.existingPools {
+				pools = append(pools, &poolWithOrdinals{
+					set: set.DeepCopy(),
+				})
+			}
+
+			tracker.addExisting(pools...)
+			tracker.addDesired(tt.desiredPools...)
+
+			actual := objectNames(tracker.ToScaleUp())
+			require.ElementsMatch(t, tt.expectedSetsToScaleUp, actual)
+		})
+	}
+}
+
+func TestPoolTrackerRequiresUpdate(t *testing.T) {
+	for name, tt := range map[string]struct {
+		generation           int64
+		existingPools        []*appsv1.StatefulSet
+		desiredPools         []*appsv1.StatefulSet
+		expectedSetsToUpdate []string
+	}{
+		"no-op": {},
+		"no-updates": {
+			generation: 1,
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool-1",
+					Labels: map[string]string{generationLabel: "1"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool-2",
+					Labels: map[string]string{generationLabel: "1"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+		},
+		"scaling-up": {
+			generation: 1,
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool-1",
+					Labels: map[string]string{generationLabel: "0"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+		},
+		"scaling-down": {
+			generation: 1,
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool-1",
+					Labels: map[string]string{generationLabel: "0"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+		},
+		"updates": {
+			generation:           1,
+			expectedSetsToUpdate: []string{"pool-1"},
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool-1",
+					Labels: map[string]string{generationLabel: "0"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(tt.generation)
+
+			pools := []*poolWithOrdinals{}
+			for _, set := range tt.existingPools {
+				pools = append(pools, &poolWithOrdinals{
+					set: set.DeepCopy(),
+				})
+			}
+
+			tracker.addExisting(pools...)
+			tracker.addDesired(tt.desiredPools...)
+
+			actual := objectNames(tracker.RequiresUpdate())
+			require.ElementsMatch(t, tt.expectedSetsToUpdate, actual)
+		})
+	}
+}
+
+func TestPoolTrackerToScaleDown(t *testing.T) {
+	for name, tt := range map[string]struct {
+		existingPools           []*poolWithOrdinals
+		desiredPools            []*appsv1.StatefulSet
+		expectedSetsToScaleDown []string
+	}{
+		"no-op": {},
+		"deleted-set": {
+			expectedSetsToScaleDown: []string{"pool-1(2): pod-3"},
+			existingPools: []*poolWithOrdinals{{
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
+				},
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-3"},
+					},
+				}},
+			}},
+		},
+		"scaling-up-set": {
+			existingPools: []*poolWithOrdinals{{
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
+				},
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-3"},
+					},
+				}},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(4))},
+			}},
+		},
+		"scaling-down-set": {
+			expectedSetsToScaleDown: []string{"pool-1(2): pod-3", "pool-3(0): pod-1"},
+			existingPools: []*poolWithOrdinals{{
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
+				},
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-2"},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-3"},
+					},
+				}},
+			}, {
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-2"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}},
+			}, {
+				set: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "pool-3"},
+					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+					},
+				}},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{Name: "pool-2"},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(1)
+			tracker.addExisting(tt.existingPools...)
+			tracker.addDesired(tt.desiredPools...)
+
+			toIDs := func(list []*ScaleDownSet) []string {
+				ids := []string{}
+				for _, o := range list {
+					ids = append(ids, fmt.Sprintf("%s(%d): %s", o.StatefulSet.Name, ptr.Deref(o.StatefulSet.Spec.Replicas, 0), o.LastPod.Name))
+				}
+				return ids
+			}
+
+			actual := toIDs(tracker.ToScaleDown())
+			require.ElementsMatch(t, tt.expectedSetsToScaleDown, actual)
+		})
+	}
+}
+
+func TestPoolTrackerToDelete(t *testing.T) {
+	for name, tt := range map[string]struct {
+		existingPools        []*appsv1.StatefulSet
+		desiredPools         []*appsv1.StatefulSet
+		expectedSetsToDelete []string
+	}{
+		"no-op": {},
+		"no-deletions": {
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}},
+		},
+		"scaling-down": {
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-3",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas: 1,
+				},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}},
+		},
+		"can-delete": {
+			expectedSetsToDelete: []string{"pool-2", "pool-3"},
+			existingPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-2",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-3",
+				},
+			}},
+			desiredPools: []*appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pool-1",
+				},
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(0)
+
+			pools := []*poolWithOrdinals{}
+			for _, set := range tt.existingPools {
+				pools = append(pools, &poolWithOrdinals{
+					set: set.DeepCopy(),
+				})
+			}
+
+			tracker.addExisting(pools...)
+			tracker.addDesired(tt.desiredPools...)
+
+			actual := objectNames(tracker.ToDelete())
+			require.ElementsMatch(t, tt.expectedSetsToDelete, actual)
+		})
+	}
+}
+
+func TestPoolTrackerPodsToRoll(t *testing.T) {
+	pool1 := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pool-1",
+		},
+	}
+	pool1Revisions := []*appsv1.ControllerRevision{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "b",
+		},
+	}}
+	pool2 := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pool-2",
+		},
+	}
+	pool2Revisions := []*appsv1.ControllerRevision{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+		},
+	}}
+
+	for name, tt := range map[string]struct {
+		existingPools      []*poolWithOrdinals
+		expectedPodsToRoll []string
+	}{
+		"no-op": {},
+		"all-up-to-date": {
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "b",
+							},
+						},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-2",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "b",
+							},
+						},
+					},
+				}},
+				set:       pool1,
+				revisions: pool1Revisions,
+			}},
+		},
+		"all-out-of-date": {
+			expectedPodsToRoll: []string{"pod-1", "pod-2"},
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "a",
+							},
+						},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-2",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "a",
+							},
+						},
+					},
+				}},
+				set:       pool1,
+				revisions: pool1Revisions,
+			}},
+		},
+		"no-revisions": {
+			expectedPodsToRoll: []string{"pod-1", "pod-2"},
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "a",
+							},
+						},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-2",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "a",
+							},
+						},
+					},
+				}},
+				set: pool1,
+			}},
+		},
+		"mixed": {
+			expectedPodsToRoll: []string{"pod-1", "pod-3"},
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "a",
+							},
+						},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-2",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "b",
+							},
+						},
+					},
+				}},
+				set:       pool1,
+				revisions: pool1Revisions,
+			}, {
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-3",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "foo",
+							},
+						},
+					},
+				}, {
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-4",
+							Labels: map[string]string{
+								appsv1.StatefulSetRevisionLabel: "bar",
+							},
+						},
+					},
+				}},
+				set:       pool2,
+				revisions: pool2Revisions,
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewPoolTracker(0)
+			tracker.addExisting(tt.existingPools...)
+
+			actual := objectNames(tracker.PodsToRoll())
+			require.ElementsMatch(t, tt.expectedPodsToRoll, actual)
+		})
+	}
+}

--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -1,0 +1,357 @@
+-- basic-test --
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test
+    namespace: basic-test
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: basic-test
+        app.kubernetes.io/name: redpanda
+    serviceName: basic-test
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: 185aaf952885b6464965abdd1757bd2962b2dc0d49aeb493feb9843203fc7833
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda-statefulset
+          app.kubernetes.io/instance: basic-test
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: redpanda
+          helm.sh/chart: redpanda-5.9.21
+          redpanda.com/poddisruptionbudget: basic-test
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: redpanda-statefulset
+                  app.kubernetes.io/instance: basic-test
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=$(SERVICE_NAME).basic-test.basic-test.svc.cluster.local.:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+                "https://${SERVICE_NAME}.basic-test.basic-test.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 101
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.basic-test.basic-test.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - args:
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - basic-test
+          - --redpanda-cluster-name
+          - basic-test
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).basic-test.basic-test.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v2.3.8-24.3.6
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          securityContext: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+          name: redpanda-configurator
+          resources: {}
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 101
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: basic-test-configurator
+        - command:
+          - /redpanda-operator
+          - envsubst
+          - /tmp/base-config/bootstrap.yaml
+          - --output
+          - /tmp/config/.bootstrap.yaml
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v2.3.8-24.3.6
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+        serviceAccountName: default
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: redpanda-statefulset
+              app.kubernetes.io/instance: basic-test
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: basic-test-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: basic-test-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: basic-test-sts-lifecycle
+        - configMap:
+            name: basic-test
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: basic-test-configurator
+          secret:
+            defaultMode: 509
+            secretName: basic-test-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: basic-test
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0

--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -11,7 +11,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test
@@ -28,14 +28,14 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: 185aaf952885b6464965abdd1757bd2962b2dc0d49aeb493feb9843203fc7833
+          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
         creationTimestamp: null
         labels:
           app.kubernetes.io/component: redpanda-statefulset
           app.kubernetes.io/instance: basic-test
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/name: redpanda
-          helm.sh/chart: redpanda-5.9.21
+          helm.sh/chart: redpanda-5.9.20
           redpanda.com/poddisruptionbudget: basic-test
       spec:
         affinity:

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -1,0 +1,1136 @@
+-- basic-test --
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-external
+    namespace: basic-test
+  spec:
+    externalTrafficPolicy: Local
+    ports:
+    - name: admin-default
+      nodePort: 31644
+      port: 9645
+      protocol: TCP
+      targetPort: 0
+    - name: kafka-default
+      nodePort: 31092
+      port: 9094
+      protocol: TCP
+      targetPort: 0
+    - name: http-default
+      nodePort: 30082
+      port: 8083
+      protocol: TCP
+      targetPort: 0
+    - name: schema-default
+      nodePort: 30081
+      port: 8084
+      protocol: TCP
+      targetPort: 0
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/name: redpanda
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test
+    namespace: basic-test
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: basic-test
+        app.kubernetes.io/name: redpanda
+        redpanda.com/poddisruptionbudget: basic-test
+  status:
+    currentHealthy: 0
+    desiredHealthy: 0
+    disruptionsAllowed: 0
+    expectedPods: 0
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+      monitoring.redpanda.com/enabled: "false"
+    name: basic-test
+    namespace: basic-test
+  spec:
+    clusterIP: None
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/name: redpanda
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-sidecar-controllers
+    namespace: basic-test
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets/status
+    verbs:
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-sidecar-controllers
+    namespace: basic-test
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: basic-test-sidecar-controllers
+  subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: basic-test
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    annotations:
+      helm.sh/hook: post-install,post-upgrade
+      helm.sh/hook-delete-policy: before-hook-creation
+      helm.sh/hook-weight: "-5"
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-configuration
+    namespace: basic-test
+  spec:
+    template:
+      metadata:
+        creationTimestamp: null
+        generateName: basic-test-post-
+        labels:
+          app.kubernetes.io/component: redpanda-post-install
+          app.kubernetes.io/instance: basic-test
+          app.kubernetes.io/name: redpanda
+      spec:
+        affinity: {}
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - /redpanda-operator
+          - sync-cluster-config
+          - --users-directory
+          - /etc/secrets/users
+          - --redpanda-yaml
+          - /tmp/base-config/redpanda.yaml
+          - --bootstrap-yaml
+          - /tmp/config/.bootstrap.yaml
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v2.3.8-24.3.6
+          name: post-install
+          resources: {}
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 101
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /tmp/config
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+        initContainers:
+        - command:
+          - /redpanda-operator
+          - envsubst
+          - /tmp/base-config/bootstrap.yaml
+          - --output
+          - /tmp/config/.bootstrap.yaml
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v2.3.8-24.3.6
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        restartPolicy: Never
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+        serviceAccountName: default
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: basic-test-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: basic-test-external-cert
+        - configMap:
+            name: basic-test
+          name: base-config
+        - emptyDir: {}
+          name: config
+  status: {}
+- apiVersion: v1
+  data:
+    bootstrap.yaml: |-
+      audit_enabled: false
+      cloud_storage_cache_size: 5368709120
+      cloud_storage_enable_remote_read: true
+      cloud_storage_enable_remote_write: true
+      cloud_storage_enabled: false
+      compacted_log_segment_size: 67108864
+      default_topic_replications: 3
+      enable_rack_awareness: false
+      enable_sasl: false
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      storage_min_free_bytes: 1073741824
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: basic-test-0.basic-test.basic-test.svc.cluster.local.
+          port: 9093
+        - address: basic-test-1.basic-test.basic-test.svc.cluster.local.
+          port: 9093
+        - address: basic-test-2.basic-test.basic-test.svc.cluster.local.
+          port: 9093
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: basic-test-0.basic-test.basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: basic-test-1.basic-test.basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: basic-test-2.basic-test.basic-test.svc.cluster.local.
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - basic-test-0.basic-test.basic-test.svc.cluster.local.:9644
+          - basic-test-1.basic-test.basic-test.svc.cluster.local.:9644
+          - basic-test-2.basic-test.basic-test.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - basic-test-0.basic-test.basic-test.svc.cluster.local.:9093
+          - basic-test-1.basic-test.basic-test.svc.cluster.local.:9093
+          - basic-test-2.basic-test.basic-test.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - basic-test-0.basic-test.basic-test.svc.cluster.local.:8081
+          - basic-test-1.basic-test.basic-test.svc.cluster.local.:8081
+          - basic-test-2.basic-test.basic-test.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: basic-test-0.basic-test.basic-test.svc.cluster.local.
+          port: 9093
+        - address: basic-test-1.basic-test.basic-test.svc.cluster.local.
+          port: 9093
+        - address: basic-test-2.basic-test.basic-test.svc.cluster.local.
+          port: 9093
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test
+    namespace: basic-test
+- apiVersion: v1
+  data:
+    profile: |-
+      admin_api:
+        addresses:
+        - basic-test-0:31644
+        - basic-test-1:31644
+        - basic-test-2:31644
+        tls:
+          ca_file: ca.crt
+      kafka_api:
+        brokers:
+        - basic-test-0:31092
+        - basic-test-1:31092
+        - basic-test-2:31092
+        tls:
+          ca_file: ca.crt
+      name: default
+      schema_registry:
+        addresses:
+        - basic-test-0:30081
+        - basic-test-1:30081
+        - basic-test-2:30081
+        tls:
+          ca_file: ca.crt
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-rpk
+    namespace: basic-test
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-default-selfsigned-issuer
+    namespace: basic-test
+  spec:
+    selfSigned: {}
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-default-root-issuer
+    namespace: basic-test
+  spec:
+    ca:
+      secretName: basic-test-default-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-external-selfsigned-issuer
+    namespace: basic-test
+  spec:
+    selfSigned: {}
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-external-root-issuer
+    namespace: basic-test
+  spec:
+    ca:
+      secretName: basic-test-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-default-root-certificate
+    namespace: basic-test
+  spec:
+    commonName: basic-test-default-root-certificate
+    duration: 43800h0m0s
+    isCA: true
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: basic-test-default-selfsigned-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: basic-test-default-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-external-root-certificate
+    namespace: basic-test
+  spec:
+    commonName: basic-test-external-root-certificate
+    duration: 43800h0m0s
+    isCA: true
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: basic-test-external-selfsigned-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: basic-test-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-default-cert
+    namespace: basic-test
+  spec:
+    dnsNames:
+    - basic-test-cluster.basic-test.basic-test.svc.cluster.local
+    - basic-test-cluster.basic-test.basic-test.svc
+    - basic-test-cluster.basic-test.basic-test
+    - '*.basic-test-cluster.basic-test.basic-test.svc.cluster.local'
+    - '*.basic-test-cluster.basic-test.basic-test.svc'
+    - '*.basic-test-cluster.basic-test.basic-test'
+    - basic-test.basic-test.svc.cluster.local
+    - basic-test.basic-test.svc
+    - basic-test.basic-test
+    - '*.basic-test.basic-test.svc.cluster.local'
+    - '*.basic-test.basic-test.svc'
+    - '*.basic-test.basic-test'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: basic-test-default-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: basic-test-default-cert
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-external-cert
+    namespace: basic-test
+  spec:
+    dnsNames:
+    - basic-test-cluster.basic-test.basic-test.svc.cluster.local
+    - basic-test-cluster.basic-test.basic-test.svc
+    - basic-test-cluster.basic-test.basic-test
+    - '*.basic-test-cluster.basic-test.basic-test.svc.cluster.local'
+    - '*.basic-test-cluster.basic-test.basic-test.svc'
+    - '*.basic-test-cluster.basic-test.basic-test'
+    - basic-test.basic-test.svc.cluster.local
+    - basic-test.basic-test.svc
+    - basic-test.basic-test
+    - '*.basic-test.basic-test.svc.cluster.local'
+    - '*.basic-test.basic-test.svc'
+    - '*.basic-test.basic-test'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: basic-test-external-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: basic-test-external-cert
+  status: {}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-sts-lifecycle
+    namespace: basic-test
+  stringData:
+    common.sh: |-
+      #!/usr/bin/env bash
+
+      # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+      CURL_URL="https://${SERVICE_NAME}.basic-test.basic-test.svc.cluster.local:9644"
+
+      # commands used throughout
+      CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+      CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+    postStart.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      postStartHook () {
+        set -x
+
+        touch /tmp/postStartHookStarted
+
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Clearing maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        # a 400 here would mean not in maintenance mode
+        until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+            status=$(${CURL_MAINTENANCE_DELETE_CMD})
+            sleep 0.5
+        done
+
+        touch /tmp/postStartHookFinished
+      }
+
+      postStartHook
+      true
+    preStop.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      touch /tmp/preStopHookStarted
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      set -x
+
+      preStopHook () {
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Setting maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        until [ "${status:-}" = '"200"' ]; do
+            status=$(${CURL_MAINTENANCE_PUT_CMD})
+            sleep 0.5
+        done
+
+        until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+            res=$(${CURL_MAINTENANCE_GET_CMD})
+            finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+            draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+            sleep 0.5
+        done
+
+        touch /tmp/preStopHookFinished
+      }
+      preStopHook
+      true
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: redpanda-5.9.21
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-configurator
+    namespace: basic-test
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+      BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.basic-test.basic-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      ADVERTISED_KAFKA_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.basic-test.basic-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      ADVERTISED_HTTP_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+  type: Opaque
+- apiVersion: v1
+  data:
+    config.yaml: |
+      # from .Values.console.config
+      kafka:
+        brokers:
+        - basic-test-0.basic-test.basic-test.svc.cluster.local.:9093
+        - basic-test-1.basic-test.basic-test.svc.cluster.local.:9093
+        - basic-test-2.basic-test.basic-test.svc.cluster.local.:9093
+        sasl:
+          enabled: false
+        schemaRegistry:
+          enabled: true
+          tls:
+            caFilepath: /etc/tls/certs/default/ca.crt
+            certFilepath: ""
+            enabled: true
+            insecureSkipTlsVerify: false
+            keyFilepath: ""
+          urls:
+          - https://basic-test-0.basic-test.basic-test.svc.cluster.local.:8081
+          - https://basic-test-1.basic-test.basic-test.svc.cluster.local.:8081
+          - https://basic-test-2.basic-test.basic-test.svc.cluster.local.:8081
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+      redpanda:
+        adminApi:
+          enabled: true
+          tls:
+            caFilepath: /etc/tls/certs/default/ca.crt
+            certFilepath: ""
+            enabled: true
+            insecureSkipTlsVerify: false
+            keyFilepath: ""
+          urls:
+          - https://basic-test.basic-test.svc.cluster.local.:9644
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-console
+    namespace: basic-test
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-console
+    namespace: basic-test
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: basic-test
+        app.kubernetes.io/name: console
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          checksum-redpanda-chart/config: 521217d2b7753580c8ef5da50a799bb4f1f123228eaa0b077105632a5685402c
+          checksum/config: e07159484f05956236f7ca9b493b61cf44715cbd5df7c0c0a0e5f9c5391bfa42
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: basic-test
+          app.kubernetes.io/name: console
+      spec:
+        affinity: {}
+        automountServiceAccountToken: false
+        containers:
+        - args:
+          - --config.filepath=/etc/console/configs/config.yaml
+          image: docker.redpanda.com/redpandadata/console:v2.8.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: console
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /etc/console/configs
+            name: configs
+            readOnly: true
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+        securityContext:
+          fsGroup: 99
+          runAsUser: 99
+        serviceAccountName: basic-test-console
+        volumes:
+        - configMap:
+            name: basic-test-console
+          name: configs
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 272
+            secretName: basic-test-default-cert
+  status: {}
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-console
+    namespace: basic-test
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: basic-test
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: basic-test
+      helm.toolkit.fluxcd.io/namespace: basic-test
+    name: basic-test-console
+    namespace: basic-test
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 0
+    selector:
+      app.kubernetes.io/instance: basic-test
+      app.kubernetes.io/name: console
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -11,7 +11,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-external
@@ -60,7 +60,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test
@@ -90,7 +90,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
       monitoring.redpanda.com/enabled: "false"
@@ -139,7 +139,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-sidecar-controllers
@@ -213,7 +213,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-sidecar-controllers
@@ -242,7 +242,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-configuration
@@ -518,7 +518,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test
@@ -559,7 +559,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-rpk
@@ -576,7 +576,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-default-selfsigned-issuer
@@ -596,7 +596,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-default-root-issuer
@@ -617,7 +617,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-external-selfsigned-issuer
@@ -637,7 +637,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-external-root-issuer
@@ -658,7 +658,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-default-root-certificate
@@ -688,7 +688,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-external-root-certificate
@@ -718,7 +718,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-default-cert
@@ -759,7 +759,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-external-cert
@@ -800,7 +800,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-sts-lifecycle
@@ -896,7 +896,7 @@
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
-      helm.sh/chart: redpanda-5.9.21
+      helm.sh/chart: redpanda-5.9.20
       helm.toolkit.fluxcd.io/name: basic-test
       helm.toolkit.fluxcd.io/namespace: basic-test
     name: basic-test-configurator
@@ -957,18 +957,6 @@
         - basic-test-2.basic-test.basic-test.svc.cluster.local.:9093
         sasl:
           enabled: false
-        schemaRegistry:
-          enabled: true
-          tls:
-            caFilepath: /etc/tls/certs/default/ca.crt
-            certFilepath: ""
-            enabled: true
-            insecureSkipTlsVerify: false
-            keyFilepath: ""
-          urls:
-          - https://basic-test-0.basic-test.basic-test.svc.cluster.local.:8081
-          - https://basic-test-1.basic-test.basic-test.svc.cluster.local.:8081
-          - https://basic-test-2.basic-test.basic-test.svc.cluster.local.:8081
         tls:
           caFilepath: /etc/tls/certs/default/ca.crt
           certFilepath: ""
@@ -986,6 +974,18 @@
             keyFilepath: ""
           urls:
           - https://basic-test.basic-test.svc.cluster.local.:9644
+      schemaRegistry:
+        enabled: true
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://basic-test-0.basic-test.basic-test.svc.cluster.local.:8081
+        - https://basic-test-1.basic-test.basic-test.svc.cluster.local.:8081
+        - https://basic-test-2.basic-test.basic-test.svc.cluster.local.:8081
   kind: ConfigMap
   metadata:
     creationTimestamp: null
@@ -993,7 +993,7 @@
       app.kubernetes.io/instance: basic-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: console
-      app.kubernetes.io/version: v2.8.0
+      app.kubernetes.io/version: v3.0.0-beta.1
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
@@ -1010,7 +1010,7 @@
       app.kubernetes.io/instance: basic-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: console
-      app.kubernetes.io/version: v2.8.0
+      app.kubernetes.io/version: v3.0.0-beta.1
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
@@ -1029,8 +1029,8 @@
     template:
       metadata:
         annotations:
-          checksum-redpanda-chart/config: 521217d2b7753580c8ef5da50a799bb4f1f123228eaa0b077105632a5685402c
-          checksum/config: e07159484f05956236f7ca9b493b61cf44715cbd5df7c0c0a0e5f9c5391bfa42
+          checksum-redpanda-chart/config: 305efbcbb703038386eb5720d60a950bfd5550f95f68020474c39e2dd545c0a6
+          checksum/config: 23e1498cb98cc20f2ac1f9810212242a0a855a456b0635259ef94d3406de3551
         creationTimestamp: null
         labels:
           app.kubernetes.io/instance: basic-test
@@ -1041,7 +1041,7 @@
         containers:
         - args:
           - --config.filepath=/etc/console/configs/config.yaml
-          image: docker.redpanda.com/redpandadata/console:v2.8.0
+          image: docker.redpanda.com/redpandadata/console:v3.0.0-beta.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -1076,6 +1076,7 @@
             name: redpanda-default-cert
         securityContext:
           fsGroup: 99
+          fsGroupChangePolicy: Always
           runAsUser: 99
         serviceAccountName: basic-test-console
         volumes:
@@ -1096,7 +1097,7 @@
       app.kubernetes.io/instance: basic-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: console
-      app.kubernetes.io/version: v2.8.0
+      app.kubernetes.io/version: v3.0.0-beta.1
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test
@@ -1113,7 +1114,7 @@
       app.kubernetes.io/instance: basic-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: console
-      app.kubernetes.io/version: v2.8.0
+      app.kubernetes.io/version: v3.0.0-beta.1
       cluster.redpanda.com/namespace: basic-test
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: basic-test

--- a/operator/internal/lifecycle/testdata/cases.txtar
+++ b/operator/internal/lifecycle/testdata/cases.txtar
@@ -1,0 +1,1 @@
+-- basic-test --

--- a/operator/internal/lifecycle/v2.go
+++ b/operator/internal/lifecycle/v2.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// V2ResourceManagers is a factory function for tying together all of our v2 interfaces.
+func V2ResourceManagers(mgr ctrl.Manager) (
+	OwnershipResolver[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+	ClusterStatusUpdater[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+	NodePoolRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+	SimpleResourceRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+) {
+	return NewV2OwnershipResolver(), NewV2ClusterStatusUpdater(), NewV2NodePoolRenderer(mgr), NewV2SimpleResourceRenderer(mgr)
+}

--- a/operator/internal/lifecycle/v2_node_pools.go
+++ b/operator/internal/lifecycle/v2_node_pools.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
+)
+
+// V2NodePoolRenderer represents a node pool renderer for v2 clusters.
+type V2NodePoolRenderer struct {
+	kubeConfig clientcmdapi.Config
+}
+
+var _ NodePoolRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda] = (*V2NodePoolRenderer)(nil)
+
+// NewV2NodePoolRenderer returns a V2NodePoolRenderer.
+func NewV2NodePoolRenderer(mgr ctrl.Manager) *V2NodePoolRenderer {
+	return &V2NodePoolRenderer{
+		kubeConfig: kube.RestToConfig(mgr.GetConfig()),
+	}
+}
+
+// Render returns a list of StatefulSets for the given Redpanda v2 cluster. It does this by
+// delegating to our particular resource rendering pipeline and filtering out anything that
+// isn't a node pool.
+func (m *V2NodePoolRenderer) Render(ctx context.Context, cluster *redpandav1alpha2.Redpanda) ([]*appsv1.StatefulSet, error) {
+	values := cluster.Spec.ClusterSpec.DeepCopy()
+
+	rendered, err := redpanda.Chart.Render(&m.kubeConfig, helmette.Release{
+		Namespace: cluster.Namespace,
+		Name:      cluster.GetHelmReleaseName(),
+		Service:   "Helm",
+		IsUpgrade: true,
+	}, values)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := []*appsv1.StatefulSet{}
+
+	// filter out non-nodepools
+	for _, object := range rendered {
+		if isNodePool(object) {
+			resources = append(resources, object.(*appsv1.StatefulSet))
+		}
+	}
+
+	return resources, nil
+}
+
+// isNodePool returns whether or not the object passed to it should be considered a node pool.
+// For now, this concrete implementation just looks for any StatefulSets and says that they are a
+// node pool.
+func isNodePool(object client.Object) bool {
+	return isStatefulSet(object)
+}
+
+// IsNodePool returns whether or not the object passed to it should be considered a node pool.
+func (m *V2NodePoolRenderer) IsNodePool(object client.Object) bool {
+	return isNodePool(object)
+}

--- a/operator/internal/lifecycle/v2_node_pools.go
+++ b/operator/internal/lifecycle/v2_node_pools.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 

--- a/operator/internal/lifecycle/v2_ownership.go
+++ b/operator/internal/lifecycle/v2_ownership.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// V2OwnershipResolver represents an ownership resolver for v2 clusters.
+type V2OwnershipResolver struct {
+	operatorLabel  string
+	ownerLabel     string
+	namespaceLabel string
+}
+
+var _ OwnershipResolver[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda] = (*V2OwnershipResolver)(nil)
+
+// NewV2OwnershipResolver returns a V2OwnershipResolver.
+func NewV2OwnershipResolver() *V2OwnershipResolver {
+	return &V2OwnershipResolver{
+		operatorLabel:  defaultOperatorLabel,
+		ownerLabel:     defaultOwnerLabel,
+		namespaceLabel: defaultNamespaceLabel,
+	}
+}
+
+// AddLabels returns the labels to add to all resources associated with a
+// v2 cluster.
+func (m *V2OwnershipResolver) AddLabels(cluster *redpandav1alpha2.Redpanda) map[string]string {
+	return map[string]string{
+		m.namespaceLabel: cluster.GetNamespace(),
+		m.ownerLabel:     cluster.GetName(),
+		m.operatorLabel:  "v2",
+		// we add these for backwards compatibility for the time being
+		fluxNameLabel:      cluster.Name,
+		fluxNamespaceLabel: cluster.Namespace,
+	}
+}
+
+// GetOwnerLabels returns the labels that can identify a resource belonging
+// to a given cluster.
+func (m *V2OwnershipResolver) GetOwnerLabels(cluster *redpandav1alpha2.Redpanda) map[string]string {
+	return map[string]string{
+		fluxNameLabel:      cluster.Name,
+		fluxNamespaceLabel: cluster.Namespace,
+	}
+}
+
+// ownerFromLabels returns the v2 cluster based on a resource's labels.
+func (m *V2OwnershipResolver) ownerFromLabels(labels map[string]string) types.NamespacedName {
+	owner := labels[m.ownerLabel]
+	if owner == "" {
+		// fallback to flux labels
+		owner = labels[fluxNameLabel]
+	}
+
+	namespace := labels[m.namespaceLabel]
+	if namespace == "" {
+		// fallback to flux labels
+		namespace = labels[fluxNamespaceLabel]
+	}
+
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      owner,
+	}
+}
+
+// OwnerForObject maps an object to the v2 cluster that owns it.
+func (m *V2OwnershipResolver) OwnerForObject(object client.Object) *types.NamespacedName {
+	if labels := object.GetLabels(); labels != nil {
+		nn := m.ownerFromLabels(labels)
+		if nn.Namespace != "" && nn.Name != "" {
+			return &nn
+		}
+	}
+	return nil
+}

--- a/operator/internal/lifecycle/v2_simple_resources.go
+++ b/operator/internal/lifecycle/v2_simple_resources.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 

--- a/operator/internal/lifecycle/v2_simple_resources.go
+++ b/operator/internal/lifecycle/v2_simple_resources.go
@@ -12,7 +12,6 @@ package lifecycle
 import (
 	"context"
 
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,7 +23,7 @@ import (
 
 // V2SimpleResourceRenderer represents an simple resource renderer for v2 clusters.
 type V2SimpleResourceRenderer struct {
-	kubeConfig clientcmdapi.Config
+	kubeConfig *kube.RESTConfig
 }
 
 var _ SimpleResourceRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda] = (*V2SimpleResourceRenderer)(nil)
@@ -32,7 +31,7 @@ var _ SimpleResourceRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpan
 // NewV2SimpleResourceRenderer returns a V2SimpleResourceRenderer.
 func NewV2SimpleResourceRenderer(mgr ctrl.Manager) *V2SimpleResourceRenderer {
 	return &V2SimpleResourceRenderer{
-		kubeConfig: kube.RestToConfig(mgr.GetConfig()),
+		kubeConfig: mgr.GetConfig(),
 	}
 }
 
@@ -42,7 +41,7 @@ func NewV2SimpleResourceRenderer(mgr ctrl.Manager) *V2SimpleResourceRenderer {
 func (m *V2SimpleResourceRenderer) Render(ctx context.Context, cluster *redpandav1alpha2.Redpanda) ([]client.Object, error) {
 	values := cluster.Spec.ClusterSpec.DeepCopy()
 
-	rendered, err := redpanda.Chart.Render(&m.kubeConfig, helmette.Release{
+	rendered, err := redpanda.Chart.Render(m.kubeConfig, helmette.Release{
 		Namespace: cluster.Namespace,
 		Name:      cluster.GetHelmReleaseName(),
 		Service:   "Helm",

--- a/operator/internal/lifecycle/v2_simple_resources.go
+++ b/operator/internal/lifecycle/v2_simple_resources.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
+)
+
+// V2SimpleResourceRenderer represents an simple resource renderer for v2 clusters.
+type V2SimpleResourceRenderer struct {
+	kubeConfig clientcmdapi.Config
+}
+
+var _ SimpleResourceRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda] = (*V2SimpleResourceRenderer)(nil)
+
+// NewV2SimpleResourceRenderer returns a V2SimpleResourceRenderer.
+func NewV2SimpleResourceRenderer(mgr ctrl.Manager) *V2SimpleResourceRenderer {
+	return &V2SimpleResourceRenderer{
+		kubeConfig: kube.RestToConfig(mgr.GetConfig()),
+	}
+}
+
+// Render returns a list of simple resources for the given Redpanda v2 cluster. It does this by
+// delegating to our particular resource rendering pipeline and filtering out anything that
+// should be considered a node pool.
+func (m *V2SimpleResourceRenderer) Render(ctx context.Context, cluster *redpandav1alpha2.Redpanda) ([]client.Object, error) {
+	values := cluster.Spec.ClusterSpec.DeepCopy()
+
+	rendered, err := redpanda.Chart.Render(&m.kubeConfig, helmette.Release{
+		Namespace: cluster.Namespace,
+		Name:      cluster.GetHelmReleaseName(),
+		Service:   "Helm",
+		IsUpgrade: true,
+	}, values)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := []client.Object{}
+
+	// filter out the statefulsets
+	for _, object := range rendered {
+		if !isNodePool(object) {
+			resources = append(resources, object)
+		}
+	}
+
+	return resources, nil
+}
+
+// WatchedResourceTypes returns the list of all the resources that the cluster
+// controller needs to watch.
+func (m *V2SimpleResourceRenderer) WatchedResourceTypes() []client.Object {
+	return redpanda.Types()
+}

--- a/operator/internal/lifecycle/v2_status.go
+++ b/operator/internal/lifecycle/v2_status.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// V2ClusterStatusUpdater represents a status updater for v2 clusters.
+type V2ClusterStatusUpdater struct{}
+
+var _ ClusterStatusUpdater[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda] = (*V2ClusterStatusUpdater)(nil)
+
+// NewV2ClusterStatusUpdater returns a V2ClusterStatusUpdater.
+func NewV2ClusterStatusUpdater() *V2ClusterStatusUpdater {
+	return &V2ClusterStatusUpdater{}
+}
+
+// Update updates the given Redpanda v2 cluster with the given cluster status.
+func (m *V2ClusterStatusUpdater) Update(cluster *redpandav1alpha2.Redpanda, status ClusterStatus) bool {
+	condition := metav1.Condition{
+		Type:               "Quiesced",
+		Status:             metav1.ConditionFalse,
+		Reason:             "Quiesced",
+		ObservedGeneration: cluster.GetGeneration(),
+	}
+	if status.Quiesced {
+		condition.Status = metav1.ConditionTrue
+	}
+	cluster.Status.ObservedGeneration = cluster.Generation
+
+	return apimeta.SetStatusCondition(&cluster.Status.Conditions, condition)
+}

--- a/operator/internal/lifecycle/v2_test.go
+++ b/operator/internal/lifecycle/v2_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/yaml"
 
 	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
@@ -80,6 +81,10 @@ func TestV2ResourceClient(t *testing.T) {
 	manager, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: controller.V2Scheme,
 		Logger: logger,
+		Metrics: metricsserver.Options{
+			// disable metrics
+			BindAddress: "0",
+		},
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: append(redpandachart.Types(), &redpandav1alpha2.Redpanda{}, &corev1.Namespace{}),
@@ -106,6 +111,8 @@ func TestV2ResourceClient(t *testing.T) {
 
 	for _, file := range casesArchive.Files {
 		t.Run(file.Name, func(t *testing.T) {
+			t.Parallel()
+
 			cluster := &redpandav1alpha2.Redpanda{}
 			require.NoError(t, yaml.Unmarshal(file.Data, cluster))
 

--- a/operator/internal/lifecycle/v2_test.go
+++ b/operator/internal/lifecycle/v2_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/tools/txtar"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/yaml"
+
+	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+)
+
+func TestV2ResourceClientStatus(t *testing.T) {
+	updater := NewV2ClusterStatusUpdater()
+
+	for _, quiesced := range []bool{true, false} {
+		cluster := &redpandav1alpha2.Redpanda{}
+		require.True(t, updater.Update(cluster, ClusterStatus{Quiesced: quiesced}))
+		require.False(t, updater.Update(cluster, ClusterStatus{Quiesced: quiesced}))
+	}
+}
+
+func TestV2ResourceClient(t *testing.T) {
+	log.SetLogger(logr.Discard())
+
+	ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
+	defer cancel()
+
+	server := &envtest.APIServer{}
+	etcd := &envtest.Etcd{}
+
+	environment := &envtest.Environment{
+		ControlPlane: envtest.ControlPlane{
+			APIServer: server,
+			Etcd:      etcd,
+		},
+	}
+	config, err := environment.Start()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := environment.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	opts := []zap.Opts{
+		zap.UseDevMode(true), zap.Level(zapcore.DebugLevel),
+	}
+
+	if !testing.Verbose() {
+		opts = append(opts, zap.WriteTo(io.Discard))
+	}
+
+	logger := zap.New(opts...)
+
+	manager, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme: controller.V2Scheme,
+		Logger: logger,
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: append(redpandachart.Types(), &redpandav1alpha2.Redpanda{}, &corev1.Namespace{}),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	go func() {
+		if err := manager.Start(ctx); err != nil {
+			panic(err)
+		}
+	}()
+
+	casesArchive, err := txtar.ParseFile("testdata/cases.txtar")
+	require.NoError(t, err)
+
+	goldenPools := testutil.NewTxTar(t, "testdata/cases.pools.golden.txtar")
+	goldenResources := testutil.NewTxTar(t, "testdata/cases.resources.golden.txtar")
+
+	resourceClient := NewResourceClient(manager, V2ResourceManagers)
+
+	require.EqualValues(t, redpandachart.Types(), resourceClient.simpleResourceRenderer.WatchedResourceTypes())
+
+	for _, file := range casesArchive.Files {
+		t.Run(file.Name, func(t *testing.T) {
+			cluster := &redpandav1alpha2.Redpanda{}
+			require.NoError(t, yaml.Unmarshal(file.Data, cluster))
+
+			// override name and namespace to make it unique
+			cluster.Name = file.Name
+			cluster.Namespace = file.Name
+
+			ownerLabels := resourceClient.ownershipResolver.GetOwnerLabels(cluster)
+
+			pools, err := resourceClient.nodePoolRenderer.Render(ctx, cluster)
+			require.NoError(t, err)
+
+			assertOwnership := func(object client.Object) {
+				labels := object.GetLabels()
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				// copied from the original redpanda_controller normalization code
+				labels["helm.toolkit.fluxcd.io/name"] = cluster.Name
+				labels["helm.toolkit.fluxcd.io/namespace"] = cluster.Namespace
+				object.SetLabels(labels)
+
+				for label, value := range ownerLabels {
+					objectLabel, ok := labels[label]
+					require.True(t, ok, "no label %q found on %q: %s", label, object.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(object).String())
+					require.Equal(t, objectLabel, value)
+				}
+
+				require.Equal(t, client.ObjectKeyFromObject(cluster), *resourceClient.ownershipResolver.OwnerForObject(object))
+
+				for label, value := range resourceClient.ownershipResolver.AddLabels(cluster) {
+					labels[label] = value
+				}
+				object.SetLabels(labels)
+			}
+
+			for _, pool := range pools {
+				assertOwnership(pool)
+				require.True(t, resourceClient.nodePoolRenderer.IsNodePool(pool))
+			}
+
+			poolBytes, err := yaml.Marshal(pools)
+			require.NoError(t, err)
+
+			goldenPools.AssertGolden(t, testutil.YAML, file.Name, poolBytes)
+
+			resources, err := resourceClient.simpleResourceRenderer.Render(ctx, cluster)
+			require.NoError(t, err)
+
+			for _, resource := range resources {
+				assertOwnership(resource)
+				require.False(t, resourceClient.nodePoolRenderer.IsNodePool(resource))
+			}
+
+			resourceBytes, err := yaml.Marshal(resources)
+			require.NoError(t, err)
+
+			goldenResources.AssertGolden(t, testutil.YAML, file.Name, resourceBytes)
+		})
+	}
+}


### PR DESCRIPTION
This adds the basic interfaces for StatefulSet-based lifecycle management for initially the v2 operator. Currently it is not leveraged in a controller, as that needs to be subsequently broken out from the original PoC.

Included in all of this is a fairly large amount of unit testing that puts the entire package at ~90% coverage. Aside from incorporating some of the feedback from https://github.com/redpanda-data/redpanda-operator/pull/526, it also moves the subpackage from `resources` to `lifecycle`.