### PR TITLE
[release/v2.4.x] operator: add annotation feature flag for restart cluster on config change (#748)

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -54,9 +54,10 @@ import (
 )
 
 const (
-	FinalizerKey            = "operator.redpanda.com/finalizer"
-	ClusterConfigVersionKey = "operator.redpanda.com/cluster-config-version"
-	FluxFinalizerKey        = "finalizers.fluxcd.io"
+	FinalizerKey                    = "operator.redpanda.com/finalizer"
+	ClusterConfigVersionKey         = "operator.redpanda.com/cluster-config-version"
+	RestartClusterOnConfigChangeKey = "operator.redpanda.com/restart-cluster-on-config-change"
+	FluxFinalizerKey                = "finalizers.fluxcd.io"
 
 	NotManaged = "false"
 
@@ -360,17 +361,19 @@ func (r *RedpandaReconciler) reconcileDefluxed(ctx context.Context, rp *redpanda
 	values := rp.Spec.ClusterSpec.DeepCopy()
 	// The pods are being annotated with the cluster config version so that they
 	// are restarted on any change to the cluster config.
-	if c := apimeta.FindStatusCondition(rp.Status.Conditions, redpandav1alpha2.ClusterConfigSynced); c != nil {
-		if values.Statefulset == nil {
-			values.Statefulset = &redpandav1alpha2.Statefulset{}
+	if rp.Annotations != nil && rp.Annotations[RestartClusterOnConfigChangeKey] == "true" {
+		if c := apimeta.FindStatusCondition(rp.Status.Conditions, redpandav1alpha2.ClusterConfigSynced); c != nil {
+			if values.Statefulset == nil {
+				values.Statefulset = &redpandav1alpha2.Statefulset{}
+			}
+			if values.Statefulset.PodTemplate == nil {
+				values.Statefulset.PodTemplate = &redpandav1alpha2.PodTemplate{}
+			}
+			if values.Statefulset.PodTemplate.Annotations == nil {
+				values.Statefulset.PodTemplate.Annotations = map[string]string{}
+			}
+			values.Statefulset.PodTemplate.Annotations[ClusterConfigVersionKey] = c.Message
 		}
-		if values.Statefulset.PodTemplate == nil {
-			values.Statefulset.PodTemplate = &redpandav1alpha2.PodTemplate{}
-		}
-		if values.Statefulset.PodTemplate.Annotations == nil {
-			values.Statefulset.PodTemplate.Annotations = map[string]string{}
-		}
-		values.Statefulset.PodTemplate.Annotations[ClusterConfigVersionKey] = c.Message
 	}
 
 	objs, err := redpanda.Chart.Render(r.KubeConfig, helmette.Release{

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	FinalizerKey                    = "operator.redpanda.com/finalizer"
-	ClusterConfigVersionKey         = "operator.redpanda.com/cluster-config-version"
+	ClusterConfigNeedRestartHashKey = "operator.redpanda.com/cluster-config-need-restart-hash"
 	RestartClusterOnConfigChangeKey = "operator.redpanda.com/restart-cluster-on-config-change"
 	FluxFinalizerKey                = "finalizers.fluxcd.io"
 
@@ -372,7 +372,7 @@ func (r *RedpandaReconciler) reconcileDefluxed(ctx context.Context, rp *redpanda
 			if values.Statefulset.PodTemplate.Annotations == nil {
 				values.Statefulset.PodTemplate.Annotations = map[string]string{}
 			}
-			values.Statefulset.PodTemplate.Annotations[ClusterConfigVersionKey] = c.Message
+			values.Statefulset.PodTemplate.Annotations[ClusterConfigNeedRestartHashKey] = c.Message
 		}
 	}
 
@@ -656,7 +656,7 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, rp *red
 		Status:             condition,
 		ObservedGeneration: rp.Generation,
 		Reason:             reason,
-		Message:            fmt.Sprintf("ClusterConfig at Version %d", configStatus.Version),
+		Message:            fmt.Sprintf("ClusterConfig with Hash %s", configStatus.PropertiesThatNeedRestartHash),
 	})
 
 	return nil

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -296,6 +296,7 @@ func (s *RedpandaControllerSuite) TestManagedDecommission() {
 
 func (s *RedpandaControllerSuite) TestClusterSettings() {
 	rp := s.minimalRP(false)
+	rp.Annotations[redpanda.RestartClusterOnConfigChangeKey] = "true"
 	// Ensure that some superusers exist.
 	rp.Spec.ClusterSpec.Auth = &redpandav1alpha2.Auth{
 		SASL: &redpandav1alpha2.SASL{
@@ -949,7 +950,8 @@ func (s *RedpandaControllerSuite) setupRBAC() string {
 func (s *RedpandaControllerSuite) minimalRP(useFlux bool) *redpandav1alpha2.Redpanda {
 	return &redpandav1alpha2.Redpanda{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "rp-" + testenv.RandString(6), // GenerateName doesn't play nice with SSA.
+			Name:        "rp-" + testenv.RandString(6), // GenerateName doesn't play nice with SSA.
+			Annotations: map[string]string{},
 		},
 		Spec: redpandav1alpha2.RedpandaSpec{
 			ChartRef: redpandav1alpha2.ChartRef{


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/v2.3.x` to `release/v2.4.x`:
 - [operator: add annotation feature flag for restart cluster on config change (#748)](https://github.com/redpanda-data/redpanda-operator/pull/748)
 - [operator: annotate pods with config hash instead of config version (#746)](https://github.com/redpanda-data/redpanda-operator/pull/746)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)