### PR TITLE
[release/v25.1.x] operator: fix nil deference in `setupLicense`

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250606-132924.yaml
+++ b/.changes/unreleased/operator-Fixed-20250606-132924.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: 'Empty Redpanda specs (i.e. `clusterSpec: null` or otherwise unspecified) no longer causes the operator to panic'
+time: 2025-06-06T13:29:24.970882-04:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -92,6 +92,7 @@ This is required to ensure that a pre-existing sts can roll over to new configur
 
 * Setting `serviceAccount.create` to `false` no longer prevents the Kubernetes ServiceAccountToken volume from being mounted to the operator Pod.
 * updated operator v1 to ignore "cluster.redpanda.com/node-pool-spec" annotation for pod rolls. previously, under certain conditions, the operator started rolling pods if this annotation changed - but there is no need to do so.
+* Empty Redpanda specs (i.e. `clusterSpec: null` or otherwise unspecified) no longer causes the operator to panic
 
 ## [v25.1.1-beta3](https://github.com/redpanda-data/redpanda-operator/releases/tag/operator%2Fv25.1.1-beta3) - 2025-05-07
 ### Added

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -447,7 +447,7 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, cluster 
 }
 
 func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alpha2.Redpanda, adminClient *rpadmin.AdminAPI) error {
-	if rp.Spec.ClusterSpec.Enterprise == nil {
+	if rp.Spec.ClusterSpec == nil || rp.Spec.ClusterSpec.Enterprise == nil {
 		return nil
 	}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `release/v2.4.x` to `release/v25.1.x`:
 - [operator: fix nil deference in `setupLicense`](https://github.com/redpanda-data/redpanda-operator/pull/891)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)