### PR TITLE
Be more lenient when parsing configuration values

### DIFF
--- a/.changes/unreleased/operator-Changed-20250529-110428.yaml
+++ b/.changes/unreleased/operator-Changed-20250529-110428.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Changed
+body: The operator will try stripping off a layer of quotation from configuration values when interpreting numeric and boolean values. These may be accidentally introduced upstream of the CR, but where the intent is obvious we don't need to be strict about it.
+time: 2025-05-29T11:04:28.672769+01:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -36,6 +36,7 @@ In the v2 operator, this value is defaulted from the operator's settings.
 * It is not the case that the OperatorQuiescent condition for the v1 operator cannot be True unless the ClusterConfigured condition is also True.
 
 The status.observedGeneration will only update when the cluster reaches the OperatorQuiescent state.
+* The operator will try stripping off a layer of quotation from configuration values when interpreting numeric and boolean values. These may be accidentally introduced upstream of the CR, but where the intent is obvious we don't need to be strict about it.
 ### Deprecated
 * v1 operator: the `clusterConfiguration` field `ExternalSecretRef` is deprecated in favour of `ExternalSecretRefSelector`. Since this field was extremely new, it will be removed in the very near future.
 ### Removed


### PR DESCRIPTION
For various historical reasons, numeric and boolean values have been passed around as strings. Be a little more flexible to account for this when attempting to interpret these values against a schema.

(The use of `repr` in `clusterConfiguration` as opposed to a raw value is precisely for this reason, but there's a lot of historical configuration that's still in the `tunable` format.)