### PR TITLE
operator: correct incorrect type marshalling in `GetValues`

### DIFF
--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -293,7 +293,7 @@ func (in *Redpanda) OwnerShipRefObj() metav1.OwnerReference {
 }
 
 func (in *Redpanda) GetValues() (redpandachart.Values, error) {
-	values, err := redpandachart.Chart.LoadValues(in)
+	values, err := redpandachart.Chart.LoadValues(in.Spec.ClusterSpec)
 	if err != nil {
 		return redpandachart.Values{}, errors.WithStack(err)
 	}

--- a/operator/api/redpanda/v1alpha2/redpanda_types_test.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types_test.go
@@ -353,3 +353,22 @@ func TestNoMarkdownLinks(t *testing.T) {
 		t.Errorf("public CRD docs use Ascii doc but found markdown link: %s\nDid you mean: %s[%s]\n(Or do you need to run task generate?)", match[0], match[2], match[1])
 	}
 }
+
+func TestGetValues(t *testing.T) {
+	rp := redpandav1alpha2.Redpanda{
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+				Auth: &redpandav1alpha2.Auth{
+					SASL: &redpandav1alpha2.SASL{
+						Enabled: ptr.To(true),
+					},
+				},
+			},
+		},
+	}
+
+	values, err := rp.GetValues()
+	require.NoError(t, err)
+
+	require.Equal(t, values.Auth.SASL.Enabled, true)
+}


### PR DESCRIPTION
retroactive description: I'm not editing the commit to avoid restarting the CI process.

The `GetValues` function was passing in the `Redpanda` CR instead of the `ClusterSpec` resulting in incorrect values merging. Thankfully, this function was only used in `usersTXTFor` which resulted in `superusers` being wiped if a non-default users secret name.

This commit adds a small regression test and corrects the type being passed to `LoadValues`