### PR TITLE
operator v1: ignore nodepool spec annotation in STS

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250521-210238.yaml
+++ b/.changes/unreleased/operator-Fixed-20250521-210238.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: updated operator v1 to ignore "cluster.redpanda.com/node-pool-spec" annotation for pod rolls. previously, under certain conditions, the operator started rolling pods if this annotation changed - but there is no need to do so.
+time: 2025-05-21T21:02:38.412528108+02:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -89,6 +89,7 @@ This is required to ensure that a pre-existing sts can roll over to new configur
 - Disabled ordinal-based broker deletion logic in Operator v1 mode, as it doesn't work reliably in a multi-STS setup.
 
 * Setting `serviceAccount.create` to `false` no longer prevents the Kubernetes ServiceAccountToken volume from being mounted to the operator Pod.
+* updated operator v1 to ignore "cluster.redpanda.com/node-pool-spec" annotation for pod rolls. previously, under certain conditions, the operator started rolling pods if this annotation changed - but there is no need to do so.
 
 ## [v25.1.1-beta3](https://github.com/redpanda-data/redpanda-operator/releases/tag/operator%2Fv25.1.1-beta3) - 2025-05-07
 ### Added

--- a/operator/pkg/resources/statefulset_update.go
+++ b/operator/pkg/resources/statefulset_update.go
@@ -617,6 +617,7 @@ func (r *StatefulSetResource) shouldUpdate(
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 		utils.IgnoreAnnotation(redpandaAnnotatorKey),
+		utils.IgnoreAnnotation(labels.NodePoolSpecKey),
 		utils.IgnoreAnnotation(CentralizedConfigurationHashAnnotationKey),
 	}
 	patchResult, err := patch.NewPatchMaker(patch.NewAnnotator(redpandaAnnotatorKey), &patch.K8sStrategicMergePatcher{}, &patch.BaseJSONMergePatcher{}).Calculate(current, modified, opts...)


### PR DESCRIPTION
this annotation is used to "store" the nodepool spec in the STS, so it can be used, if the CR spec.nodepool entry is removed ("nodepool deleted").

we suspect, based on the logs, that the operator uses this as a reason to set status restarting=true - even if this annotation does not require the cluster to restart - it's just storage of some information. (certainly not affecting pod spec or so - if sts spec changes, we would see the actual sts spec change).

it is surprising that this happens - this code has been in for months, and not triggered restarts. It might be some weird combo with the recent refactorings around configuration, and for some reason this "wrong restarting" was abandoned by other code.

it should be a positive change, in any case, to ignore this annotation. Any changes to actual pods would be seen in a different field, eg. STS.spec.* (especially pod template).