### PR TITLE
[External Secrets] Fix up image setting code

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -48,7 +48,7 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 		RegisterProvider("k3d", providers.NewK3D(5).RetainCluster()).
 		WithDefaultProvider("k3d").
 		WithImportedImages([]string{
-			"localhost/redpanda-operator:dev",
+			imageRepo + ":" + imageTag,
 			"docker.redpanda.com/redpandadata/redpanda:v25.1.1",
 			"quay.io/jetstack/cert-manager-controller:v1.14.2",
 			"quay.io/jetstack/cert-manager-cainjector:v1.14.2",

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -576,26 +576,27 @@ func Run(
 
 		factory := internalclient.NewFactory(mgr.GetConfig(), mgr.GetClient()).WithAdminClientTimeout(rpClientTimeout)
 
+		cloudSecrets := lifecycle.CloudSecretsFlags{
+			CloudSecretsEnabled:          cloudSecretsEnabled,
+			CloudSecretsPrefix:           cloudSecretsPrefix,
+			CloudSecretsAWSRegion:        cloudSecretsAWSRegion,
+			CloudSecretsAWSRoleARN:       cloudSecretsAWSRoleARN,
+			CloudSecretsGCPProjectID:     cloudSecretsGCPProjectID,
+			CloudSecretsAzureKeyVaultURI: cloudSecretsAzureKeyVaultURI,
+		}
+		redpandaImage := lifecycle.Image{
+			Repository: configuratorBaseImage,
+			Tag:        configuratorTag,
+		}
+
 		// Redpanda Reconciler
 		if err = (&redpandacontrollers.RedpandaReconciler{
 			KubeConfig:           mgr.GetConfig(),
 			Client:               mgr.GetClient(),
 			EventRecorder:        mgr.GetEventRecorderFor("RedpandaReconciler"),
-			LifecycleClient:      lifecycle.NewResourceClient(mgr, lifecycle.V2ResourceManagers),
+			LifecycleClient:      lifecycle.NewResourceClient(mgr, lifecycle.V2ResourceManagers(redpandaImage, cloudSecrets)),
 			ClientFactory:        factory,
 			CloudSecretsExpander: cloudExpander,
-			CloudSecretsFlags: redpandacontrollers.CloudSecretsFlags{
-				CloudSecretsEnabled:          cloudSecretsEnabled,
-				CloudSecretsPrefix:           cloudSecretsPrefix,
-				CloudSecretsAWSRegion:        cloudSecretsAWSRegion,
-				CloudSecretsAWSRoleARN:       cloudSecretsAWSRoleARN,
-				CloudSecretsGCPProjectID:     cloudSecretsGCPProjectID,
-				CloudSecretsAzureKeyVaultURI: cloudSecretsAzureKeyVaultURI,
-			},
-			OperatorImage: redpandacontrollers.Image{
-				Repository: configuratorBaseImage,
-				Tag:        configuratorTag,
-			},
 		}).SetupWithManager(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Redpanda")
 			return err

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -60,11 +60,6 @@ const (
 	requeueTimeout = 10 * time.Second
 )
 
-type Image struct {
-	Repository string
-	Tag        string
-}
-
 // RedpandaReconciler reconciles a Redpanda object
 type RedpandaReconciler struct {
 	// KubeConfig is the [rest.Config] that provides the go helm chart
@@ -75,51 +70,6 @@ type RedpandaReconciler struct {
 	EventRecorder        kuberecorder.EventRecorder
 	ClientFactory        internalclient.ClientFactory
 	CloudSecretsExpander *pkgsecrets.CloudExpander
-	// CloudSecretsFlags holds the settings required to instantiate a CloudExpander.
-	// This is used to generate the CLI arguments to the bootstrap templater.
-	CloudSecretsFlags CloudSecretsFlags
-
-	// OperatorImage is the image to use for any instances of the operator
-	// within redpanda deployments. e.g. StatefulSet.Sidecar.Image. The
-	// redpanda chart ships with it's own default but we want this field to be
-	// controlled by the operator.
-	OperatorImage Image
-}
-
-// CloudSecretsFlags contains the flags required to generate a default set of
-// CLI arguments to the configurator / bootstrap templater to correctly instantiate
-// a CloudExpander.
-// TODO: find a way to deduplicate this machinery - perhaps move to a standard configuration struct in pkgsecrets
-type CloudSecretsFlags struct {
-	CloudSecretsEnabled          bool
-	CloudSecretsPrefix           string
-	CloudSecretsAWSRegion        string
-	CloudSecretsAWSRoleARN       string
-	CloudSecretsGCPProjectID     string
-	CloudSecretsAzureKeyVaultURI string
-}
-
-// AdditionalConfiguratorArgs constructs a "standard" set of arguments to pass to a
-// configurator (or bootstrap) initContainer, to specify the CloudExpander to instantiate.
-func (c CloudSecretsFlags) AdditionalConfiguratorArgs() []string {
-	var result []string
-	if c.CloudSecretsEnabled {
-		result = append(result, "--enable-cloud-secrets=true")
-		result = append(result, fmt.Sprintf("--cloud-secrets-prefix=%s", c.CloudSecretsPrefix))
-		if c.CloudSecretsAWSRegion != "" {
-			result = append(result, fmt.Sprintf("--cloud-secrets-aws-region=%s", c.CloudSecretsAWSRegion))
-		}
-		if c.CloudSecretsAWSRoleARN != "" {
-			result = append(result, fmt.Sprintf("--cloud-secrets-aws-role-arn=%s", c.CloudSecretsAWSRoleARN))
-		}
-		if c.CloudSecretsGCPProjectID != "" {
-			result = append(result, fmt.Sprintf("--cloud-secrets-gcp-project-id=%s", c.CloudSecretsGCPProjectID))
-		}
-		if c.CloudSecretsAzureKeyVaultURI != "" {
-			result = append(result, fmt.Sprintf("--cloud-secrets-azure-key-vault-uri=%s", c.CloudSecretsAzureKeyVaultURI))
-		}
-	}
-	return result
 }
 
 // Any resource that the Redpanda helm chart creates and needs to reconcile.
@@ -302,53 +252,7 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *RedpandaReconciler) reconcileResources(ctx context.Context, rp *redpandav1alpha2.Redpanda) error {
 	defer timing.Execution(ctx).Stop("reconciling resources")
-
-	cloned := rp.DeepCopy()
-	if cloned.Spec.ClusterSpec == nil {
-		cloned.Spec.ClusterSpec = &redpandav1alpha2.RedpandaClusterSpec{}
-	}
-
-	if cloned.Spec.ClusterSpec.Statefulset == nil {
-		cloned.Spec.ClusterSpec.Statefulset = &redpandav1alpha2.Statefulset{}
-	}
-
-	if cloned.Spec.ClusterSpec.Statefulset.SideCars == nil {
-		cloned.Spec.ClusterSpec.Statefulset.SideCars = &redpandav1alpha2.SideCars{}
-	}
-
-	if cloned.Spec.ClusterSpec.Statefulset.SideCars.Image == nil {
-		cloned.Spec.ClusterSpec.Statefulset.SideCars.Image = &redpandav1alpha2.RedpandaImage{}
-	}
-
-	// If not explicitly specified, set the tag and repository of the sidecar
-	// to the image specified via CLI args rather than relying on the default
-	// of the redpanda chart.
-	// This ensures that custom deployments (e.g.
-	// localhost/redpanda-operator:dev) will use the image they are deployed
-	// with.
-	if cloned.Spec.ClusterSpec.Statefulset.SideCars.Image.Tag == nil {
-		cloned.Spec.ClusterSpec.Statefulset.SideCars.Image.Tag = &r.OperatorImage.Tag
-	}
-
-	if cloned.Spec.ClusterSpec.Statefulset.SideCars.Image.Repository == nil {
-		cloned.Spec.ClusterSpec.Statefulset.SideCars.Image.Repository = &r.OperatorImage.Repository
-	}
-
-	// If not explicitly specified, set the initContainer flags for the bootstrap
-	// templating to instantiate an appropriate CloudExpander
-	if cloned.Spec.ClusterSpec.Statefulset.InitContainers == nil {
-		cloned.Spec.ClusterSpec.Statefulset.InitContainers = &redpandav1alpha2.InitContainers{}
-	}
-
-	if cloned.Spec.ClusterSpec.Statefulset.InitContainers.Configurator == nil {
-		cloned.Spec.ClusterSpec.Statefulset.InitContainers.Configurator = &redpandav1alpha2.Configurator{}
-	}
-
-	if len(cloned.Spec.ClusterSpec.Statefulset.InitContainers.Configurator.AdditionalCLIArgs) == 0 {
-		cloned.Spec.ClusterSpec.Statefulset.InitContainers.Configurator.AdditionalCLIArgs = r.CloudSecretsFlags.AdditionalConfiguratorArgs()
-	}
-
-	return r.LifecycleClient.SyncAll(ctx, cloned)
+	return r.LifecycleClient.SyncAll(ctx, rp)
 }
 
 // reconcilePools is the meat of the controller. It handles creation and scale up/scale down

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -639,15 +639,16 @@ func (s *RedpandaControllerSuite) SetupSuite() {
 
 		// TODO should probably run other reconcilers here.
 		return (&redpanda.RedpandaReconciler{
-			Client:          mgr.GetClient(),
-			KubeConfig:      mgr.GetConfig(),
-			EventRecorder:   mgr.GetEventRecorderFor("Redpanda"),
-			ClientFactory:   s.clientFactory,
-			LifecycleClient: lifecycle.NewResourceClient(mgr, lifecycle.V2ResourceManagers),
-			OperatorImage: redpanda.Image{
+			Client:        mgr.GetClient(),
+			KubeConfig:    mgr.GetConfig(),
+			EventRecorder: mgr.GetEventRecorderFor("Redpanda"),
+			ClientFactory: s.clientFactory,
+			LifecycleClient: lifecycle.NewResourceClient(mgr, lifecycle.V2ResourceManagers(lifecycle.Image{
 				Repository: "localhost/redpanda-operator",
 				Tag:        "dev",
-			},
+			}, lifecycle.CloudSecretsFlags{
+				CloudSecretsEnabled: false,
+			})),
 		}).SetupWithManager(s.ctx, mgr)
 	})
 

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -192,11 +192,16 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 
 	// Redpanda Reconciler
 	err = (&redpandacontrollers.RedpandaReconciler{
-		KubeConfig:      k8sManager.GetConfig(),
-		Client:          k8sManager.GetClient(),
-		ClientFactory:   internalclient.NewFactory(k8sManager.GetConfig(), k8sManager.GetClient()),
-		LifecycleClient: lifecycle.NewResourceClient(k8sManager, lifecycle.V2ResourceManagers),
-		EventRecorder:   k8sManager.GetEventRecorderFor("RedpandaReconciler"),
+		KubeConfig:    k8sManager.GetConfig(),
+		Client:        k8sManager.GetClient(),
+		ClientFactory: internalclient.NewFactory(k8sManager.GetConfig(), k8sManager.GetClient()),
+		LifecycleClient: lifecycle.NewResourceClient(k8sManager, lifecycle.V2ResourceManagers(lifecycle.Image{
+			Repository: "localhost/redpanda-operator",
+			Tag:        "dev",
+		}, lifecycle.CloudSecretsFlags{
+			CloudSecretsEnabled: false,
+		})),
+		EventRecorder: k8sManager.GetEventRecorderFor("RedpandaReconciler"),
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/operator/internal/lifecycle/interfaces.go
+++ b/operator/internal/lifecycle/interfaces.go
@@ -127,6 +127,15 @@ type ClusterStatusUpdater[T any, U Cluster[T]] interface {
 	Update(cluster U, status *ClusterStatus) bool
 }
 
+// Image represents a general docker image repo/tag that can be used for setting
+// the default values of things like sidecars and init containers
+type Image struct {
+	// Repository is the repository of the docker image
+	Repository string
+	// Tag is the tag of the docker image
+	Tag string
+}
+
 // ResourceManagerFactory bundles together concrete implementations of OwnershipResolver
 // ClusterStatusUpdater, NodePoolRenderer, and SimpleResourceRenderer for our various
 // cluster versions.

--- a/operator/internal/lifecycle/secrets.go
+++ b/operator/internal/lifecycle/secrets.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import "fmt"
+
+// CloudSecretsFlags contains the flags required to generate a default set of
+// CLI arguments to the configurator / bootstrap templater to correctly instantiate
+// a CloudExpander.
+// TODO: find a way to deduplicate this machinery - perhaps move to a standard configuration struct in pkgsecrets
+type CloudSecretsFlags struct {
+	CloudSecretsEnabled          bool
+	CloudSecretsPrefix           string
+	CloudSecretsAWSRegion        string
+	CloudSecretsAWSRoleARN       string
+	CloudSecretsGCPProjectID     string
+	CloudSecretsAzureKeyVaultURI string
+}
+
+// AdditionalConfiguratorArgs constructs a "standard" set of arguments to pass to a
+// configurator (or bootstrap) initContainer, to specify the CloudExpander to instantiate.
+func (c CloudSecretsFlags) AdditionalConfiguratorArgs() []string {
+	var result []string
+	if c.CloudSecretsEnabled {
+		result = append(result, "--enable-cloud-secrets=true")
+		result = append(result, fmt.Sprintf("--cloud-secrets-prefix=%s", c.CloudSecretsPrefix))
+		if c.CloudSecretsAWSRegion != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-aws-region=%s", c.CloudSecretsAWSRegion))
+		}
+		if c.CloudSecretsAWSRoleARN != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-aws-role-arn=%s", c.CloudSecretsAWSRoleARN))
+		}
+		if c.CloudSecretsGCPProjectID != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-gcp-project-id=%s", c.CloudSecretsGCPProjectID))
+		}
+		if c.CloudSecretsAzureKeyVaultURI != "" {
+			result = append(result, fmt.Sprintf("--cloud-secrets-azure-key-vault-uri=%s", c.CloudSecretsAzureKeyVaultURI))
+		}
+	}
+	return result
+}

--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -172,7 +172,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: docker.redpanda.com/redpandadata/redpanda-operator:v25.1.1-beta3
+          image: localhost/redpanda-operator:dev
           name: sidecar
           readinessProbe:
             failureThreshold: 3
@@ -257,7 +257,7 @@
           - /tmp/base-config
           - --out-dir
           - /tmp/config
-          image: docker.redpanda.com/redpandadata/redpanda-operator:v25.1.1-beta3
+          image: localhost/redpanda-operator:dev
           name: bootstrap-yaml-envsubst
           resources:
             limits:

--- a/operator/internal/lifecycle/v2.go
+++ b/operator/internal/lifecycle/v2.go
@@ -16,11 +16,18 @@ import (
 )
 
 // V2ResourceManagers is a factory function for tying together all of our v2 interfaces.
-func V2ResourceManagers(mgr ctrl.Manager) (
+func V2ResourceManagers(image Image, cloudSecrets CloudSecretsFlags) func(mgr ctrl.Manager) (
 	OwnershipResolver[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
 	ClusterStatusUpdater[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
 	NodePoolRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
 	SimpleResourceRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
 ) {
-	return NewV2OwnershipResolver(), NewV2ClusterStatusUpdater(), NewV2NodePoolRenderer(mgr), NewV2SimpleResourceRenderer(mgr)
+	return func(mgr ctrl.Manager) (
+		OwnershipResolver[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+		ClusterStatusUpdater[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+		NodePoolRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+		SimpleResourceRenderer[redpandav1alpha2.Redpanda, *redpandav1alpha2.Redpanda],
+	) {
+		return NewV2OwnershipResolver(), NewV2ClusterStatusUpdater(), NewV2NodePoolRenderer(mgr, image, cloudSecrets), NewV2SimpleResourceRenderer(mgr)
+	}
 }

--- a/operator/internal/lifecycle/v2_test.go
+++ b/operator/internal/lifecycle/v2_test.go
@@ -95,7 +95,15 @@ func TestV2ResourceClient(t *testing.T) {
 	goldenPools := testutil.NewTxTar(t, "testdata/cases.pools.golden.txtar")
 	goldenResources := testutil.NewTxTar(t, "testdata/cases.resources.golden.txtar")
 
-	resourceClient := NewResourceClient(manager, V2ResourceManagers)
+	cloudSecrets := CloudSecretsFlags{
+		CloudSecretsEnabled: false,
+	}
+	redpandaImage := Image{
+		Repository: "localhost/redpanda-operator",
+		Tag:        "dev",
+	}
+
+	resourceClient := NewResourceClient(manager, V2ResourceManagers(redpandaImage, cloudSecrets))
 
 	require.EqualValues(t, redpandachart.Types(), resourceClient.simpleResourceRenderer.WatchedResourceTypes())
 


### PR DESCRIPTION
Here are the fixes for making sure that image tags are set up properly. I'm also assuming that the cloud secrets stuff is at least *somewhat* implementation specific, so I moved it to the lifecycle interfaces for now, as the general idea is that those interfaces are what should wrap any CRD implementation-specific code, and then we can pull it out as v1 and v2 coallesce. If this isn't the case feel free to pull it back into the controller.