### PR TITLE
ci: automatically retry acceptance and integration tests 3 times

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -99,6 +99,9 @@ steps:
           failed: true
         message: ':cloud: Integration Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
+    retry:
+      automatic:
+        limit: 3
     soft_fail: false
     timeout_in_minutes: 90
   - continue_on_failure: true
@@ -145,6 +148,9 @@ steps:
           failed: true
         message: ':cloud: Acceptance Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
+    retry:
+      automatic:
+        limit: 3
     soft_fail: false
     timeout_in_minutes: 60
   - continue_on_failure: true
@@ -192,6 +198,9 @@ steps:
           failed: true
         message: ':cloud: Kuttl-V1 Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
+    retry:
+      automatic:
+        limit: 3
     soft_fail: false
     timeout_in_minutes: 90
   - continue_on_failure: true

--- a/gen/pipeline/helpers.go
+++ b/gen/pipeline/helpers.go
@@ -46,6 +46,9 @@ type TestSuite struct {
 	Required  bool
 	Timeout   time.Duration
 	Condition string
+	// Retry, if provided, is the upper limit of how many times to
+	// automatically retry this TestSuite.
+	Retry *int
 
 	JUnitPattern *string
 }
@@ -70,6 +73,14 @@ func (suite *TestSuite) ToStep() pipeline.Step {
 	}
 	if suite.Condition != "" {
 		remainingFields["if"] = suite.Condition
+	}
+	if suite.Retry != nil {
+		// See https://buildkite.com/docs/pipelines/configure/step-types/command-step#retry-attributes
+		remainingFields["retry"] = map[string]any{
+			"automatic": map[string]any{
+				"limit": *suite.Retry,
+			},
+		}
 	}
 	return &pipeline.GroupStep{
 		Key:   strings.ToLower(suite.Name),

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -38,11 +38,13 @@ var suites = []TestSuite{
 		Name:     "integration",
 		Required: true,
 		Timeout:  30*time.Minute + time.Hour,
+		Retry:    ptr.To(3),
 	},
 	{
 		Name:     "acceptance",
 		Required: true,
 		Timeout:  time.Hour,
+		Retry:    ptr.To(3),
 	},
 	// kuttl-v1 is currently the slowest and flakiest of our test suites. The
 	// majority of changes made aren't exercised by this suite. It runs conditionally
@@ -53,6 +55,7 @@ var suites = []TestSuite{
 		Timeout:      30*time.Minute + time.Hour,
 		JUnitPattern: ptr.To("work/operator/tests/_e2e_artifacts/kuttl-report.xml"),
 		Condition:    `build.pull_request.labels includes "run-kuttl-v1"`,
+		Retry:        ptr.To(3),
 	},
 	{
 		Name:         "kuttl-v1-nodepools",


### PR DESCRIPTION
I've found myself in the habit of mindlessly pressing retry on any set of failed acceptance or integration tests. While I was initially opposed to automatic retries, we've all wasted ample time needing to "baby sit" PRs and that is only going to increase in frequency as we increase the number of PRs that need to be backported.

This commit bites the bullet and adds 3 automatic retries to both the integration and acceptance test suites.