### PR TITLE
operator: Set condition to mount ca.crt based on self sign function

### DIFF
--- a/operator/pkg/resources/certmanager/type_helpers.go
+++ b/operator/pkg/resources/certmanager/type_helpers.go
@@ -634,8 +634,8 @@ func (cc *ClusterCertificates) Volumes() (
 		mountPoints.SchemaRegistryAPI.NodeCertMountDir,
 		schemaRegistryClientCAVolName,
 		mountPoints.SchemaRegistryAPI.ClientCAMountDir,
-		true,
-		true,
+		cc.schemaRegistryAPI.selfSignedNodeCertificate,
+		len(cc.schemaRegistryAPI.clientCertificates) > 0,
 	)
 	vols = append(vols, vol...)
 	mounts = append(mounts, mount...)

--- a/operator/pkg/resources/certmanager/type_helpers_test.go
+++ b/operator/pkg/resources/certmanager/type_helpers_test.go
@@ -564,7 +564,7 @@ func TestClusterCertificates(t *testing.T) {
 				},
 			},
 			[]string{"test-schema-registry-trusted-client-ca", "test-schema-registry-selfsigned-issuer", "test-schema-registry-root-certificate", "test-schema-registry-root-issuer", "test-schema-registry-node", "test-schema-registry-client"},
-			2, validateVolumesFn("tlsschemaregistrycert", []string{"ca.crt", "tls.crt", "tls.key"}), nil,
+			2, validateVolumesFn("tlsschemaregistrycert", []string{"tls.crt", "tls.key"}), nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
If certificate is pointing to issuer that is public certificate issuer e.g.
Let's encrypt the ca.crt will not be provided in secret. There is already
function that tries to calculate if secret created from certificate will have
ca.crt included. That change should allow our cloud deployment to correctly
mount secret to Redpanda Pod.