### PR TITLE
[release/v25.1.x] Make bootstrap user generated password immutable

### DIFF
--- a/.changes/unreleased/charts-redpanda-Changed-20250618-182809.yaml
+++ b/.changes/unreleased/charts-redpanda-Changed-20250618-182809.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Changed
+body: The generated bootstrap user password secret is now immutable. It was always intended to be a single-time generation, and now that is enforced at the Kubernetes API layer.
+time: 2025-06-18T18:28:09.325375-04:00

--- a/charts/redpanda/secrets.go
+++ b/charts/redpanda/secrets.go
@@ -211,6 +211,8 @@ func SecretBootstrapUser(dot *helmette.Dot) *corev1.Secret {
 	// that a password be explicitly set?
 	// See also: https://github.com/redpanda-data/helm-charts/issues/1596
 	if existing, ok := helmette.Lookup[corev1.Secret](dot, dot.Release.Namespace, secretName); ok {
+		// make any existing secret immutable
+		existing.Immutable = ptr.To(true)
 		return existing
 	}
 
@@ -231,7 +233,8 @@ func SecretBootstrapUser(dot *helmette.Dot) *corev1.Secret {
 			Namespace: dot.Release.Namespace,
 			Labels:    FullLabels(dot),
 		},
-		Type: corev1.SecretTypeOpaque,
+		Immutable: ptr.To(true),
+		Type:      corev1.SecretTypeOpaque,
 		StringData: map[string]string{
 			"password": password,
 		},

--- a/charts/redpanda/templates/_secrets.go.tpl
+++ b/charts/redpanda/templates/_secrets.go.tpl
@@ -99,6 +99,7 @@
 {{- $existing_4 := (index $_207_existing_4_ok_5 0) -}}
 {{- $ok_5 := (index $_207_existing_4_ok_5 1) -}}
 {{- if $ok_5 -}}
+{{- $_ := (set $existing_4 "immutable" true) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $existing_4) | toJson -}}
 {{- break -}}
@@ -109,7 +110,7 @@
 {{- $password = $userPassword -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil))) (mustMergeOverwrite (dict) (dict "apiVersion" "v1" "kind" "Secret")) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil)) (dict "name" $secretName "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot)))) "r"))) "type" "Opaque" "stringData" (dict "password" $password)))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil))) (mustMergeOverwrite (dict) (dict "apiVersion" "v1" "kind" "Secret")) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil)) (dict "name" $secretName "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot)))) "r"))) "immutable" true "type" "Opaque" "stringData" (dict "password" $password)))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [Make bootstrap user generated password immutable](https://github.com/redpanda-data/redpanda-operator/pull/925)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)