### PR TITLE
always mount access token

### DIFF
--- a/operator/chart/deployment.go
+++ b/operator/chart/deployment.go
@@ -284,24 +284,20 @@ func kubeTokenAPIVolume(name string) corev1.Volume {
 }
 
 func operatorPodVolumesMounts(dot *helmette.Dot) []corev1.VolumeMount {
-	values := helmette.Unwrap[Values](dot.Values)
-
 	volMount := []corev1.VolumeMount{}
 
-	if values.ServiceAccount.Create {
-		mountName := ServiceAccountVolumeName
-		for _, vol := range operatorPodVolumes(dot) {
-			if strings.HasPrefix(ServiceAccountVolumeName+"-", vol.Name) {
-				mountName = vol.Name
-			}
+	mountName := ServiceAccountVolumeName
+	for _, vol := range operatorPodVolumes(dot) {
+		if strings.HasPrefix(ServiceAccountVolumeName+"-", vol.Name) {
+			mountName = vol.Name
 		}
-
-		volMount = append(volMount, corev1.VolumeMount{
-			Name:      mountName,
-			ReadOnly:  true,
-			MountPath: DefaultAPITokenMountPath,
-		})
 	}
+
+	volMount = append(volMount, corev1.VolumeMount{
+		Name:      mountName,
+		ReadOnly:  true,
+		MountPath: DefaultAPITokenMountPath,
+	})
 
 	if !isWebhookEnabled(dot) {
 		return volMount

--- a/operator/chart/templates/_deployment.go.tpl
+++ b/operator/chart/templates/_deployment.go.tpl
@@ -132,9 +132,7 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $values := $dot.Values.AsMap -}}
 {{- $volMount := (list) -}}
-{{- if $values.serviceAccount.create -}}
 {{- $mountName := "kube-api-access" -}}
 {{- range $_, $vol := (get (fromJson (include "operator.operatorPodVolumes" (dict "a" (list $dot)))) "r") -}}
 {{- if (hasPrefix $vol.name (printf "%s%s" "kube-api-access" "-")) -}}
@@ -145,7 +143,6 @@
 {{- break -}}
 {{- end -}}
 {{- $volMount = (concat (default (list) $volMount) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" $mountName "readOnly" true "mountPath" "/var/run/secrets/kubernetes.io/serviceaccount")))) -}}
-{{- end -}}
 {{- if (not (get (fromJson (include "operator.isWebhookEnabled" (dict "a" (list $dot)))) "r")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $volMount) | toJson -}}

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -13474,7 +13474,10 @@ spec:
             memory: "13"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsPolicy: 禉ȎÝ汱
       ephemeralContainers: null
       hostAliases:
@@ -17672,7 +17675,10 @@ spec:
             memory: "628"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - QXyBi4x
@@ -20852,7 +20858,10 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - uFFDQ
@@ -24796,7 +24805,10 @@ spec:
             memory: "826"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - 9uF4n
@@ -25874,7 +25886,10 @@ spec:
             memory: "396"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - bnxKu
@@ -29037,7 +29052,10 @@ spec:
             memory: "183"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - Nr
@@ -30674,7 +30692,10 @@ spec:
             memory: "961"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         searches:
         - ""
@@ -31199,7 +31220,10 @@ spec:
             memory: "579"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - YISghsOm
@@ -32854,7 +32878,10 @@ spec:
             memory: "462"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         searches:
         - 1M9d
@@ -34383,7 +34410,10 @@ spec:
             memory: "494"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - "34"
@@ -35620,7 +35650,10 @@ spec:
             memory: "65"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - g9
@@ -37286,7 +37319,10 @@ spec:
             memory: "670"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - fjX4eE
@@ -39649,7 +39685,10 @@ spec:
             memory: "133"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - XQQvkKFB7z
@@ -40633,7 +40672,10 @@ spec:
             memory: "805"
         securityContext:
           allowPrivilegeEscalation: false
-        volumeMounts: []
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
       dnsConfig:
         nameservers:
         - OKrRLUXo1z
@@ -52245,6 +52287,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -53603,6 +53648,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -55026,6 +55074,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -55611,6 +55662,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -57362,6 +57416,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -58450,6 +58507,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -59228,6 +59288,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -60649,6 +60712,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -62960,6 +63026,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -68640,6 +68709,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -69731,6 +69803,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -71945,6 +72020,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -73691,6 +73769,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -74857,6 +74938,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -80854,6 +80938,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -83764,6 +83851,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true


### PR DESCRIPTION
This fixes the missing mount for access token. Without it, it's not mounted and the operator does not work