### PR TITLE
[release/v25.1.x] pkg: fix `TestToolVersions` on macos

### DIFF
--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -52,7 +52,7 @@ func TestToolVersions(t *testing.T) {
 		"helm-docs -v",
 		"ct version",
 		"changie --version",
-		"aws --version",
+		"aws --version | cut -d ' ' -f 1-2", // cut removes os/arch
 	} {
 		out := sh(cmd)
 		bin := strings.SplitN(cmd, " ", 2)[0]

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -1,8 +1,8 @@
 version.BuildInfo{Version:"v3.17.2", GitCommit:"v3.17.2", GitTreeState:"", GoVersion:"go1.24.1"}
 
 -- aws --
-# aws --version
-aws-cli/2.24.24 Python/3.12.9 Linux/6.1.128-136.201.amzn2023.x86_64 source/x86_64
+# aws --version | cut -d ' ' -f 1-2
+aws-cli/2.24.24 Python/3.12.9
 
 -- changie --
 # changie --version


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [pkg: fix `TestToolVersions` on macos](https://github.com/redpanda-data/redpanda-operator/pull/638)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)