### PR TITLE
remove references to `release/v25.1.x`

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,7 +3,7 @@
   "autoMerge": true,
   "repoOwner": "redpanda-data",
   "repoName": "redpanda-operator",
-  "targetBranchChoices": ["release/v25.1.x", "release/v2.4.x", "release/v2.3.x"],
+  "targetBranchChoices": ["release/v2.4.x", "release/v2.3.x"],
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v(\\d+).(\\d+).\\d+$": "release/v$1.$2.x"

--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -1,1 +1,1 @@
-active: ["main", "release/v25.1.x", "release/v2.4.x", "release/v2.3.x"]
+active: ["main", "release/v2.4.x", "release/v2.3.x"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,14 @@ Last step would be to perform the following command
 kubectl set image deployment/OPERATOR_DEPLOYMENT_NAME manager=YOUR_CONTAINER_REGISTRY:YOUR_CONTAINER_TAG 
 ```
 
+## Branching
+
+This repository follows [trunk based development](https://trunkbaseddevelopment.com/) practices.
+
+Releases are performed with git tags on `main` until breaking/backwards incompatible changes are necessary in which case we will ["branch late"](https://trunkbaseddevelopment.com/branch-for-release/#late-creation-of-release-branches).
+
+The "map" of active branches can be found in the [README.md](README.md) of `main`.
+
 ## Backporting
 
 We are currently experimenting with workflows for backporting leveraging the

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 
 | Branch                                                                                       | Release Series | [End of Support](https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions) |
 | :------------------------------------------------------------------------------------------: | :------------: | :---------------------------------------------------------------------------------------------------------: |
-| [`main`](https://github.com/redpanda-data/redpanda-operator/tree/main)                       | v25.2.x-alpha  | TBD                                                                                                         |
-| [`release/v25.1.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.1.x) | v25.1.x-beta   | TBD                                                                                                         |
+| [`main`](https://github.com/redpanda-data/redpanda-operator/tree/main)                       | v25.1.x        | TBD                                                                                                         |
 | [`release/v2.4.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v2.4.x)   | v2.4.x         | Dec 3, 2025 (est.)                                                                                          |
 | [`release/v2.3.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v2.3.x)   | v2.3.x         | Dec 3, 2025 (est.)                                                                                          |


### PR DESCRIPTION
This commit removes all in-repo references to `release/v25.1.x` in preparation for deleting the `release/v25.1.x` branch in favor of using `main`.

We've found that "branching early" introduces needless overhead and confusion and are reverting back to "late branching" to reduce the CI/backport overhead of development.