### PR TITLE
[release/v2.3.x] operator: Fix inconsistency with superusers configuration ordering

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -436,6 +436,13 @@ func (s *RedpandaControllerSuite) TestClusterSettings() {
 
 			config, err := adminClient.Config(s.ctx, false)
 			s.Require().NoError(err)
+
+			arr := config["superusers"].([]any)
+
+			sort.Slice(arr, func(i, j int) bool {
+				return arr[i].(string) < arr[j].(string)
+			})
+
 			// Only assert that c.Expected is a subset of the set config.
 			// The chart/operator injects a bunch of "useful" values by default.
 			s.Subset(config, c.Expected)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [operator: Fix inconsistency with superusers configuration ordering](https://github.com/redpanda-data/redpanda-operator/pull/761)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)