### PR TITLE
operator: SetLicense before cluster configuration

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250429-193357.yaml
+++ b/.changes/unreleased/operator-Fixed-20250429-193357.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: The Redpanda license was not set by operator. Now it will be set in the first reconciliation. After initial setup the consequent license re-set will be reconciled after client-go cache resync timeout (default 10h).
+time: 2025-04-29T19:33:57.266428+02:00

--- a/gen/pipeline/helpers.go
+++ b/gen/pipeline/helpers.go
@@ -83,8 +83,8 @@ func (suite *TestSuite) ToStep() pipeline.Step {
 				Plugins: pipeline.Plugins{
 					secretEnvVars(
 						GITHUB_API_TOKEN, // Required to clone private GH repos (Flux Shims, buildkite slack).
-						REDPANDA_LICENSE,
-						REDPANDA_LICENSE2,
+						REDPANDA_SAMPLE_LICENSE,
+						REDPANDA_SECOND_SAMPLE_LICENSE,
 						SLACK_VBOT_TOKEN, // Used to notify us of build failures in slack.
 					),
 					// Inform us about failures on main.

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -17,10 +17,10 @@ import (
 var (
 	// Known/Permitted environment variables pulled from AWS secret store.
 
-	GITHUB_API_TOKEN  = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
-	REDPANDA_LICENSE  = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
-	REDPANDA_LICENSE2 = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_second_sample_license"}
-	SLACK_VBOT_TOKEN  = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}
+	GITHUB_API_TOKEN               = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
+	REDPANDA_SAMPLE_LICENSE        = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
+	REDPANDA_SECOND_SAMPLE_LICENSE = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_second_sample_license"}
+	SLACK_VBOT_TOKEN               = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}
 
 	// Known/Permitted Agent Pools
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -66,6 +66,7 @@ operator helm chart. The same ports will continue to serve metrics using kubebui
   kafka, admin and schema registry client. Now deprecated fullNameOverride will be used only
   if correct FullNameOverride is not provided and handled the same way for both
   client creation and render function.
+* The Redpanda license was not set by operator. Now it will be set in the first reconciliation. After initial setup the consequent license re-set will be reconciled after client-go cache resync timeout (default 10h).
 
 ## [v25.1.1-beta2](https://github.com/redpanda-data/redpanda-operator/releases/tag/operator%2Fv25.1.1-beta2) - 2025-04-24
 ### Added

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -11,6 +11,7 @@
 package redpanda
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"slices"
@@ -447,6 +448,39 @@ func (r *RedpandaReconciler) ratelimitCondition(ctx context.Context, rp *redpand
 	return previouslySynced && !(generationChanged || recheck)
 }
 
+func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alpha2.Redpanda, adminClient *rpadmin.AdminAPI) error {
+	if rp.Spec.ClusterSpec.Enterprise == nil {
+		return nil
+	}
+
+	if literalLicense := ptr.Deref(rp.Spec.ClusterSpec.Enterprise.License, ""); literalLicense != "" {
+		if err := adminClient.SetLicense(ctx, strings.NewReader(literalLicense)); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	if secretReference := rp.Spec.ClusterSpec.Enterprise.LicenseSecretRef; secretReference != nil {
+		var licenseSecret corev1.Secret
+
+		name := ptr.Deref(secretReference.Name, "")
+		key := ptr.Deref(secretReference.Key, "")
+		if name == "" || key == "" {
+			return errors.Newf("both name %q and key %q of the secret can not be empty string", name, key)
+		}
+
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: rp.Namespace, Name: name}, &licenseSecret); err != nil {
+			return errors.WithStack(err)
+		}
+
+		literalLicense := licenseSecret.Data[key]
+		if err := adminClient.SetLicense(ctx, bytes.NewReader(literalLicense)); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
 func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, rp *redpandav1alpha2.Redpanda) error {
 	if r.ratelimitCondition(ctx, rp, redpandav1alpha2.ClusterLicenseValid) {
 		return nil
@@ -457,6 +491,10 @@ func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, rp *redpandav
 		return errors.WithStack(err)
 	}
 	defer client.Close()
+
+	if err = r.setupLicense(ctx, rp, client); err != nil {
+		return errors.WithStack(err)
+	}
 
 	features, err := client.GetEnterpriseFeatures(ctx)
 	if err != nil {


### PR DESCRIPTION
In deflux mode the Redpanda license was not set by operator. Now it will be set in the first reconciliation. Then it will be reconciled after client-go cache resync timeout (default 10h).

[K8S-781](https://redpandadata.atlassian.net/browse/INC-781)