### PR TITLE
[release/v25.1.x] Start certificate watchers (#592)

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250328-112231.yaml
+++ b/.changes/unreleased/operator-Fixed-20250328-112231.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Certificate reloading for webhook and metrics endpoints should now behave correctly.
+time: 2025-03-28T11:22:31.608235Z

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -48,6 +48,7 @@ For more details see: https://github.com/kubernetes-sigs/kubebuilder/discussions
 * Toggling `useFlux`, in either direction, no longer causes the bootstrap user's password to be regenerated.
 
   Manual mitigation steps are available [here](https://github.com/redpanda-data/helm-charts/issues/1596#issuecomment-2628356953).
+* Certificate reloading for webhook and metrics endpoints should now behave correctly.
 
 ## v2.3.8-24.3.6 - 2025-03-05
 ### Fixed

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -321,6 +321,9 @@ func Run(
 				setupLog.Error(err, "Failed to initialize webhook certificate watcher")
 				os.Exit(1)
 			}
+			go func() {
+				setupLog.Error(webhookCertWatcher.Start(ctx), "webhook cert watcher exits")
+			}()
 
 			webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
 				config.GetCertificate = webhookCertWatcher.GetCertificate
@@ -371,6 +374,9 @@ func Run(
 			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
 			os.Exit(1)
 		}
+		go func() {
+			setupLog.Error(metricsCertWatcher.Start(ctx), "metrics cert watcher exits")
+		}()
 
 		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
 			config.GetCertificate = metricsCertWatcher.GetCertificate


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [Start certificate watchers (#592)](https://github.com/redpanda-data/redpanda-operator/pull/592)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)