### PR TITLE
redpanda: Add assert-golden to see resources in text format

### DIFF
--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -1481,6 +1481,7 @@ tuning:
 # assertion prevents any rogue containers from the default podTemplate from
 # slipping in.
 # ASSERT-NO-ERROR
+# ASSERT-GOLDEN
 # ASSERT-FIELD-EQUALS ["apps/v1/StatefulSet", "default/also-not-redpanda", "{.spec.template.spec.containers[*].name}", ["not-redpanda", "sidecar"]]
 nameOverride: "not-redpanda"
 fullnameOverride: "also-not-redpanda"


### PR DESCRIPTION
During debugging of issue related to fullnameOverride I stumble upon missing resources in `charts/redpanda/testdata/template-cases.golden.txtar` file. This commit adds generated resources to golden file.