### PR TITLE
gotohelm: handle various Kubernetes types in `helmette.Unwrap`

### DIFF
--- a/gotohelm/helmette/shims_test.go
+++ b/gotohelm/helmette/shims_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestSortedMap(t *testing.T) {
@@ -17,4 +20,26 @@ func TestSortedMap(t *testing.T) {
 	}
 
 	require.Equal(t, []string{"0", "a", "z"}, keys)
+}
+
+func TestUnwrap(t *testing.T) {
+	// A type with fields that shown to be difficult for Unwrap to handled
+	type S struct {
+		Quantity    *resource.Quantity
+		IntOrString *intstr.IntOrString
+		Time        *metav1.Time
+		Duration    metav1.Duration
+	}
+
+	s := Unwrap[S](map[string]any{
+		"Quantity":    "10Gi",
+		"IntOrString": 10,
+		"Time":        "2025-06-04T05:46:00Z",
+		"Duration":    "10s",
+	})
+
+	require.Equal(t, s.IntOrString.IntVal, int32(10))
+	require.Equal(t, s.Quantity.String(), "10Gi")
+	require.Equal(t, s.Time.Time.UTC().String(), "2025-06-04 05:46:00 +0000 UTC")
+	require.Equal(t, s.Duration.Duration.String(), "10s")
 }


### PR DESCRIPTION
Prior to this commit `intstr.IntOrString`, `metav1.Time`, and `metav1.Duration` would cause `helmette.Unwrap` to error when called from go due to the JSON serialization being a scalar- not an object, as indicated by the types being structs.

This commit adds a special cases for said types and adds a regression test.