### PR TITLE
[release/v2.4.x] bk: skip removing images from hook (#684)

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -4,7 +4,7 @@
 set +e
 
 if [[ $BUILDKITE_AGENT_META_DATA_QUEUE == "pipeline-uploader" ]]; then
-  echo "Skipping on `pipeline-uploader` agents"
+  echo "Skipping on 'pipeline-uploader' agents"
   exit 0
 fi
 
@@ -14,4 +14,6 @@ for id in $(docker ps --quiet); do
   docker kill $id
 done
 
-docker system prune --all --volumes --force
+docker container prune --force
+docker volume prune --force
+docker network prune --force


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [bk: skip removing images from hook (#684)](https://github.com/redpanda-data/redpanda-operator/pull/684)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)