### PR TITLE
[release/v2.4.x] ci: automatically retry acceptance and integration tests 3 times

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -91,6 +91,9 @@ steps:
           failed: true
         message: ':cloud: Integration Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
+    retry:
+      automatic:
+        limit: 3
     soft_fail: true
     timeout_in_minutes: 90
   - continue_on_failure: true
@@ -133,6 +136,9 @@ steps:
           failed: true
         message: ':cloud: Acceptance Tests Job Failed'
         slack_token_env_var_name: SLACK_VBOT_TOKEN
+    retry:
+      automatic:
+        limit: 3
     soft_fail: true
     timeout_in_minutes: 60
   - continue_on_failure: true

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -38,11 +38,13 @@ var suites = []TestSuite{
 		Name:     "integration",
 		Required: false,
 		Timeout:  30*time.Minute + time.Hour,
+		Retry:    ptr.To(3),
 	},
 	{
 		Name:     "acceptance",
 		Required: false,
 		Timeout:  time.Hour,
+		Retry:    ptr.To(3),
 	},
 	// kuttl-v1 is currently the slowest and flakiest of our test suites. The
 	// majority of changes made aren't exercised by this suite. It's disabled


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [ci: automatically retry acceptance and integration tests 3 times](https://github.com/redpanda-data/redpanda-operator/pull/898)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)