### PR TITLE
operator/chart: fix nightly build

### DIFF
--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -149,7 +149,7 @@ tasks:
       # NB: cp -r/-R is dependent on the implementation (macOS vs Linux).
       # cp -R src/. dest/ <- Same behavior, copy contents of src to dest.
       # cp -r src/ dest <- Different. macOS == copy contents, linux == copy src folder into dest.
-      - cp -R charts/operator/. {{.TMP_PATH}}
+      - cp -R operator/chart/. {{.TMP_PATH}}
       # The Chart.yaml name needs to match with docker hub OCI registry, so that helm push correctly
       # finds OCI registry.
       # Reference


### PR DESCRIPTION
The backport of binding the operator and chart version had conflicts in the task file that got resolved incorrectly due to `main` containing builds for both the operator and console charts.

This commit fixes the source path of the operator chart in the build task.