### PR TITLE
Switch from Quiesced to Stable for waitUntilReady check

### DIFF
--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -657,9 +657,10 @@ func (s *RedpandaControllerSuite) SetupSuite() {
 	// rest config given to the manager.
 	s.ctx = context.Background()
 	s.env = testenv.New(t, testenv.Options{
-		Scheme: controller.V2Scheme,
-		CRDs:   crds.All(),
-		Logger: testr.New(t),
+		Scheme:       controller.V2Scheme,
+		CRDs:         crds.All(),
+		Logger:       testr.New(t),
+		SkipVCluster: true,
 		ImportImages: []string{
 			"localhost/redpanda-operator:dev",
 		},

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -847,14 +847,14 @@ func (s *RedpandaControllerSuite) waitUntilReady(objs ...client.Object) {
 			}
 			switch obj := obj.(type) {
 			case *redpandav1alpha2.Redpanda:
-				// Check "Quiesced" to make sure we're done reconciling
-				quiesced := apimeta.FindStatusCondition(obj.Status.Conditions, statuses.ClusterQuiesced)
-				if quiesced == nil {
+				// Check "Stable" to make sure we're both done reconciling and we have a healthy cluster
+				stable := apimeta.FindStatusCondition(obj.Status.Conditions, statuses.ClusterStable)
+				if stable == nil {
 					return false, nil
 				}
 
-				ready := quiesced.Status == metav1.ConditionTrue
-				upToDate := obj.Generation == quiesced.ObservedGeneration
+				ready := stable.Status == metav1.ConditionTrue
+				upToDate := obj.Generation == stable.ObservedGeneration
 				return upToDate && ready, nil
 
 			case *corev1.Secret, *corev1.ConfigMap, *corev1.ServiceAccount,

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -135,7 +135,7 @@ func New(t *testing.T, options Options) *Env {
 
 	if !options.SkipVCluster {
 		t.Logf("Executing in namespace '%s' of vCluster '%s'", ns.Name, cluster.Name())
-		t.Logf("Connect to vCluster using 'vcluster connect --namespace %s %s -- '", ns.Name, cluster.Name())
+		t.Logf("Connect to vCluster using 'vcluster connect --namespace %s %s -- '", cluster.Name(), cluster.Name())
 	} else {
 		t.Logf("Executing in namespace '%s'", ns.Name)
 	}

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -104,7 +104,7 @@ func New(t *testing.T, options Options) *Env {
 
 	if len(options.CRDs) > 0 {
 		crds, err := envtest.InstallCRDs(config, envtest.CRDInstallOptions{
-			CRDs: options.CRDs,
+			CRDs: dupCRDs(options.CRDs),
 		})
 		require.NoError(t, err)
 		require.Equal(t, len(options.CRDs), len(crds))

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -94,30 +94,20 @@ func New(t *testing.T, options Options) *Env {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var cluster *vcluster.Cluster
-	var config *rest.Config
+	config := host.RESTConfig()
+
 	if !options.SkipVCluster {
 		cluster, err = vcluster.New(ctx, host)
 		require.NoError(t, err)
-
-		if len(options.CRDs) > 0 {
-			crds, err := envtest.InstallCRDs(cluster.RESTConfig(), envtest.CRDInstallOptions{
-				CRDs: options.CRDs,
-			})
-			require.NoError(t, err)
-			require.Equal(t, len(options.CRDs), len(crds))
-		}
-
 		config = cluster.RESTConfig()
-	} else {
-		if len(options.CRDs) > 0 {
-			crds, err := envtest.InstallCRDs(host.RESTConfig(), envtest.CRDInstallOptions{
-				CRDs: dupCRDs(options.CRDs),
-			})
-			require.NoError(t, err)
-			require.Equal(t, len(options.CRDs), len(crds))
-		}
+	}
 
-		config = host.RESTConfig()
+	if len(options.CRDs) > 0 {
+		crds, err := envtest.InstallCRDs(config, envtest.CRDInstallOptions{
+			CRDs: options.CRDs,
+		})
+		require.NoError(t, err)
+		require.Equal(t, len(options.CRDs), len(crds))
 	}
 
 	c, err := client.New(config, client.Options{Scheme: options.Scheme})


### PR DESCRIPTION
Pretty sure this is causing some test flakes as technically we could "quiesce" even if pods are not yet ready (Quiesced just means the reconciler itself has no more work to do until a watch retriggers it). Switching to Stable ensures that the pods are actually up and healthy. Thinking this is at least the cause of some of our EOF issues with trying to dial out to the cluster in tests.