### PR TITLE
Add vcluster capabilities for acceptance tests

### DIFF
--- a/harpoon/features/stub.feature
+++ b/harpoon/features/stub.feature
@@ -1,4 +1,4 @@
-@isolated
+@vcluster @isolated
 Feature: stub
   Scenario Outline: templated stub
     Given there is a stub

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -100,6 +100,7 @@ func SuiteBuilderFromFlags() *SuiteBuilder {
 	}
 
 	builder.RegisterTag("isolated", -1000, isolatedTag)
+	builder.RegisterTag("vcluster", -2000, vclusterTag)
 
 	return builder
 }

--- a/harpoon/tags.go
+++ b/harpoon/tags.go
@@ -17,3 +17,8 @@ func isolatedTag(ctx context.Context, t TestingT, args ...string) context.Contex
 	t.IsolateNamespace(ctx)
 	return ctx
 }
+
+func vclusterTag(ctx context.Context, t TestingT, args ...string) context.Context {
+	t.VCluster(ctx)
+	return ctx
+}

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -48,6 +48,7 @@ type TestingT interface {
 	AddNode(ctx context.Context, name string)
 
 	IsolateNamespace(ctx context.Context) string
+	VCluster(ctx context.Context) string
 
 	InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions)
 	InstallLocalHelmChart(ctx context.Context, path string, options helm.InstallOptions, deps ...helm.Dependency)

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/vcluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/pkg/vcluster"
 )
 
 func init() {
@@ -92,7 +92,7 @@ func New(t *testing.T, options Options) *Env {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cluster, err := vcluster.New(ctx, host)
+	cluster, err := vcluster.New(ctx, host.RESTConfig())
 	require.NoError(t, err)
 
 	if len(options.CRDs) > 0 {

--- a/pkg/vcluster/vcluster.go
+++ b/pkg/vcluster/vcluster.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
-	"github.com/redpanda-data/redpanda-operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 
@@ -29,18 +28,18 @@ const (
 )
 
 type Cluster struct {
-	config    *kube.RESTConfig
-	helm      *helm.Client
-	release   helm.Release
-	host      *k3d.Cluster
-	namespace *corev1.Namespace
+	config     *kube.RESTConfig
+	hostConfig *kube.RESTConfig
+	helm       *helm.Client
+	release    helm.Release
+	namespace  *corev1.Namespace
 }
 
-func New(ctx context.Context, host *k3d.Cluster) (*Cluster, error) {
-	ctx, cancel := context.WithTimeoutCause(ctx, time.Minute, errors.New("vCluster creation timed out"))
+func New(ctx context.Context, config *kube.RESTConfig) (*Cluster, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, 3*time.Minute, errors.New("vCluster creation timed out"))
 	defer cancel()
 
-	c, err := client.New(host.RESTConfig(), client.Options{})
+	c, err := client.New(config, client.Options{})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -55,7 +54,7 @@ func New(ctx context.Context, host *k3d.Cluster) (*Cluster, error) {
 	}
 
 	hc, err := helm.New(helm.Options{
-		KubeConfig: host.RESTConfig(),
+		KubeConfig: config,
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -127,7 +126,7 @@ func New(ctx context.Context, host *k3d.Cluster) (*Cluster, error) {
 	}
 
 	// To access the vCluster's API server, we dial into the api-server Pod on the host.
-	dialer := kube.NewPodDialer(host.RESTConfig())
+	dialer := kube.NewPodDialer(config)
 
 	cfg.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
 		// It's fairly safe to assume that all connections are meant for the
@@ -138,11 +137,11 @@ func New(ctx context.Context, host *k3d.Cluster) (*Cluster, error) {
 	}
 
 	return &Cluster{
-		config:    cfg,
-		helm:      hc,
-		release:   rel,
-		host:      host,
-		namespace: namespace,
+		config:     cfg,
+		helm:       hc,
+		release:    rel,
+		hostConfig: config,
+		namespace:  namespace,
 	}, nil
 }
 
@@ -194,14 +193,9 @@ func (c *Cluster) PortForwardedRESTConfig(ctx context.Context) (*kube.RESTConfig
 	return cfg, nil
 }
 
-// Host returns the host Cluster this vCluster is deployed onto.
-func (c *Cluster) Host() *k3d.Cluster {
-	return c.host
-}
-
 // Delete deletes this vCluster by deleting the Namespace it's deployed into.
 func (c *Cluster) Delete() error {
-	client, err := client.New(c.host.RESTConfig(), client.Options{})
+	client, err := client.New(c.hostConfig, client.Options{})
 	if err != nil {
 		return err
 	}

--- a/pkg/vcluster/vcluster_test.go
+++ b/pkg/vcluster/vcluster_test.go
@@ -16,10 +16,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/vcluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/pkg/vcluster"
 )
 
 func TestIntegrationVCluster(t *testing.T) {
@@ -30,7 +30,7 @@ func TestIntegrationVCluster(t *testing.T) {
 	host, err := k3d.GetShared()
 	require.NoError(t, err)
 
-	cluster, err := vcluster.New(ctx, host)
+	cluster, err := vcluster.New(ctx, host.RESTConfig())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
This adds the ability to leverage vclusters in acceptance tests and introduces a new `vcluster` tag that can be used on features. My hope is that doing something like this could potentially allow me to introduce the concurrent acceptance test code sooner than later. Nothing uses the vcluster stuff right now in acceptance tests other than the test for the framework itself, but I want to test it out with my acceptance test concurrency branch down the line.