### PR TITLE
operator: Correct helm chart version passing to the helm template

### DIFF
--- a/operator/internal/controller/legacypermissions/legacypermissions_test.go
+++ b/operator/internal/controller/legacypermissions/legacypermissions_test.go
@@ -34,10 +34,9 @@ func TestLegacyPermissions(t *testing.T) {
 	require.NoError(t, client.RepoAdd(ctx, "redpanda", "https://charts.redpanda.com"))
 
 	cases := []struct {
-		Name                 string
-		RedpandaChartVersion string
-		RedpandaValues       redpanda.PartialValues
-		OperatorValues       operator.PartialValues
+		Name           string
+		RedpandaValues redpanda.PartialValues
+		OperatorValues operator.PartialValues
 	}{
 		{
 			Name:           "defaults",
@@ -68,7 +67,7 @@ func TestLegacyPermissions(t *testing.T) {
 			t.Run(tc.Name+"-"+version, func(t *testing.T) {
 				out, err := client.Template(ctx, "redpanda/redpanda", helm.TemplateOptions{
 					Name:    "redpanda",
-					Version: tc.RedpandaChartVersion,
+					Version: version,
 					Values:  tc.RedpandaValues,
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
Version from the test case struct was not set. With this change the version will be passed to the helm template function, but to work correctly the https://github.com/redpanda-data/redpanda-operator/pull/800 needs to be merged and then go.mod needs to reference the fix.

Reference:
https://github.com/redpanda-data/redpanda-operator/pull/800 
https://github.com/redpanda-data/redpanda-operator/pull/787
https://github.com/redpanda-data/redpanda-operator/pull/791