### PR TITLE
Enable use of Node and Cluster config separately

### DIFF
--- a/operator/pkg/clusterconfiguration/cel_patcher.go
+++ b/operator/pkg/clusterconfiguration/cel_patcher.go
@@ -189,7 +189,9 @@ func fieldByNameOrJSON(v reflect.Value, name string) (reflect.Value, *reflect.Va
 		zero := reflect.New(v.Type().Elem())
 		return zero.Elem(), &v
 	default:
-		panic(fmt.Errorf("unhandled default case %q", v.Kind()))
+		// The user's specified a path to a structure element we can't handle.
+		// Common causes here include using `redpanda.` prefixes on clusterConfiguration.
+		return reflect.Value{}, nil
 	}
 	return reflect.Value{}, nil
 }


### PR DESCRIPTION
Small refactor that enables the use of a Node or Cluster configuration without having to instantiate both; this to assist with the v2 shift to fixup templates.

Also: don't panic when locating items to patch. This was triggered if the user included a `redpanda.` prefix on clusterConfiguration - which has a flat keyspace.