### PR TITLE
ci: Adjust path to junit report

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -63,7 +63,7 @@ steps:
     label: Parse and annotate Unit Tests results
     plugins:
     - github.com/buildkite-plugins/junit-annotate-buildkite-plugin#v2.4.1:
-        artifacts: work/unit-tests.xml
+        artifacts: work/artifacts/unit-tests.xml
         context: unit
         report-slowest: 10
     soft_fail: true
@@ -107,7 +107,7 @@ steps:
     label: Parse and annotate Integration Tests results
     plugins:
     - github.com/buildkite-plugins/junit-annotate-buildkite-plugin#v2.4.1:
-        artifacts: work/integration-tests.xml
+        artifacts: work/artifacts/integration-tests.xml
         context: integration
         report-slowest: 10
     soft_fail: true
@@ -151,7 +151,7 @@ steps:
     label: Parse and annotate Acceptance Tests results
     plugins:
     - github.com/buildkite-plugins/junit-annotate-buildkite-plugin#v2.4.1:
-        artifacts: work/acceptance-tests.xml
+        artifacts: work/artifacts/acceptance-tests.xml
         context: acceptance
         report-slowest: 10
     soft_fail: true

--- a/gen/pipeline/helpers.go
+++ b/gen/pipeline/helpers.go
@@ -54,7 +54,7 @@ func (suite *TestSuite) junitPattern() string {
 	if suite.JUnitPattern != nil {
 		return *suite.JUnitPattern
 	}
-	return fmt.Sprintf("work/%s-tests.xml", strings.ToLower(suite.Name))
+	return fmt.Sprintf("work/artifacts/%s-tests.xml", strings.ToLower(suite.Name))
 }
 
 func (suite *TestSuite) ToStep() pipeline.Step {


### PR DESCRIPTION
After https://github.com/redpanda-data/redpanda-operator/pull/832 the path to junit report changed from '/work` to `/work/artifacts`. This change adjust it to new location.