### PR TITLE
[main] operator: add annotation feature flag for restart cluster on config change (#748)

### DIFF
--- a/operator/cmd/syncclusterconfig/sync.go
+++ b/operator/cmd/syncclusterconfig/sync.go
@@ -20,7 +20,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"os"
 	"path/filepath"
@@ -276,6 +279,8 @@ type Syncer struct {
 type ClusterConfigStatus struct {
 	Version      int64
 	NeedsRestart bool
+	// Hash of the properties that need restart
+	PropertiesThatNeedRestartHash string
 }
 
 // Sync will compare the current cluster configuration with the desired
@@ -308,6 +313,14 @@ func (s *Syncer) Sync(ctx context.Context, desired map[string]any, usersTXT map[
 	status, err := s.Client.ClusterConfigStatus(ctx, true)
 	if err != nil {
 		return nil, err
+	}
+	schema, err := s.Client.ClusterConfigSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	hashOfConfigsThatNeedRestart, err := hashConfigsThatNeedRestart(desired, schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash config: %w", err)
 	}
 	if s.Mode == SyncerModeDeclarative {
 		for key, value := range current {
@@ -343,7 +356,6 @@ func (s *Syncer) Sync(ctx context.Context, desired map[string]any, usersTXT map[
 			changed = append(changed, key)
 		}
 	}
-
 	if len(added) == 0 && len(changed) == 0 && len(removed) == 0 {
 		logger.Info("no cluster config changes to apply")
 		// find the highest config version
@@ -351,7 +363,8 @@ func (s *Syncer) Sync(ctx context.Context, desired map[string]any, usersTXT map[
 			Version: slices.MaxFunc(status, func(a, b rpadmin.ConfigStatus) int {
 				return int(a.ConfigVersion - b.ConfigVersion)
 			}).ConfigVersion,
-			NeedsRestart: slices.ContainsFunc(status, func(s rpadmin.ConfigStatus) bool { return s.Restart }),
+			NeedsRestart:                  slices.ContainsFunc(status, func(s rpadmin.ConfigStatus) bool { return s.Restart }),
+			PropertiesThatNeedRestartHash: hashOfConfigsThatNeedRestart,
 		}, nil
 	}
 
@@ -378,8 +391,9 @@ func (s *Syncer) Sync(ctx context.Context, desired map[string]any, usersTXT map[
 		return nil, err
 	}
 	return &ClusterConfigStatus{
-		Version:      int64(result.ConfigVersion),
-		NeedsRestart: slices.ContainsFunc(status, func(s rpadmin.ConfigStatus) bool { return s.Restart }),
+		Version:                       int64(result.ConfigVersion),
+		NeedsRestart:                  slices.ContainsFunc(status, func(s rpadmin.ConfigStatus) bool { return s.Restart }),
+		PropertiesThatNeedRestartHash: hashOfConfigsThatNeedRestart,
 	}, nil
 }
 
@@ -409,4 +423,20 @@ func (s *Syncer) maybeMergeSuperusers(ctx context.Context, config map[string]any
 	}
 
 	config[superusersEntry] = normalizeSuperusers(append(superusers, mapConvertibleTo[string](logger, superusersAny)...))
+}
+
+// hashConfigsThatNeedRestart returns a hash of the config that needs the
+// cluster to restart when changed.
+func hashConfigsThatNeedRestart(m map[string]any, schema rpadmin.ConfigSchema) (string, error) {
+	configNeedRestart := make(map[string]any)
+	for k, v := range m {
+		if meta, ok := schema[k]; ok && meta.NeedsRestart {
+			configNeedRestart[k] = v
+		}
+	}
+	hasher := fnv.New64()
+	if err := json.NewEncoder(hasher).Encode(configNeedRestart); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	FinalizerKey                    = "operator.redpanda.com/finalizer"
-	ClusterConfigVersionKey         = "operator.redpanda.com/cluster-config-version"
+	ClusterConfigNeedRestartHashKey = "operator.redpanda.com/cluster-config-need-restart-hash"
 	RestartClusterOnConfigChangeKey = "operator.redpanda.com/restart-cluster-on-config-change"
 	FluxFinalizerKey                = "finalizers.fluxcd.io"
 
@@ -310,7 +310,7 @@ func (r *RedpandaReconciler) reconcileResources(ctx context.Context, rp *redpand
 			if helmChartValues.Statefulset.PodTemplate.Annotations == nil {
 				helmChartValues.Statefulset.PodTemplate.Annotations = map[string]string{}
 			}
-			helmChartValues.Statefulset.PodTemplate.Annotations[ClusterConfigVersionKey] = c.Message
+			helmChartValues.Statefulset.PodTemplate.Annotations[ClusterConfigNeedRestartHashKey] = c.Message
 		}
 	}
 
@@ -576,7 +576,7 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, rp *red
 		Status:             condition,
 		ObservedGeneration: rp.Generation,
 		Reason:             reason,
-		Message:            fmt.Sprintf("ClusterConfig at Version %d", configStatus.Version),
+		Message:            fmt.Sprintf("ClusterConfig with Hash %s", configStatus.PropertiesThatNeedRestartHash),
 	})
 
 	return nil

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -294,6 +294,7 @@ func (s *RedpandaControllerSuite) TestManagedDecommission() {
 
 func (s *RedpandaControllerSuite) TestClusterSettings() {
 	rp := s.minimalRP()
+	rp.Annotations[redpanda.RestartClusterOnConfigChangeKey] = "true"
 	// Ensure that some superusers exist.
 	rp.Spec.ClusterSpec.Auth = &redpandav1alpha2.Auth{
 		SASL: &redpandav1alpha2.SASL{
@@ -709,7 +710,8 @@ func (s *RedpandaControllerSuite) setupRBAC() string {
 func (s *RedpandaControllerSuite) minimalRP() *redpandav1alpha2.Redpanda {
 	return &redpandav1alpha2.Redpanda{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "rp-" + testenv.RandString(6), // GenerateName doesn't play nice with SSA.
+			Name:        "rp-" + testenv.RandString(6), // GenerateName doesn't play nice with SSA.
+			Annotations: map[string]string{},
 		},
 		Spec: redpandav1alpha2.RedpandaSpec{
 			// Any empty structs are to make setting them more ergonomic


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/v2.3.x` to `main`:
 - [operator: add annotation feature flag for restart cluster on config change (#748)](https://github.com/redpanda-data/redpanda-operator/pull/748)
 - [operator: annotate pods with config hash instead of config version (#746)](https://github.com/redpanda-data/redpanda-operator/pull/746)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)