### PR TITLE
[release/v2.3.x] ci: Move authentication to container registry inside nix container | Migrate to latest golangci-lint configuration | Bump go version in all modules | Update lint golden files after nix flake update

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,6 @@ steps:
       queue: k8s-m6id12xlarge
     commands:
       - |
-        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/l9j0i2e0
         ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:publish-nightly-artifacts
     # Build nightly releases whenever NIGHTLY_RELEASE is set and it's triggered
     # from a schedule or the BK UI. Notably, we permit building nightlies from

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,10 @@ formatters:
     generated: strict
 
 linters:
+  default: none
   enable:
   - depguard
-  - errcheck
+#  - errcheck
   - gocritic
   - gosec
   - govet
@@ -30,9 +31,6 @@ linters:
   - unparam
   - unused
   settings:
-    errcheck:
-      exclude-functions:
-      - io.Close()
 
     depguard:
       rules:
@@ -54,6 +52,7 @@ linters:
     gosec:
       excludes:
       - G115 # integer overflows aren't super likely to be a problem for us and we're really just at the mercy of the APIs we use.
+      - G304 # Potential file inclusion via variable
 
       config:
         G306: "0644" # Maximum allowed os.WriteFile Permissions
@@ -95,7 +94,14 @@ linters:
           failOn: all # all ensures we get nice error messages if something is misconfigured.
 
     staticcheck:
-      checks: ["all", "-ST1005", "-ST1000"]
+      # We should revisit
+      # S1009: should omit nil check; len() for nil slices is defined as zero
+      # QF1008: could remove embedded field "ObjectMeta" from selector
+      # QF1001: could apply De Morgan's law
+      # ST1003: struct field ApiVersion should be APIVersion
+      # ST1019: package "bytes" is being imported more than once
+      # ST1021: comment on exported type Resources should be of the form "Resources ..." (with optional leading article)
+      checks: ["all", "-ST1005", "-ST1000", "-QF1003", "-ST1020", "-S1009", "-QF1008", "-ST1003", "-QF1001", "-ST1019", "-ST1021"]
 
   exclusions:
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,108 +1,111 @@
-linters:
-  # Disable all linters, we explicitly opt into ones we want.
-  disable-all: true
+version: "2"
+formatters:
+  enable:
+  - gci
+  - gofumpt
+  settings:
+    gci:
+      sections:
+      - standard
+      - default
+      - prefix(github.com/redpanda-data/redpanda-operator)
 
+      custom-order: true
+      no-inline-comments: false
+      no-prefix-comments: false
+  exclusions:
+    generated: strict
+
+linters:
   enable:
   - depguard
   - errcheck
-  - gci
   - gocritic
-  - gofumpt
   - gosec
-  - gosimple
   - govet
   - importas
   - ineffassign
   - misspell
   - staticcheck
-  - stylecheck
   - unparam
   - unused
+  settings:
+    errcheck:
+      exclude-functions:
+      - io.Close()
 
-linters-settings:
-  depguard:
+    depguard:
+      rules:
+        # cockroachdb errors is the most complete error library. It automatically
+        # adds stack traces and has a very pleasant %v formatting.
+        errors:
+          deny:
+          - pkg: "^errors$"
+            desc: 'use "github.com/cockroachdb/errors"'
+          - pkg: "^github.com/pkg/errors"
+            desc: 'use "github.com/cockroachdb/errors"'
+        chart-versions:
+          deny:
+          - pkg: "^github.com/redpanda-data/redpanda-operator/charts/redpanda$"
+            desc: 'use "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"'
+          - pkg: "^github.com/redpanda-data/redpanda-operator/charts$"
+            desc: 'import specific charts, the overarching charts module is now deprecated'
+
+    gosec:
+      excludes:
+      - G115 # integer overflows aren't super likely to be a problem for us and we're really just at the mercy of the APIs we use.
+
+      config:
+        G306: "0644" # Maximum allowed os.WriteFile Permissions
+
+    importas:
+      # Disallow not using aliases for all matches of the below alias list.
+      no-unaliased: true
+      # Enforce standard import aliases for k8s type packages of (group)(version)
+      alias:
+      - pkg: k8s.io/api/(\w+)/(v\d)
+        alias: $1$2
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/client-go/applyconfigurations/(\w+)/(v\w+)
+        alias: apply$1$2
+      - pkg: github.com/redpanda-data/redpanda-operator/operator/api/(\w+)/(v\w+)
+        alias: $1$2
+      - pkg: github.com/cert-manager/cert-manager/pkg/apis/meta/v1
+        alias: cmmetav1
+      - pkg: github.com/cert-manager/cert-manager/pkg/apis/certmanager/(v\w+)
+        alias: certmanager$1
+      - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/(v\w+)
+        alias: monitoring$1
+
+    gocritic:
+      disable-all: true
+      enabled-checks:
+        - ruleguard
+      settings:
+        # NB: For ruleguard to work, every go.mod must include the ruleguard
+        # library. This is handled with a stub rules.go file in every module in
+        # this repository.
+        ruleguard:
+          # ${configDir} is the only expanded variable. Paths are otherwise
+          # relative to the directory that golangci-lint is invoked in.
+          # rules.go
+          # - "rules.go" -> Load rules.go for each linted go.mod file due to taskfile cd'ing into each module.
+          rules: "rules.go"
+          failOn: all # all ensures we get nice error messages if something is misconfigured.
+
+    staticcheck:
+      checks: ["all", "-ST1005", "-ST1000"]
+
+  exclusions:
     rules:
-      # cockroachdb errors is the most complete error library. It automatically
-      # adds stack traces and has a very pleasant %v formatting.
-      errors:
-        deny:
-        - pkg: "^errors$"
-          desc: 'use "github.com/cockroachdb/errors"'
-        - pkg: "^github.com/pkg/errors"
-          desc: 'use "github.com/cockroachdb/errors"'
-      chart-versions:
-        deny:
-        - pkg: "^github.com/redpanda-data/redpanda-operator/charts/redpanda$"
-          desc: 'use "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"'
-        - pkg: "^github.com/redpanda-data/redpanda-operator/charts$"
-          desc: 'import specific charts, the overarching charts module is now deprecated'
-
-  gci:
-    sections:
-    - standard
-    - default
-    - prefix(github.com/redpanda-data/redpanda-operator)
-
-    custom-order: true
-    skip-generated: true
-    no-inline-comments: false
-    no-prefix-comments: false
-
-  gosec:
-    excludes:
-    - G115 # integer overflows aren't super likely to be a problem for us and we're really just at the mercy of the APIs we use.
-
-    config:
-      G306: "0644" # Maximum allowed os.WriteFile Permissions
-
-  importas:
-    # Disallow not using aliases for all matches of the below alias list.
-    no-unaliased: true
-    # Enforce standard import aliases for k8s type packages of (group)(version)
-    alias:
-    - pkg: k8s.io/api/(\w+)/(v\d)
-      alias: $1$2
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/client-go/applyconfigurations/(\w+)/(v\w+)
-      alias: apply$1$2
-    - pkg: github.com/redpanda-data/redpanda-operator/operator/api/(\w+)/(v\w+)
-      alias: $1$2
-    - pkg: github.com/cert-manager/cert-manager/pkg/apis/meta/v1
-      alias: cmmetav1
-    - pkg: github.com/cert-manager/cert-manager/pkg/apis/certmanager/(v\w+)
-      alias: certmanager$1
-    - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/(v\w+)
-      alias: monitoring$1
-
-  gocritic:
-    disable-all: true
-    enabled-checks:
-      - ruleguard
-    settings:
-      # NB: For ruleguard to work, every go.mod must include the ruleguard
-      # library. This is handled with a stub rules.go file in every module in
-      # this repository.
-      ruleguard:
-        # ${configDir} is the only expanded variable. Paths are otherwise
-        # relative to the directory that golangci-lint is invoked in.
-        # rules.go
-        # - "rules.go" -> Load rules.go for each linted go.mod file due to taskfile cd'ing into each module.
-        rules: "rules.go"
-        failOn: all # all ensures we get nice error messages if something is misconfigured.
-
-  stylecheck:
-    checks: ["*", "-ST1005"]
-
-issues:
-  exclude-rules:
     # unparam will complain about functions that are called with a constant
     # parameter. In production code, that may be helpful but it harms the
     # readability of test code to eliminate such cases.
-    - linters:
-      - unparam
+    - path: '(.+)_test\.go'
       text: "always receives"
-      path: '(.+)_test\.go'
+      linters:
+      - unparam
     # We're not aiming to be secure in our tests.
     - linters:
       - gosec

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,5 +1,5 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.23.2
+go 1.23.7
 
 require github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/operator/go.mod
+++ b/charts/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/operator
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda/v5
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/ci/scripts/run-in-nix-docker.sh
+++ b/ci/scripts/run-in-nix-docker.sh
@@ -59,6 +59,8 @@ docker run --rm -it \
 	-e GITHUB_API_TOKEN \
 	-e RPK_TEST_CLIENT_ID \
 	-e RPK_TEST_CLIENT_SECRET \
+	-e AWS_ACCESS_KEY_ID \
+	-e AWS_SECRET_ACCESS_KEY \
 	-e TESTCONTAINERS_RYUK_DISABLED \
 	--user 0:$(id -g) \
 	--privileged \

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -55,14 +55,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
             packages = [
               pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               pkgs.applyconfiguration-gen
+              pkgs.awscli2
               pkgs.backport
               pkgs.buildkite-agent
               pkgs.changie # Changelog manager

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.23.2
+go 1.23.7
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/gen/partial/partial.go
+++ b/gen/partial/partial.go
@@ -94,7 +94,7 @@ func run(args []string, outFlag, headerFlag, structFlag string) {
 	}
 
 	if outFlag == "-" {
-		fmt.Println(buf.Bytes())
+		fmt.Println(buf.String())
 	} else {
 		if err := os.WriteFile(outFlag, buf.Bytes(), 0o644); err != nil {
 			panic(err)

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/gotohelm/main.go
+++ b/gotohelm/main.go
@@ -71,7 +71,7 @@ func writeToStdout(chart *gotohelm.Chart) {
 
 func writeToDir(chart *gotohelm.Chart, dir string) error {
 	for _, f := range chart.Files {
-		file, err := os.OpenFile(path.Join(dir, f.Name), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		file, err := os.OpenFile(path.Join(dir, f.Name), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) //nolint:gosec
 		if err != nil {
 			return err
 		}

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/licenseupdater/config.go
+++ b/licenseupdater/config.go
@@ -346,7 +346,7 @@ func (c *config) writeLicenses() error {
 
 	directory := c.getLicenseDirectory()
 
-	if err := os.MkdirAll(directory, 0o755); err != nil {
+	if err := os.MkdirAll(directory, 0o750); err != nil {
 		return err
 	}
 

--- a/licenseupdater/go.mod
+++ b/licenseupdater/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licenseupdater
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/operator/cmd/envsubst/envsubst.go
+++ b/operator/cmd/envsubst/envsubst.go
@@ -38,7 +38,7 @@ empty string.
 
 			if output != "" && output != "-" {
 				var err error
-				out, err = os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o775)
+				out, err = os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o775) //nolint:gosec
 				if err != nil {
 					return err
 				}

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/operator/internal/testutils/delete_all_in_namespace.go
+++ b/operator/internal/testutils/delete_all_in_namespace.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	//nolint:stylecheck // gomega
+	//nolint:stylecheck,staticcheck // gomega
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.23.2
+go 1.23.7
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/gotohelm/ast.go
+++ b/pkg/gotohelm/ast.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-//nolint:errcheck
+//nolint:errcheck,gosec
 package gotohelm
 
 import (

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -491,7 +491,7 @@ func Contains(substr, s string) bool {
 // +gotohelm:builtin=indent
 func Indent(spaces int, v string) string {
 	pad := strings.Repeat(" ", spaces)
-	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+	return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
 }
 
 // +gotohelm:builtin=nindent

--- a/pkg/gotohelm/testdata/src/example/go.mod
+++ b/pkg/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.23.2
+go 1.23.7
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/pkg/kube/dialer.go
+++ b/pkg/kube/dialer.go
@@ -98,7 +98,7 @@ func (p *PodDialer) DialContext(ctx context.Context, network string, address str
 	headers.Set(corev1.StreamType, corev1.StreamTypeError)
 	errorStream, err := conn.CreateStream(headers)
 	if err != nil {
-		conn.Close()
+		conn.Close() //nolint:gosec
 
 		return nil, fmt.Errorf("creating error stream: %w", err)
 	}
@@ -106,13 +106,13 @@ func (p *PodDialer) DialContext(ctx context.Context, network string, address str
 	headers.Set(corev1.StreamType, corev1.StreamTypeData)
 	dataStream, err := conn.CreateStream(headers)
 	if err != nil {
-		conn.Close()
+		conn.Close() //nolint:gosec
 
 		return nil, fmt.Errorf("creating data stream: %w", err)
 	}
 
 	onClose := func() {
-		conn.Close()
+		conn.Close() //nolint:gosec
 	}
 
 	return wrapConn(onClose, network, address, dataStream, errorStream), nil
@@ -233,7 +233,7 @@ func (p *PodDialer) connectionForPod(pod types.NamespacedName) (httpstream.Conne
 
 	if protocol != portForwardProtocolV1Name {
 		if conn != nil {
-			conn.Close()
+			conn.Close() //nolint:gosec
 		}
 
 		return nil, fmt.Errorf("unable to negotiate protocol: client supports %q, server returned %q", portForwardProtocolV1Name, protocol)

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -65,6 +65,7 @@ func TestToolVersions(t *testing.T) {
 		"helm-docs -v",
 		"ct version",
 		"changie --version",
+		"aws --version",
 	} {
 		out := sh(cmd)
 		bin := strings.SplitN(cmd, " ", 2)[0]

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -1,6 +1,12 @@
+version.BuildInfo{Version:"v3.17.2", GitCommit:"v3.17.2", GitTreeState:"", GoVersion:"go1.24.1"}
+
+-- aws --
+# aws --version
+aws-cli/2.24.24 Python/3.12.9 Linux/6.1.128-136.201.amzn2023.x86_64 source/x86_64
+
 -- changie --
 # changie --version
-changie version v1.19.1
+changie version v1.21.1
 
 -- ct --
 # ct version
@@ -11,7 +17,7 @@ License:	 Apache 2.0
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.23.2
+go version go1.23.7
 
 -- goreleaser --
 # goreleaser --version | awk 'NR>2 {print last} {last=$0}'
@@ -19,7 +25,7 @@ sh: line 1: goreleaser: command not found
 
 -- helm --
 # helm version
-version.BuildInfo{Version:"v3.16.2", GitCommit:"v3.16.2", GitTreeState:"", GoVersion:"go1.23.2"}
+version.BuildInfo{Version:"v3.17.2", GitCommit:"v3.17.2", GitTreeState:"", GoVersion:"go1.24.1"}
 
 -- helm-docs --
 # helm-docs -v
@@ -27,21 +33,21 @@ helm-docs version 1.14.2
 
 -- k3d --
 # k3d version
-k3d version v5.7.4
+k3d version v5.8.3
 k3s version v1.21.7-k3s1 (default)
 
 -- kind --
 # kind version | cut -d ' ' -f 1-3
-kind v0.24.0 go1.23.2
+kind v0.27.0 go1.24.1
 
 -- kubectl --
 # kubectl version --client=true
-Client Version: v1.31.2
-Kustomize Version: v5.4.2
+Client Version: v1.32.3
+Kustomize Version: v5.5.0
 
 -- kustomize --
 # kustomize version
-5.5.0
+5.6.0
 
 -- kuttl --
 # kuttl version | cut -d ' ' -f 1-7
@@ -49,9 +55,9 @@ KUTTL Version: version.Info{GitVersion:"0.19.0", GitCommit:"733ad16", BuildDate:
 
 -- task --
 # task --version
-Task version: 3.39.2 ()
+Task version: 3.41.0 ()
 
 -- yq --
 # yq --version
-yq (https://github.com/mikefarah/yq/) version v4.44.3
+yq (https://github.com/mikefarah/yq/) version v4.45.1
 

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -135,6 +135,9 @@ tasks:
       - cmd: docker login --username {{.DOCKERHUB_USER}} --password {{.DOCKERHUB_TOKEN}}
         silent: true
       - defer: docker logout
+      - cmd: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/l9j0i2e0
+        silent: true
+      - defer: docker logout public.ecr.aws
       - 'echo "~~~ Tagging and uploading images to nightly Dockerhub :docker:"'
       - task: :build:operator-image
         vars:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [ci: Move authentication to container registry inside nix container](https://github.com/redpanda-data/redpanda-operator/pull/610)
 - [Migrate to latest golangci-lint configuration](https://github.com/redpanda-data/redpanda-operator/pull/610)
 - [Bump go version in all modules](https://github.com/redpanda-data/redpanda-operator/pull/610)
 - [Update lint golden files after nix flake update](https://github.com/redpanda-data/redpanda-operator/pull/610)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)