### PR TITLE
gotohelm: add support for subchart aliases

### DIFF
--- a/gotohelm/testdata/subchart/dependency-excluded-by-default/templates/config-map.tpl
+++ b/gotohelm/testdata/subchart/dependency-excluded-by-default/templates/config-map.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: dep-excluded
+  name: {{ .Chart.Name }}-{{ .Release.Name }}
 data:
   values: |
     {{- toYaml .Values | nindent 4 }}

--- a/gotohelm/testdata/subchart/dependency-included-by-default/Chart.lock
+++ b/gotohelm/testdata/subchart/dependency-included-by-default/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: dependency
   repository: file://../dependency
   version: 0.0.1
-digest: sha256:0967a8e5b168d98113b2cdc928c21f11f49e5623e451e73a3ea55c26307f7871
-generated: "2024-10-12T15:30:04.192588+02:00"
+digest: sha256:8feca67bcba3d731a1f0e063c3f6c09f5835e53fba6c70b7d4789e67237a4112
+generated: "2025-03-27T10:20:12.189404-04:00"

--- a/gotohelm/testdata/subchart/dependency-included-by-default/Chart.yaml
+++ b/gotohelm/testdata/subchart/dependency-included-by-default/Chart.yaml
@@ -24,3 +24,4 @@ dependencies:
     condition: enabled-dependency
     repository: "file://../dependency"
     version: 0.0.1
+    alias: dependency-alias

--- a/gotohelm/testdata/subchart/dependency-included-by-default/templates/config-map.tpl
+++ b/gotohelm/testdata/subchart/dependency-included-by-default/templates/config-map.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: dependency-included-by-default
+  name: {{ .Chart.Name }}-{{ .Release.Name }}
 data:
   values: |
     {{- toYaml .Values | nindent 4 }}

--- a/gotohelm/testdata/subchart/dependency-included-by-default/values.yaml
+++ b/gotohelm/testdata/subchart/dependency-included-by-default/values.yaml
@@ -17,7 +17,7 @@
 # that dependency helm chart values and resources will be rendered.
 enabled-dependency: true
 
-dependency:
+dependency-alias:
   # This key and value should be rendered by helm engine regardless of the
   # dependency condition
   change-me: enabled-dependency-change

--- a/gotohelm/testdata/subchart/dependency/templates/config-map.tpl
+++ b/gotohelm/testdata/subchart/dependency/templates/config-map.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: dependency
+  name: {{ .Chart.Name }}-{{ .Release.Name }}
 data:
   values: |
     {{- toYaml .Values | nindent 4 }}

--- a/gotohelm/testdata/subchart/root/templates/config-map.tpl
+++ b/gotohelm/testdata/subchart/root/templates/config-map.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: root-chart-test
+  name: {{ .Chart.Name }}-{{ .Release.Name }}
 data:
   values: |
     {{- toYaml .Values | nindent 4 }}

--- a/gotohelm/testdata/subchart/values-overwrite/templates/config-map.tpl
+++ b/gotohelm/testdata/subchart/values-overwrite/templates/config-map.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: values-overwrite
+  name: {{ .Chart.Name }}-{{ .Release.Name }}
 data:
   values: |
     {{- toYaml .Values | nindent 4 }}


### PR DESCRIPTION
Prior to this commit gotohelm's `GoChart`s did not support the [`alias`](https://helm.sh/docs/topics/charts/#the-chartyaml-file) field of dependencies.

This commit aligns the behavior of `GoChart` and helm itself when alias is specified. Support for `alias` makes it possible to reference nightly builds of our charts. e.g. console.