### PR TITLE
temporarily disable kuttl-v1 tests

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -149,48 +149,6 @@ steps:
         context: acceptance
         report-slowest: 10
     soft_fail: true
-- group: Kuttl-V1 Tests
-  key: kuttl-v1
-  steps:
-  - agents:
-      queue: k8s-m6id12xlarge
-    command: ./ci/scripts/run-in-nix-docker.sh task ci:configure ci:test:kuttl-v1
-    key: kuttl-v1-run
-    label: Run Kuttl-V1 Tests
-    notify:
-    - github_commit_status:
-        context: Kuttl-V1 Tests
-    plugins:
-    - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
-        json-to-env:
-        - secret-id: sdlc/prod/buildkite/github_api_token
-        - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
-        - secret-id: sdlc/prod/buildkite/slack_vbot_token
-    - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
-        channel_name: kubernetes-tests
-        conditions:
-          branches:
-          - main
-          failed: true
-        message: ':cloud: Kuttl-V1 Tests Job Failed'
-        slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: false
-    timeout_in_minutes: 90
-  - continue_on_failure: true
-    wait: null
-  - agents:
-      queue: pipeline-uploader
-    allow_dependency_failure: true
-    command: ""
-    key: kuttl-v1-parse
-    label: Parse and annotate Kuttl-V1 Tests results
-    plugins:
-    - github.com/buildkite-plugins/junit-annotate-buildkite-plugin#v2.4.1:
-        artifacts: work/operator/tests/_e2e_artifacts/kuttl-report.xml
-        context: kuttl-v1
-        report-slowest: 10
-    soft_fail: true
 - group: Kuttl-V1-Nodepools Tests
   key: kuttl-v1-nodepools
   steps:

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -44,12 +44,15 @@ var suites = []TestSuite{
 		Required: true,
 		Timeout:  time.Hour,
 	},
-	{
-		Name:         "kuttl-v1",
-		Required:     true,
-		Timeout:      30*time.Minute + time.Hour,
-		JUnitPattern: ptr.To("work/operator/tests/_e2e_artifacts/kuttl-report.xml"),
-	},
+	// kuttl-v1 is currently the slowest and flakiest of our test suites. The
+	// majority of changes made aren't exercised by this suite. It's disabled
+	// until we have time to speed it up and deflake it.
+	// {
+	// 	Name:         "kuttl-v1",
+	// 	Required:     true,
+	// 	Timeout:      30*time.Minute + time.Hour,
+	// 	JUnitPattern: ptr.To("work/operator/tests/_e2e_artifacts/kuttl-report.xml"),
+	// },
 	{
 		Name:         "kuttl-v1-nodepools",
 		Required:     true,


### PR DESCRIPTION
kuttl-v1 is currently the slowest and flakiest of our test suites. As the majority of changes made aren't even exercised by this suite, it's being disabled until we can make time to deflake and speed it up.

This test alone is responsible for ~48 hours of wasted time during this last release cycle.