### PR TITLE
operator v1: adapt ghost broker decommissioner for NodePools

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250514-171000.yaml
+++ b/.changes/unreleased/operator-Fixed-20250514-171000.yaml
@@ -1,0 +1,9 @@
+project: operator
+kind: Fixed
+body: |
+    Improved support for multi-STSes (e.g., multiple NodePools) in the ghost broker decommissioning logic.
+
+    - Desired replicas were previously fetched from a single STS, leading to incorrect broker count decisions when multiple STSes were present. Now, the logic accounts for all STSes.
+    - Fixed incorrect broker map keying: previously used pod ordinal, which is not unique across STSes (e.g., `blue-0` and `green-0` both mapped to `0`). Switched to using the pod name as the key to correctly distinguish brokers.
+    - Disabled ordinal-based broker deletion logic in Operator v1 mode, as it doesn't work reliably in a multi-STS setup.
+time: 2025-05-14T17:10:00.054146868+02:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -79,6 +79,12 @@ Previously it attempted to leave existing sts resources unpatched if it seemed l
 * The operator now unconditionally produces an environment for the initContainer that supports CEL-based patching.
 
 This is required to ensure that a pre-existing sts can roll over to new configuration correctly.
+* Improved support for multi-STSes (e.g., multiple NodePools) in the ghost broker decommissioning logic.
+
+- Desired replicas were previously fetched from a single STS, leading to incorrect broker count decisions when multiple STSes were present. Now, the logic accounts for all STSes.
+- Fixed incorrect broker map keying: previously used pod ordinal, which is not unique across STSes (e.g., `blue-0` and `green-0` both mapped to `0`). Switched to using the pod name as the key to correctly distinguish brokers.
+- Disabled ordinal-based broker deletion logic in Operator v1 mode, as it doesn't work reliably in a multi-STS setup.
+
 
 ## [v25.1.1-beta3](https://github.com/redpanda-data/redpanda-operator/releases/tag/operator%2Fv25.1.1-beta3) - 2025-05-07
 ### Added


### PR DESCRIPTION
- Desired replicas was fetched from an STS. This made the ghost broker decommissioner only consider a single STS for the desired size. This means, while multiple NodePools/STS are active, the actual RP broker count was (almost) always higher than the sts size (since we did only consider one STS, and not all).
- Pod ordinal was used as map key, to identify if a pod has multiple brokers in redpanda pointing to its FQDN. This is, because Pod ordinals are not unique w/ NodePools (multi-STS).

  Example: blue-0 and green-0 were mapped to key 0, and therefore two RP brokers were assigned to 0. This made these pods eligible for ghost broker decommissioning (which is not right, they are different pods)
  Therefore, made pod name the key of the map, instead of the ordinal.
- Some logic deletes brokers that have a "too high ordinal", compared to the desired size. This logic is not possible anymore w/ multiple STS. It's now turned off in Operator v1 mode via an option.

Ultimately, i think, that we are still prone to race conditions, where concurrently the cluster controller does something - and we cannot stop this separate decommissioner from running concurrently.

Looking forward, further improvements we could do:
- Integrate this code into main reconciliation loop of Cluster CR. Then, cluster reconciler can't run concurrently (it's made part of it). Old ghost broker decommissioner had this, and it was quite good i think.
- Maybe write to status.DecommissionBrokerID instead of directly decommissioning. This would force the ghost broker decommissioning through the ordinary decom cycle, which should be safer
- ^ actually, doing both