### PR TITLE
v1: OperatorQuiescent requires ClusterConfigured

### DIFF
--- a/.changes/unreleased/operator-Changed-20250519-121920.yaml
+++ b/.changes/unreleased/operator-Changed-20250519-121920.yaml
@@ -1,0 +1,7 @@
+project: operator
+kind: Changed
+body: |-
+    It is not the case that the OperatorQuiescent condition for the v1 operator cannot be True unless the ClusterConfigured condition is also True.
+
+    The status.observedGeneration will only update when the cluster reaches the OperatorQuiescent state.
+time: 2025-05-19T12:19:20.692725+01:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -33,6 +33,9 @@ In the v2 operator, this value is defaulted from the operator's settings.
   sidecar/initcontainer behavior, if using an older redpanda chart.
 * Bootstrap expansion in the v2 operator's initContainer now uses CEL-patching for its expansion, much like the v1 operator.
 
+* It is not the case that the OperatorQuiescent condition for the v1 operator cannot be True unless the ClusterConfigured condition is also True.
+
+The status.observedGeneration will only update when the cluster reaches the OperatorQuiescent state.
 ### Deprecated
 * v1 operator: the `clusterConfiguration` field `ExternalSecretRef` is deprecated in favour of `ExternalSecretRefSelector`. Since this field was extremely new, it will be removed in the very near future.
 ### Removed

--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -160,8 +160,8 @@ func (r *ClusterReconciler) Reconcile(
 				log.Info("Changing OperatorQuiescent condition after reconciliation", "status", cond.Status, "reason", cond.Reason, "message", cond.Message)
 			}
 
-			// Only set observedGeneration if there's no error.
-			if err == nil {
+			// Only set observedGeneration if there's no error and there's nothing left to do.
+			if err == nil && cond.Status == corev1.ConditionTrue {
 				cluster.Status.ObservedGeneration = vectorizedCluster.Generation
 			}
 		})
@@ -1206,7 +1206,6 @@ func getQuiescentCondition(redpandaCluster *vectorizedv1alpha1.Cluster) vectoriz
 	}
 
 	for npName, np := range redpandaCluster.Status.NodePools {
-
 		idx := slices.IndexFunc(redpandaCluster.Spec.NodePools, func(npSpec vectorizedv1alpha1.NodePoolSpec) bool {
 			return npSpec.Name == npName
 		})
@@ -1247,6 +1246,15 @@ func getQuiescentCondition(redpandaCluster *vectorizedv1alpha1.Cluster) vectoriz
 		condition.Status = corev1.ConditionFalse
 		condition.Reason = "UpgradeInProgress"
 		condition.Message = fmt.Sprintf("Upgrade from %s to %s in progress", redpandaCluster.Spec.Version, redpandaCluster.Status.Version)
+		return condition
+	}
+
+	// If the cluster is not fully configured, then we are not quiescent
+	cfgCond := redpandaCluster.Status.GetCondition(vectorizedv1alpha1.ClusterConfiguredConditionType)
+	if cfgCond == nil || cfgCond.Status != corev1.ConditionTrue {
+		condition.Status = corev1.ConditionFalse
+		condition.Reason = "ConfigurationNotApplied"
+		condition.Message = "Configuration for is not applied"
 		return condition
 	}
 


### PR DESCRIPTION
* Ensure that a cluster that doesn't have ClusterConfigured on it cannot be in OperatorQuiescent state
* Ensure that the ObservedGeneration is only updated once the OperatorQuiescent condition has become true (ie, there's no further action that we'll take).