### PR TITLE
bk: add `post-checkout` hook to cleanup leftover containers

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,17 @@
+# important: assumes that each agent runs a single job at a time
+
+# ignore errors
+set +e
+
+if [[ $BUILDKITE_AGENT_META_DATA_QUEUE == "pipeline-uploader" ]]; then
+  echo "Skipping on `pipeline-uploader` agents"
+  exit 0
+fi
+
+echo "Cleaning up unused docker containers"
+for id in $(docker ps --quiet); do
+  echo "Killing $id"
+  docker kill $id
+done
+
+docker system prune --all --volumes --force


### PR DESCRIPTION
Add a `post-checkout` hook to properly cleanup leftover containers from previous jobs.

fixes https://redpandadata.atlassian.net/browse/DEVPROD-2817