### PR TITLE
[release/v25.1.x] bk: add pre-exit hook to cleanup containers (#621)

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,17 @@
+# important: assumes that each agent runs a single job at a time
+
+# ignore errors
+set +e
+
+if [[ $BUILDKITE_AGENT_META_DATA_QUEUE == "pipeline-uploader" ]]; then
+  echo "Skipping on `pipeline-uploader` agents"
+  exit 0
+fi
+
+echo "Cleaning up unused docker containers"
+for id in $(docker ps --quiet); do
+  echo "Killing $id"
+  docker kill $id
+done
+
+docker system prune --all --volumes --force


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [bk: add pre-exit hook to cleanup containers (#621)](https://github.com/redpanda-data/redpanda-operator/pull/621)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)