### PR TITLE
operator: annotate pods with config hash instead of config version

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	FinalizerKey                    = "operator.redpanda.com/finalizer"
-	ClusterConfigVersionKey         = "operator.redpanda.com/cluster-config-version"
+	ClusterConfigNeedRestartHashKey = "operator.redpanda.com/cluster-config-need-restart-hash"
 	RestartClusterOnConfigChangeKey = "operator.redpanda.com/restart-cluster-on-config-change"
 	FluxFinalizerKey                = "finalizers.fluxcd.io"
 
@@ -372,7 +372,7 @@ func (r *RedpandaReconciler) reconcileDefluxed(ctx context.Context, rp *redpanda
 			if values.Statefulset.PodTemplate.Annotations == nil {
 				values.Statefulset.PodTemplate.Annotations = map[string]string{}
 			}
-			values.Statefulset.PodTemplate.Annotations[ClusterConfigVersionKey] = c.Message
+			values.Statefulset.PodTemplate.Annotations[ClusterConfigNeedRestartHashKey] = c.Message
 		}
 	}
 
@@ -656,7 +656,7 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, rp *red
 		Status:             condition,
 		ObservedGeneration: rp.Generation,
 		Reason:             reason,
-		Message:            fmt.Sprintf("ClusterConfig at Version %d", configStatus.Version),
+		Message:            fmt.Sprintf("ClusterConfig with Hash %s", configStatus.PropertiesThatNeedRestartHash),
 	})
 
 	return nil


### PR DESCRIPTION
Annotate pods with config hash instead of config version.

@chrisseto found an issue with RP config:

The admin API does some amount of type coalescing. e.g. `{"kafka_batch_max_bytes": "10000"} == {"kafka_batch_max_bytes": 10000}` (This causes problems for our sync algo)

The admin API (or rather it's underlying YAML / JSON libraries) consider scientific notation to always be a float. Golang uses scientific notation for both floats and integers (or perhaps its handling of numbers is a bit more creative than expected). This mismatch is why we've had so much trouble. Try setting `"{kafka_memory_share_for_fetch": "1e+1"}`, you'll get the error: `too large, must be at most 1`.

It's appears to be possible to cause the cluster config version to increment without actually changing the cluster config. I haven't figured out why this yet. I suspect the issue is on the redpanda side but the jury is still out.
