### PR TITLE
pass in secret config to configurator

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -219,6 +219,12 @@ func Command() *cobra.Command {
 				enableGhostBrokerDecommissioner,
 				ghostBrokerDecommissionerSyncPeriod,
 				cloudExpander,
+				cloudSecretsEnabled,
+				cloudSecretsPrefix,
+				cloudSecretsAWSRegion,
+				cloudSecretsAWSRoleARN,
+				cloudSecretsGCPProjectID,
+				cloudSecretsAzureKeyVaultURI,
 			)
 		},
 	}
@@ -327,6 +333,12 @@ func Run(
 	enableGhostBrokerDecommissioner bool,
 	ghostBrokerDecommissionerSyncPeriod time.Duration,
 	cloudExpander *pkgsecrets.CloudExpander,
+	cloudSecretsEnabled bool,
+	cloudSecretsPrefix string,
+	cloudSecretsAWSRegion string,
+	cloudSecretsAWSRoleARN string,
+	cloudSecretsGCPProjectID string,
+	cloudSecretsAzureKeyVaultURI string,
 ) error {
 	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
 
@@ -446,9 +458,15 @@ func Run(
 	}
 
 	configurator := resources.ConfiguratorSettings{
-		ConfiguratorBaseImage: configuratorBaseImage,
-		ConfiguratorTag:       configuratorTag,
-		ImagePullPolicy:       corev1.PullPolicy(configuratorImagePullPolicy),
+		ConfiguratorBaseImage:        configuratorBaseImage,
+		ConfiguratorTag:              configuratorTag,
+		ImagePullPolicy:              corev1.PullPolicy(configuratorImagePullPolicy),
+		CloudSecretsEnabled:          cloudSecretsEnabled,
+		CloudSecretsPrefix:           cloudSecretsPrefix,
+		CloudSecretsAWSRegion:        cloudSecretsAWSRegion,
+		CloudSecretsAWSRoleARN:       cloudSecretsAWSRoleARN,
+		CloudSecretsGCPProjectID:     cloudSecretsGCPProjectID,
+		CloudSecretsAzureKeyVaultURI: cloudSecretsAzureKeyVaultURI,
 	}
 
 	// init running state values if we are not in operator mode

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -89,6 +89,13 @@ type ConfiguratorSettings struct {
 	ConfiguratorBaseImage string
 	ConfiguratorTag       string
 	ImagePullPolicy       corev1.PullPolicy
+
+	CloudSecretsEnabled          bool
+	CloudSecretsPrefix           string
+	CloudSecretsAWSRegion        string
+	CloudSecretsAWSRoleARN       string
+	CloudSecretsGCPProjectID     string
+	CloudSecretsAzureKeyVaultURI string
 }
 
 // StatefulSetResource is part of the reconciliation of redpanda.vectorized.io CRD
@@ -509,7 +516,7 @@ func (r *StatefulSetResource) obj(
 							Name:            configuratorContainerName,
 							Image:           r.fullConfiguratorImage(),
 							Command:         []string{"/redpanda-operator"},
-							Args:            []string{"configure"},
+							Args:            r.getConfiguratorArgs(),
 							ImagePullPolicy: r.configuratorSettings.ImagePullPolicy,
 							Env: append([]corev1.EnvVar{
 								{
@@ -811,6 +818,27 @@ func (r *StatefulSetResource) canOverwriteBootstrapForAnyPreexistingResource(ctx
 	// Otherwise, we'll leave this untouched for the moment; it's already running,
 	// and so the bootstrap configuration is irrelevant.
 	return false, nil
+}
+
+func (r *StatefulSetResource) getConfiguratorArgs() []string {
+	result := []string{"configure"}
+	if r.configuratorSettings.CloudSecretsEnabled {
+		result = append(result, "--enable-cloud-secrets=true")
+		result = append(result, fmt.Sprintf("--cloud-secrets-prefix=%s", r.configuratorSettings.CloudSecretsPrefix))
+		if r.configuratorSettings.CloudSecretsAWSRegion != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-aws-region=%s", r.configuratorSettings.CloudSecretsAWSRegion))
+		}
+		if r.configuratorSettings.CloudSecretsAWSRoleARN != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-aws-role-arn=%s", r.configuratorSettings.CloudSecretsAWSRoleARN))
+		}
+		if r.configuratorSettings.CloudSecretsGCPProjectID != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-gcp-project-id=%s", r.configuratorSettings.CloudSecretsGCPProjectID))
+		}
+		if r.configuratorSettings.CloudSecretsAzureKeyVaultURI != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-azure-key-vault-ur=%s", r.configuratorSettings.CloudSecretsAzureKeyVaultURI))
+		}
+	}
+	return result
 }
 
 // getPrestopHook creates a hook that drains the node before shutting down.

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -158,9 +158,13 @@ func TestEnsure(t *testing.T) {
 				TestAdminTLSConfigProvider{},
 				"",
 				resources.ConfiguratorSettings{
-					ConfiguratorBaseImage: "redpanda-data/redpanda-operator",
-					ConfiguratorTag:       "latest",
-					ImagePullPolicy:       "Always",
+					ConfiguratorBaseImage:  "redpanda-data/redpanda-operator",
+					ConfiguratorTag:        "latest",
+					ImagePullPolicy:        "Always",
+					CloudSecretsEnabled:    true,
+					CloudSecretsPrefix:     "test",
+					CloudSecretsAWSRegion:  "region",
+					CloudSecretsAWSRoleARN: "arn",
 				},
 				func(ctx context.Context) (string, error) { return hash, nil },
 				func(ctx context.Context) (*configuration.GlobalConfiguration, error) {
@@ -239,6 +243,9 @@ func TestEnsure(t *testing.T) {
 				err = c.Delete(context.Background(), tt.existingObject)
 				assert.NoError(t, err, tt.name)
 			}
+			actualConfiguratorArgs := actual.Spec.Template.Spec.InitContainers[0].Args
+			assert.Equal(t, 5, len(actualConfiguratorArgs))
+
 			err = c.Delete(context.Background(), tt.pandaCluster)
 			if !apierrors.IsNotFound(err) {
 				assert.NoError(t, err, tt.name)


### PR DESCRIPTION
If the operator is configured with secrets, it's not being passed to configurator so it fails on cluster restart by not being able to resolve a secret.