### PR TITLE
[release/v2.3.x] operator/chart: fix nightly build

### DIFF
--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -149,7 +149,7 @@ tasks:
       # NB: cp -r/-R is dependent on the implementation (macOS vs Linux).
       # cp -R src/. dest/ <- Same behavior, copy contents of src to dest.
       # cp -r src/ dest <- Different. macOS == copy contents, linux == copy src folder into dest.
-      - cp -R charts/operator/. {{.TMP_PATH}}
+      - cp -R operator/chart/. {{.TMP_PATH}}
       # The Chart.yaml name needs to match with docker hub OCI registry, so that helm push correctly
       # finds OCI registry.
       # Reference


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/v2.4.x` to `release/v2.3.x`:
 - [operator/chart: fix nightly build](https://github.com/redpanda-data/redpanda-operator/pull/701)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)