### PR TITLE
Backport/release/v2.3.x/pr 821 cherry pick take two

### DIFF
--- a/operator/cmd/bootstrap/bootstrap.go
+++ b/operator/cmd/bootstrap/bootstrap.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package bootstrap contains exports a subcommand that configures the
+// .bootstrap.yaml for V2 clusters, using the same teamplate-and-fixup mechanism
+// used by the V1 operator.
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/configurator"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/clusterconfiguration"
+	pkgsecrets "github.com/redpanda-data/redpanda-operator/operator/pkg/secrets"
+)
+
+func Command() *cobra.Command {
+	var (
+		configSrcDir  string
+		configDestDir string
+
+		cloudSecretsEnabled          bool
+		cloudSecretsPrefix           string
+		cloudSecretsAWSRegion        string
+		cloudSecretsAWSRoleARN       string
+		cloudSecretsGCPProjectID     string
+		cloudSecretsAzureKeyVaultURI string
+	)
+	cmd := &cobra.Command{
+		Use:     "bootstrap",
+		Short:   "Configure .bootstrap.yaml based on supplied fixups",
+		Aliases: []string{"configure"},
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			var cloudExpander *pkgsecrets.CloudExpander
+			if cloudSecretsEnabled {
+				cloudConfig := pkgsecrets.ExpanderCloudConfiguration{}
+				if cloudSecretsAWSRegion != "" {
+					cloudConfig.AWSRegion = cloudSecretsAWSRegion
+					cloudConfig.AWSRoleARN = cloudSecretsAWSRoleARN
+				} else if cloudSecretsGCPProjectID != "" {
+					cloudConfig.GCPProjectID = cloudSecretsGCPProjectID
+				} else if cloudSecretsAzureKeyVaultURI != "" {
+					cloudConfig.AzureKeyVaultURI = cloudSecretsAzureKeyVaultURI
+				} else {
+					log.Fatal("Cloud secrets are enabled but configuration for cloud provider is missing or invalid")
+				}
+				var err error
+				cloudExpander, err = pkgsecrets.NewCloudExpander(ctx, cloudSecretsPrefix, cloudConfig)
+				if err != nil {
+					log.Fatalf("Unable to start manager: %s", err)
+				}
+			}
+
+			run(
+				ctx,
+				cloudExpander,
+				configSrcDir,
+				configDestDir,
+			)
+		},
+	}
+
+	// Filesystem path-related flags
+	cmd.Flags().StringVar(&configSrcDir, "in-dir", "", "Location of bootstrap template and fixups")
+	cmd.Flags().StringVar(&configDestDir, "out-dir", "", "Target directory for .bootstrap.yaml")
+
+	// secret store related flags
+	cmd.Flags().BoolVar(&cloudSecretsEnabled, "enable-cloud-secrets", false, "Set to true if config values can reference secrets from cloud secret store")
+	cmd.Flags().StringVar(&cloudSecretsPrefix, "cloud-secrets-prefix", "", "Prefix for all names of cloud secrets")
+	cmd.Flags().StringVar(&cloudSecretsAWSRegion, "cloud-secrets-aws-region", "", "AWS Region in which the secrets are stored")
+	cmd.Flags().StringVar(&cloudSecretsAWSRoleARN, "cloud-secrets-aws-role-arn", "", "AWS role ARN to assume when fetching secrets")
+	cmd.Flags().StringVar(&cloudSecretsGCPProjectID, "cloud-secrets-gcp-project-id", "", "GCP project ID in which the secrets are stored")
+	cmd.Flags().StringVar(&cloudSecretsAzureKeyVaultURI, "cloud-secrets-azure-key-vault-uri", "", "Azure Key Vault URI in which the secrets are stored")
+
+	return cmd
+}
+
+func run(
+	ctx context.Context,
+	cloudExpander *pkgsecrets.CloudExpander,
+	configSrcDir string,
+	configDestDir string,
+) {
+	log.Print("Expanding bootstrap template file")
+
+	err := configurator.TemplateBootstrapYaml(ctx, cloudExpander,
+		path.Join(configSrcDir, clusterconfiguration.BootstrapTemplateFile),
+		path.Join(configDestDir, clusterconfiguration.BootstrapTargetFile),
+		path.Join(configSrcDir, clusterconfiguration.BootstrapFixupFile),
+	)
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to template the .bootstrap.yaml file: %w", err))
+	}
+
+	log.Printf("Bootstrap saved to: %s", configDestDir)
+}

--- a/operator/cmd/configurator/bootstrap.go
+++ b/operator/cmd/configurator/bootstrap.go
@@ -13,9 +13,9 @@ import (
 	pkgsecrets "github.com/redpanda-data/redpanda-operator/operator/pkg/secrets"
 )
 
-// Template out the bootstrap file
+// TemplateBootstrapYaml expands the bootstrap file
 // This takes an input template, resolves any remaining external references, then writes out the resulting bootstrap file
-func templateBootstrapYaml(ctx context.Context, cloudExpander *pkgsecrets.CloudExpander, inFile, outFile, fixups string) error {
+func TemplateBootstrapYaml(ctx context.Context, cloudExpander *pkgsecrets.CloudExpander, inFile, outFile, fixups string) error {
 	var bootstrap map[string]string
 	buf, err := os.ReadFile(inFile)
 	if err != nil {

--- a/operator/cmd/configurator/configurator.go
+++ b/operator/cmd/configurator/configurator.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/clusterconfiguration"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
 	pkgsecrets "github.com/redpanda-data/redpanda-operator/operator/pkg/secrets"
@@ -194,7 +195,7 @@ func run(
 
 	log.Print(c.String())
 
-	p := path.Join(c.configSourceDir, "redpanda.yaml")
+	p := path.Join(c.configSourceDir, clusterconfiguration.RedpandaYamlTemplateFile)
 	cf, err := os.ReadFile(p)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to read the redpanda configuration file, %q: %w", p, err))
@@ -264,7 +265,7 @@ func run(
 	}
 
 	// Perform optional fixups if required
-	cfg, err = applyFixups(ctx, cfg, path.Join(c.configSourceDir, "redpanda.yaml.fixups"), cloudExpander)
+	cfg, err = applyFixups(ctx, cfg, path.Join(c.configSourceDir, clusterconfiguration.RedpandaYamlFixupFile), cloudExpander)
 	if err != nil {
 		log.Fatalf("%s", fmt.Errorf("unable to apply fixups to redpanda.yaml: %w", err))
 	}
@@ -280,7 +281,7 @@ func run(
 
 	if c.bootstrapTemplate != "" && c.bootstrapDestination != "" {
 		// Perform the bootstrap templating
-		err := templateBootstrapYaml(ctx, cloudExpander, c.bootstrapTemplate, c.bootstrapDestination, path.Join(c.configSourceDir, "bootstrap.yaml.fixups"))
+		err := TemplateBootstrapYaml(ctx, cloudExpander, c.bootstrapTemplate, c.bootstrapDestination, path.Join(c.configSourceDir, clusterconfiguration.BootstrapFixupFile))
 		if err != nil {
 			log.Fatalf("%s", fmt.Errorf("unable to template the .bootstrap.yaml file: %w", err))
 		}

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/bootstrap"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/configurator"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/envsubst"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/ready"
@@ -43,6 +44,7 @@ var (
 func init() {
 	rootCmd.AddCommand(
 		configurator.Command(),
+		bootstrap.Command(),
 		envsubst.Command(),
 		run.Command(),
 		syncclusterconfig.Command(),

--- a/operator/pkg/clusterconfiguration/cel_patcher.go
+++ b/operator/pkg/clusterconfiguration/cel_patcher.go
@@ -189,7 +189,9 @@ func fieldByNameOrJSON(v reflect.Value, name string) (reflect.Value, *reflect.Va
 		zero := reflect.New(v.Type().Elem())
 		return zero.Elem(), &v
 	default:
-		panic(fmt.Errorf("unhandled default case %q", v.Kind()))
+		// The user's specified a path to a structure element we can't handle.
+		// Common causes here include using `redpanda.` prefixes on clusterConfiguration.
+		return reflect.Value{}, nil
 	}
 	return reflect.Value{}, nil
 }

--- a/operator/pkg/clusterconfiguration/configuration_combined.go
+++ b/operator/pkg/clusterconfiguration/configuration_combined.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -170,10 +171,15 @@ func (c *CombinedCfg) Templates() (map[string]string, error) {
 
 // AdditionalInitEnvVars will finalise the set of any remaining env variables to add,
 // then return that final list.
+// The list is always sorted by name; this is to ensure that map iteration order when
+// constructing a configuration doesn't trigger a spurious sts restart.
 func (c *CombinedCfg) AdditionalInitEnvVars() ([]corev1.EnvVar, error) {
 	if _, err := c.Templates(); err != nil {
 		return nil, err
 	}
+	sort.Slice(c.initEnvVars, func(i, j int) bool {
+		return c.initEnvVars[i].Name < c.initEnvVars[j].Name
+	})
 	return c.initEnvVars, nil
 }
 

--- a/operator/pkg/resources/configuration.go
+++ b/operator/pkg/resources/configuration.go
@@ -12,6 +12,8 @@ package resources
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cockroachdb/errors"
@@ -220,7 +222,10 @@ func CreateConfiguration(
 	}
 
 	// Fold in any last overriding attributes. Prefer the new ClusterConfiguration attribute.
-	for k, v := range pandaCluster.Spec.ClusterConfiguration {
+	// These are injected in a stable order to preserve the resulting environment settings
+	// on any initContainer.
+	for _, k := range slices.Sorted(maps.Keys(pandaCluster.Spec.ClusterConfiguration)) {
+		v := pandaCluster.Spec.ClusterConfiguration[k]
 		cfg.Cluster.Set(k, *(v.DeepCopy()))
 	}
 


### PR DESCRIPTION
- [x] Enabling commits to permit the operator to use the bootstrap templating only
- [x] add "bootstrap" target to operator, don't use it yet - this is code from https://github.com/redpanda-data/redpanda-operator/commit/012e7e9bf47bd9ef1afe83d17bf1e7b73ff5ea46 without the redpanda_controller changes

Merge at this point!

These are for follow-up PRs:

- Add all values & helm changes to use "bootstrap" fixups

Merge here, release helm chart.

- Refer to newer helm chart.
- Use bootstrap templating in reconcileConfiguration
- plumb through cloud expander
