### PR TITLE
BSD-proof `task:generate`

### DIFF
--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -81,7 +81,7 @@ tasks:
         --output-dir "api/applyconfiguration" \
         --output-pkg "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration" \
         ./api/redpanda/v1alpha2
-      - find ./api/applyconfiguration/redpanda/v1alpha2 -type f -exec sed -i'' 's/"redpanda\/v1/"cluster.redpanda.com\/v1/g' {} \;
+      - find ./api/applyconfiguration/redpanda/v1alpha2 -type f -exec sed -i '' -e 's/"redpanda\/v1/"cluster.redpanda.com\/v1/g' {} \;
       - rm -rf api/applyconfiguration/utils.go api/applyconfiguration/internal
 
   generate:crd-docs:


### PR DESCRIPTION
The macos `sed` needs an explicit parameter to `-i`.