### PR TITLE
[main] operator: correct incorrect type marshalling in `GetValues`

### DIFF
--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -280,7 +280,7 @@ func (in *Redpanda) OwnerShipRefObj() metav1.OwnerReference {
 }
 
 func (in *Redpanda) GetValues() (redpandachart.Values, error) {
-	values, err := redpandachart.Chart.LoadValues(in)
+	values, err := redpandachart.Chart.LoadValues(in.Spec.ClusterSpec)
 	if err != nil {
 		return redpandachart.Values{}, errors.WithStack(err)
 	}

--- a/operator/api/redpanda/v1alpha2/redpanda_types_test.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types_test.go
@@ -344,3 +344,22 @@ func TestNoMarkdownLinks(t *testing.T) {
 		t.Errorf("public CRD docs use Ascii doc but found markdown link: %s\nDid you mean: %s[%s]\n(Or do you need to run task generate?)", match[0], match[2], match[1])
 	}
 }
+
+func TestGetValues(t *testing.T) {
+	rp := redpandav1alpha2.Redpanda{
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+				Auth: &redpandav1alpha2.Auth{
+					SASL: &redpandav1alpha2.SASL{
+						Enabled: ptr.To(true),
+					},
+				},
+			},
+		},
+	}
+
+	values, err := rp.GetValues()
+	require.NoError(t, err)
+
+	require.Equal(t, values.Auth.SASL.Enabled, true)
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/v2.3.x` to `main`:
 - [operator: correct incorrect type marshalling in `GetValues`](https://github.com/redpanda-data/redpanda-operator/pull/764)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)