### PR TITLE
Revert "ci: change BK pool used and add push nightlies to new ECR registry (#563)"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,10 +46,9 @@ steps:
     label: ":gandalf: Nightly Releases"
     timeout_in_minutes: 10
     agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     commands:
       - |
-        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/l9j0i2e0
         ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:publish-nightly-artifacts
     # Build nightly releases whenever NIGHTLY_RELEASE is set and it's triggered
     # from a schedule or the BK UI. Notably, we permit building nightlies from
@@ -97,7 +96,7 @@ steps:
       build.branch == build.tag
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:publish-operator-image
     agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     plugins:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:

--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -11,7 +11,7 @@ notify:
     context: k8s-operator-v2-helm
 steps:
 - agents:
-    queue: k8s-m6id12xlarge
+    queue: v6-amd64-builders-m6id
   command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:lint
   key: lint
   label: Lint
@@ -27,7 +27,7 @@ steps:
   key: unit
   steps:
   - agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:unit
     key: unit-run
     label: Run Unit Tests
@@ -69,7 +69,7 @@ steps:
   key: integration
   steps:
   - agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:integration
     key: integration-run
     label: Run Integration Tests
@@ -111,7 +111,7 @@ steps:
   key: acceptance
   steps:
   - agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:acceptance
     key: acceptance-run
     label: Run Acceptance Tests
@@ -153,7 +153,7 @@ steps:
   key: kuttl-v1
   steps:
   - agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:kuttl-v1
     key: kuttl-v1-run
     label: Run Kuttl-V1 Tests
@@ -195,7 +195,7 @@ steps:
   key: kuttl-v1-nodepools
   steps:
   - agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:kuttl-v1-nodepools
     key: kuttl-v1-nodepools-run
     label: Run Kuttl-V1-Nodepools Tests
@@ -237,7 +237,7 @@ steps:
   key: kuttl-v2
   steps:
   - agents:
-      queue: k8s-m6id12xlarge
+      queue: v6-amd64-builders-m6id
     command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:kuttl-v2
     key: kuttl-v2-run
     label: Run Kuttl-V2 Tests

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -25,7 +25,7 @@ var (
 	// Known/Permitted Agent Pools
 
 	AgentsPipeLineUploader = map[string]any{"queue": "pipeline-uploader"}
-	AgentsLarge            = map[string]any{"queue": "k8s-m6id12xlarge"}
+	AgentsLarge            = map[string]any{"queue": "v6-amd64-builders-m6id"}
 )
 
 var suites = []TestSuite{

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -140,7 +140,6 @@ tasks:
         vars:
           TAGS:
           - docker.io/redpandadata/redpanda-operator-nightly:{{.OPERATOR_VERSION}}
-          - public.ecr.aws/l9j0i2e0/redpanda-operator-nightly:{{.OPERATOR_VERSION}}
           PLATFORMS:
           - linux/amd64
           - linux/arm64


### PR DESCRIPTION
This reverts commit 8f60f9d599b6ea8eea047630f726814ae86ed025.

https://github.com/redpanda-data/redpanda-operator/pull/563
https://github.com/redpanda-data/redpanda-operator/pull/589