### PR TITLE
[release/v2.3.x] make role arn optional (#741)

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -184,8 +184,9 @@ func Command() *cobra.Command {
 			var cloudExpander *pkgsecrets.CloudExpander
 			if cloudSecretsEnabled {
 				cloudConfig := pkgsecrets.ExpanderCloudConfiguration{}
-				if cloudSecretsAWSRegion != "" && cloudSecretsAWSRoleARN != "" {
+				if cloudSecretsAWSRegion != "" {
 					cloudConfig.AWSRegion = cloudSecretsAWSRegion
+					// if AWSRoleARN is empty, it uses the assumed role of the pod
 					cloudConfig.AWSRoleARN = cloudSecretsAWSRoleARN
 				} else if cloudSecretsGCPProjectID != "" {
 					cloudConfig.GCPProjectID = cloudSecretsGCPProjectID


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [make role arn optional (#741)](https://github.com/redpanda-data/redpanda-operator/pull/741)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)