### PR TITLE
[release/v2.3.x] pass in secret config to configurator (#717)

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -236,6 +236,12 @@ func Command() *cobra.Command {
 				enableGhostBrokerDecommissioner,
 				ghostBrokerDecommissionerSyncPeriod,
 				cloudExpander,
+				cloudSecretsEnabled,
+				cloudSecretsPrefix,
+				cloudSecretsAWSRegion,
+				cloudSecretsAWSRoleARN,
+				cloudSecretsGCPProjectID,
+				cloudSecretsAzureKeyVaultURI,
 			)
 		},
 	}
@@ -353,6 +359,12 @@ func Run(
 	enableGhostBrokerDecommissioner bool,
 	ghostBrokerDecommissionerSyncPeriod time.Duration,
 	cloudExpander *pkgsecrets.CloudExpander,
+	cloudSecretsEnabled bool,
+	cloudSecretsPrefix string,
+	cloudSecretsAWSRegion string,
+	cloudSecretsAWSRoleARN string,
+	cloudSecretsGCPProjectID string,
+	cloudSecretsAzureKeyVaultURI string,
 ) error {
 	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
 
@@ -472,9 +484,15 @@ func Run(
 	}
 
 	configurator := resources.ConfiguratorSettings{
-		ConfiguratorBaseImage: configuratorBaseImage,
-		ConfiguratorTag:       configuratorTag,
-		ImagePullPolicy:       corev1.PullPolicy(configuratorImagePullPolicy),
+		ConfiguratorBaseImage:        configuratorBaseImage,
+		ConfiguratorTag:              configuratorTag,
+		ImagePullPolicy:              corev1.PullPolicy(configuratorImagePullPolicy),
+		CloudSecretsEnabled:          cloudSecretsEnabled,
+		CloudSecretsPrefix:           cloudSecretsPrefix,
+		CloudSecretsAWSRegion:        cloudSecretsAWSRegion,
+		CloudSecretsAWSRoleARN:       cloudSecretsAWSRoleARN,
+		CloudSecretsGCPProjectID:     cloudSecretsGCPProjectID,
+		CloudSecretsAzureKeyVaultURI: cloudSecretsAzureKeyVaultURI,
 	}
 
 	// init running state values if we are not in operator mode

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -165,9 +165,13 @@ func TestEnsure(t *testing.T) {
 				TestAdminTLSConfigProvider{},
 				"",
 				resources.ConfiguratorSettings{
-					ConfiguratorBaseImage: "redpanda-data/redpanda-operator",
-					ConfiguratorTag:       "latest",
-					ImagePullPolicy:       "Always",
+					ConfiguratorBaseImage:  "redpanda-data/redpanda-operator",
+					ConfiguratorTag:        "latest",
+					ImagePullPolicy:        "Always",
+					CloudSecretsEnabled:    true,
+					CloudSecretsPrefix:     "test",
+					CloudSecretsAWSRegion:  "region",
+					CloudSecretsAWSRoleARN: "arn",
 				},
 				func(ctx context.Context) (string, error) { return hash, nil },
 				func(ctx context.Context) (*configuration.GlobalConfiguration, error) {
@@ -246,6 +250,9 @@ func TestEnsure(t *testing.T) {
 				err = c.Delete(context.Background(), tt.existingObject)
 				assert.NoError(t, err, tt.name)
 			}
+			actualConfiguratorArgs := actual.Spec.Template.Spec.InitContainers[0].Args
+			assert.Equal(t, 5, len(actualConfiguratorArgs))
+
 			err = c.Delete(context.Background(), tt.pandaCluster)
 			if !apierrors.IsNotFound(err) {
 				assert.NoError(t, err, tt.name)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [pass in secret config to configurator (#717)](https://github.com/redpanda-data/redpanda-operator/pull/717)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)