### PR TITLE
operator: Fix inconsistency with superusers configuration ordering

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -438,6 +439,13 @@ func (s *RedpandaControllerSuite) TestClusterSettings() {
 
 			config, err := adminClient.Config(s.ctx, false)
 			s.Require().NoError(err)
+
+			arr := config["superusers"].([]any)
+
+			sort.Slice(arr, func(i, j int) bool {
+				return arr[i].(string) < arr[j].(string)
+			})
+
 			// Only assert that c.Expected is a subset of the set config.
 			// The chart/operator injects a bunch of "useful" values by default.
 			s.Subset(config, c.Expected)


### PR DESCRIPTION
Due to the fact that Redpanda can return it's configuration of superusers in different order than the expected output.

As Subset requires the same order the array is first sorted. You can see that error if you execute the following test case:

```go
func TestSubset(t *testing.T) {
	config := map[string]any{
		"superusers": []any{"kubernetes-controller", "bob", "alice"},
	}
	expected := map[string]any{
		"superusers": []any{"alice", "bob", "kubernetes-controller"},
	}

	assert.Subset(t, config, expected)
}
```