### PR TITLE
[release/v25.1.x] [25.x] Use hashed properties rather than version (#922)

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250617-113325.yaml
+++ b/.changes/unreleased/operator-Fixed-20250617-113325.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed a bug where pods would be restarted indefinitely in the case of config version changes when syncing cluster configuration.
+time: 2025-06-17T11:33:25.480184-04:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -98,6 +98,7 @@ This is required to ensure that a pre-existing sts can roll over to new configur
 * `get` permissions on `Node` resources is now correctly configured by default.
 
    `--set rbac.createAdditionalControllerCRs=true` is no longer required for rackawareness to work.
+* Fixed a bug where pods would be restarted indefinitely in the case of config version changes when syncing cluster configuration.
 
 ## [v25.1.1-beta3](https://github.com/redpanda-data/redpanda-operator/releases/tag/operator%2Fv25.1.1-beta3) - 2025-05-07
 ### Added

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -584,8 +583,7 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, admin *
 		return "", false, errors.WithStack(err)
 	}
 
-	// TODO: this needs to be updated when the hashing code lands
-	return strconv.FormatInt(configStatus.Version, 10), configStatus.NeedsRestart, nil
+	return configStatus.PropertiesThatNeedRestartHash, configStatus.NeedsRestart, nil
 }
 
 func (r *RedpandaReconciler) configSyncMode(ctx context.Context, rp *redpandav1alpha2.Redpanda) syncclusterconfig.SyncerMode {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [[25.x] Use hashed properties rather than version (#922)](https://github.com/redpanda-data/redpanda-operator/pull/922)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)