### PR TITLE
Use RC release for Redpanda chart

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -27,7 +27,9 @@ version: 5.9.20
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v24.3.6
+appVersion: v25.1.1-rc5
+# TODO: Move back to official releases once redpanda 25.1.1 has been cut
+# appVersion: v25.1.1
 
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
@@ -56,6 +58,8 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+      image: docker.redpanda.com/redpandadata/redpanda-unstable:v25.1.1-rc5
+      # TODO: Move back to official releases once redpanda 25.1.1 has been cut
+      # image: docker.redpanda.com/redpandadata/redpanda:v25.1.1
     - name: busybox
       image: busybox:latest

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.20](https://img.shields.io/badge/Version-5.9.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.3.6](https://img.shields.io/badge/AppVersion-v24.3.6-informational?style=flat-square)
+![Version: 5.9.20](https://img.shields.io/badge/Version-5.9.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.1.1-rc5](https://img.shields.io/badge/AppVersion-v25.1.1--rc5-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
@@ -311,7 +311,7 @@ Redpanda Docker image settings.
 **Default:**
 
 ```
-{"pullPolicy":"IfNotPresent","repository":"docker.redpanda.com/redpandadata/redpanda","tag":""}
+{"pullPolicy":"IfNotPresent","repository":"docker.redpanda.com/redpandadata/redpanda-unstable","tag":""}
 ```
 
 ### [image.pullPolicy](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=image.pullPolicy)
@@ -327,7 +327,7 @@ Docker repository from which to pull the Redpanda Docker image.
 **Default:**
 
 ```
-"docker.redpanda.com/redpandadata/redpanda"
+"docker.redpanda.com/redpandadata/redpanda-unstable"
 ```
 
 ### [image.tag](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=image.tag)

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -49,7 +49,10 @@ tolerations: []
 # -- Redpanda Docker image settings.
 image:
   # -- Docker repository from which to pull the Redpanda Docker image.
-  repository: docker.redpanda.com/redpandadata/redpanda
+  repository: docker.redpanda.com/redpandadata/redpanda-unstable
+  # TODO: Move back to official releases once redpanda 25.1.1 has been cut
+  # repository: docker.redpanda.com/redpandadata/redpanda
+  
   # -- The Redpanda version.
   # See DockerHub for:
   # [All stable versions](https://hub.docker.com/r/redpandadata/redpanda/tags)


### PR DESCRIPTION
This swaps our chart version to use the Redpanda RC release so we can stage the alpha of the chart release.