### PR TITLE
[release/v2.3.x] Make ARN also optional in the operator

### DIFF
--- a/operator/cmd/configurator/configurator.go
+++ b/operator/cmd/configurator/configurator.go
@@ -146,7 +146,7 @@ func Command() *cobra.Command {
 			var cloudExpander *pkgsecrets.CloudExpander
 			if cloudSecretsEnabled {
 				cloudConfig := pkgsecrets.ExpanderCloudConfiguration{}
-				if cloudSecretsAWSRegion != "" && cloudSecretsAWSRoleARN != "" {
+				if cloudSecretsAWSRegion != "" {
 					cloudConfig.AWSRegion = cloudSecretsAWSRegion
 					cloudConfig.AWSRoleARN = cloudSecretsAWSRoleARN
 				} else if cloudSecretsGCPProjectID != "" {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [Make ARN also optional in the operator](https://github.com/redpanda-data/redpanda-operator/pull/745)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)