### PR TITLE
[release/v2.3.x] operator/chart: remove `--configurator-tag` override

### DIFF
--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -1592,7 +1592,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=a35
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -3591,7 +3590,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=Ae
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -5554,7 +5552,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=a4SuUdq
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -7539,7 +7536,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=OdrK
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -8012,7 +8008,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=Y
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -9026,7 +9021,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=gT
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -10005,7 +9999,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=Qgv
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -13043,7 +13036,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=HhY5pV
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -14076,7 +14068,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=DCM8
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -15559,7 +15550,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=vOvAQKBh
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -17269,7 +17259,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=BpnfO
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -19439,7 +19428,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=5ruW
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -22781,7 +22769,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=zoF
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -24197,7 +24184,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=S3
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -26049,7 +26035,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=NaLO9z
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -30418,7 +30403,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=hPrI1P
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -31252,7 +31236,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=v1480
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -46015,7 +45998,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -47671,7 +47653,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=TwQtVGrOeJf
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -50541,7 +50522,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=ozF
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -52943,7 +52923,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -54656,7 +54635,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -55535,7 +55513,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -56419,7 +56396,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -57806,7 +57782,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -59273,7 +59248,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -60157,7 +60131,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -62121,7 +62094,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -63219,7 +63191,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -66423,7 +66394,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -67453,7 +67423,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -76605,7 +76574,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -77852,7 +77820,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -79925,7 +79892,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -81153,7 +81119,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -83217,7 +83182,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -87748,7 +87712,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -88925,7 +88888,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -90243,7 +90205,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -91069,7 +91030,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -92298,7 +92258,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -98318,7 +98277,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -99121,7 +99079,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -102616,7 +102573,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -103726,7 +103682,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=info
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -104673,7 +104628,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=info
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -105637,7 +105591,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=info
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -106584,7 +106537,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=info
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -107404,7 +107356,6 @@ spec:
         - --webhook-enabled=true
         - --webhook-enabled=true
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []
@@ -108362,7 +108313,6 @@ spec:
         - --webhook-enabled=false
         - --namespace=default
         - --log-level=info
-        - --configurator-tag=v2.3.6-24.3.3
         command:
         - /manager
         env: []

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -136,8 +136,7 @@ podLabels: {}
 # Additional flags include:
 #
 # - `--additional-controllers`: Additional controllers to deploy. Valid values are nodeWatcher or decommission. For more information about the Nodewatcher controller, see [Install the Nodewatcher controller](https://docs.redpanda.com/current/manage/kubernetes/k-scale-redpanda/#node-pvc). For more information about the Decommission controller, see [Use the Decommission controller](https://docs.redpanda.com/current/manage/kubernetes/k-decommission-brokers/#Automated).
-additionalCmdFlags:
-- --configurator-tag=v2.3.6-24.3.3
+additionalCmdFlags: []
 # - --additional-controllers="<controller-name"
 
 # -- Additional labels to add to all Kubernetes objects.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [operator/chart: remove `--configurator-tag` override](https://github.com/redpanda-data/redpanda-operator/pull/680)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)