### PR TITLE
redpanda: add rpadmin.Opt to client funcs

### DIFF
--- a/charts/redpanda/client/client.go
+++ b/charts/redpanda/client/client.go
@@ -55,7 +55,7 @@ type DialContextFunc = func(ctx context.Context, network, host string) (net.Conn
 
 // AdminClient creates a client to talk to a Redpanda cluster admin API based on its helm
 // configuration over its internal listeners.
-func AdminClient(dot *helmette.Dot, dialer DialContextFunc) (*rpadmin.AdminAPI, error) {
+func AdminClient(dot *helmette.Dot, dialer DialContextFunc, opts ...rpadmin.Opt) (*rpadmin.AdminAPI, error) {
 	values := helmette.Unwrap[redpanda.Values](dot.Values)
 	name := redpanda.Fullname(dot)
 	domain := redpanda.InternalDomain(dot)
@@ -90,7 +90,7 @@ func AdminClient(dot *helmette.Dot, dialer DialContextFunc) (*rpadmin.AdminAPI, 
 
 	hosts := redpanda.ServerList(values.Statefulset.Replicas, prefix, name, domain, values.Listeners.Admin.Port)
 
-	client, err := rpadmin.NewAdminAPIWithDialer(hosts, auth, tlsConfig, dialer)
+	client, err := rpadmin.NewAdminAPIWithDialer(hosts, auth, tlsConfig, dialer, opts...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
-	github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95
+	github.com/redpanda-data/common-go/rpadmin v0.1.14-0.20250425125657-8ab73f3ad62e
 	github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8
 	github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8
 	github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0

--- a/charts/redpanda/go.sum
+++ b/charts/redpanda/go.sum
@@ -432,8 +432,8 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
-github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95 h1:TmbXxlIHlKEF2wO5z82sQz98Su/WSgs+bC0k8s26Lsg=
-github.com/redpanda-data/common-go/rpadmin v0.1.13-0.20250109154132-12ac78a58f95/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
+github.com/redpanda-data/common-go/rpadmin v0.1.14-0.20250425125657-8ab73f3ad62e h1:0kdPPgbSCZ8XX6K/51x61/9cas2/sXj8UgdoiLJnOqQ=
+github.com/redpanda-data/common-go/rpadmin v0.1.14-0.20250425125657-8ab73f3ad62e/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
 github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 h1:aSlJX+HNh9C9NKA0+xp9DfYwfVs1fp4tkFaZS9DUkXM=
 github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:o6FEj/SPoAxl6Rn1X9+XO1tlzSl2V64vAiBDgHntfVc=
 github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 h1:HIkLbEDKeCALHFytZdHfeWYo/9JMa1yh4QlsIlhlsB8=


### PR DESCRIPTION
This commit adds a variadic `rpadmin.Opt` argument to various functions in the `redpanda/v5/client` package which makes it compatible with the interface of `redpanda/v25/client`.

The original change was introduced in c87ec376088e230bb7efe4c2fc2640efacda59bd which can't be backported.