### PR TITLE
Add back rate-limiting to cluster configuration and license reconciliation

### DIFF
--- a/gen/status/templates/status.tpl
+++ b/gen/status/templates/status.tpl
@@ -13,7 +13,7 @@ package {{ $.Package }}
 
 import (
 	"strings"
-    "time"
+	"time"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/gen/status/templates/status.tpl
+++ b/gen/status/templates/status.tpl
@@ -13,6 +13,7 @@ package {{ $.Package }}
 
 import (
 	"strings"
+    "time"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,7 +83,7 @@ func (s *{{ $status.GoName }}) UpdateConditions(o client.Object) bool {
 
     updated := false
     for _, condition := range s.getConditions(o.GetGeneration()) {
-        if apimeta.SetStatusCondition(conditions, condition) {
+        if setStatusCondition(conditions, condition) {
             updated = true
         }
     }
@@ -126,6 +127,16 @@ func (s *{{ $status.GoName }}) getConditions(generation int64) []metav1.Conditio
 }
 
 {{- range $condition := $status.ManualConditions }}{{/* ManualConditions */}}
+// Set{{ $condition.Name }}FromCurrent sets the underlying condition based on an existing object.
+func (s *{{ $status.GoName }}) Set{{ $condition.Name }}FromCurrent(o client.Object) {
+    condition := apimeta.FindStatusCondition(GetConditions(o), {{ $condition.GoName }})
+    if condition == nil {
+        return
+    }
+
+    s.Set{{ $condition.Name }}({{ $condition.GoConditionName }}(condition.Reason), condition.Message)
+}
+
 // Set{{ $condition.Name }} sets the underlying condition to the given reason.
 func (s *{{ $status.GoName }}) Set{{ $condition.Name }}(reason {{ $condition.GoConditionName }}, messages ...string) {
     if s.is{{ $condition.Name }}Set {
@@ -232,3 +243,82 @@ func (s *{{ $status.GoName }}) get{{ $condition.Name }}(conditions []metav1.Cond
 }
 {{- end }}{{/* Rollup Conditions */}}
 {{ end }}{{/* Status Structure */}}
+
+// HasRecentCondition returns whether or not an object has a given condition with the given value that is up-to-date and set
+// within the given time period.
+func HasRecentCondition[T ~string](o client.Object, conditionType T, value metav1.ConditionStatus, period time.Duration) bool {
+    condition := apimeta.FindStatusCondition(GetConditions(o), string(conditionType))
+    if condition == nil {
+        return false
+    }
+
+	recent := time.Since(condition.LastTransitionTime.Time) > period
+    matchedCondition := condition.Status == value
+    generationChanged := condition.ObservedGeneration != 0 && condition.ObservedGeneration < o.GetGeneration()
+
+    return matchedCondition && !(generationChanged || recent)
+}
+
+// GetConditions returns the conditions for a given object.
+func GetConditions(o client.Object) []metav1.Condition {
+    switch kind := o.(type) {
+        {{- range $status := $.Statuses -}}
+        {{- range $kind := $status.ImportedKinds }}
+    case {{ $kind }}:
+        return kind.Status.Conditions
+        {{- end }}
+        {{- end }}
+    default:
+        panic("unsupported kind")
+    }
+}
+
+// setStatusCondition is a copy of the apimeta.SetStatusCondition with one primary change. Rather
+// than only change the .LastTransitionTime if the .Status field of the condition changes, it
+// sets it if .Status, .Reason, .Message, or .ObservedGeneration changes, which works nicely with our recent check leveraged
+// for rate limiting above. It also normalizes this to be the same as what utils.StatusConditionConfigs does
+func setStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Condition) (changed bool) {
+	if conditions == nil {
+		return false
+	}
+	existingCondition := apimeta.FindStatusCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		if newCondition.LastTransitionTime.IsZero() {
+			newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+		*conditions = append(*conditions, newCondition)
+		return true
+	}
+
+    setTransitionTime := func() {
+		if !newCondition.LastTransitionTime.IsZero() {
+			existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+		} else {
+			existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+    }
+    
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		setTransitionTime()
+		changed = true
+	}
+
+	if existingCondition.Reason != newCondition.Reason {
+		existingCondition.Reason = newCondition.Reason
+		setTransitionTime()
+		changed = true
+	}
+	if existingCondition.Message != newCondition.Message {
+		existingCondition.Message = newCondition.Message
+		setTransitionTime()
+		changed = true
+	}
+	if existingCondition.ObservedGeneration != newCondition.ObservedGeneration {
+		existingCondition.ObservedGeneration = newCondition.ObservedGeneration
+		setTransitionTime()
+		changed = true
+	}
+
+	return changed
+}

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -111,7 +111,6 @@ run `task generate:third-party-licenses-list`
 | github.com/gonvenience/ytbx | [MIT](https://github.com/gonvenience/ytbx/blob/v1.4.4/LICENSE) |
 | github.com/google/btree | [Apache-2.0](https://github.com/google/btree/blob/v1.1.3/LICENSE) |
 | github.com/google/cel-go | [Apache-2.0](https://github.com/google/cel-go/blob/v0.17.8/LICENSE) |
-| github.com/google/cel-go | [BSD-3-Clause](https://github.com/google/cel-go/blob/v0.17.8/LICENSE) |
 | github.com/google/gnostic-models | [Apache-2.0](https://github.com/google/gnostic-models/blob/v0.6.9/LICENSE) |
 | github.com/google/go-cmp/cmp | [BSD-3-Clause](https://github.com/google/go-cmp/blob/v0.6.0/LICENSE) |
 | github.com/google/gofuzz | [Apache-2.0](https://github.com/google/gofuzz/blob/v1.2.0/LICENSE) |
@@ -142,9 +141,7 @@ run `task generate:third-party-licenses-list`
 | github.com/josharian/intern | [MIT](https://github.com/josharian/intern/blob/v1.0.0/license.md) |
 | github.com/json-iterator/go | [MIT](https://github.com/json-iterator/go/blob/v1.1.12/LICENSE) |
 | github.com/kballard/go-shellquote | [MIT](https://github.com/kballard/go-shellquote/blob/95032a82bc51/LICENSE) |
-| github.com/klauspost/compress | [MIT](https://github.com/klauspost/compress/blob/v1.17.9/LICENSE) |
 | github.com/klauspost/compress | [Apache-2.0](https://github.com/klauspost/compress/blob/v1.17.9/LICENSE) |
-| github.com/klauspost/compress | [BSD-3-Clause](https://github.com/klauspost/compress/blob/v1.17.9/LICENSE) |
 | github.com/klauspost/compress/internal/snapref | [BSD-3-Clause](https://github.com/klauspost/compress/blob/v1.17.9/internal/snapref/LICENSE) |
 | github.com/klauspost/compress/s2 | [BSD-3-Clause](https://github.com/klauspost/compress/blob/v1.17.9/s2/LICENSE) |
 | github.com/klauspost/compress/zstd/internal/xxhash | [MIT](https://github.com/klauspost/compress/blob/v1.17.9/zstd/internal/xxhash/LICENSE.txt) |
@@ -292,14 +289,11 @@ run `task generate:third-party-licenses-list`
 | sigs.k8s.io/controller-runtime | [Apache-2.0](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.18.5/LICENSE) |
 | sigs.k8s.io/gateway-api/apis/v1 | [Apache-2.0](https://github.com/kubernetes-sigs/gateway-api/blob/v1.1.0/LICENSE) |
 | sigs.k8s.io/json | [Apache-2.0](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8/LICENSE) |
-| sigs.k8s.io/json | [BSD-3-Clause](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8/LICENSE) |
 | sigs.k8s.io/kustomize/api | [Apache-2.0](https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/LICENSE) |
 | sigs.k8s.io/kustomize/kyaml | [Apache-2.0](https://github.com/kubernetes-sigs/kustomize/blob/kyaml/v0.17.2/kyaml/LICENSE) |
 | sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/qri-io/starlib/util | [MIT](https://github.com/kubernetes-sigs/kustomize/blob/kyaml/v0.17.2/kyaml/internal/forked/github.com/qri-io/starlib/util/LICENSE) |
 | sigs.k8s.io/structured-merge-diff/v4 | [Apache-2.0](https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.4.1/LICENSE) |
-| sigs.k8s.io/yaml | [MIT](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/LICENSE) |
 | sigs.k8s.io/yaml | [Apache-2.0](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/LICENSE) |
-| sigs.k8s.io/yaml | [BSD-3-Clause](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/LICENSE) |
 | sigs.k8s.io/yaml/goyaml.v2 | [Apache-2.0](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/goyaml.v2/LICENSE) |
 | sigs.k8s.io/yaml/goyaml.v3 | [MIT](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/goyaml.v3/LICENSE) |
 

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -111,6 +111,7 @@ run `task generate:third-party-licenses-list`
 | github.com/gonvenience/ytbx | [MIT](https://github.com/gonvenience/ytbx/blob/v1.4.4/LICENSE) |
 | github.com/google/btree | [Apache-2.0](https://github.com/google/btree/blob/v1.1.3/LICENSE) |
 | github.com/google/cel-go | [Apache-2.0](https://github.com/google/cel-go/blob/v0.17.8/LICENSE) |
+| github.com/google/cel-go | [BSD-3-Clause](https://github.com/google/cel-go/blob/v0.17.8/LICENSE) |
 | github.com/google/gnostic-models | [Apache-2.0](https://github.com/google/gnostic-models/blob/v0.6.9/LICENSE) |
 | github.com/google/go-cmp/cmp | [BSD-3-Clause](https://github.com/google/go-cmp/blob/v0.6.0/LICENSE) |
 | github.com/google/gofuzz | [Apache-2.0](https://github.com/google/gofuzz/blob/v1.2.0/LICENSE) |
@@ -141,7 +142,9 @@ run `task generate:third-party-licenses-list`
 | github.com/josharian/intern | [MIT](https://github.com/josharian/intern/blob/v1.0.0/license.md) |
 | github.com/json-iterator/go | [MIT](https://github.com/json-iterator/go/blob/v1.1.12/LICENSE) |
 | github.com/kballard/go-shellquote | [MIT](https://github.com/kballard/go-shellquote/blob/95032a82bc51/LICENSE) |
+| github.com/klauspost/compress | [MIT](https://github.com/klauspost/compress/blob/v1.17.9/LICENSE) |
 | github.com/klauspost/compress | [Apache-2.0](https://github.com/klauspost/compress/blob/v1.17.9/LICENSE) |
+| github.com/klauspost/compress | [BSD-3-Clause](https://github.com/klauspost/compress/blob/v1.17.9/LICENSE) |
 | github.com/klauspost/compress/internal/snapref | [BSD-3-Clause](https://github.com/klauspost/compress/blob/v1.17.9/internal/snapref/LICENSE) |
 | github.com/klauspost/compress/s2 | [BSD-3-Clause](https://github.com/klauspost/compress/blob/v1.17.9/s2/LICENSE) |
 | github.com/klauspost/compress/zstd/internal/xxhash | [MIT](https://github.com/klauspost/compress/blob/v1.17.9/zstd/internal/xxhash/LICENSE.txt) |
@@ -289,11 +292,14 @@ run `task generate:third-party-licenses-list`
 | sigs.k8s.io/controller-runtime | [Apache-2.0](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.18.5/LICENSE) |
 | sigs.k8s.io/gateway-api/apis/v1 | [Apache-2.0](https://github.com/kubernetes-sigs/gateway-api/blob/v1.1.0/LICENSE) |
 | sigs.k8s.io/json | [Apache-2.0](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8/LICENSE) |
+| sigs.k8s.io/json | [BSD-3-Clause](https://github.com/kubernetes-sigs/json/blob/cfa47c3a1cc8/LICENSE) |
 | sigs.k8s.io/kustomize/api | [Apache-2.0](https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/LICENSE) |
 | sigs.k8s.io/kustomize/kyaml | [Apache-2.0](https://github.com/kubernetes-sigs/kustomize/blob/kyaml/v0.17.2/kyaml/LICENSE) |
 | sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/qri-io/starlib/util | [MIT](https://github.com/kubernetes-sigs/kustomize/blob/kyaml/v0.17.2/kyaml/internal/forked/github.com/qri-io/starlib/util/LICENSE) |
 | sigs.k8s.io/structured-merge-diff/v4 | [Apache-2.0](https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.4.1/LICENSE) |
+| sigs.k8s.io/yaml | [MIT](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/LICENSE) |
 | sigs.k8s.io/yaml | [Apache-2.0](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/LICENSE) |
+| sigs.k8s.io/yaml | [BSD-3-Clause](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/LICENSE) |
 | sigs.k8s.io/yaml/goyaml.v2 | [Apache-2.0](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/goyaml.v2/LICENSE) |
 | sigs.k8s.io/yaml/goyaml.v3 | [MIT](https://github.com/kubernetes-sigs/yaml/blob/v1.4.0/goyaml.v3/LICENSE) |
 


### PR DESCRIPTION
This adds back in the concept of "rate-limiting" to our controller so that we don't hammer the cluster API so often. There is a big, long note here about the benefits/perils of doing this:

https://github.com/redpanda-data/redpanda-operator/blob/2e90256bea5af7f6ad94bb2bac4287887724ec18/operator/internal/controller/redpanda/redpanda_controller.go#L256-L265

There is an open question about whether we should do this with fetching cluster node health/decommissioning as well, as the process of internal decommissioning requires a call out via the admin API (my thought is, no, don't rate-limit the decommissioning process, only the license checks/updates and the configuration code).