### PR TITLE
operator/chart: remove unused `KubeRBACProxy` field

### DIFF
--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -160,54 +160,6 @@ Pull secrets may be used to provide credentials to image repositories See the [K
 
 **Default:** `[]`
 
-### [kubeRbacProxy](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=kubeRbacProxy)
-
-Configuration for the `kube-rbac-proxy`, a component that provides an HTTP proxy to perform authorization checks.
-
-**Default:**
-
-```
-{"image":{"pullPolicy":"IfNotPresent","repository":"gcr.io/kubebuilder/kube-rbac-proxy","tag":"v0.14.0"},"logLevel":10}
-```
-
-### [kubeRbacProxy.image](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=kubeRbacProxy.image)
-
-Sets settings for pulling the `kube-rbac-proxy` image.
-
-**Default:**
-
-```
-{"pullPolicy":"IfNotPresent","repository":"gcr.io/kubebuilder/kube-rbac-proxy","tag":"v0.14.0"}
-```
-
-### [kubeRbacProxy.image.pullPolicy](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=kubeRbacProxy.image.pullPolicy)
-
-Sets the `pullPolicy` for `kube-rbac-proxy` image
-
-**Default:** `"IfNotPresent"`
-
-### [kubeRbacProxy.image.repository](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=kubeRbacProxy.image.repository)
-
-Sets the repository in which the `kube-rbac-proxy` image is available.
-
-**Default:**
-
-```
-"gcr.io/kubebuilder/kube-rbac-proxy"
-```
-
-### [kubeRbacProxy.image.tag](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=kubeRbacProxy.image.tag)
-
-Sets the `kube-rbac-proxy` image tag.
-
-**Default:** `"v0.14.0"`
-
-### [kubeRbacProxy.logLevel](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=kubeRbacProxy.logLevel)
-
-Sets log level for kube rbac proxy
-
-**Default:** `10`
-
 ### [logLevel](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=logLevel)
 
 Log level Valid values (from least to most verbose) are: `warn`, `info`, `debug`, and `trace`.

--- a/operator/chart/testdata/template-cases-generated.txtar
+++ b/operator/chart/testdata/template-cases-generated.txtar
@@ -301,8 +301,6 @@ configurator:
   repository: qylxfyVep
   tag: q
 fullnameOverride: kdh6Z
-kubeRbacProxy:
-  logLevel: 500
 livenessProbe:
   failureThreshold: 335
   initialDelaySeconds: 578
@@ -362,8 +360,6 @@ image:
   pullPolicy: Always
   repository: Rr9cCH8
   tag: IyW
-kubeRbacProxy:
-  logLevel: 445
 livenessProbe:
   failureThreshold: 527
   initialDelaySeconds: 795
@@ -694,12 +690,6 @@ annotations:
   hw87: p7dM7cs
 clusterDomain: SHg60I
 fullnameOverride: rcE
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: ""
-    tag: qDuS
-  logLevel: 310
 livenessProbe:
   failureThreshold: 107
   initialDelaySeconds: 293
@@ -819,8 +809,6 @@ image:
   pullPolicy: IfNotPresent
   repository: DpT1qi9X
   tag: iRz
-kubeRbacProxy:
-  logLevel: 339
 livenessProbe:
   failureThreshold: 77
   initialDelaySeconds: 492
@@ -1048,12 +1036,6 @@ configurator:
   repository: R4X
   tag: Q8X86Dd4
 fullnameOverride: NofaS
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: BEuqFP
-    tag: fel7iI4
-  logLevel: 109
 livenessProbe:
   failureThreshold: 971
   initialDelaySeconds: 160
@@ -1384,12 +1366,6 @@ configurator:
   repository: ix
   tag: z
 fullnameOverride: K9R
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: wMt
-    tag: KUgVbNQmz
-  logLevel: 263
 livenessProbe:
   failureThreshold: 618
   initialDelaySeconds: 473
@@ -2130,12 +2106,6 @@ imagePullSecrets:
 - name: 7B
 - name: iT52FG
 - name: 2p
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: DiySuZhqL
-    tag: 8Z
-  logLevel: 277
 livenessProbe:
   failureThreshold: 789
   initialDelaySeconds: 277
@@ -2711,12 +2681,6 @@ annotations:
   Nm4maThP4X: v
 clusterDomain: BYy0s8
 fullnameOverride: UHlKDi
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: WwSCIw
-    tag: ABSHPzN
-  logLevel: 229
 livenessProbe:
   failureThreshold: 448
   initialDelaySeconds: 92
@@ -2855,12 +2819,6 @@ image:
 imagePullSecrets:
 - name: LBeC5t
 - name: TFCWBezm
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: PCYk
-    tag: AnH7
-  logLevel: 362
 livenessProbe:
   failureThreshold: 199
   initialDelaySeconds: 704
@@ -3572,12 +3530,6 @@ image:
   pullPolicy: IfNotPresent
   repository: 5T8t
   tag: fK
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: fLJ
-    tag: aG
-  logLevel: 145
 livenessProbe:
   failureThreshold: 621
   initialDelaySeconds: 500
@@ -4845,12 +4797,6 @@ configurator:
   repository: 5bwwdif
   tag: cVDIGtHX
 fullnameOverride: bi
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: 3vVEuSY
-    tag: LX
-  logLevel: 33
 livenessProbe:
   failureThreshold: 49
   initialDelaySeconds: 575
@@ -5128,8 +5074,6 @@ image:
   tag: z7F5fT
 imagePullSecrets:
 - name: 2di49JY
-kubeRbacProxy:
-  logLevel: 245
 livenessProbe:
   failureThreshold: 89
   initialDelaySeconds: 174
@@ -5446,12 +5390,6 @@ image:
   pullPolicy: Never
   repository: g96
   tag: Lotm9epAH
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: qn
-    tag: kT
-  logLevel: 307
 livenessProbe:
   failureThreshold: 347
   initialDelaySeconds: 320
@@ -6301,12 +6239,6 @@ image:
   tag: 5yg4G
 imagePullSecrets:
 - name: KXA1
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: lOU
-    tag: 9Z
-  logLevel: 291
 livenessProbe:
   failureThreshold: 397
   initialDelaySeconds: 401
@@ -7248,12 +7180,6 @@ configurator:
   repository: dS6V2tB
   tag: Mn2B
 fullnameOverride: z7BRO
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: QmP
-    tag: LRmkId
-  logLevel: 109
 livenessProbe:
   failureThreshold: 231
   initialDelaySeconds: 282
@@ -8242,12 +8168,6 @@ imagePullSecrets:
 - name: 1ug
 - name: AfaA9Ea2u
 - name: tko8Pb
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: 5Aj
-    tag: Et1
-  logLevel: 367
 livenessProbe:
   failureThreshold: 402
   initialDelaySeconds: 74
@@ -8959,12 +8879,6 @@ image:
   pullPolicy: Always
   repository: 8mlV
   tag: Gd0
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: Q9SKJed
-    tag: Pm5
-  logLevel: 125
 livenessProbe:
   failureThreshold: 240
   initialDelaySeconds: 292
@@ -9789,12 +9703,6 @@ image:
 imagePullSecrets:
 - {}
 - name: 0z
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: ""
-    tag: WEMN
-  logLevel: 64
 livenessProbe:
   failureThreshold: 174
   initialDelaySeconds: 781
@@ -11097,12 +11005,6 @@ imagePullSecrets:
 - name: 9Ek8sUB
 - name: t5ZN
 - name: eRKid
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: WPPKhIlvmxeug
-    tag: VMn7v9B
-  logLevel: 330
 livenessProbe:
   failureThreshold: 363
   initialDelaySeconds: 6
@@ -12501,12 +12403,6 @@ image:
   tag: RK6Ba96O
 imagePullSecrets:
 - name: pRYX8NI9
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: 8eQInSt
-    tag: rhfUTa
-  logLevel: 68
 livenessProbe:
   failureThreshold: 434
   initialDelaySeconds: 154
@@ -13889,12 +13785,6 @@ image:
 imagePullSecrets:
 - name: 1G3qsUeX
 - name: MfQ3EzTp7q9k
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: qPSB7h6jS
-    tag: qr
-  logLevel: 64
 livenessProbe:
   failureThreshold: 555
   initialDelaySeconds: 880
@@ -14748,12 +14638,6 @@ image:
   pullPolicy: Never
   repository: 5Q
   tag: jr9
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: TY
-    tag: Xk
-  logLevel: 384
 livenessProbe:
   failureThreshold: 810
   initialDelaySeconds: 500
@@ -16042,12 +15926,6 @@ image:
   pullPolicy: IfNotPresent
   repository: P9JMlA
   tag: i6Q4sn53d
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: eF
-    tag: Tnx
-  logLevel: 7
 livenessProbe:
   failureThreshold: 122
   initialDelaySeconds: 163
@@ -17546,12 +17424,6 @@ image:
   pullPolicy: Never
   repository: dOHS
   tag: 4hS76
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: ze9Osk6tOx2
-    tag: nWuywKVlk
-  logLevel: 168
 livenessProbe:
   failureThreshold: 599
   initialDelaySeconds: 221
@@ -18980,12 +18852,6 @@ image:
   pullPolicy: Never
   repository: 5R2fC0t
   tag: C5
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: MLG8
-    tag: Fj4j
-  logLevel: 186
 livenessProbe:
   failureThreshold: 76
   initialDelaySeconds: 324
@@ -20111,12 +19977,6 @@ imagePullSecrets:
 - name: dWgsEJ3vFfP0B
 - name: Go
 - name: HfbLZ
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: 4jdbu
-    tag: THCADXet
-  logLevel: 278
 livenessProbe:
   failureThreshold: 488
   initialDelaySeconds: 89
@@ -21525,12 +21385,6 @@ image:
   pullPolicy: Never
   repository: h
   tag: 95V5Gm
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: R
-    tag: B9
-  logLevel: 186
 livenessProbe:
   failureThreshold: 462
   initialDelaySeconds: 702
@@ -22440,12 +22294,6 @@ image:
   tag: YHoj
 imagePullSecrets:
 - name: b6Bc9Ikm
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: amuilGh
-    tag: LzDC4Xxr
-  logLevel: 294
 livenessProbe:
   failureThreshold: 531
   initialDelaySeconds: 583
@@ -23883,12 +23731,6 @@ image:
   tag: X
 imagePullSecrets:
 - name: BFg
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: mZ
-    tag: cpGiTs039e
-  logLevel: 62
 livenessProbe:
   failureThreshold: 798
   initialDelaySeconds: 312
@@ -25391,12 +25233,6 @@ imagePullSecrets:
 - name: x63fPIC
 - name: tgBP9
 - name: RQI98Sg
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: DydZz
-    tag: IJ
-  logLevel: 464
 livenessProbe:
   failureThreshold: 953
   initialDelaySeconds: 551
@@ -26493,12 +26329,6 @@ imagePullSecrets:
 - name: LRSNBs
 - name: L4R2AM
 - name: 0sZYIqj
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: ""
-    tag: 8ET6P
-  logLevel: 254
 livenessProbe:
   failureThreshold: 74
   initialDelaySeconds: 990
@@ -28169,12 +27999,6 @@ image:
   pullPolicy: Never
   repository: a7e7
   tag: QiVn05LHP7O
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: PS9rQIXzEM
-    tag: huSub
-  logLevel: 427
 livenessProbe:
   failureThreshold: 562
   initialDelaySeconds: 357
@@ -29582,12 +29406,6 @@ imagePullSecrets:
 - name: QmJcc
 - name: EMrtn
 - name: XCUfxrh
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: Oa40e8D
-    tag: 9U5s2
-  logLevel: 51
 livenessProbe:
   failureThreshold: 122
   initialDelaySeconds: 598
@@ -30632,12 +30450,6 @@ image:
 imagePullSecrets:
 - name: ggPp
 - name: ORs
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: gGB
-    tag: NOt
-  logLevel: 255
 livenessProbe:
   failureThreshold: 590
   initialDelaySeconds: 662
@@ -32226,12 +32038,6 @@ image:
   tag: pneZv
 imagePullSecrets:
 - name: CrI52F
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: 7OdjR
-    tag: C7SY
-  logLevel: 339
 livenessProbe:
   failureThreshold: 723
   initialDelaySeconds: 831
@@ -33281,12 +33087,6 @@ imagePullSecrets:
 - name: I6Na86OnyBNx
 - name: "3"
 - name: J1RoqWBLo
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: I6mqY
-    tag: z
-  logLevel: 230
 livenessProbe:
   failureThreshold: 760
   initialDelaySeconds: 987
@@ -34807,12 +34607,6 @@ image:
   tag: CyopzJ
 imagePullSecrets:
 - name: w5uad
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: SJbGg9G
-    tag: TerHhXnk
-  logLevel: 487
 livenessProbe:
   failureThreshold: 438
   initialDelaySeconds: 607
@@ -35971,8 +35765,6 @@ image:
   pullPolicy: Always
   repository: AzmZ3dTJs
   tag: WHh
-kubeRbacProxy:
-  logLevel: 388
 livenessProbe:
   failureThreshold: 954
   initialDelaySeconds: 209
@@ -36553,8 +36345,6 @@ imagePullSecrets:
 - name: WWFoP
 - name: WsYnXzso01
 - name: IX6v
-kubeRbacProxy:
-  logLevel: 177
 livenessProbe:
   failureThreshold: 271
   initialDelaySeconds: 332
@@ -37143,8 +36933,6 @@ config:
   metrics:
     bindAddress: 31mM
 fullnameOverride: X374QF3AYX
-kubeRbacProxy:
-  logLevel: 456
 livenessProbe:
   failureThreshold: 941
   initialDelaySeconds: 378
@@ -37376,12 +37164,6 @@ image:
 imagePullSecrets:
 - name: Qzv
 - name: 3TWwF
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: VXepc3
-    tag: zN
-  logLevel: 232
 livenessProbe:
   failureThreshold: 127
   initialDelaySeconds: 324
@@ -37703,12 +37485,6 @@ configurator:
 fullnameOverride: 79ioSjMT8KG
 imagePullSecrets:
 - name: GI3C2
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: RE
-    tag: re
-  logLevel: 144
 livenessProbe:
   failureThreshold: 801
   initialDelaySeconds: 382
@@ -37868,12 +37644,6 @@ image:
   pullPolicy: Always
   repository: cd7qo
   tag: vJ7ET
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: yP
-    tag: KhfSU
-  logLevel: 190
 livenessProbe:
   failureThreshold: 226
   initialDelaySeconds: 129
@@ -38488,12 +38258,6 @@ image:
   tag: DF517x
 imagePullSecrets:
 - name: Qi
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: ntF
-    tag: AnS1f
-  logLevel: 183
 livenessProbe:
   failureThreshold: 941
   initialDelaySeconds: 763
@@ -38719,12 +38483,6 @@ imagePullSecrets:
 - name: R3ewDf6
 - name: bkmeF
 - name: E
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: j3r
-    tag: XPG6J
-  logLevel: 288
 livenessProbe:
   failureThreshold: 304
   initialDelaySeconds: 302
@@ -40185,12 +39943,6 @@ imagePullSecrets:
 - name: T
 - name: nOg2mwF
 - name: i
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: J67dgqgI
-    tag: k4c
-  logLevel: 22
 livenessProbe:
   failureThreshold: 624
   initialDelaySeconds: 221
@@ -40442,12 +40194,6 @@ image:
 imagePullSecrets:
 - name: Dr
 - name: JFQ
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: q1szt2
-    tag: tmKv
-  logLevel: 63
 livenessProbe:
   failureThreshold: 957
   initialDelaySeconds: 464
@@ -41615,12 +41361,6 @@ imagePullSecrets:
 - name: hzASfrJ
 - name: N2Jx
 - name: H8tarJ7RL
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: e04Gnjsm
-    tag: 6lY4KM
-  logLevel: 43
 livenessProbe:
   failureThreshold: 945
   initialDelaySeconds: 682
@@ -42256,12 +41996,6 @@ image:
   tag: Vk
 imagePullSecrets:
 - name: oKUkpgf
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: DCg5AwUni
-    tag: xIDQv4
-  logLevel: 123
 livenessProbe:
   failureThreshold: 41
   initialDelaySeconds: 771
@@ -43092,12 +42826,6 @@ imagePullSecrets:
 - name: voAR
 - name: x
 - name: ZwA2p5
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: PnVf8
-    tag: "2"
-  logLevel: 239
 livenessProbe:
   failureThreshold: 903
   initialDelaySeconds: 76
@@ -44908,12 +44636,6 @@ image:
   tag: TPaa
 imagePullSecrets:
 - name: Snq58
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: VNg6D2sx8T
-    tag: 9e
-  logLevel: 420
 livenessProbe:
   failureThreshold: 589
   initialDelaySeconds: 759
@@ -45733,12 +45455,6 @@ imagePullSecrets:
 - name: 69h6
 - name: k
 - name: WpGyrs
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: FjPCP
-    tag: sTRN33j
-  logLevel: 240
 livenessProbe:
   failureThreshold: 952
   initialDelaySeconds: 274
@@ -46769,12 +46485,6 @@ image:
   pullPolicy: Always
   repository: Ozfq
   tag: 3ncj
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: W7Gm
-    tag: CwGlxr
-  logLevel: 67
 livenessProbe:
   failureThreshold: 321
   initialDelaySeconds: 406
@@ -48241,12 +47951,6 @@ image:
   tag: 8YPjvr
 imagePullSecrets:
 - name: 5k
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: c
-    tag: U
-  logLevel: 392
 livenessProbe:
   failureThreshold: 617
   initialDelaySeconds: 538
@@ -49851,12 +49555,6 @@ image:
   pullPolicy: Never
   repository: 9kg
   tag: hk
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: 582AO
-    tag: S8bAQfhT9M
-  logLevel: 139
 livenessProbe:
   failureThreshold: 501
   initialDelaySeconds: 430
@@ -51544,12 +51242,6 @@ imagePullSecrets:
 - name: RRfZPIJFA
 - name: 8F
 - name: S
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: oULd
-    tag: yPOGFghUo
-  logLevel: 152
 livenessProbe:
   failureThreshold: 136
   initialDelaySeconds: 391
@@ -53529,12 +53221,6 @@ image:
   pullPolicy: Never
   repository: M2Q
   tag: Q9Q
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: sftJ
-    tag: JajgrDP
-  logLevel: 403
 livenessProbe:
   failureThreshold: 986
   initialDelaySeconds: 618
@@ -54795,12 +54481,6 @@ image:
   tag: EQ6C
 imagePullSecrets:
 - name: pczOr
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: yW4j
-    tag: 6qlKjn
-  logLevel: 429
 livenessProbe:
   failureThreshold: 914
   initialDelaySeconds: 655
@@ -56172,12 +55852,6 @@ image:
 imagePullSecrets:
 - name: an7mYZA0XBQvu
 - name: wluRKw8
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: omQS
-    tag: o9JkuA
-  logLevel: 295
 livenessProbe:
   failureThreshold: 197
   initialDelaySeconds: 411
@@ -57478,12 +57152,6 @@ image:
   tag: ZpYBKn
 imagePullSecrets:
 - name: 6ykZxpWS
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: NA
-    tag: VBjy5N
-  logLevel: 78
 livenessProbe:
   failureThreshold: 691
   initialDelaySeconds: 271
@@ -58423,12 +58091,6 @@ image:
   pullPolicy: IfNotPresent
   repository: YYLGC7
   tag: okj1Bqm1LHE
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: h1
-    tag: d0sg
-  logLevel: 292
 livenessProbe:
   failureThreshold: 483
   initialDelaySeconds: 398
@@ -59379,12 +59041,6 @@ image:
   pullPolicy: Never
   repository: kG9n
   tag: H0aN
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: Zt
-    tag: lZcBojk
-  logLevel: 296
 livenessProbe:
   failureThreshold: 210
   initialDelaySeconds: 483
@@ -60901,12 +60557,6 @@ image:
   pullPolicy: Always
   repository: BkpCoE
   tag: 3BE
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: u
-    tag: e8Pqlld
-  logLevel: 47
 livenessProbe:
   failureThreshold: 578
   initialDelaySeconds: 963
@@ -62340,12 +61990,6 @@ image:
 imagePullSecrets:
 - name: a
 - name: hVcvKeV
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: RPN0vgCLR
-    tag: Tf5R
-  logLevel: 267
 livenessProbe:
   failureThreshold: 64
   initialDelaySeconds: 547
@@ -63662,12 +63306,6 @@ image:
   pullPolicy: Always
   repository: ftKlY
   tag: bBlM
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: Ng
-    tag: 5qq
-  logLevel: 356
 livenessProbe:
   failureThreshold: 554
   initialDelaySeconds: 941
@@ -64815,12 +64453,6 @@ image:
 imagePullSecrets:
 - {}
 - name: fBJ5v
-kubeRbacProxy:
-  image:
-    pullPolicy: Always
-    repository: B
-    tag: iTS
-  logLevel: 27
 livenessProbe:
   failureThreshold: 610
   initialDelaySeconds: 194
@@ -65863,12 +65495,6 @@ image:
   tag: 1XQEc73
 imagePullSecrets:
 - name: jeZIr
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: WVH
-    tag: EUjjP
-  logLevel: 386
 livenessProbe:
   failureThreshold: 623
   initialDelaySeconds: 53
@@ -67286,12 +66912,6 @@ image:
 imagePullSecrets:
 - name: C
 - name: InndAaMMOJD8
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: UZO6
-    tag: OZLi6ZK
-  logLevel: 445
 livenessProbe:
   failureThreshold: 895
   initialDelaySeconds: 342
@@ -68553,12 +68173,6 @@ image:
   pullPolicy: IfNotPresent
   repository: TPAc
   tag: u
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: 4ZneBG
-    tag: wMF1
-  logLevel: 405
 livenessProbe:
   failureThreshold: 399
   initialDelaySeconds: 720
@@ -70114,12 +69728,6 @@ image:
   pullPolicy: Never
   repository: MxYHsvk3O
   tag: tr
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: L1M6F
-    tag: QOyMi
-  logLevel: 477
 livenessProbe:
   failureThreshold: 751
   initialDelaySeconds: 167
@@ -71746,12 +71354,6 @@ imagePullSecrets:
 - name: V88Tar
 - name: w
 - name: "0"
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: zkjPJE
-    tag: udvp
-  logLevel: 489
 livenessProbe:
   failureThreshold: 693
   initialDelaySeconds: 775
@@ -73279,12 +72881,6 @@ imagePullSecrets:
 - name: Mi1MYJzNO
 - name: 26ZHhprrx
 - name: I
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: nYU
-    tag: 3WGWloTA
-  logLevel: 226
 livenessProbe:
   failureThreshold: 42
   initialDelaySeconds: 33
@@ -74469,12 +74065,6 @@ image:
 imagePullSecrets:
 - name: s
 - name: ruW7l0J
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: Mzt
-    tag: YjH8Y
-  logLevel: 231
 livenessProbe:
   failureThreshold: 375
   initialDelaySeconds: 882
@@ -75882,12 +75472,6 @@ image:
 imagePullSecrets:
 - name: X2mw
 - name: jB
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: UETwk
-    tag: L
-  logLevel: 153
 livenessProbe:
   failureThreshold: 402
   initialDelaySeconds: 358
@@ -77290,12 +76874,6 @@ image:
   tag: ob8Ckc
 imagePullSecrets:
 - name: ecK
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: mbREx
-    tag: jpy
-  logLevel: 125
 livenessProbe:
   failureThreshold: 268
   initialDelaySeconds: 536
@@ -79032,12 +78610,6 @@ imagePullSecrets:
 - name: QcP
 - name: R2U0oMf0N
 - name: 0drXBt
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: H
-    tag: D
-  logLevel: 353
 livenessProbe:
   failureThreshold: 136
   initialDelaySeconds: 953
@@ -80614,12 +80186,6 @@ imagePullSecrets:
 - name: 4Ig
 - name: aS
 - name: zg
-kubeRbacProxy:
-  image:
-    pullPolicy: IfNotPresent
-    repository: O50k5k
-    tag: kkIJqNV
-  logLevel: 43
 livenessProbe:
   failureThreshold: 847
   initialDelaySeconds: 922
@@ -82295,12 +81861,6 @@ image:
   tag: P
 imagePullSecrets:
 - name: kLOCe
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: BCQC
-    tag: I7
-  logLevel: 372
 livenessProbe:
   failureThreshold: 807
   initialDelaySeconds: 369
@@ -83539,12 +83099,6 @@ image:
 imagePullSecrets:
 - name: gbX
 - name: 5zrmBn
-kubeRbacProxy:
-  image:
-    pullPolicy: Never
-    repository: x
-    tag: fwIj
-  logLevel: 432
 livenessProbe:
   failureThreshold: 391
   initialDelaySeconds: 425

--- a/operator/chart/values.go
+++ b/operator/chart/values.go
@@ -36,7 +36,6 @@ type Values struct {
 	ReplicaCount       int32                         `json:"replicaCount"`
 	ClusterDomain      string                        `json:"clusterDomain"`
 	Image              Image                         `json:"image"`
-	KubeRBACProxy      KubeRBACProxyConfig           `json:"kubeRbacProxy"`
 	Config             Config                        `json:"config"`
 	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets"`
 	LogLevel           string                        `json:"logLevel"`

--- a/operator/chart/values.schema.json
+++ b/operator/chart/values.schema.json
@@ -713,35 +713,6 @@
         }
       ]
     },
-    "kubeRbacProxy": {
-      "additionalProperties": false,
-      "properties": {
-        "image": {
-          "additionalProperties": false,
-          "properties": {
-            "pullPolicy": {
-              "description": "The Kubernetes Pod image pull policy.",
-              "pattern": "^(Always|Never|IfNotPresent)$",
-              "type": "string"
-            },
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "pullPolicy"
-          ],
-          "type": "object"
-        },
-        "logLevel": {
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
     "livenessProbe": {
       "additionalProperties": false,
       "properties": {

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -25,19 +25,6 @@ image:
   # -- Sets the `pullPolicy` for the `redpanda-operator` image.
   pullPolicy: IfNotPresent
 
-# -- Configuration for the `kube-rbac-proxy`, a component that provides an HTTP proxy to perform authorization checks.
-kubeRbacProxy:
-  # -- Sets log level for kube rbac proxy
-  logLevel: 10
-  # -- Sets settings for pulling the `kube-rbac-proxy` image.
-  image:
-    # -- Sets the repository in which the `kube-rbac-proxy` image is available.
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    # -- Sets the `kube-rbac-proxy` image tag.
-    tag: v0.14.0
-    # -- Sets the `pullPolicy` for `kube-rbac-proxy` image
-    pullPolicy: IfNotPresent
-
 # -- Configuration for the Kubernetes Controller Manager used by Redpanda Operator.
 # The Controller Manager is a component of the Kubernetes control plane that runs controller processes. These controllers are background threads that handle the orchestration and operational logic of Kubernetes, ensuring the desired state of the cluster matches the observed state.
 config:

--- a/operator/chart/values_partial.gen.go
+++ b/operator/chart/values_partial.gen.go
@@ -24,7 +24,6 @@ type PartialValues struct {
 	ReplicaCount       *int32                        "json:\"replicaCount,omitempty\""
 	ClusterDomain      *string                       "json:\"clusterDomain,omitempty\""
 	Image              *PartialImage                 "json:\"image,omitempty\""
-	KubeRBACProxy      *PartialKubeRBACProxyConfig   "json:\"kubeRbacProxy,omitempty\""
 	Config             *PartialConfig                "json:\"config,omitempty\""
 	ImagePullSecrets   []corev1.LocalObjectReference "json:\"imagePullSecrets,omitempty\""
 	LogLevel           *string                       "json:\"logLevel,omitempty\""
@@ -53,11 +52,6 @@ type PartialImage struct {
 	Repository *string            "json:\"repository,omitempty\""
 	PullPolicy *corev1.PullPolicy "json:\"pullPolicy,omitempty\" jsonschema:\"required,pattern=^(Always|Never|IfNotPresent)$,description=The Kubernetes Pod image pull policy.\""
 	Tag        *string            "json:\"tag,omitempty\""
-}
-
-type PartialKubeRBACProxyConfig struct {
-	LogLevel *int          "json:\"logLevel,omitempty\""
-	Image    *PartialImage "json:\"image,omitempty\""
 }
 
 type PartialConfig struct {


### PR DESCRIPTION
Kube RBAC Proxy was removed in a previous commit but the field in the values struct was left behind. This commit removes the leftover field.