### PR TITLE
[release/v2.4.x] require integration and kuttl tests to pass

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -91,7 +91,7 @@ steps:
           failed: true
         message: ':cloud: Integration Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: true
+    soft_fail: false
     timeout_in_minutes: 90
   - continue_on_failure: true
     wait: null
@@ -133,7 +133,7 @@ steps:
           failed: true
         message: ':cloud: Acceptance Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: true
+    soft_fail: false
     timeout_in_minutes: 60
   - continue_on_failure: true
     wait: null
@@ -217,8 +217,8 @@ steps:
           failed: true
         message: ':cloud: Kuttl-V2 Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
-    soft_fail: true
-    timeout_in_minutes: 60
+    soft_fail: false
+    timeout_in_minutes: 90
   - continue_on_failure: true
     wait: null
   - agents:

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -36,12 +36,12 @@ var suites = []TestSuite{
 	},
 	{
 		Name:     "integration",
-		Required: false,
+		Required: true,
 		Timeout:  30*time.Minute + time.Hour,
 	},
 	{
 		Name:     "acceptance",
-		Required: false,
+		Required: true,
 		Timeout:  time.Hour,
 	},
 	// kuttl-v1 is currently the slowest and flakiest of our test suites. The
@@ -61,8 +61,8 @@ var suites = []TestSuite{
 	},
 	{
 		Name:         "kuttl-v2",
-		Required:     false,
-		Timeout:      time.Hour,
+		Required:     true,
+		Timeout:      90 * time.Minute,
 		JUnitPattern: ptr.To("work/operator/tests/_e2e_artifacts_v2/kuttl-report.xml"),
 	},
 }


### PR DESCRIPTION
In `main` all test suites are required. This change wasn't backported either by accident or because the older release branches are notoriously slow and flaky.

Either way, we've been bitten by enough regressions that it's time to pay the piper and make these suites required once again.