### PR TITLE
[release/v2.3.x] operator: enable `rbac.createAdditionalControllerCRs` by default

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -69,11 +69,6 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 						"tag":        imageTag,
 						"repository": imageRepo,
 					},
-					"rbac": map[string]any{
-						"createAdditionalControllerCRs": true,
-						"createRPKBundleCRs":            true,
-					},
-					"additionalCmdFlags": []string{"--additional-controllers=all", "--enable-helm-controllers=false", "--force-defluxed-mode"},
 				},
 			})
 			t.Log("Successfully installed Redpanda operator chart")

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -273,7 +273,7 @@ Role-based Access Control (RBAC) configuration for the Redpanda Operator.
 **Default:**
 
 ```
-{"create":true,"createAdditionalControllerCRs":false,"createCompatCRs":true,"createRPKBundleCRs":true}
+{"create":true,"createAdditionalControllerCRs":true,"createCompatCRs":true,"createRPKBundleCRs":true}
 ```
 
 ### [rbac.create](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=rbac.create)
@@ -284,9 +284,9 @@ Enables the creation of additional RBAC roles.
 
 ### [rbac.createAdditionalControllerCRs](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=rbac.createAdditionalControllerCRs)
 
-Creates additional RBAC cluster roles that are needed to run additional controllers using `additionalCmdFlags`.
+Creates additional RBAC cluster roles that are needed to run additional controllers using `additionalCmdFlags`. WARNING: Disabling this value may prevent the operator from deploying certain configurations of redpanda.
 
-**Default:** `false`
+**Default:** `true`
 
 ### [rbac.createCompatCRs](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=rbac.createCompatCRs)
 

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -159,6 +159,91 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-compat
 rules:
 - apiGroups:
@@ -196,6 +281,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -507,6 +614,101 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -601,6 +803,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -1185,6 +1410,91 @@ metadata:
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: koBY-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aNfgS0
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: koBY-compat
 rules:
 - apiGroups:
@@ -1222,6 +1532,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: koBY
+subjects:
+- kind: ServiceAccount
+  name: S
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aNfgS0
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: koBY-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: koBY-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: S
@@ -1533,6 +1865,101 @@ metadata:
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: koBY-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aNfgS0
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: koBY-rpk-bundle
   namespace: default
 rules:
@@ -1627,6 +2054,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: koBY
+subjects:
+- kind: ServiceAccount
+  name: S
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aNfgS0
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: koBY-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: koBY-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: S
@@ -2268,6 +2718,91 @@ metadata:
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: WSGbu-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: EbX3hB7N
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: WSGbu-compat
 rules:
 - apiGroups:
@@ -2305,6 +2840,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: WSGbu
+subjects:
+- kind: ServiceAccount
+  name: WSGbu
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: EbX3hB7N
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: WSGbu-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: WSGbu-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: WSGbu
@@ -2616,6 +3173,101 @@ metadata:
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: WSGbu-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: EbX3hB7N
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: WSGbu-rpk-bundle
   namespace: default
 rules:
@@ -2710,6 +3362,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: WSGbu
+subjects:
+- kind: ServiceAccount
+  name: WSGbu
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: EbX3hB7N
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: WSGbu-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: WSGbu-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: WSGbu
@@ -3311,6 +3986,94 @@ metadata:
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Dx441G-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    BYFlp: 1ue
+    PW45cS5PlOC: K5ky3WbW
+    Rb: A
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: HICN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: Dx441G-compat
 rules:
 - apiGroups:
@@ -3351,6 +4114,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: Dx441G
+subjects:
+- kind: ServiceAccount
+  name: Dx441G
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    BYFlp: 1ue
+    PW45cS5PlOC: K5ky3WbW
+    Rb: A
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: HICN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Dx441G-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: Dx441G-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: Dx441G
@@ -3674,6 +4462,104 @@ metadata:
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Dx441G-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    BYFlp: 1ue
+    PW45cS5PlOC: K5ky3WbW
+    Rb: A
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: HICN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: Dx441G-rpk-bundle
   namespace: default
 rules:
@@ -3777,6 +4663,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: Dx441G
+subjects:
+- kind: ServiceAccount
+  name: Dx441G
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    BYFlp: 1ue
+    PW45cS5PlOC: K5ky3WbW
+    Rb: A
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: HICN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Dx441G-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: Dx441G-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: Dx441G
@@ -4384,6 +5296,91 @@ metadata:
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rEba-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kzHCtV
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: rEba-compat
 rules:
 - apiGroups:
@@ -4421,6 +5418,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: rEba
+subjects:
+- kind: ServiceAccount
+  name: rEba
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kzHCtV
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rEba-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rEba-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: rEba
@@ -4732,6 +5751,101 @@ metadata:
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rEba-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kzHCtV
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: rEba-rpk-bundle
   namespace: default
 rules:
@@ -4826,6 +5940,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rEba
+subjects:
+- kind: ServiceAccount
+  name: rEba
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kzHCtV
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rEba-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rEba-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: rEba
@@ -5453,6 +6590,92 @@ metadata:
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kdh6Z-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    F0wS: vBToTa
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: BRlD
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: kdh6Z-compat
 rules:
 - apiGroups:
@@ -5491,6 +6714,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kdh6Z
+subjects:
+- kind: ServiceAccount
+  name: SpE0
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    F0wS: vBToTa
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: BRlD
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kdh6Z-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kdh6Z-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: SpE0
@@ -5806,6 +7052,102 @@ metadata:
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kdh6Z-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    F0wS: vBToTa
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: BRlD
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: kdh6Z-rpk-bundle
   namespace: default
 rules:
@@ -5903,6 +7245,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: kdh6Z
+subjects:
+- kind: ServiceAccount
+  name: SpE0
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    F0wS: vBToTa
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: BRlD
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kdh6Z-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kdh6Z-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: SpE0
@@ -6515,6 +7881,94 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     wU3MsxN: 4Bn0vQj
+  name: WM7nRI7B-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "1": Waszk6s
+    AhQJg: sYlEc
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: zejbO
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-compat
 rules:
 - apiGroups:
@@ -6555,6 +8009,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: WM7nRI7B
+subjects:
+- kind: ServiceAccount
+  name: WM7nRI7B
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "1": Waszk6s
+    AhQJg: sYlEc
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: zejbO
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    wU3MsxN: 4Bn0vQj
+  name: WM7nRI7B-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: WM7nRI7B-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: WM7nRI7B
@@ -6878,6 +8357,104 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     wU3MsxN: 4Bn0vQj
+  name: WM7nRI7B-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "1": Waszk6s
+    AhQJg: sYlEc
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: zejbO
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-rpk-bundle
   namespace: default
 rules:
@@ -6981,6 +8558,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: WM7nRI7B
+subjects:
+- kind: ServiceAccount
+  name: WM7nRI7B
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "1": Waszk6s
+    AhQJg: sYlEc
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: zejbO
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    wU3MsxN: 4Bn0vQj
+  name: WM7nRI7B-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: WM7nRI7B-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: WM7nRI7B
@@ -7611,6 +9214,92 @@ metadata:
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Em-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    CQkNCSKpK8nmJ: B
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: di
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: Em-compat
 rules:
 - apiGroups:
@@ -7649,6 +9338,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: Em
+subjects:
+- kind: ServiceAccount
+  name: Em
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    CQkNCSKpK8nmJ: B
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: di
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Em-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: Em-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: Em
@@ -7964,6 +9676,102 @@ metadata:
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Em-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    CQkNCSKpK8nmJ: B
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: di
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: Em-rpk-bundle
   namespace: default
 rules:
@@ -8061,6 +9869,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: Em
+subjects:
+- kind: ServiceAccount
+  name: Em
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    CQkNCSKpK8nmJ: B
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: di
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: Em-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: Em-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: Em
@@ -9138,6 +10970,95 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     u: yT9Aqc
+  name: DBMkVbLNvvZn-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    5mUYOp: Eqc
+    AsH: OAiucz
+    eEDhSFGX: WSL6MXpbA
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: GNbmN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    u: yT9Aqc
   name: DBMkVbLNvvZn-compat
 rules:
 - apiGroups:
@@ -9179,6 +11100,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: DBMkVbLNvvZn
+subjects:
+- kind: ServiceAccount
+  name: q5hs
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    5mUYOp: Eqc
+    AsH: OAiucz
+    eEDhSFGX: WSL6MXpbA
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: GNbmN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    u: yT9Aqc
+  name: DBMkVbLNvvZn-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: DBMkVbLNvvZn-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: q5hs
@@ -9506,6 +11453,105 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     u: yT9Aqc
+  name: DBMkVbLNvvZn-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    5mUYOp: Eqc
+    AsH: OAiucz
+    eEDhSFGX: WSL6MXpbA
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: GNbmN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    u: yT9Aqc
   name: DBMkVbLNvvZn-rpk-bundle
   namespace: default
 rules:
@@ -9612,6 +11658,33 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: DBMkVbLNvvZn
+subjects:
+- kind: ServiceAccount
+  name: q5hs
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    5mUYOp: Eqc
+    AsH: OAiucz
+    eEDhSFGX: WSL6MXpbA
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: GNbmN
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    u: yT9Aqc
+  name: DBMkVbLNvvZn-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: DBMkVbLNvvZn-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: q5hs
@@ -10244,6 +12317,93 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     gLlqKr: m
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kBI8lEs-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "": Wyz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: 6n9214EY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gLlqKr: m
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: kBI8lEs-compat
 rules:
 - apiGroups:
@@ -10283,6 +12443,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kBI8lEs
+subjects:
+- kind: ServiceAccount
+  name: kBI8lEs
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "": Wyz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: 6n9214EY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gLlqKr: m
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kBI8lEs-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kBI8lEs-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: kBI8lEs
@@ -10602,6 +12786,103 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     gLlqKr: m
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kBI8lEs-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "": Wyz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: 6n9214EY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gLlqKr: m
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: kBI8lEs-rpk-bundle
   namespace: default
 rules:
@@ -10702,6 +12983,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: kBI8lEs
+subjects:
+- kind: ServiceAccount
+  name: kBI8lEs
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    "": Wyz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: 6n9214EY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gLlqKr: m
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: kBI8lEs-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kBI8lEs-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: kBI8lEs
@@ -11313,6 +13619,93 @@ metadata:
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rcE-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    7Kz: 6vhFA
+    hw87: p7dM7cs
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Ubj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: rcE-compat
 rules:
 - apiGroups:
@@ -11352,6 +13745,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: rcE
+subjects:
+- kind: ServiceAccount
+  name: rcE
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    7Kz: 6vhFA
+    hw87: p7dM7cs
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Ubj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rcE-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rcE-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: rcE
@@ -11671,6 +14088,103 @@ metadata:
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rcE-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    7Kz: 6vhFA
+    hw87: p7dM7cs
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Ubj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: rcE-rpk-bundle
   namespace: default
 rules:
@@ -11771,6 +14285,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rcE
+subjects:
+- kind: ServiceAccount
+  name: rcE
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    7Kz: 6vhFA
+    hw87: p7dM7cs
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Ubj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: rcE-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rcE-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: rcE
@@ -12432,6 +14971,94 @@ metadata:
     helm.sh/chart: operator-v2.3.9-24.3.11
     mOxaE: dEuL
     w49JChsEQqA0: "3"
+  name: 7guti07-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    VTHH: SaDKhXP
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: pP
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    mOxaE: dEuL
+    w49JChsEQqA0: "3"
   name: 7guti07-compat
 rules:
 - apiGroups:
@@ -12472,6 +15099,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: 7guti07
+subjects:
+- kind: ServiceAccount
+  name: 7guti07
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    VTHH: SaDKhXP
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: pP
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    mOxaE: dEuL
+    w49JChsEQqA0: "3"
+  name: 7guti07-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 7guti07-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: 7guti07
@@ -12795,6 +15447,104 @@ metadata:
     helm.sh/chart: operator-v2.3.9-24.3.11
     mOxaE: dEuL
     w49JChsEQqA0: "3"
+  name: 7guti07-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    VTHH: SaDKhXP
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: pP
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    mOxaE: dEuL
+    w49JChsEQqA0: "3"
   name: 7guti07-rpk-bundle
   namespace: default
 rules:
@@ -12898,6 +15648,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: 7guti07
+subjects:
+- kind: ServiceAccount
+  name: 7guti07
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    VTHH: SaDKhXP
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: pP
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    mOxaE: dEuL
+    w49JChsEQqA0: "3"
+  name: 7guti07-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 7guti07-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: 7guti07
@@ -13498,6 +16274,91 @@ metadata:
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: J5MiI-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: E4UR
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: J5MiI-compat
 rules:
 - apiGroups:
@@ -13535,6 +16396,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: J5MiI
+subjects:
+- kind: ServiceAccount
+  name: J5MiI
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: E4UR
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: J5MiI-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: J5MiI-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: J5MiI
@@ -13846,6 +16729,101 @@ metadata:
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: J5MiI-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: E4UR
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: J5MiI-rpk-bundle
   namespace: default
 rules:
@@ -13940,6 +16918,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: J5MiI
+subjects:
+- kind: ServiceAccount
+  name: J5MiI
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: E4UR
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: J5MiI-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: J5MiI-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: J5MiI
@@ -14588,6 +17589,93 @@ metadata:
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: NofaS-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    71sOOTU: en8OPZRyg7
+    L2FlwR: TODz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: xALbe0A
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: NofaS-compat
 rules:
 - apiGroups:
@@ -14627,6 +17715,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: NofaS
+subjects:
+- kind: ServiceAccount
+  name: NofaS
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    71sOOTU: en8OPZRyg7
+    L2FlwR: TODz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: xALbe0A
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: NofaS-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: NofaS-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: NofaS
@@ -14946,6 +18058,103 @@ metadata:
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: NofaS-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    71sOOTU: en8OPZRyg7
+    L2FlwR: TODz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: xALbe0A
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: NofaS-rpk-bundle
   namespace: default
 rules:
@@ -15046,6 +18255,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: NofaS
+subjects:
+- kind: ServiceAccount
+  name: NofaS
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    71sOOTU: en8OPZRyg7
+    L2FlwR: TODz
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: xALbe0A
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: NofaS-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: NofaS-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: NofaS
@@ -19161,6 +22395,94 @@ metadata:
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: x8K24mCZYsnh-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bhU: AcTdNUdgDaT
+    iH: X4s
+    ieFAk: TxA0xeci
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: "5"
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: x8K24mCZYsnh-compat
 rules:
 - apiGroups:
@@ -19201,6 +22523,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: x8K24mCZYsnh
+subjects:
+- kind: ServiceAccount
+  name: x8K24mCZYsnh
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    bhU: AcTdNUdgDaT
+    iH: X4s
+    ieFAk: TxA0xeci
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: "5"
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: x8K24mCZYsnh-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: x8K24mCZYsnh-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: x8K24mCZYsnh
@@ -19524,6 +22871,104 @@ metadata:
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: x8K24mCZYsnh-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    bhU: AcTdNUdgDaT
+    iH: X4s
+    ieFAk: TxA0xeci
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: "5"
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: x8K24mCZYsnh-rpk-bundle
   namespace: default
 rules:
@@ -19627,6 +23072,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: x8K24mCZYsnh
+subjects:
+- kind: ServiceAccount
+  name: x8K24mCZYsnh
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    bhU: AcTdNUdgDaT
+    iH: X4s
+    ieFAk: TxA0xeci
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: "5"
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: x8K24mCZYsnh-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: x8K24mCZYsnh-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: x8K24mCZYsnh
@@ -20296,6 +23767,94 @@ metadata:
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: UHlKDi-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    8dRB: 5cv
+    EfHk: fBL
+    Nm4maThP4X: v
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Fk
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: UHlKDi-compat
 rules:
 - apiGroups:
@@ -20336,6 +23895,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: UHlKDi
+subjects:
+- kind: ServiceAccount
+  name: UHlKDi
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    8dRB: 5cv
+    EfHk: fBL
+    Nm4maThP4X: v
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Fk
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: UHlKDi-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: UHlKDi-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: UHlKDi
@@ -20659,6 +24243,104 @@ metadata:
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: UHlKDi-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    8dRB: 5cv
+    EfHk: fBL
+    Nm4maThP4X: v
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Fk
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: UHlKDi-rpk-bundle
   namespace: default
 rules:
@@ -20762,6 +24444,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: UHlKDi
+subjects:
+- kind: ServiceAccount
+  name: UHlKDi
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    8dRB: 5cv
+    EfHk: fBL
+    Nm4maThP4X: v
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: Fk
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: UHlKDi-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: UHlKDi-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: UHlKDi
@@ -21405,6 +25113,93 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     ruSHmUUvOj1: h3BuiPAHIC
+  name: wINY4HR-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    NoeniB5: Fc1
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: IC6CHScZj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-compat
 rules:
 - apiGroups:
@@ -21444,6 +25239,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: wINY4HR
+subjects:
+- kind: ServiceAccount
+  name: ft
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    NoeniB5: Fc1
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: IC6CHScZj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    ruSHmUUvOj1: h3BuiPAHIC
+  name: wINY4HR-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wINY4HR-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: ft
@@ -21763,6 +25582,103 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     ruSHmUUvOj1: h3BuiPAHIC
+  name: wINY4HR-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    NoeniB5: Fc1
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: IC6CHScZj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-rpk-bundle
   namespace: default
 rules:
@@ -21863,6 +25779,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: wINY4HR
+subjects:
+- kind: ServiceAccount
+  name: ft
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    NoeniB5: Fc1
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: IC6CHScZj
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    ruSHmUUvOj1: h3BuiPAHIC
+  name: wINY4HR-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: wINY4HR-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: ft
@@ -22627,6 +26568,92 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     kxvj1aV: un4v2
+  name: 5-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ZtDuI
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    kxvj1aV: un4v2
   name: 5-compat
 rules:
 - apiGroups:
@@ -22665,6 +26692,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: "5"
+subjects:
+- kind: ServiceAccount
+  name: 12bwUKO
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ZtDuI
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    kxvj1aV: un4v2
+  name: 5-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 5-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: 12bwUKO
@@ -22980,6 +27030,102 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
     kxvj1aV: un4v2
+  name: 5-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ZtDuI
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    kxvj1aV: un4v2
   name: 5-rpk-bundle
   namespace: default
 rules:
@@ -23077,6 +27223,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: "5"
+subjects:
+- kind: ServiceAccount
+  name: 12bwUKO
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ZtDuI
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+    kxvj1aV: un4v2
+  name: 5-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 5-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: 12bwUKO
@@ -23715,6 +27885,96 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     gWL: pM
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: sFwgtf-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    1DvJW: rHStv2tPg
+    nol: gP
+  creationTimestamp: null
+  labels:
+    8BO5: Bd5OIo
+    JnjTVDz: 5xDh
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: NY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gWL: pM
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: sFwgtf-compat
 rules:
 - apiGroups:
@@ -23757,6 +28017,33 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: sFwgtf
+subjects:
+- kind: ServiceAccount
+  name: sFwgtf
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    1DvJW: rHStv2tPg
+    nol: gP
+  creationTimestamp: null
+  labels:
+    8BO5: Bd5OIo
+    JnjTVDz: 5xDh
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: NY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gWL: pM
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: sFwgtf-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sFwgtf-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: sFwgtf
@@ -24088,6 +28375,106 @@ metadata:
     app.kubernetes.io/version: v2.3.9-24.3.11
     gWL: pM
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: sFwgtf-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    1DvJW: rHStv2tPg
+    nol: gP
+  creationTimestamp: null
+  labels:
+    8BO5: Bd5OIo
+    JnjTVDz: 5xDh
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: NY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gWL: pM
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: sFwgtf-rpk-bundle
   namespace: default
 rules:
@@ -24197,6 +28584,34 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: sFwgtf
+subjects:
+- kind: ServiceAccount
+  name: sFwgtf
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    1DvJW: rHStv2tPg
+    nol: gP
+  creationTimestamp: null
+  labels:
+    8BO5: Bd5OIo
+    JnjTVDz: 5xDh
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: NY
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    gWL: pM
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: sFwgtf-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sFwgtf-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: sFwgtf
@@ -26525,6 +30940,94 @@ metadata:
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-YCs-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    "": d0zsybqG
+    JuYYWSQr: R3Yk7
+    TtPk6C: ivO8
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: YCs
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-YCs-compat
 rules:
 - apiGroups:
@@ -26565,6 +31068,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator-YCs
+subjects:
+- kind: ServiceAccount
+  name: a
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    "": d0zsybqG
+    JuYYWSQr: R3Yk7
+    TtPk6C: ivO8
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: YCs
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-YCs-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-YCs-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: a
@@ -26888,6 +31416,104 @@ metadata:
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-YCs-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    "": d0zsybqG
+    JuYYWSQr: R3Yk7
+    TtPk6C: ivO8
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: YCs
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-YCs-rpk-bundle
   namespace: default
 rules:
@@ -26991,6 +31617,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator-YCs
+subjects:
+- kind: ServiceAccount
+  name: a
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "": d0zsybqG
+    JuYYWSQr: R3Yk7
+    TtPk6C: ivO8
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: YCs
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-YCs-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-YCs-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: a
@@ -28506,6 +33158,95 @@ metadata:
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: 2-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    Xpmsmk: xwQ7HYnx
+    nht: xpYQ9rPl
+  creationTimestamp: null
+  labels:
+    9Yl4uYdhi: AwRf
+    SX: I
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: VhCMS
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: 2-compat
 rules:
 - apiGroups:
@@ -28547,6 +33288,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: "2"
+subjects:
+- kind: ServiceAccount
+  name: blB
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    Xpmsmk: xwQ7HYnx
+    nht: xpYQ9rPl
+  creationTimestamp: null
+  labels:
+    9Yl4uYdhi: AwRf
+    SX: I
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: VhCMS
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: 2-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 2-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: blB
@@ -28874,6 +33641,105 @@ metadata:
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: 2-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    Xpmsmk: xwQ7HYnx
+    nht: xpYQ9rPl
+  creationTimestamp: null
+  labels:
+    9Yl4uYdhi: AwRf
+    SX: I
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: VhCMS
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: 2-rpk-bundle
   namespace: default
 rules:
@@ -28980,6 +33846,33 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: "2"
+subjects:
+- kind: ServiceAccount
+  name: blB
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    Xpmsmk: xwQ7HYnx
+    nht: xpYQ9rPl
+  creationTimestamp: null
+  labels:
+    9Yl4uYdhi: AwRf
+    SX: I
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: VhCMS
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: 2-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 2-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: blB
@@ -31821,6 +36714,94 @@ metadata:
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: D-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    H15A: FR
+    ImNZ2R: 4b11Ajcj71
+    MkV5WTrr: tzjZwG
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aYT
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: D-compat
 rules:
 - apiGroups:
@@ -31861,6 +36842,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: D
+subjects:
+- kind: ServiceAccount
+  name: 40Wt
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    H15A: FR
+    ImNZ2R: 4b11Ajcj71
+    MkV5WTrr: tzjZwG
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aYT
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: D-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: D-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: 40Wt
@@ -32184,6 +37190,104 @@ metadata:
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: D-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    H15A: FR
+    ImNZ2R: 4b11Ajcj71
+    MkV5WTrr: tzjZwG
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aYT
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: D-rpk-bundle
   namespace: default
 rules:
@@ -32287,6 +37391,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: D
+subjects:
+- kind: ServiceAccount
+  name: 40Wt
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    H15A: FR
+    ImNZ2R: 4b11Ajcj71
+    MkV5WTrr: tzjZwG
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: aYT
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: D-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: D-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: 40Wt
@@ -106681,6 +111811,91 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-compat
 rules:
 - apiGroups:
@@ -106718,6 +111933,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -107029,6 +112266,101 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -107123,6 +112455,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -107701,6 +113056,91 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-compat
 rules:
 - apiGroups:
@@ -107738,6 +113178,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -108049,6 +113511,101 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -108143,6 +113700,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -108738,6 +114318,91 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-compat
 rules:
 - apiGroups:
@@ -108775,6 +114440,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -109086,6 +114773,101 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -109180,6 +114962,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -109758,6 +115563,91 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-compat
 rules:
 - apiGroups:
@@ -109795,6 +115685,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -110106,6 +116018,101 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -110200,6 +116207,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -111644,6 +117674,91 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-compat
 rules:
 - apiGroups:
@@ -111681,6 +117796,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -111992,6 +118129,101 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.3.9-24.3.11
     helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -112086,6 +118318,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.3.9-24.3.11
+    helm.sh/chart: operator-v2.3.9-24.3.11
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
 subjects:
 - kind: ServiceAccount
   name: operator

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -76,7 +76,8 @@ rbac:
   create: true
   # -- Creates additional RBAC cluster roles that are
   # needed to run additional controllers using `additionalCmdFlags`.
-  createAdditionalControllerCRs: false
+  # WARNING: Disabling this value may prevent the operator from deploying certain configurations of redpanda.
+  createAdditionalControllerCRs: true
   # -- Create ClusterRoles needed for the Redpanda Helm chart's 'rbac.rpkDebugBundle' feature.
   createRPKBundleCRs: true
   # -- Create ClusterRoles needed for compatibility with charts < v5.10.2 or < v5.9.22.


### PR DESCRIPTION
Due to some buggy checks in the redpanda chart's RBAC it, by default, requires permissions to persistentvolumes for the PVCUnbinder.

This issue went unnoticed due to a lack of appropriate chart tests and our integration tests overriding the default rbac configuration of the operator chart.

As the releases of the chart and operator image have already been cut, it's been decided that we'll solve the problem in this patch release by defaulting `rbac.createAdditionalControllerCRs` to `true`.

This commit additionally resets the acceptance tests to use the default configuration of the helm chart and adds a regression test that checks the operator's RBAC against the redpanda chart's.

The follow fix is tracked in [K8s-605](https://redpandadata.atlassian.net/browse/K8S-605).