### PR TITLE
chart/redpanda: Handle trustStore configuration from intenral Kafka listener

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20250418-150810.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250418-150810.yaml
@@ -1,0 +1,7 @@
+project: charts/redpanda
+kind: Fixed
+body: |
+  The `schema_registry_client` and `pandaproxy_client` stanzas of `redpanda.yaml`
+    now respect `listeners.kafka.tls.trustStore`, when provided.
+    See also [helm-chart 1573 issue](https://github.com/redpanda-data/helm-charts/issues/1573).
+time: 2025-04-18T15:08:10.408204+02:00

--- a/charts/redpanda/CHANGELOG.md
+++ b/charts/redpanda/CHANGELOG.md
@@ -123,6 +123,10 @@ of `enterprise.license` and `enterprise.licenseSecretRef`, respectively.
 * Fixed rack awareness by mounting a service account token to the initcontainer when rack awareness is enabled.
 * Broken `Issuer`s and `Certificate`s are no longer needlessly generated when `tls.<cert>.issuerRef` is provided.
 * Fixed the security contexts' of `set-datadir-ownership` and `set-tiered-storage-cache-dir-ownership`.
+* The `schema_registry_client` and `pandaproxy_client` stanzas of `redpanda.yaml`
+  now respect `listeners.kafka.tls.trustStore`, when provided.
+  See also [helm-chart 1573 issue](https://github.com/redpanda-data/helm-charts/issues/1573).
+
 
 ## v25.1.1-beta1 - 2025-04-08
 ### Added

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -832,6 +832,11 @@
 {{- $tls := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
+{{- if (ne (toJson $t.trustStore) "null") -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (get (fromJson (include "redpanda.TrustStore.TrustStoreFilePath" (dict "a" (list $t.trustStore)))) "r")) | toJson -}}
+{{- break -}}
+{{- end -}}
 {{- if (get (fromJson (include "redpanda.TLSCertMap.MustGet" (dict "a" (list (deepCopy $tls.certs) $t.cert)))) "r").caEnabled -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (printf "%s/%s/ca.crt" "/etc/tls/certs" $t.cert)) | toJson -}}
@@ -1399,9 +1404,9 @@
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_1866___ok_18 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
-{{- $_ := ((index $_1866___ok_18 0) | float64) -}}
-{{- $ok_18 := (index $_1866___ok_18 1) -}}
+{{- $_1870___ok_18 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
+{{- $_ := ((index $_1870___ok_18 0) | float64) -}}
+{{- $ok_18 := (index $_1870___ok_18 1) -}}
 {{- if $ok_18 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
@@ -1427,9 +1432,9 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
-{{- $_1886_b_19_ok_20 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
-{{- $b_19 := (index $_1886_b_19_ok_20 0) -}}
-{{- $ok_20 := (index $_1886_b_19_ok_20 1) -}}
+{{- $_1890_b_19_ok_20 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
+{{- $b_19 := (index $_1890_b_19_ok_20 0) -}}
+{{- $ok_20 := (index $_1890_b_19_ok_20 1) -}}
 {{- if $ok_20 -}}
 {{- $_ := (set $result $k $b_19) -}}
 {{- continue -}}
@@ -1472,15 +1477,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1931___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1931___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_1931___hasAccessKey 1) -}}
-{{- $_1932___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1932___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_1932___hasSecretKey 1) -}}
-{{- $_1933___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1933___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_1933___hasSharedKey 1) -}}
+{{- $_1935___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1935___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_1935___hasAccessKey 1) -}}
+{{- $_1936___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1936___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_1936___hasSecretKey 1) -}}
+{{- $_1937___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1937___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_1937___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey)))) "r")) -}}
 {{- $envvars = (concat (default (list) $envvars) (list (mustMergeOverwrite (dict "name" "") (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey)))) "r"))))) -}}
@@ -1503,12 +1508,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1969___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1969___containerExists 0) -}}
-{{- $containerExists := (index $_1969___containerExists 1) -}}
-{{- $_1970___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1970___accountExists 0) -}}
-{{- $accountExists := (index $_1970___accountExists 1) -}}
+{{- $_1973___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1973___containerExists 0) -}}
+{{- $containerExists := (index $_1973___containerExists 1) -}}
+{{- $_1974___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1974___accountExists 0) -}}
+{{- $accountExists := (index $_1974___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1519,9 +1524,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1975_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
-{{- $value := (index $_1975_value_ok 0) -}}
-{{- $ok := (index $_1975_value_ok 1) -}}
+{{- $_1979_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
+{{- $value := (index $_1979_value_ok 0) -}}
+{{- $ok := (index $_1979_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -948,3 +948,156 @@ statefulset:
 # ASSERT-FIELD-EQUALS ["apps/v1/StatefulSet", "default/also-not-redpanda", "{.spec.template.spec.containers[*].name}", ["redpanda", "sidecar"]]
 nameOverride: "not-redpanda"
 fullnameOverride: "also-not-redpanda"
+
+-- trust-store-reference --
+# ASSERT-NO-ERROR
+# ASSERT-GOLDEN
+# The trust store test defined in any listener (internal or external) should allow referencing external certificate authority (trust store)
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.pandaproxy.pandaproxy_api_tls[0].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.pandaproxy.pandaproxy_api_tls[1].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.pandaproxy_client.broker_tls.truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.redpanda.admin_api_tls[0].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.redpanda.admin_api_tls[1].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.redpanda.kafka_api_tls[0].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.redpanda.kafka_api_tls[1].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.redpanda.rpc_server_tls.truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.rpk.admin_api.tls.ca_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.rpk.kafka_api.tls.ca_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.rpk.schema_registry.tls.ca_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.schema_registry_client.broker_tls.truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.schema_registry.schema_registry_api_tls[0].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+# ASSERT-NESTED-FIELD-EQUALS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "{.schema_registry.schema_registry_api_tls[1].truststore_file}", "/etc/truststores/configmaps/redpanda-company-cacrt-ca.crt"]
+auth:
+  sasl:
+    enabled: false
+
+external:
+  enabled: true
+  type: LoadBalancer
+  domain: <our domain>
+  addresses:
+    - redpanda-0
+    - redpanda-1
+    - redpanda-2
+  externalDns:
+    enabled: true
+  service:
+    enabled: true
+
+tls:
+  enabled: true
+  certs:
+    default:
+      caEnabled: true
+      secretRef:
+        name: redpanda-tls-cert
+      clientSecretRef:
+        name: redpanda-admin-cert
+
+listeners:
+  admin:
+    port: 9643
+    tls:
+      enabled: true
+      cert: default
+      requireClientAuth: true
+      trustStore:
+        configMapKeyRef:
+          name: redpanda-company-cacrt
+          key: ca.crt
+    external:
+      default:
+        port: 9644
+        tls:
+          enabled: true
+          cert: default
+          requireClientAuth: true
+          trustStore:
+            configMapKeyRef:
+              name: redpanda-company-cacrt
+              key: ca.crt
+        advertisedPorts:
+          - 9644
+  kafka:
+    port: 9093
+    tls:
+      enabled: true
+      cert: default
+      requireClientAuth: true
+      trustStore:
+        configMapKeyRef:
+          name: redpanda-company-cacrt
+          key: ca.crt
+    external:
+      default:
+        port: 9094
+        tls:
+          enabled: true
+          cert: default
+          requireClientAuth: true
+          trustStore:
+            configMapKeyRef:
+              name: redpanda-company-cacrt
+              key: ca.crt
+        advertisedPorts:
+          - 9094
+  http:
+    enabled: true
+    port: 8082
+    kafkaEndpoint: default
+    tls:
+      enabled: true
+      cert: default
+      requireClientAuth: true
+      trustStore:
+        configMapKeyRef:
+          name: redpanda-company-cacrt
+          key: ca.crt
+    external:
+      default:
+        port: 8083
+        tls:
+          enabled: true
+          cert: default
+          requireClientAuth: true
+          trustStore:
+            configMapKeyRef:
+              name: redpanda-company-cacrt
+              key: ca.crt
+        advertisedPorts:
+          - 8083
+  rpc:
+    port: 33145
+    tls:
+      enabled: true
+      cert: default
+      requireClientAuth: true
+      trustStore:
+        configMapKeyRef:
+          name: redpanda-company-cacrt
+          key: ca.crt
+  schemaRegistry:
+    enabled: true
+    port: 8081
+    kafkaEndpoint: default
+    tls:
+      enabled: true
+      cert: default
+      requireClientAuth: true
+      trustStore:
+        configMapKeyRef:
+          name: redpanda-company-cacrt
+          key: ca.crt
+    external:
+      default:
+        port: 8084
+        tls:
+          enabled: true
+          cert: default
+          requireClientAuth: true
+          trustStore:
+            configMapKeyRef:
+              name: redpanda-company-cacrt
+              key: ca.crt
+        advertisedPorts:
+          - 8084

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -1203,6 +1203,10 @@ func (t *InternalTLS) TrustStoreFilePath(tls *TLS) string {
 // ServerCAPath returns the path on disk to a certificate that may be used to
 // verify a connection with this server.
 func (t *InternalTLS) ServerCAPath(tls *TLS) string {
+	if t.TrustStore != nil {
+		return t.TrustStore.TrustStoreFilePath()
+	}
+
 	if tls.Certs.MustGet(t.Cert).CAEnabled {
 		return fmt.Sprintf("%s/%s/ca.crt", certificateMountPoint, t.Cert)
 	}


### PR DESCRIPTION
For both schema registry client and pandaproxy client the trustStore of the internal Kafka listener was not taken into account. With this change the trustStore config map or secret reference takes precedence.

[K8S-395](https://redpandadata.atlassian.net/browse/K8S-395)
https://github.com/redpanda-data/helm-charts/issues/1573

[K8S-395]: https://redpandadata.atlassian.net/browse/K8S-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ