### PR TITLE
charts/redpanda: fix chown'ing init containers

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20250416-160323.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250416-160323.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Fixed the security contexts' of `set-datadir-ownership` and `set-tiered-storage-cache-dir-ownership`.
+time: 2025-04-16T16:03:23.265594-04:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,10 +159,10 @@ tasks:
   test:integration:
     desc: "Run all integration tests (~90m)"
     deps:
+    # The operator image is required to test the configurator and sidecar.
+    # In integration tests, the operator itself will be run from the go test process.
     - build:image
     cmds:
-    - task: charts:kind-cluster # Kind cluster is currently used for chart integration tests
-    - kind load docker-image localhost/redpanda-operator:dev
     - task: test:unit
       vars:
         GO_TEST_RUNNER:

--- a/charts/redpanda/CHANGELOG.md
+++ b/charts/redpanda/CHANGELOG.md
@@ -104,6 +104,7 @@ of `enterprise.license` and `enterprise.licenseSecretRef`, respectively.
 
 * Fixed an issue where not explicitly specifying a SASL auth mechanism when SASL is enabled caused Console to fail to start up.
 * Prevent broker nodes from restarting when solely the cluster replica amount changes
+* Fixed the security contexts' of `set-datadir-ownership` and `set-tiered-storage-cache-dir-ownership`.
 
 ## v25.1.1-beta1 - 2025-04-08
 ### Added

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -115,6 +115,35 @@ func TestIntegrationChart(t *testing.T) {
 
 	h := helmtest.Setup(t)
 
+	t.Run("set-datadir-ownership", func(t *testing.T) {
+		env := h.Namespaced(t)
+		ctx := testutil.Context(t)
+
+		// If the install succeeds, then the init container has worked as
+		// expected.
+		_ = env.Install(ctx, redpandaChart, helm.InstallOptions{
+			Values: minimalValues(&redpanda.PartialValues{
+				Statefulset: &redpanda.PartialStatefulset{
+					InitContainers: &struct {
+						FSValidator *struct {
+							Enabled    *bool   "json:\"enabled,omitempty\""
+							ExpectedFS *string "json:\"expectedFS,omitempty\""
+						} "json:\"fsValidator,omitempty\""
+						SetDataDirOwnership *struct {
+							Enabled *bool "json:\"enabled,omitempty\""
+						} "json:\"setDataDirOwnership,omitempty\""
+					}{
+						SetDataDirOwnership: &struct {
+							Enabled *bool "json:\"enabled,omitempty\""
+						}{
+							Enabled: ptr.To(true),
+						},
+					},
+				},
+			}),
+		})
+	})
+
 	t.Run("mtls-using-cert-manager", func(t *testing.T) {
 		ctx := testutil.Context(t)
 

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -5,6 +5,7 @@ go 1.23.7
 require (
 	github.com/cert-manager/cert-manager v1.14.5
 	github.com/cockroachdb/errors v1.11.3
+	github.com/imdario/mergo v0.3.16
 	github.com/invopop/jsonschema v0.12.0
 	github.com/json-iterator/go v1.1.12
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2
@@ -109,7 +110,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/homeport/dyff v1.7.1 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
-	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -416,6 +416,10 @@ func statefulSetInitContainerSetDataDirOwnership(dot *helmette.Dot) *corev1.Cont
 			`-c`,
 			fmt.Sprintf(`chown %d:%d -R /var/lib/redpanda/data`, uid, gid),
 		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  ptr.To[int64](0),
+			RunAsGroup: ptr.To[int64](0),
+		},
 		VolumeMounts: append(
 			CommonMounts(dot),
 			corev1.VolumeMount{
@@ -543,6 +547,10 @@ func statefulSetInitContainerSetTieredStorageCacheDirOwnership(dot *helmette.Dot
 				uid, gid,
 				cacheDir,
 			),
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  ptr.To[int64](0),
+			RunAsGroup: ptr.To[int64](0),
 		},
 		VolumeMounts: mounts,
 	}

--- a/charts/redpanda/templates/_statefulset.go.tpl
+++ b/charts/redpanda/templates/_statefulset.go.tpl
@@ -232,7 +232,7 @@
 {{- $uid := ((index $_415_uid_gid 0) | int64) -}}
 {{- $gid := ((index $_415_uid_gid 1) | int64) -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "set-datadir-ownership" "image" (printf "%s:%s" $values.statefulset.initContainerImage.repository $values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `chown %d:%d -R /var/lib/redpanda/data` $uid $gid)) "volumeMounts" (concat (default (list) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot)))) "r")) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" `datadir` "mountPath" `/var/lib/redpanda/data`))))))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "set-datadir-ownership" "image" (printf "%s:%s" $values.statefulset.initContainerImage.repository $values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `chown %d:%d -R /var/lib/redpanda/data` $uid $gid)) "securityContext" (mustMergeOverwrite (dict) (dict "runAsUser" (0 | int64) "runAsGroup" (0 | int64))) "volumeMounts" (concat (default (list) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot)))) "r")) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" `datadir` "mountPath" `/var/lib/redpanda/data`))))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -243,12 +243,12 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $_439_gid_uid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $values.podTemplate "redpanda")))) "r") -}}
-{{- $gid := (index $_439_gid_uid 0) -}}
-{{- $uid := (index $_439_gid_uid 1) -}}
-{{- $_440_sgid_suid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $values.statefulset.podTemplate "redpanda")))) "r") -}}
-{{- $sgid := (index $_440_sgid_suid 0) -}}
-{{- $suid := (index $_440_sgid_suid 1) -}}
+{{- $_443_gid_uid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $values.podTemplate "redpanda")))) "r") -}}
+{{- $gid := (index $_443_gid_uid 0) -}}
+{{- $uid := (index $_443_gid_uid 1) -}}
+{{- $_444_sgid_suid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $values.statefulset.podTemplate "redpanda")))) "r") -}}
+{{- $sgid := (index $_444_sgid_suid 0) -}}
+{{- $suid := (index $_444_sgid_suid 1) -}}
 {{- if (ne (toJson $sgid) "null") -}}
 {{- $gid = $sgid -}}
 {{- end -}}
@@ -325,9 +325,9 @@
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $_523_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $dot "set-tiered-storage-cache-dir-ownership")))) "r") -}}
-{{- $uid := ((index $_523_uid_gid 0) | int64) -}}
-{{- $gid := ((index $_523_uid_gid 1) | int64) -}}
+{{- $_527_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $dot "set-tiered-storage-cache-dir-ownership")))) "r") -}}
+{{- $uid := ((index $_527_uid_gid 0) | int64) -}}
+{{- $gid := ((index $_527_uid_gid 1) | int64) -}}
 {{- $cacheDir := (get (fromJson (include "redpanda.Storage.TieredCacheDirectory" (dict "a" (list $values.storage $dot)))) "r") -}}
 {{- $mounts := (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot)))) "r") -}}
 {{- $mounts = (concat (default (list) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" "datadir" "mountPath" "/var/lib/redpanda/data")))) -}}
@@ -339,7 +339,7 @@
 {{- $mounts = (concat (default (list) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" $name "mountPath" $cacheDir)))) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" `set-tiered-storage-cache-dir-ownership` "image" (printf `%s:%s` $values.statefulset.initContainerImage.repository $values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `mkdir -p %s; chown %d:%d -R %s` $cacheDir $uid $gid $cacheDir)) "volumeMounts" $mounts))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" `set-tiered-storage-cache-dir-ownership` "image" (printf `%s:%s` $values.statefulset.initContainerImage.repository $values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `mkdir -p %s; chown %d:%d -R %s` $cacheDir $uid $gid $cacheDir)) "securityContext" (mustMergeOverwrite (dict) (dict "runAsUser" (0 | int64) "runAsGroup" (0 | int64))) "volumeMounts" $mounts))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/operator/pkg/k3d/k3d.go
+++ b/operator/pkg/k3d/k3d.go
@@ -124,6 +124,11 @@ func GetOrCreate(name string, opts ...ClusterOpt) (*Cluster, error) {
 		}
 		return nil, err
 	}
+
+	if err := cluster.ImportImage("localhost/redpanda-operator:dev"); err != nil {
+		return nil, err
+	}
+
 	return cluster, nil
 }
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/homeport/dyff v1.7.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb
+	github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250416175220-c6f8d18c5557
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.32.0
@@ -94,14 +95,12 @@ require (
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7 // indirect
@@ -146,8 +145,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/onsi/ginkgo/v2 v2.19.0 // indirect
-	github.com/onsi/gomega v1.34.1 // indirect
 	github.com/opencontainers/go-digest v1.0.1-0.20231025023718-d50d2fec9c98 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -184,12 +181,9 @@ require (
 	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	go.starlark.net v0.0.0-20231121155337-90ade8b19d09 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
@@ -197,7 +191,6 @@ require (
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect
 	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -217,6 +217,7 @@ github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -397,6 +398,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250416175220-c6f8d18c5557 h1:a0CR1G769iEwsfSiZpsapChNSX1qW+ihOtZUM3bJv7U=
+github.com/redpanda-data/redpanda-operator/operator v0.0.0-20250416175220-c6f8d18c5557/go.mod h1:IGmuwDlTdncuGz/fJEFnbxrAeuBqduDcSHqGF1Khby8=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -611,6 +614,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
+google.golang.org/genproto v0.0.0-20241015192408-796eee8c2d53 h1:Df6WuGvthPzc+JiQ/G+m+sNX24kc0aTBqoDN/0yyykE=
 google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 h1:T6rh4haD3GVYsgEfWExoCZA2o2FmbNyKpTuAxbEFPTg=
 google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9/go.mod h1:wp2WsuBYj6j8wUdo3ToZsdxxixbvQNAHqVJrTgi5E5M=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 h1:X58yt85/IXCx0Y3ZwN6sEIKZzQtDEYaBWrDvErdXrRE=


### PR DESCRIPTION
#### efc618d7adb7edad5ef376f04119cc39da1686a7 *: remove `kind` from integration tests

Prior to this commit `kind` was used for chart based integration tests. This
lead to increased test overhead in CI and locally as images would have to be
pulled twice and multiple clusters would have to run together.

This commit swaps the helm test package to use the shared k3d testenv cluster.


#### 68eb99f964c9946466d9bb46dee92c8a7398d634 charts/redpanda: fix `chown`'ing init containers

Prior to this commit `chown`'ing init containers, `set-datadir-ownership` and
`set-tiered-stroage-cache-dir-ownership`, failed with permissions errors due to
a refactor in how we handle security contexts and a lack of recession tests.

This commit explicitly sets the security contexts of those containers to root
to restore them to working order and adds a regression test.