### PR TITLE
[release/v2.4.x] PVCUnbinder: Restore and flag claimRef clearing

### DIFF
--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -158,6 +158,7 @@ func Command() *cobra.Command {
 		ghostbuster                         bool
 		unbindPVCsAfter                     time.Duration
 		unbinderSelector                    LabelSelectorValue
+		allowPVRebinding                    bool
 		autoDeletePVCs                      bool
 		forceDefluxedMode                   bool
 		helmRepositoryURL                   string
@@ -225,6 +226,7 @@ func Command() *cobra.Command {
 				ghostbuster,
 				unbindPVCsAfter,
 				unbinderSelector.Selector,
+				allowPVRebinding,
 				autoDeletePVCs,
 				forceDefluxedMode,
 				pprofAddr,
@@ -276,6 +278,7 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&operatorMode, "operator-mode", true, "enables to run as an operator, setting this to false will disable cluster (deprecated), redpanda resources reconciliation.")
 	cmd.Flags().BoolVar(&enableHelmControllers, "enable-helm-controllers", true, "if a namespace is defined and operator mode is true, this enables the use of helm controllers to manage fluxcd helm resources.")
 	cmd.Flags().DurationVar(&unbindPVCsAfter, "unbind-pvcs-after", 0, "if not zero, runs the PVCUnbinder controller which attempts to 'unbind' the PVCs' of Pods that are Pending for longer than the given duration")
+	cmd.Flags().BoolVar(&allowPVRebinding, "allow-pv-rebinding", false, "controls whether or not PVs unbound by the PVCUnbinder have their .ClaimRef cleared, which allows them to be reused")
 	cmd.Flags().Var(&unbinderSelector, "unbinder-label-selector", "if provided, a Kubernetes label selector that will filter Pods to be considered by the PVCUnbinder.")
 	cmd.Flags().BoolVar(&autoDeletePVCs, "auto-delete-pvcs", false, "Use StatefulSet PersistentVolumeClaimRetentionPolicy to auto delete PVCs on scale down and Cluster resource delete.")
 	cmd.Flags().BoolVar(&forceDefluxedMode, "force-defluxed-mode", true, "specifies the negated default for useFlux of Redpanda CRs if not specified. May be used in conjunction with enable-helm-controllers=false (true = don't use flux, false = use flux)")
@@ -348,6 +351,7 @@ func Run(
 	ghostbuster bool,
 	unbindPVCsAfter time.Duration,
 	unbinderSelector labels.Selector,
+	allowPVRebinding bool,
 	autoDeletePVCs bool,
 	forceDefluxedMode bool,
 	pprofAddr string,
@@ -702,14 +706,15 @@ func Run(
 
 	// The unbinder gets to run in any mode, if it's enabled.
 	if unbindPVCsAfter <= 0 {
-		setupLog.Info("PVCUnbinder controller not active", "unbind-after", unbindPVCsAfter, "selector", unbinderSelector)
+		setupLog.Info("PVCUnbinder controller not active", "unbind-after", unbindPVCsAfter, "selector", unbinderSelector, "allow-pv-rebinding", allowPVRebinding)
 	} else {
-		setupLog.Info("starting PVCUnbinder controller", "unbind-after", unbindPVCsAfter, "selector", unbinderSelector)
+		setupLog.Info("starting PVCUnbinder controller", "unbind-after", unbindPVCsAfter, "selector", unbinderSelector, "allow-pv-rebinding", allowPVRebinding)
 
 		if err := (&pvcunbinder.Controller{
-			Client:   mgr.GetClient(),
-			Timeout:  unbindPVCsAfter,
-			Selector: unbinderSelector,
+			Client:         mgr.GetClient(),
+			Timeout:        unbindPVCsAfter,
+			Selector:       unbinderSelector,
+			AllowRebinding: allowPVRebinding,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PVCUnbinder")
 			return err


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [PVCUnbinder: Restore and flag claimRef clearing](https://github.com/redpanda-data/redpanda-operator/pull/914)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)