### PR TITLE
Ensure that we periodically reconcile

### DIFF
--- a/.changes/unreleased/operator-Changed-20250605-122221.yaml
+++ b/.changes/unreleased/operator-Changed-20250605-122221.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Changed
+body: The `Redpanda` controller will now unconditionally re-queue for reconciliation periodically. This permits it to pick up configuration changes in external secrets.
+time: 2025-06-05T12:22:21.481344+01:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -38,6 +38,7 @@ In the v2 operator, this value is defaulted from the operator's settings.
 
 The status.observedGeneration will only update when the cluster reaches the OperatorQuiescent state.
 * The operator will try stripping off a layer of quotation from configuration values when interpreting numeric and boolean values. These may be accidentally introduced upstream of the CR, but where the intent is obvious we don't need to be strict about it.
+* The `Redpanda` controller will now unconditionally re-queue for reconciliation periodically. This permits it to pick up configuration changes in external secrets.
 ### Deprecated
 * v1 operator: the `clusterConfiguration` field `ExternalSecretRef` is deprecated in favour of `ExternalSecretRefSelector`. Since this field was extremely new, it will be removed in the very near future.
 ### Removed


### PR DESCRIPTION
The v1 operator was already doing this - but we use the same belt-and-braces check in Reconcile for both v1 and v2 to ensure this behaviour remains the same in the future.

https://redpandadata.atlassian.net/browse/K8S-643