### PR TITLE
taskfile/ci: Taskfile needs to call itself again as subprocess in defer statement

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,7 +95,7 @@ tasks:
       - task: generate:third-party-licenses-list
       - task: generate:changelog
       - task: generate:buildkite-pipelines
-      - nix fmt # Ensure flake.nix has been formatted.
+      - nix fmt . # Ensure flake.nix has been formatted.
 
   generate:buildkite-pipelines:
     deps:

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,5 +1,5 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.23.7
+go 1.23.8
 
 require github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda/v5
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/ci/docker/nix.Dockerfile
+++ b/ci/docker/nix.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM nixos/nix:2.21.2
+FROM nixos/nix:2.28.2
 
 WORKDIR "/work"
 

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1745794561,
+        "narHash": "sha256-T36rUZHUART00h3dW4sV5tv4MrXKT7aWjNfHiZz7OHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "5461b7fa65f3ca74cef60be837fd559a8918eaa0",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.23.7
+go 1.23.8
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/licenseupdater/go.mod
+++ b/licenseupdater/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licenseupdater
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.23.7
+go 1.23.8
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/gotohelm/testdata/src/example/go.mod
+++ b/pkg/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -2,7 +2,7 @@ version.BuildInfo{Version:"v3.17.2", GitCommit:"v3.17.2", GitTreeState:"", GoVer
 
 -- aws --
 # aws --version | cut -d ' ' -f 1-2
-aws-cli/2.24.24 Python/3.12.9
+aws-cli/2.26.4 Python/3.12.9
 
 -- changie --
 # changie --version
@@ -17,7 +17,7 @@ License:	 Apache 2.0
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.23.7
+go version go1.23.8
 
 -- goreleaser --
 # goreleaser --version | awk 'NR>2 {print last} {last=$0}'
@@ -25,7 +25,7 @@ sh: line 1: goreleaser: command not found
 
 -- helm --
 # helm version
-version.BuildInfo{Version:"v3.17.2", GitCommit:"v3.17.2", GitTreeState:"", GoVersion:"go1.24.1"}
+version.BuildInfo{Version:"v3.17.3", GitCommit:"v3.17.3", GitTreeState:"", GoVersion:"go1.24.2"}
 
 -- helm-docs --
 # helm-docs -v
@@ -38,7 +38,7 @@ k3s version v1.21.7-k3s1 (default)
 
 -- kind --
 # kind version | cut -d ' ' -f 1-3
-kind v0.27.0 go1.24.1
+kind v0.27.0 go1.24.2
 
 -- kubectl --
 # kubectl version --client=true
@@ -55,7 +55,7 @@ KUTTL Version: version.Info{GitVersion:"0.19.0", GitCommit:"733ad16", BuildDate:
 
 -- task --
 # task --version
-Task version: 3.41.0 ()
+3.43.2
 
 -- yq --
 # yq --version

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gonvenience/ytbx"
 	"github.com/homeport/dyff/pkg/dyff"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/txtar"
 )
@@ -177,11 +178,11 @@ func assertGolden(t *testing.T, assertionType GoldenAssertion, path string, expe
 
 	switch assertionType {
 	case Text:
-		require.Equal(t, string(expected), string(actual), msg, path)
+		assert.Equal(t, string(expected), string(actual), msg, path)
 	case Bytes:
-		require.Equal(t, expected, actual, msg, path)
+		assert.Equal(t, expected, actual, msg, path)
 	case JSON:
-		require.JSONEq(t, string(expected), string(actual), msg, path)
+		assert.JSONEq(t, string(expected), string(actual), msg, path)
 	case YAML:
 		actualDocuments, err := ytbx.LoadDocuments(actual)
 		require.NoError(t, err)

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -78,7 +78,7 @@ tasks:
   run-kuttl-tests:
     cmds:
       - defer:
-          task: ci:kuttl-artifact-upload
+          task: kuttl-artifact-upload
           vars:
             KUTTL_CONFIG_FILE: '{{.KUTTL_CONFIG_FILE}}'
       - task: :k8s:run-kuttl-tests


### PR DESCRIPTION
Due to the following example
```
version: '3'

run: once

shopt: [globstar]

tasks:
  entrypoint:
    cmds:
      - defer: 'task cleanup'
      - defer:
          task: mocked-kuttl-command
          vars:
            KUTTL_CONFIG_FILE: 'defer-file'

      - task: mocked-kuttl-command
        vars:
          KUTTL_CONFIG_FILE: 'some-file'

  mocked-kuttl-command:
    cmds:
      - echo 'the input var -> {{.KUTTL_CONFIG_FILE}}'

  cleanup:
    cmds:
    - echo 'in clean up'
```

The output shows:
```
$ task entrypoint
  task: [mocked-kuttl-command] echo 'the input var -> some-file'
  the input var -> some-file
  task: [entrypoint] task cleanup
  task: [cleanup] echo 'in clean up'
  in clean up
```

which means that defer is very picky about how the task can be called.

In this change the upload task will not be internal as the defer call will use another task process to correctly execute upload commands.