### PR TITLE
Add operator upgrade acceptance test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -196,14 +196,20 @@ tasks:
     vars:
       DEFAULT_TEST_CERTMANAGER_VERSION: v1.14.2
       DEFAULT_TEST_REDPANDA_VERSION: v25.1.1
+      DEFAULT_TEST_UPGRADE_REDPANDA_VERSION: v24.3.11
+      DEFAULT_TEST_UPGRADE_OPERATOR_VERSION: v2.3.9-24.3.11
       TEST_CERTMANAGER_VERSION: '{{ .TEST_CERTMANAGER_VERSION | default .DEFAULT_TEST_CERTMANAGER_VERSION }}'
       TEST_REDPANDA_VERSION: '{{ .TEST_REDPANDA_VERSION | default .DEFAULT_TEST_REDPANDA_VERSION }}'
+      TEST_UPGRADE_REDPANDA_VERSION: '{{ .TEST_UPGRADE_REDPANDA_VERSION | default .DEFAULT_TEST_UPGRADE_REDPANDA_VERSION }}'
+      TEST_UPGRADE_OPERATOR_VERSION: '{{ .TEST_UPGRADE_OPERATOR_VERSION | default .DEFAULT_TEST_UPGRADE_OPERATOR_VERSION }}'
     cmds:
       - docker pull quay.io/jetstack/cert-manager-controller:{{.TEST_CERTMANAGER_VERSION}}
       - docker pull quay.io/jetstack/cert-manager-cainjector:{{.TEST_CERTMANAGER_VERSION}}
       - docker pull quay.io/jetstack/cert-manager-startupapicheck:{{.TEST_CERTMANAGER_VERSION}}
       - docker pull quay.io/jetstack/cert-manager-webhook:{{.TEST_CERTMANAGER_VERSION}}
       - docker pull docker.redpanda.com/redpandadata/redpanda:{{.TEST_REDPANDA_VERSION}}
+      - docker pull docker.redpanda.com/redpandadata/redpanda:{{.TEST_UPGRADE_REDPANDA_VERSION}}
+      - docker pull docker.redpanda.com/redpandadata/redpanda-operator:{{.TEST_UPGRADE_OPERATOR_VERSION}}
 
   pending-prs:
     desc: "Get all pending PRs for watched branches"

--- a/acceptance/features/operator-upgrades.feature
+++ b/acceptance/features/operator-upgrades.feature
@@ -1,0 +1,31 @@
+@operator:none
+Feature: Upgrading the operator
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Operator upgrade from 2.3.x
+    Given I install redpanda helm chart version "v2.3.9-24.3.11" with the values:
+    """
+    
+    """
+    And I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Redpanda
+    metadata:
+      name: operator-upgrade
+    spec:
+      clusterSpec:
+        statefulset:
+          replicas: 1
+    """
+    # use just a Ready status check here since that's all the
+    # old operator supports
+    And cluster "operator-upgrade" is available
+    Then I can upgrade to the latest operator with the values:
+    """
+    image:
+      tag: dev
+      repository: localhost/redpanda-operator
+    """
+    # use the new status as this will eventually get set
+    And cluster "operator-upgrade" should be stable with 1 nodes

--- a/acceptance/steps/cluster.go
+++ b/acceptance/steps/cluster.go
@@ -34,11 +34,19 @@ func checkClusterAvailability(ctx context.Context, t framework.TestingT, cluster
 	t.Logf("Checking cluster %q is ready", clusterName)
 	require.Eventually(t, func() bool {
 		require.NoError(t, t.Get(ctx, key, &cluster))
-		hasCondition := t.HasCondition(metav1.Condition{
+		hasConditionReady := t.HasCondition(metav1.Condition{
 			Type:   "Ready",
 			Status: metav1.ConditionTrue,
 			Reason: "Ready",
 		}, cluster.Status.Conditions)
+		// legacy status condition below
+		hasConditionDeployed := t.HasCondition(metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionTrue,
+			Reason: "RedpandaClusterDeployed",
+		}, cluster.Status.Conditions)
+
+		hasCondition := hasConditionDeployed || hasConditionReady
 
 		t.Logf(`Checking cluster resource conditions contains "Ready"? %v`, hasCondition)
 		return hasCondition

--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -32,7 +32,9 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -472,5 +474,17 @@ func clientsForOperator(ctx context.Context, includeTLS bool, serviceAccountName
 			TLSClientConfig: &tlsCfg,
 			DialContext:     kube.NewPodDialer(t.RestConfig()).DialContext,
 		}},
+	}
+}
+
+func removeAllFinalizers(ctx context.Context, t framework.TestingT, gvk schema.GroupVersionKind) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+
+	require.NoError(t, t.List(ctx, list))
+	for i := range list.Items {
+		item := list.Items[i]
+		item.SetFinalizers(nil)
+		require.NoError(t, t.Update(ctx, &item))
 	}
 }

--- a/acceptance/steps/operator.go
+++ b/acceptance/steps/operator.go
@@ -11,13 +11,18 @@ package steps
 
 import (
 	"context"
+	"fmt"
+	"os"
 
+	"github.com/cucumber/godog"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 )
 
 func operatorIsRunning(ctx context.Context, t framework.TestingT) {
@@ -74,5 +79,66 @@ func createClusterRoleBinding(ctx context.Context, serviceAccountName, clusterRo
 				Namespace: t.Namespace(),
 			},
 		}))
+	})
+}
+
+func iCanUpgradeToTheLatestOperatorWithTheValues(ctx context.Context, t framework.TestingT, values *godog.DocString) {
+	file, err := os.CreateTemp("", "values-*.yaml")
+	require.NoError(t, err)
+
+	_, err = file.Write([]byte(values.Content))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	t.Cleanup(func(ctx context.Context) {
+		require.NoError(t, os.RemoveAll(file.Name()))
+	})
+
+	t.UpgradeLocalHelmChart(ctx, "../operator/chart", "redpanda-operator", helm.UpgradeOptions{
+		Namespace:  t.Namespace(),
+		ValuesFile: file.Name(),
+	})
+}
+
+func iInstallRedpandaHelmChartVersionWithTheValues(ctx context.Context, t framework.TestingT, version string, values *godog.DocString) {
+	file, err := os.CreateTemp("", "values-*.yaml")
+	require.NoError(t, err)
+
+	_, err = file.Write([]byte(values.Content))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	t.Cleanup(func(ctx context.Context) {
+		require.NoError(t, os.RemoveAll(file.Name()))
+	})
+
+	// these are needed for old versions of the operator
+	t.ApplyManifest(ctx, fmt.Sprintf("https://raw.githubusercontent.com/redpanda-data/redpanda-operator/refs/tags/%s/operator/config/crd/bases/toolkit.fluxcd.io/helm-controller.yaml", version))
+	t.ApplyManifest(ctx, fmt.Sprintf("https://raw.githubusercontent.com/redpanda-data/redpanda-operator/refs/tags/%s/operator/config/crd/bases/toolkit.fluxcd.io/source-controller.yaml", version))
+
+	t.Cleanup(func(ctx context.Context) {
+		// make sure we remove all finalizers for these or the CRD cleanup will get wedged
+		removeAllFinalizers(ctx, t, schema.GroupVersionKind{
+			Group:   "helm.toolkit.fluxcd.io",
+			Kind:    "HelmRelease",
+			Version: "v2beta2",
+		})
+		removeAllFinalizers(ctx, t, schema.GroupVersionKind{
+			Group:   "source.toolkit.fluxcd.io",
+			Kind:    "HelmRepository",
+			Version: "v1beta1",
+		})
+		removeAllFinalizers(ctx, t, schema.GroupVersionKind{
+			Group:   "source.toolkit.fluxcd.io",
+			Kind:    "HelmChart",
+			Version: "v1beta2",
+		})
+	})
+
+	t.InstallHelmChart(ctx, "https://charts.redpanda.com", "redpanda", "operator", helm.InstallOptions{
+		Name:       "redpanda-operator",
+		Namespace:  t.Namespace(),
+		Version:    version,
+		ValuesFile: file.Name(),
 	})
 }

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -52,7 +52,7 @@ func init() {
 	framework.RegisterStep(`^its metrics endpoint should accept https request with "([^"]*)" service account token$`, acceptServiceAccountMetricsRequest)
 
 	// Helm migration scenario steps
-	framework.RegisterStep(`^a Helm release named "([^"]*)" of the "([^"]*)" Helm chart with the values:$`, iInstallHelmRelease)
+	framework.RegisterStep(`^a Helm release named "([^"]*)" of the "([^"]*)" helm chart with the values:$`, iInstallHelmRelease)
 	framework.RegisterStep(`^the Kubernetes object of type "([^"]*)" with name "([^"]*)" has an OwnerReference pointing to the cluster "([^"]*)"$`, kubernetesObjectHasClusterOwner)
 	framework.RegisterStep(`^the helm release for "([^"]*)" can be deleted by removing its stored secret$`, iDeleteHelmReleaseSecret)
 	framework.RegisterStep(`^the cluster "([^"]*)" is healthy$`, redpandaClusterIsHealthy)

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -73,4 +73,8 @@ func init() {
 	framework.RegisterStep(`^I physically shutdown a kubernetes node for cluster "([^"]*)"$`, shutdownRandomClusterNode)
 	framework.RegisterStep(`^I prune any kubernetes node that is now in a NotReady status$`, deleteNotReadyKubernetesNodes)
 	framework.RegisterStep(`^cluster "([^"]*)" has only (\d+) remaining nodes$`, checkClusterNodeCount)
+
+	// Operator upgrade scenario steps
+	framework.RegisterStep(`^I can upgrade to the latest operator with the values:$`, iCanUpgradeToTheLatestOperatorWithTheValues)
+	framework.RegisterStep(`^I install redpanda helm chart version "([^"]*)" with the values:$`, iInstallRedpandaHelmChartVersionWithTheValues)
 }

--- a/harpoon/internal/testing/helm.go
+++ b/harpoon/internal/testing/helm.go
@@ -42,6 +42,18 @@ func (t *TestingT) InstallHelmChart(ctx context.Context, url, repo, chart string
 	})
 }
 
+func (t *TestingT) UpgradeHelmChart(ctx context.Context, repo, chart, release string, options helm.UpgradeOptions) {
+	helmClient, err := helm.New(helm.Options{
+		KubeConfig: rest.CopyConfig(t.restConfig),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, "", options.Namespace, "namespace must not be blank")
+
+	t.Logf("upgrading chart %q", repo+"/"+chart)
+	_, err = helmClient.Upgrade(ctx, release, repo+"/"+chart, options)
+	require.NoError(t, err)
+}
+
 func (t *TestingT) InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions, deps ...helm.Dependency) {
 	helmClient, err := helm.New(helm.Options{
 		KubeConfig: rest.CopyConfig(t.restConfig),
@@ -69,4 +81,16 @@ func (t *TestingT) InstallLocalHelmChart(ctx context.Context, path string, optio
 			Namespace: options.Namespace,
 		}))
 	})
+}
+
+func (t *TestingT) UpgradeLocalHelmChart(ctx context.Context, path, release string, options helm.UpgradeOptions) {
+	helmClient, err := helm.New(helm.Options{
+		KubeConfig: rest.CopyConfig(t.restConfig),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, "", options.Namespace, "namespace must not be blank")
+
+	t.Logf("upgrading local chart %q", path)
+	_, err = helmClient.Upgrade(ctx, release, path, options)
+	require.NoError(t, err)
 }

--- a/harpoon/internal/testing/tags.go
+++ b/harpoon/internal/testing/tags.go
@@ -19,9 +19,14 @@ import (
 type CleanupFunc func(context.Context)
 
 type ParsedTagHandler struct {
-	Priority  int
+	ParsedTag
+	Priority int
+	Handler  func(context.Context, *TestingT, []string) context.Context
+}
+
+type ParsedTag struct {
+	Name      string
 	Arguments []string
-	Handler   func(context.Context, *TestingT, []string) context.Context
 }
 
 type PriorityTagHandler struct {
@@ -60,9 +65,12 @@ func (r *TagRegistry) Handlers(tags []string) []ParsedTagHandler {
 
 		if handler, ok := r.tags[tag]; ok {
 			handlers = append(handlers, ParsedTagHandler{
-				Arguments: args,
-				Priority:  handler.Priority,
-				Handler:   handler.Handler,
+				ParsedTag: ParsedTag{
+					Name:      tag,
+					Arguments: args,
+				},
+				Priority: handler.Priority,
+				Handler:  handler.Handler,
 			})
 		}
 	}
@@ -73,4 +81,13 @@ func (r *TagRegistry) Handlers(tags []string) []ParsedTagHandler {
 	})
 
 	return handlers
+}
+
+func ParsedTags(handlers []ParsedTagHandler) []ParsedTag {
+	tags := []ParsedTag{}
+	for _, handler := range handlers {
+		tags = append(tags, handler.ParsedTag)
+	}
+
+	return tags
 }

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -54,8 +54,8 @@ type SuiteBuilder struct {
 	injectors             []func(context.Context) context.Context
 	crdDirectories        []string
 	helmCharts            []helmChart
-	onFeatures            []func(context.Context, *internaltesting.TestingT)
-	onScenarios           []func(context.Context, *internaltesting.TestingT)
+	onFeatures            []func(context.Context, *internaltesting.TestingT, []internaltesting.ParsedTag)
+	onScenarios           []func(context.Context, *internaltesting.TestingT, []internaltesting.ParsedTag)
 	exitOnCleanupFailures bool
 }
 
@@ -138,18 +138,32 @@ func (b *SuiteBuilder) WithImportedImages(images ...string) *SuiteBuilder {
 	return b
 }
 
-func (b *SuiteBuilder) OnFeature(fn func(context.Context, TestingT)) *SuiteBuilder {
-	b.onFeatures = append(b.onFeatures, func(ctx context.Context, tt *internaltesting.TestingT) {
+func (b *SuiteBuilder) OnFeature(fn func(context.Context, TestingT, ...ParsedTag)) *SuiteBuilder {
+	b.onFeatures = append(b.onFeatures, func(ctx context.Context, tt *internaltesting.TestingT, tags []internaltesting.ParsedTag) {
+		parsed := []ParsedTag{}
+		for _, tag := range tags {
+			parsed = append(parsed, ParsedTag{
+				Name:      tag.Name,
+				Arguments: tag.Arguments,
+			})
+		}
 		// wrap since we move into the internal implementation of the interface
-		fn(ctx, tt)
+		fn(ctx, tt, parsed...)
 	})
 	return b
 }
 
-func (b *SuiteBuilder) OnScenario(fn func(context.Context, TestingT)) *SuiteBuilder {
-	b.onScenarios = append(b.onScenarios, func(ctx context.Context, tt *internaltesting.TestingT) {
+func (b *SuiteBuilder) OnScenario(fn func(context.Context, TestingT, ...ParsedTag)) *SuiteBuilder {
+	b.onScenarios = append(b.onScenarios, func(ctx context.Context, tt *internaltesting.TestingT, tags []internaltesting.ParsedTag) {
+		parsed := []ParsedTag{}
+		for _, tag := range tags {
+			parsed = append(parsed, ParsedTag{
+				Name:      tag.Name,
+				Arguments: tag.Arguments,
+			})
+		}
 		// wrap since we move into the internal implementation of the interface
-		fn(ctx, tt)
+		fn(ctx, tt, parsed...)
 	})
 	return b
 }

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -31,6 +31,11 @@ type (
 	FullProvider = internaltesting.Provider
 )
 
+type ParsedTag struct {
+	Name      string
+	Arguments []string
+}
+
 type TestingT interface {
 	godog.TestingT
 	client.Client
@@ -50,7 +55,9 @@ type TestingT interface {
 	IsolateNamespace(ctx context.Context) string
 
 	InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions)
+	UpgradeHelmChart(ctx context.Context, repo, chart, release string, options helm.UpgradeOptions)
 	InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions, deps ...helm.Dependency)
+	UpgradeLocalHelmChart(ctx context.Context, path, release string, options helm.UpgradeOptions)
 
 	Namespace() string
 	RestConfig() *rest.Config


### PR DESCRIPTION
This adds an acceptance test for verifying operator upgrades and does the groundwork for adding some more exotic operator configurations. Aside from the test itself, what it does is:

1. Modifies the `OnFeature` and `OnScenario` hooks for `harpoon` to allow for passing off a list of tags on either the feature or scenario
2. Adds a check on our `OnFeature` operator installation in the acceptance tests to skip the default operator installation if an `operator` tag is found
3. Adds an `operator` tag that can be set on a feature and/or scenario that if supplied with `operator:none` will entirely skip operator installation or if supplied with `operator:my-configuration-name` will install the local operator with the values file `acceptance/operator/my-configuration-name.yaml`