### PR TITLE
Remove under replicated partitions and leaderless partition checks 

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250404-122046.yaml
+++ b/.changes/unreleased/operator-Fixed-20250404-122046.yaml
@@ -1,0 +1,5 @@
+project: operator
+kind: Fixed
+body: |
+    Removed check for under replicated partitions in healthz to prevent unhealthy pods in cluster when one pod fails
+time: 2025-04-04T12:20:46.081-04:00

--- a/operator/internal/probes/broker.go
+++ b/operator/internal/probes/broker.go
@@ -130,12 +130,6 @@ func (p *Prober) IsClusterBrokerHealthy(ctx context.Context, brokerURL string) (
 		return false, fmt.Errorf("fetching broker partitions: %w", err)
 	}
 
-	// do we have any leaderless or under-replicated nodes?
-	if summary.Leaderless != 0 || summary.UnderReplicated != 0 {
-		p.logger.Info("broker has leaderless or under-replicated partitions", "leaderless", summary.Leaderless, "under-replicated", summary.UnderReplicated)
-		return false, nil
-	}
-
 	clusterHealth, err := client.GetHealthOverview(ctx)
 	if err != nil {
 		return false, fmt.Errorf("fetching cluster health: %w", err)


### PR DESCRIPTION
This is needed to ensure that pods remain healthy for access during single node failure events which cause under replicated partitions