### PR TITLE
[release/v2.4.x] fix GOROOT in nix (#700)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
           devshells.default = {
             env = [
               { name = "GOPRIVATE"; value = "github.com/redpanda-data/flux-controller-shim"; }
+              { name = "GOROOT"; value = "${pkgs.go_1_23}/share/go"; }
               { name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.29.x)"; }
               { name = "PATH"; eval = "$(pwd)/.build:$PATH"; }
             ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [fix GOROOT in nix (#700)](https://github.com/redpanda-data/redpanda-operator/pull/700)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)