### PR TITLE
[release/v2.3.x] operator: always mount service account token volume

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250521-111352.yaml
+++ b/.changes/unreleased/operator-Fixed-20250521-111352.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Setting `serviceAccount.create` to `false` no longer prevents the Kubernetes ServiceAccountToken volume from being mounted to the operator Pod.
+time: 2025-05-21T11:13:52.428703-04:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -24,6 +24,7 @@ This is required to ensure that a pre-existing sts can roll over to new configur
 - Fixed incorrect broker map keying: previously used pod ordinal, which is not unique across STSes (e.g., `blue-0` and `green-0` both mapped to `0`). Switched to using the pod name as the key to correctly distinguish brokers.
 - Disabled ordinal-based broker deletion logic in Operator v1 mode, as it doesn't work reliably in a multi-STS setup.
 
+* Setting `serviceAccount.create` to `false` no longer prevents the Kubernetes ServiceAccountToken volume from being mounted to the operator Pod.
 
 ## v2.3.9-24.3.11 - 2025-05-02
 ### Added

--- a/operator/chart/deployment.go
+++ b/operator/chart/deployment.go
@@ -207,10 +207,8 @@ func isWebhookEnabled(dot *helmette.Dot) bool {
 func operatorPodVolumes(dot *helmette.Dot) []corev1.Volume {
 	values := helmette.Unwrap[Values](dot.Values)
 
-	vol := []corev1.Volume{}
-
-	if values.ServiceAccount.Create {
-		vol = append(vol, kubeTokenAPIVolume(ServiceAccountVolumeName))
+	vol := []corev1.Volume{
+		kubeTokenAPIVolume(ServiceAccountVolumeName),
 	}
 
 	if !isWebhookEnabled(dot) {

--- a/operator/chart/templates/_deployment.go.tpl
+++ b/operator/chart/templates/_deployment.go.tpl
@@ -92,10 +92,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $vol := (list) -}}
-{{- if $values.serviceAccount.create -}}
-{{- $vol = (concat (default (list) $vol) (list (get (fromJson (include "operator.kubeTokenAPIVolume" (dict "a" (list "kube-api-access")))) "r"))) -}}
-{{- end -}}
+{{- $vol := (list (get (fromJson (include "operator.kubeTokenAPIVolume" (dict "a" (list "kube-api-access")))) "r")) -}}
 {{- if (not (get (fromJson (include "operator.isWebhookEnabled" (dict "a" (list $dot)))) "r")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $vol) | toJson -}}

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -19991,7 +19991,25 @@ spec:
         nodeTaintsPolicy: Ąʟ/鍽A瘠Iʥ淧BĜ,Ü杵姽4u
         topologyKey: T6H
         whenUnsatisfiable: 禳鯋龖鱯筁İ赠ƄǪ|杮ɗ吻űU纕聓z序
-      volumes: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -26153,6 +26171,24 @@ spec:
         topologyKey: uPOu8jgVXuK
         whenUnsatisfiable: ñA鿔[vǬɊTûg
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: ""
       - name: CM
 ---
@@ -30518,6 +30554,24 @@ spec:
         operator: Ʀ猥喞ȼȦ槮VěnX
         value: y1LkLkU
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: dZEjjoa
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
@@ -36272,7 +36326,25 @@ spec:
         nodeTaintsPolicy: Łļǻ軀折TŜ崵駿Sã8ō'ɷ嵡
         topologyKey: R
         whenUnsatisfiable: Es織ŸgÉw5-颒辰gÝ
-      volumes: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -37762,6 +37834,24 @@ spec:
         topologyKey: hnK
         whenUnsatisfiable: G蹃
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: 2vvwzU
       - name: KiD
       - name: ZxdGol15G
@@ -42252,6 +42342,24 @@ spec:
         topologyKey: 3vd
         whenUnsatisfiable: ȶ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: Y4eYBG
       - name: wtbsGN
 ---
@@ -44579,6 +44687,24 @@ spec:
         topologyKey: y3F2Ss
         whenUnsatisfiable: 奂閙ɏiģpȝůƤĮĶ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: ORR
       - name: jh435G
 ---
@@ -45346,6 +45472,24 @@ spec:
         topologyKey: dnKKLwixm
         whenUnsatisfiable: pb>ʯ僙ȴō
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: ""
 ---
 # Source: operator/templates/entry-point.yaml
@@ -47650,6 +47794,24 @@ spec:
         topologyKey: O9NaFa
         whenUnsatisfiable: 缌睩氜栢ʦ是Ǉ廬茞^Žȟ塖
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: A2B8
       - name: G
       - name: ZtPPBy
@@ -49794,7 +49956,25 @@ spec:
         operator: ŕ瓹ƖbƟvŃ3"ť'嶮õ§苰f5顗
         tolerationSeconds: 3452689405398166000
         value: uC3s
-      volumes: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -51491,6 +51671,24 @@ spec:
         topologyKey: D
         whenUnsatisfiable: 紒_尘LɼO槆
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: noEL0
       - name: v
 ---
@@ -53827,6 +54025,24 @@ spec:
         topologyKey: T4wz
         whenUnsatisfiable: Œ1
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: 7wEL0
       - name: EeMIH
       - name: iQoV
@@ -57029,6 +57245,24 @@ spec:
         tolerationSeconds: 3316644788216531500
         value: A
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: W9
       - name: xuaa0
 ---
@@ -58430,6 +58664,24 @@ spec:
         tolerationSeconds: -8913348716878803000
         value: 7o
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: ""
       - name: "1"
       - name: zEJeXFitCdV
@@ -72624,6 +72876,24 @@ spec:
         tolerationSeconds: 2796595789192197000
         value: AUvS2
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -74281,6 +74551,24 @@ spec:
         topologyKey: WP4QXxrf
         whenUnsatisfiable: ǋČI蒓2Ċ檗毦I_\鶚5柴ŨhȖ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -76009,6 +76297,24 @@ spec:
         topologyKey: nk
         whenUnsatisfiable: éɘ.R5鏝àå=澕
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -76748,6 +77054,24 @@ spec:
         topologyKey: IPa5T
         whenUnsatisfiable: nČ俪辨u'Ł9Yė°竣]ć擯>b屠ƕ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -78776,6 +79100,24 @@ spec:
         topologyKey: QJ1wtpuk
         whenUnsatisfiable: /
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -79990,6 +80332,24 @@ spec:
         topologyKey: 1BnA
         whenUnsatisfiable: '}|ǗȳȽ抧ǎŤĿ仇恹'
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -80884,6 +81244,24 @@ spec:
         topologyKey: ybGWO0YEF1
         whenUnsatisfiable: KƿĻ觮ȑmvǯ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -82622,6 +83000,24 @@ spec:
         topologyKey: "Y"
         whenUnsatisfiable: ""
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -85178,6 +85574,24 @@ spec:
         tolerationSeconds: -8265045332720818000
         value: e0JnkTa
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -91821,6 +92235,24 @@ spec:
         topologyKey: "y"
         whenUnsatisfiable: ǩ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -93063,6 +93495,24 @@ spec:
         topologyKey: vZ
         whenUnsatisfiable: mUƚ;ʗƷ嶑铻
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -95545,6 +95995,24 @@ spec:
         topologyKey: h3hAibfhYC
         whenUnsatisfiable: 攻/yʢH鄹謞膭筎
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -97518,6 +97986,24 @@ spec:
         tolerationSeconds: -4336237698479852500
         value: Mv
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -98840,6 +99326,24 @@ spec:
         topologyKey: dTqiO
         whenUnsatisfiable: ȍ
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -105730,6 +106234,24 @@ spec:
         topologyKey: 8LMG23
         whenUnsatisfiable: ' 褼ƶÎa'
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420
@@ -109129,6 +109651,24 @@ spec:
         topologyKey: WGNmR
         whenUnsatisfiable: ȇ]漞ɜ煔C!rFÚ[ù&'
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
       - name: cert
         secret:
           defaultMode: 420


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [operator: always mount service account token volume](https://github.com/redpanda-data/redpanda-operator/pull/846)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)