### PR TITLE
[release/v2.4.x] redpanda: Add assert-golden to see resources in text format

### DIFF
--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -1481,6 +1481,7 @@ tuning:
 # assertion prevents any rogue containers from the default podTemplate from
 # slipping in.
 # ASSERT-NO-ERROR
+# ASSERT-GOLDEN
 # ASSERT-FIELD-EQUALS ["apps/v1/StatefulSet", "default/also-not-redpanda", "{.spec.template.spec.containers[*].name}", ["not-redpanda", "sidecar"]]
 nameOverride: "not-redpanda"
 fullnameOverride: "also-not-redpanda"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [redpanda: Add assert-golden to see resources in text format](https://github.com/redpanda-data/redpanda-operator/pull/572)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)