### PR TITLE
v1: fix upgrade of older clusters

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250506-111303.yaml
+++ b/.changes/unreleased/operator-Fixed-20250506-111303.yaml
@@ -1,0 +1,7 @@
+project: operator
+kind: Fixed
+body: |-
+    The operator now unconditionally produces statefulsets that have environment variables available to the initContainer that are used for CEL-based config patching.
+
+    Previously it attempted to leave existing sts resources unpatched if it seemed like they had already been bootstrapped. With the adoption of CEL patching for node configuration, that left sts pods unable to restart.
+time: 2025-05-06T11:13:03.863535+01:00

--- a/.changes/unreleased/operator-Fixed-20250506-111414.yaml
+++ b/.changes/unreleased/operator-Fixed-20250506-111414.yaml
@@ -1,0 +1,7 @@
+project: operator
+kind: Fixed
+body: |-
+    The operator now unconditionally produces an environment for the initContainer that supports CEL-based patching.
+
+    This is required to ensure that a pre-existing sts can roll over to new configuration correctly.
+time: 2025-05-06T11:14:14.360346+01:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -67,6 +67,12 @@ operator helm chart. The same ports will continue to serve metrics using kubebui
   if correct FullNameOverride is not provided and handled the same way for both
   client creation and render function.
 * The Redpanda license was not set by operator. Now it will be set in the first reconciliation. After initial setup the consequent license re-set will be reconciled after client-go cache resync timeout (default 10h).
+* The operator now unconditionally produces statefulsets that have environment variables available to the initContainer that are used for CEL-based config patching.
+
+Previously it attempted to leave existing sts resources unpatched if it seemed like they had already been bootstrapped. With the adoption of CEL patching for node configuration, that left sts pods unable to restart.
+* The operator now unconditionally produces an environment for the initContainer that supports CEL-based patching.
+
+This is required to ensure that a pre-existing sts can roll over to new configuration correctly.
 
 ## [v25.1.1-beta2](https://github.com/redpanda-data/redpanda-operator/releases/tag/operator%2Fv25.1.1-beta2) - 2025-04-24
 ### Added


### PR DESCRIPTION
The sts initContainer code used `okToPatch` which attempted to avoid a superfluous restart of the sts the first time it was patched for the new bootstrap mechanism.

Since then, the same CEL-based patching has been included in both node configuration and bootstrap, and is thus required on any sts change (that is: the initContainer must not fail), so we include the required env vars unconditionally here.