### PR TITLE
[release/v25.1.x] operator: handle `ServiceMonitorList`'s Items

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,9 +73,22 @@ tasks:
       MOD:
         sh: go work edit -json | jq -r '.Use.[].DiskPath'
     cmds:
+    # go.works make things a bit funky. We have to sync twice to avoid
+    # accidentally upgrading deps everywhere which can be quite disruptive.
+    #
+    # The first sync will ensure that any newly added transient deps get pulled
+    # in at the same version as our other modules, if applicable.
+    # If we have Mod A and B and a 3rd party dep X such that:
+    # A -> B -> X
+    # if A imports X:
+    # `go mod tidy` will pull in the most recent version of X.
+    # `go work sync` will pull in the version that B is using.
+    - go work sync
     - for:
         var: MOD
       cmd: go mod tidy -C {{.ITEM}}
+    # The second go work sync, is the more standard go work sync. Any newly
+    # added deps will get added to the go.work.sum file.
     - go work sync
 
   fmt:

--- a/harpoon/go.sum
+++ b/harpoon/go.sum
@@ -377,6 +377,8 @@ github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3g
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2 h1:BpGDC87A2SaxbKgONsFLEX3kRcRJee2aLQbjXsuz0hA=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2/go.mod h1:Rd8YnCqz+2FYsiGmE2DMlaLjQRB4v2jFNnzCt9YY4IM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/homeport/dyff v1.7.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.32.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -368,6 +368,8 @@ github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3g
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2 h1:BpGDC87A2SaxbKgONsFLEX3kRcRJee2aLQbjXsuz0hA=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2/go.mod h1:Rd8YnCqz+2FYsiGmE2DMlaLjQRB4v2jFNnzCt9YY4IM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/pkg/kube/generics_test.go
+++ b/pkg/kube/generics_test.go
@@ -1,0 +1,49 @@
+package kube
+
+import (
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestItems(t *testing.T) {
+	// Unlike other types, ServiceMonitorList's Items is []*T instead of []T.
+	// As we need to use reflection to get Items out, we need to be careful to
+	// not panic.
+	_, err := Items[Object](&monitoringv1.ServiceMonitorList{Items: []*monitoringv1.ServiceMonitor{{}}})
+	require.NoError(t, err)
+
+	_, err = Items[*monitoringv1.ServiceMonitor](&monitoringv1.ServiceMonitorList{Items: []*monitoringv1.ServiceMonitor{{}}})
+	require.NoError(t, err)
+
+	_, err = Items[Object](&corev1.PodList{Items: []corev1.Pod{{}}})
+	require.NoError(t, err)
+
+	_, err = Items[*corev1.Pod](&corev1.PodList{Items: []corev1.Pod{{}}})
+	require.NoError(t, err)
+
+	_, err = Items[Object](&BogusList{Items: []struct{}{{}}})
+	require.EqualError(t, err, "can't convert struct {} to client.Object")
+}
+
+type BogusList struct {
+	Items []struct{}
+}
+
+var _ client.ObjectList = (*BogusList)(nil)
+
+func (*BogusList) GetObjectKind() schema.ObjectKind  { return schema.EmptyObjectKind }
+func (*BogusList) DeepCopyObject() runtime.Object    { return nil }
+func (*BogusList) GetResourceVersion() string        { return "" }
+func (*BogusList) SetResourceVersion(version string) {}
+func (*BogusList) GetSelfLink() string               { return "" }
+func (*BogusList) SetSelfLink(selfLink string)       {}
+func (*BogusList) GetContinue() string               { return "" }
+func (*BogusList) SetContinue(c string)              {}
+func (*BogusList) GetRemainingItemCount() *int64     { return nil }
+func (*BogusList) SetRemainingItemCount(c *int64)    {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [operator: handle `ServiceMonitorList`'s Items](https://github.com/redpanda-data/redpanda-operator/pull/918)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)