### PR TITLE
Correct "Release on Tag" GHA

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -43,7 +43,7 @@ projects:
     # Update operator's Chart.yaml
     - path: operator/chart/Chart.yaml
       find: '^version: .*$'
-      replace: 'version: {{.Version}}'
+      replace: 'version: {{.VersionNoPrefix}}'
     - path: operator/chart/Chart.yaml
       find: '^appVersion: .*$'
       replace: 'appVersion: {{.Version}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             tag="${{ github.ref_name }}"
           fi
           echo "using ref name: $tag"
-          echo "ref_name=$tag" >> "$github_output"
+          echo "ref_name=$tag" >> "$GITHUB_OUTPUT"
 
       - name: checkout code
         uses: actions/checkout@v4
@@ -53,35 +53,52 @@ jobs:
         run: |
           # turn refs into slightly friendlier names. e.g. operator/v1.2.3 -> operator: v1.2.3
           release_name="$(echo "${{ steps.get_ref.outputs.ref_name }}" | sed 's|/v|: v|')"
-          echo "release_name=$release_name" >> "$github_output"
+          echo "release_name=$release_name" >> "$GITHUB_OUTPUT"
 
       - name: package helm chart
         run: |
+          set -ex
           tag="${{ steps.get_ref.outputs.ref_name }}"
           # extract the directory from the tag (e.g., "operator" from "operator/v1.2.3")
           dir="$(dirname "$tag")"
           # search for chart.yaml in $dir or one directory deep (e.g., operator/chart)
-          chart_path=$(find "$dir" -maxdepth 2 -type f -name "chart.yaml" | head -n 1)
+          chart_path=$(find "$dir" -maxdepth 2 -type f -name "Chart.yaml" | head -n 1)
           # exit early if no chart.yaml file is found
           if [[ -z "$chart_path" ]]; then
             echo "no chart.yaml found for $tag. skipping step."
             exit 0
           fi
 
+          # Explicitly set the version based on the tag, stripping the leading
+          # v. This is done due to a mishap in managing the operator's version.
+          # All our charts specify `version` without a leading v but the
+          # operator's chart accidentally began doing so when binding version
+          # and appVersion.
+          # We enforce uniformity here, which retroactively corrects this
+          # issue.
+          version="$(basename "$tag")"
+          version="${version#v}"
+
           echo "packaging chart at $chart_path"
-          helm package -u "$(dirname "$chart_path")"
+          helm package -u --version "$version" "$(dirname "$chart_path")"
+
+      - name: reformat change log
+        run: |
+          # Our CHANGE LOGS begin with '## VERSION - DATE', which is
+          # duplicative to include in the GH release body. tail -n +2 will
+          # remove the first line.
+          tail -n +2 .changes/${{ steps.get_ref.outputs.ref_name }}.md > RELEASE_BODY.md
 
       # create github release and upload file
       - name: create github release
-        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
-          name: steps.release_name.outputs.release_name
-          tag_name: steps.get_ref.outputs.ref_name
+          name: ${{ steps.release_name.outputs.release_name }}
+          tag_name: ${{ steps.get_ref.outputs.ref_name }}
           draft: false
           make_latest: false
           prerelease: ${{ contains(steps.get_ref.outputs.ref_name, '-alpha') || contains(steps.get_ref.outputs.ref_name, '-beta') }}
-          body_path: ".changes/${{ steps.get_ref.outputs.ref_name }}.md" # pull the release body from changie.
+          body_path: RELEASE_BODY.md
           # if a chart was packaged, we'll upload it to this release preserving helm's naming convention.
           files: |
             ./*.tgz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,11 +97,12 @@ Releases](https://redpandadata.atlassian.net/projects/K8S?selectedItem=com.atlas
 To release any project in this repository:
 1. Mint the version and its CHANGELOG.md entry via `changie batch -j <project> <version>`
     - If minting a pre-release, specify `-k` to keep the unreleased changes in place for the official release.
+    - Manually review the contents and make any formatting or language adjustments as need be.
 2. Run `task test:unit` and `task lint`, they will report additional required actions, if any.
 4. Commit the resultant diff with the commit message `<project>: cut release <version>` and rebase it into master via a Pull Request.
 5. Tag the above commit with as `<project>/v<version>` with `git tag $(changie latest -j <project>) <commit-sha>`.
 6. Push the tags.
-7. Verify that the Release Workflow ran successfully.
+7. Verify that the [Release Workflow](./.github/workflows/release.yml) ran successfully.
 8. If applicable, mark the newly minted release as the "latest".
 
 ## Nightly build

--- a/operator/chart/Chart.yaml
+++ b/operator/chart/Chart.yaml
@@ -4,8 +4,9 @@ description: Redpanda operator helm chart
 type: application
 
 # The operator helm chart is considered part of the operator itself. Therefore
-# version == appVersion.
-version: v25.1.1-beta3
+# version == appVersion. Our charts' versions, don't include a leading `v`, so
+# we match that precedence here.
+version: 25.1.1-beta3
 appVersion: v25.1.1-beta3
 kubeVersion: ">= 1.25.0-0"
 

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: v25.1.1-beta3](https://img.shields.io/badge/Version-v25.1.1--beta3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.1.1-beta3](https://img.shields.io/badge/AppVersion-v25.1.1--beta3-informational?style=flat-square)
+![Version: 25.1.1-beta3](https://img.shields.io/badge/Version-25.1.1--beta3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v25.1.1-beta3](https://img.shields.io/badge/AppVersion-v25.1.1--beta3-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](./values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -55,7 +55,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -158,7 +158,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -243,7 +243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -265,7 +265,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -334,7 +334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -633,7 +633,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -656,7 +656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -679,7 +679,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -702,7 +702,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -725,7 +725,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -856,7 +856,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: S
   namespace: default
 ---
@@ -884,7 +884,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-config
   namespace: default
 ---
@@ -899,7 +899,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-metrics-reader
 rules:
 - nonResourceURLs:
@@ -918,7 +918,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY
 rules:
 - apiGroups:
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-additional-controllers
 rules:
 - apiGroups:
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1109,7 +1109,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1131,7 +1131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-election-role
   namespace: default
 rules:
@@ -1178,7 +1178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY
   namespace: default
 rules:
@@ -1349,7 +1349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-additional-controllers
   namespace: default
 rules:
@@ -1444,7 +1444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-rpk-bundle
   namespace: default
 rules:
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-election-role
   namespace: default
 roleRef:
@@ -1500,7 +1500,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY
   namespace: default
 roleRef:
@@ -1523,7 +1523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-additional-controllers
   namespace: default
 roleRef:
@@ -1546,7 +1546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-rpk-bundle
   namespace: default
 roleRef:
@@ -1569,7 +1569,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-metrics-service
   namespace: default
 spec:
@@ -1592,7 +1592,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY
   namespace: default
 spec:
@@ -1719,7 +1719,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: koBY-metrics-monitor
   namespace: default
 spec:
@@ -1741,7 +1741,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: aNfgS0
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-001.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -1756,7 +1756,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu
   namespace: default
 ---
@@ -1784,7 +1784,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-config
   namespace: default
 ---
@@ -1799,7 +1799,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1818,7 +1818,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu
 rules:
 - apiGroups:
@@ -1902,7 +1902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-additional-controllers
 rules:
 - apiGroups:
@@ -1987,7 +1987,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2009,7 +2009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2031,7 +2031,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-election-role
   namespace: default
 rules:
@@ -2078,7 +2078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu
   namespace: default
 rules:
@@ -2249,7 +2249,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-additional-controllers
   namespace: default
 rules:
@@ -2344,7 +2344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-rpk-bundle
   namespace: default
 rules:
@@ -2377,7 +2377,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-election-role
   namespace: default
 roleRef:
@@ -2400,7 +2400,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu
   namespace: default
 roleRef:
@@ -2423,7 +2423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-additional-controllers
   namespace: default
 roleRef:
@@ -2446,7 +2446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-rpk-bundle
   namespace: default
 roleRef:
@@ -2469,7 +2469,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu-metrics-service
   namespace: default
 spec:
@@ -2492,7 +2492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: WSGbu
   namespace: default
 spec:
@@ -2607,7 +2607,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G
   namespace: default
 ---
@@ -2638,7 +2638,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-config
   namespace: default
 ---
@@ -2656,7 +2656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-metrics-reader
 rules:
 - nonResourceURLs:
@@ -2678,7 +2678,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G
 rules:
 - apiGroups:
@@ -2765,7 +2765,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-additional-controllers
 rules:
 - apiGroups:
@@ -2853,7 +2853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2878,7 +2878,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2903,7 +2903,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-election-role
   namespace: default
 rules:
@@ -2953,7 +2953,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G
   namespace: default
 rules:
@@ -3127,7 +3127,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-additional-controllers
   namespace: default
 rules:
@@ -3225,7 +3225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-rpk-bundle
   namespace: default
 rules:
@@ -3261,7 +3261,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-election-role
   namespace: default
 roleRef:
@@ -3287,7 +3287,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G
   namespace: default
 roleRef:
@@ -3313,7 +3313,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-additional-controllers
   namespace: default
 roleRef:
@@ -3339,7 +3339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-rpk-bundle
   namespace: default
 roleRef:
@@ -3365,7 +3365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G-metrics-service
   namespace: default
 spec:
@@ -3391,7 +3391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Dx441G
   namespace: default
 spec:
@@ -3512,7 +3512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba
   namespace: default
 ---
@@ -3540,7 +3540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-config
   namespace: default
 ---
@@ -3555,7 +3555,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-metrics-reader
 rules:
 - nonResourceURLs:
@@ -3574,7 +3574,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba
 rules:
 - apiGroups:
@@ -3658,7 +3658,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-additional-controllers
 rules:
 - apiGroups:
@@ -3743,7 +3743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3765,7 +3765,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3787,7 +3787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-election-role
   namespace: default
 rules:
@@ -3834,7 +3834,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba
   namespace: default
 rules:
@@ -4005,7 +4005,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-additional-controllers
   namespace: default
 rules:
@@ -4100,7 +4100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-rpk-bundle
   namespace: default
 rules:
@@ -4133,7 +4133,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-election-role
   namespace: default
 roleRef:
@@ -4156,7 +4156,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba
   namespace: default
 roleRef:
@@ -4179,7 +4179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-additional-controllers
   namespace: default
 roleRef:
@@ -4202,7 +4202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-rpk-bundle
   namespace: default
 roleRef:
@@ -4225,7 +4225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba-metrics-service
   namespace: default
 spec:
@@ -4248,7 +4248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rEba
   namespace: default
 spec:
@@ -4397,7 +4397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: SpE0
   namespace: default
 ---
@@ -4426,7 +4426,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-config
   namespace: default
 ---
@@ -4442,7 +4442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-metrics-reader
 rules:
 - nonResourceURLs:
@@ -4462,7 +4462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z
 rules:
 - apiGroups:
@@ -4547,7 +4547,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-additional-controllers
 rules:
 - apiGroups:
@@ -4633,7 +4633,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4656,7 +4656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4679,7 +4679,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-election-role
   namespace: default
 rules:
@@ -4727,7 +4727,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z
   namespace: default
 rules:
@@ -4899,7 +4899,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-additional-controllers
   namespace: default
 rules:
@@ -4995,7 +4995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-rpk-bundle
   namespace: default
 rules:
@@ -5029,7 +5029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-election-role
   namespace: default
 roleRef:
@@ -5053,7 +5053,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z
   namespace: default
 roleRef:
@@ -5077,7 +5077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-additional-controllers
   namespace: default
 roleRef:
@@ -5101,7 +5101,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-rpk-bundle
   namespace: default
 roleRef:
@@ -5125,7 +5125,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z-metrics-service
   namespace: default
 spec:
@@ -5149,7 +5149,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kdh6Z
   namespace: default
 spec:
@@ -5270,7 +5270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -5301,7 +5301,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-config
   namespace: default
@@ -5319,7 +5319,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-metrics-reader
 rules:
@@ -5341,7 +5341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
 rules:
@@ -5428,7 +5428,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
 rules:
@@ -5516,7 +5516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
 roleRef:
@@ -5541,7 +5541,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
 roleRef:
@@ -5566,7 +5566,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-election-role
   namespace: default
@@ -5616,7 +5616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -5790,7 +5790,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
   namespace: default
@@ -5888,7 +5888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-rpk-bundle
   namespace: default
@@ -5924,7 +5924,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-election-role
   namespace: default
@@ -5950,7 +5950,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -5976,7 +5976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
   namespace: default
@@ -6002,7 +6002,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-rpk-bundle
   namespace: default
@@ -6028,7 +6028,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-metrics-service
   namespace: default
@@ -6054,7 +6054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -6192,7 +6192,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em
   namespace: default
 ---
@@ -6221,7 +6221,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-config
   namespace: default
 ---
@@ -6237,7 +6237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-metrics-reader
 rules:
 - nonResourceURLs:
@@ -6257,7 +6257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em
 rules:
 - apiGroups:
@@ -6342,7 +6342,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-additional-controllers
 rules:
 - apiGroups:
@@ -6428,7 +6428,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6451,7 +6451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6474,7 +6474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-election-role
   namespace: default
 rules:
@@ -6522,7 +6522,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em
   namespace: default
 rules:
@@ -6694,7 +6694,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-additional-controllers
   namespace: default
 rules:
@@ -6790,7 +6790,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-rpk-bundle
   namespace: default
 rules:
@@ -6824,7 +6824,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-election-role
   namespace: default
 roleRef:
@@ -6848,7 +6848,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em
   namespace: default
 roleRef:
@@ -6872,7 +6872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-additional-controllers
   namespace: default
 roleRef:
@@ -6896,7 +6896,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-rpk-bundle
   namespace: default
 roleRef:
@@ -6920,7 +6920,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-metrics-service
   namespace: default
 spec:
@@ -6944,7 +6944,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em
   namespace: default
 spec:
@@ -7057,7 +7057,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Em-metrics-monitor
   namespace: default
 spec:
@@ -7080,7 +7080,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: di
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-007.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -7097,7 +7097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QOxZ1
   namespace: default
 ---
@@ -7128,7 +7128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 6yA-config
   namespace: default
 ---
@@ -7146,7 +7146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 6yA-metrics-service
   namespace: default
 spec:
@@ -7172,7 +7172,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 6yA
   namespace: default
 spec:
@@ -7284,7 +7284,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: q5hs
   namespace: default
@@ -7316,7 +7316,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-config
   namespace: default
@@ -7335,7 +7335,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-metrics-reader
 rules:
@@ -7358,7 +7358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn
 rules:
@@ -7446,7 +7446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
 rules:
@@ -7535,7 +7535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn
 roleRef:
@@ -7561,7 +7561,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
 roleRef:
@@ -7587,7 +7587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-election-role
   namespace: default
@@ -7638,7 +7638,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn
   namespace: default
@@ -7813,7 +7813,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
   namespace: default
@@ -7912,7 +7912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-rpk-bundle
   namespace: default
@@ -7949,7 +7949,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-election-role
   namespace: default
@@ -7976,7 +7976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn
   namespace: default
@@ -8003,7 +8003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
   namespace: default
@@ -8030,7 +8030,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-rpk-bundle
   namespace: default
@@ -8057,7 +8057,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn-metrics-service
   namespace: default
@@ -8084,7 +8084,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     u: yT9Aqc
   name: DBMkVbLNvvZn
   namespace: default
@@ -8219,7 +8219,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs
   namespace: default
 ---
@@ -8249,7 +8249,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-config
   namespace: default
 ---
@@ -8266,7 +8266,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-metrics-reader
 rules:
 - nonResourceURLs:
@@ -8287,7 +8287,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs
 rules:
 - apiGroups:
@@ -8373,7 +8373,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-additional-controllers
 rules:
 - apiGroups:
@@ -8460,7 +8460,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8484,7 +8484,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8508,7 +8508,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-election-role
   namespace: default
 rules:
@@ -8557,7 +8557,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs
   namespace: default
 rules:
@@ -8730,7 +8730,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-additional-controllers
   namespace: default
 rules:
@@ -8827,7 +8827,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-rpk-bundle
   namespace: default
 rules:
@@ -8862,7 +8862,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-election-role
   namespace: default
 roleRef:
@@ -8887,7 +8887,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs
   namespace: default
 roleRef:
@@ -8912,7 +8912,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-additional-controllers
   namespace: default
 roleRef:
@@ -8937,7 +8937,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-rpk-bundle
   namespace: default
 roleRef:
@@ -8962,7 +8962,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs-metrics-service
   namespace: default
 spec:
@@ -8987,7 +8987,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v25.1.1-beta3
     gLlqKr: m
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kBI8lEs
   namespace: default
 spec:
@@ -9108,7 +9108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE
   namespace: default
 ---
@@ -9138,7 +9138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-config
   namespace: default
 ---
@@ -9155,7 +9155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-metrics-reader
 rules:
 - nonResourceURLs:
@@ -9176,7 +9176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE
 rules:
 - apiGroups:
@@ -9262,7 +9262,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-additional-controllers
 rules:
 - apiGroups:
@@ -9349,7 +9349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9373,7 +9373,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9397,7 +9397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-election-role
   namespace: default
 rules:
@@ -9446,7 +9446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE
   namespace: default
 rules:
@@ -9619,7 +9619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-additional-controllers
   namespace: default
 rules:
@@ -9716,7 +9716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-rpk-bundle
   namespace: default
 rules:
@@ -9751,7 +9751,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-election-role
   namespace: default
 roleRef:
@@ -9776,7 +9776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE
   namespace: default
 roleRef:
@@ -9801,7 +9801,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-additional-controllers
   namespace: default
 roleRef:
@@ -9826,7 +9826,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-rpk-bundle
   namespace: default
 roleRef:
@@ -9851,7 +9851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE-metrics-service
   namespace: default
 spec:
@@ -9876,7 +9876,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: rcE
   namespace: default
 spec:
@@ -10041,7 +10041,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -10072,7 +10072,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-config
@@ -10090,7 +10090,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-metrics-reader
@@ -10112,7 +10112,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -10199,7 +10199,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -10287,7 +10287,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -10312,7 +10312,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -10337,7 +10337,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-election-role
@@ -10387,7 +10387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -10561,7 +10561,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -10659,7 +10659,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-rpk-bundle
@@ -10695,7 +10695,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-election-role
@@ -10721,7 +10721,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -10747,7 +10747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -10773,7 +10773,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-rpk-bundle
@@ -10799,7 +10799,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-metrics-service
@@ -10825,7 +10825,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -10941,7 +10941,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI
   namespace: default
 ---
@@ -10969,7 +10969,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-config
   namespace: default
 ---
@@ -10984,7 +10984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-metrics-reader
 rules:
 - nonResourceURLs:
@@ -11003,7 +11003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI
 rules:
 - apiGroups:
@@ -11087,7 +11087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-additional-controllers
 rules:
 - apiGroups:
@@ -11172,7 +11172,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11194,7 +11194,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11216,7 +11216,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-election-role
   namespace: default
 rules:
@@ -11263,7 +11263,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI
   namespace: default
 rules:
@@ -11434,7 +11434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-additional-controllers
   namespace: default
 rules:
@@ -11529,7 +11529,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-rpk-bundle
   namespace: default
 rules:
@@ -11562,7 +11562,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-election-role
   namespace: default
 roleRef:
@@ -11585,7 +11585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI
   namespace: default
 roleRef:
@@ -11608,7 +11608,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-additional-controllers
   namespace: default
 roleRef:
@@ -11631,7 +11631,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-rpk-bundle
   namespace: default
 roleRef:
@@ -11654,7 +11654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI-metrics-service
   namespace: default
 spec:
@@ -11677,7 +11677,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J5MiI
   namespace: default
 spec:
@@ -11840,7 +11840,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS
   namespace: default
 ---
@@ -11870,7 +11870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-config
   namespace: default
 ---
@@ -11887,7 +11887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-metrics-reader
 rules:
 - nonResourceURLs:
@@ -11908,7 +11908,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS
 rules:
 - apiGroups:
@@ -11994,7 +11994,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-additional-controllers
 rules:
 - apiGroups:
@@ -12081,7 +12081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12105,7 +12105,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12129,7 +12129,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-election-role
   namespace: default
 rules:
@@ -12178,7 +12178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS
   namespace: default
 rules:
@@ -12351,7 +12351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-additional-controllers
   namespace: default
 rules:
@@ -12448,7 +12448,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-rpk-bundle
   namespace: default
 rules:
@@ -12483,7 +12483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-election-role
   namespace: default
 roleRef:
@@ -12508,7 +12508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS
   namespace: default
 roleRef:
@@ -12533,7 +12533,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-additional-controllers
   namespace: default
 roleRef:
@@ -12558,7 +12558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-rpk-bundle
   namespace: default
 roleRef:
@@ -12583,7 +12583,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS-metrics-service
   namespace: default
 spec:
@@ -12608,7 +12608,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: NofaS
   namespace: default
 spec:
@@ -12732,7 +12732,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: g5
   namespace: default
 ---
@@ -12763,7 +12763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: o2lMoG-config
   namespace: default
 ---
@@ -12781,7 +12781,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: o2lMoG-metrics-service
   namespace: default
 spec:
@@ -12807,7 +12807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: o2lMoG
   namespace: default
 spec:
@@ -13003,7 +13003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R-config
   namespace: default
 ---
@@ -13019,7 +13019,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R-metrics-reader
 rules:
 - nonResourceURLs:
@@ -13039,7 +13039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R
 rules:
 - apiGroups:
@@ -13124,7 +13124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13147,7 +13147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R-election-role
   namespace: default
 rules:
@@ -13195,7 +13195,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R
   namespace: default
 rules:
@@ -13367,7 +13367,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R-election-role
   namespace: default
 roleRef:
@@ -13391,7 +13391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R
   namespace: default
 roleRef:
@@ -13415,7 +13415,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R-metrics-service
   namespace: default
 spec:
@@ -13439,7 +13439,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K9R
   namespace: default
 spec:
@@ -13607,7 +13607,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL
   namespace: default
@@ -13637,7 +13637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL-config
   namespace: default
@@ -13654,7 +13654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL-metrics-service
   namespace: default
@@ -13679,7 +13679,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL
   namespace: default
@@ -13914,7 +13914,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: pHzNPjb
   namespace: default
@@ -13944,7 +13944,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-config
   namespace: default
@@ -13961,7 +13961,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-metrics-reader
 rules:
@@ -13982,7 +13982,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O
 rules:
@@ -14068,7 +14068,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-additional-controllers
 rules:
@@ -14155,7 +14155,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O
 roleRef:
@@ -14179,7 +14179,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-additional-controllers
 roleRef:
@@ -14203,7 +14203,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-election-role
   namespace: default
@@ -14252,7 +14252,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O
   namespace: default
@@ -14425,7 +14425,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-additional-controllers
   namespace: default
@@ -14522,7 +14522,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-rpk-bundle
   namespace: default
@@ -14557,7 +14557,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-election-role
   namespace: default
@@ -14582,7 +14582,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O
   namespace: default
@@ -14607,7 +14607,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-additional-controllers
   namespace: default
@@ -14632,7 +14632,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-rpk-bundle
   namespace: default
@@ -14657,7 +14657,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-metrics-service
   namespace: default
@@ -14682,7 +14682,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O
   namespace: default
@@ -14895,7 +14895,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v25.1.1-beta3
     bKX: d
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     m2Z8Z: wRw
   name: DX7O-metrics-monitor
   namespace: default
@@ -14919,7 +14919,7 @@ spec:
       app.kubernetes.io/name: NlE3orKsq9
       app.kubernetes.io/version: v25.1.1-beta3
       bKX: d
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       m2Z8Z: wRw
 -- testdata/case-018.yaml.golden --
 ---
@@ -14935,7 +14935,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh
   namespace: default
 ---
@@ -14966,7 +14966,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-config
   namespace: default
 ---
@@ -14984,7 +14984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-metrics-reader
 rules:
 - nonResourceURLs:
@@ -15006,7 +15006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh
 rules:
 - apiGroups:
@@ -15093,7 +15093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-additional-controllers
 rules:
 - apiGroups:
@@ -15181,7 +15181,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15206,7 +15206,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15231,7 +15231,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-election-role
   namespace: default
 rules:
@@ -15281,7 +15281,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh
   namespace: default
 rules:
@@ -15455,7 +15455,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-additional-controllers
   namespace: default
 rules:
@@ -15553,7 +15553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-rpk-bundle
   namespace: default
 rules:
@@ -15589,7 +15589,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-election-role
   namespace: default
 roleRef:
@@ -15615,7 +15615,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh
   namespace: default
 roleRef:
@@ -15641,7 +15641,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-additional-controllers
   namespace: default
 roleRef:
@@ -15667,7 +15667,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-rpk-bundle
   namespace: default
 roleRef:
@@ -15693,7 +15693,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-metrics-service
   namespace: default
 spec:
@@ -15719,7 +15719,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh
   namespace: default
 spec:
@@ -15853,7 +15853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: x8K24mCZYsnh-metrics-monitor
   namespace: default
 spec:
@@ -15875,7 +15875,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: "5"
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-019.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -15890,7 +15890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi
   namespace: default
 ---
@@ -15921,7 +15921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-config
   namespace: default
 ---
@@ -15939,7 +15939,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-metrics-reader
 rules:
 - nonResourceURLs:
@@ -15961,7 +15961,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi
 rules:
 - apiGroups:
@@ -16048,7 +16048,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-additional-controllers
 rules:
 - apiGroups:
@@ -16136,7 +16136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16161,7 +16161,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16186,7 +16186,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-election-role
   namespace: default
 rules:
@@ -16236,7 +16236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi
   namespace: default
 rules:
@@ -16410,7 +16410,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-additional-controllers
   namespace: default
 rules:
@@ -16508,7 +16508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-rpk-bundle
   namespace: default
 rules:
@@ -16544,7 +16544,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-election-role
   namespace: default
 roleRef:
@@ -16570,7 +16570,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi
   namespace: default
 roleRef:
@@ -16596,7 +16596,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-additional-controllers
   namespace: default
 roleRef:
@@ -16622,7 +16622,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-rpk-bundle
   namespace: default
 roleRef:
@@ -16648,7 +16648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-metrics-service
   namespace: default
 spec:
@@ -16674,7 +16674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi
   namespace: default
 spec:
@@ -16802,7 +16802,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: UHlKDi-metrics-monitor
   namespace: default
 spec:
@@ -16824,7 +16824,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Fk
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-020.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -16852,7 +16852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-config
   namespace: default
@@ -16869,7 +16869,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-metrics-reader
 rules:
@@ -16890,7 +16890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
 rules:
@@ -16976,7 +16976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
 rules:
@@ -17063,7 +17063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
 roleRef:
@@ -17087,7 +17087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
 roleRef:
@@ -17111,7 +17111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-election-role
   namespace: default
@@ -17160,7 +17160,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
   namespace: default
@@ -17333,7 +17333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
   namespace: default
@@ -17430,7 +17430,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-rpk-bundle
   namespace: default
@@ -17465,7 +17465,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-election-role
   namespace: default
@@ -17490,7 +17490,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
   namespace: default
@@ -17515,7 +17515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
   namespace: default
@@ -17540,7 +17540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-rpk-bundle
   namespace: default
@@ -17565,7 +17565,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-metrics-service
   namespace: default
@@ -17590,7 +17590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
   namespace: default
@@ -17886,7 +17886,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 12bwUKO
   namespace: default
@@ -17915,7 +17915,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-config
   namespace: default
@@ -17931,7 +17931,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-metrics-reader
 rules:
@@ -17951,7 +17951,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: "5"
 rules:
@@ -18036,7 +18036,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-additional-controllers
 rules:
@@ -18122,7 +18122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: "5"
 roleRef:
@@ -18145,7 +18145,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-additional-controllers
 roleRef:
@@ -18168,7 +18168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-election-role
   namespace: default
@@ -18216,7 +18216,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: "5"
   namespace: default
@@ -18388,7 +18388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-additional-controllers
   namespace: default
@@ -18484,7 +18484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-rpk-bundle
   namespace: default
@@ -18518,7 +18518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-election-role
   namespace: default
@@ -18542,7 +18542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: "5"
   namespace: default
@@ -18566,7 +18566,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-additional-controllers
   namespace: default
@@ -18590,7 +18590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-rpk-bundle
   namespace: default
@@ -18614,7 +18614,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: 5-metrics-service
   namespace: default
@@ -18638,7 +18638,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kxvj1aV: un4v2
   name: "5"
   namespace: default
@@ -18779,7 +18779,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf
   namespace: default
 ---
@@ -18812,7 +18812,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-config
   namespace: default
 ---
@@ -18832,7 +18832,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-metrics-reader
 rules:
 - nonResourceURLs:
@@ -18856,7 +18856,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf
 rules:
 - apiGroups:
@@ -18945,7 +18945,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-additional-controllers
 rules:
 - apiGroups:
@@ -19035,7 +19035,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -19062,7 +19062,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -19089,7 +19089,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-election-role
   namespace: default
 rules:
@@ -19141,7 +19141,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf
   namespace: default
 rules:
@@ -19317,7 +19317,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-additional-controllers
   namespace: default
 rules:
@@ -19417,7 +19417,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-rpk-bundle
   namespace: default
 rules:
@@ -19455,7 +19455,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-election-role
   namespace: default
 roleRef:
@@ -19483,7 +19483,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf
   namespace: default
 roleRef:
@@ -19511,7 +19511,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-additional-controllers
   namespace: default
 roleRef:
@@ -19539,7 +19539,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-rpk-bundle
   namespace: default
 roleRef:
@@ -19567,7 +19567,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf-metrics-service
   namespace: default
 spec:
@@ -19595,7 +19595,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v25.1.1-beta3
     gWL: pM
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sFwgtf
   namespace: default
 spec:
@@ -19921,7 +19921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-config
   namespace: default
@@ -19937,7 +19937,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-metrics-reader
 rules:
@@ -19957,7 +19957,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi
 rules:
@@ -20042,7 +20042,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-additional-controllers
 rules:
@@ -20128,7 +20128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi
 roleRef:
@@ -20151,7 +20151,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-additional-controllers
 roleRef:
@@ -20174,7 +20174,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-election-role
   namespace: default
@@ -20222,7 +20222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi
   namespace: default
@@ -20394,7 +20394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-additional-controllers
   namespace: default
@@ -20490,7 +20490,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-rpk-bundle
   namespace: default
@@ -20524,7 +20524,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-election-role
   namespace: default
@@ -20548,7 +20548,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi
   namespace: default
@@ -20572,7 +20572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-additional-controllers
   namespace: default
@@ -20596,7 +20596,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-rpk-bundle
   namespace: default
@@ -20620,7 +20620,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi-metrics-service
   namespace: default
@@ -20644,7 +20644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     iW8sRg: to
   name: bi
   namespace: default
@@ -21026,7 +21026,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: a
   namespace: default
 ---
@@ -21057,7 +21057,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-config
   namespace: default
 ---
@@ -21075,7 +21075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-metrics-reader
 rules:
 - nonResourceURLs:
@@ -21097,7 +21097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs
 rules:
 - apiGroups:
@@ -21184,7 +21184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-additional-controllers
 rules:
 - apiGroups:
@@ -21272,7 +21272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21297,7 +21297,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21322,7 +21322,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-election-role
   namespace: default
 rules:
@@ -21372,7 +21372,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs
   namespace: default
 rules:
@@ -21546,7 +21546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-additional-controllers
   namespace: default
 rules:
@@ -21644,7 +21644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-rpk-bundle
   namespace: default
 rules:
@@ -21680,7 +21680,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-election-role
   namespace: default
 roleRef:
@@ -21706,7 +21706,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs
   namespace: default
 roleRef:
@@ -21732,7 +21732,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-additional-controllers
   namespace: default
 roleRef:
@@ -21758,7 +21758,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-rpk-bundle
   namespace: default
 roleRef:
@@ -21784,7 +21784,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs-metrics-service
   namespace: default
 spec:
@@ -21810,7 +21810,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-YCs
   namespace: default
 spec:
@@ -22075,7 +22075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: sA
   namespace: default
 ---
@@ -22106,7 +22106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: VI1RU-config
   namespace: default
 ---
@@ -22124,7 +22124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: VI1RU-metrics-service
   namespace: default
 spec:
@@ -22150,7 +22150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: VI1RU
   namespace: default
 spec:
@@ -22578,7 +22578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: blB
   namespace: default
 ---
@@ -22610,7 +22610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-config
   namespace: default
 ---
@@ -22629,7 +22629,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-metrics-reader
 rules:
 - nonResourceURLs:
@@ -22652,7 +22652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "2"
 rules:
 - apiGroups:
@@ -22740,7 +22740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-additional-controllers
 rules:
 - apiGroups:
@@ -22829,7 +22829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22855,7 +22855,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22881,7 +22881,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-election-role
   namespace: default
 rules:
@@ -22932,7 +22932,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "2"
   namespace: default
 rules:
@@ -23107,7 +23107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-additional-controllers
   namespace: default
 rules:
@@ -23206,7 +23206,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-rpk-bundle
   namespace: default
 rules:
@@ -23243,7 +23243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-election-role
   namespace: default
 roleRef:
@@ -23270,7 +23270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "2"
   namespace: default
 roleRef:
@@ -23297,7 +23297,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-additional-controllers
   namespace: default
 roleRef:
@@ -23324,7 +23324,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-rpk-bundle
   namespace: default
 roleRef:
@@ -23351,7 +23351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-metrics-service
   namespace: default
 spec:
@@ -23378,7 +23378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "2"
   namespace: default
 spec:
@@ -23697,7 +23697,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2-metrics-monitor
   namespace: default
 spec:
@@ -23721,7 +23721,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: VhCMS
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-027.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -23738,7 +23738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tIa
   namespace: default
 ---
@@ -23768,7 +23768,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO-config
   namespace: default
 ---
@@ -23785,7 +23785,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO-metrics-reader
 rules:
 - nonResourceURLs:
@@ -23806,7 +23806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO
 rules:
 - apiGroups:
@@ -23892,7 +23892,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -23916,7 +23916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO-election-role
   namespace: default
 rules:
@@ -23965,7 +23965,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO
   namespace: default
 rules:
@@ -24138,7 +24138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO-election-role
   namespace: default
 roleRef:
@@ -24163,7 +24163,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO
   namespace: default
 roleRef:
@@ -24188,7 +24188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO-metrics-service
   namespace: default
 spec:
@@ -24213,7 +24213,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO
   namespace: default
 spec:
@@ -24652,7 +24652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: z7BRO-metrics-monitor
   namespace: default
 spec:
@@ -24676,7 +24676,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Qi
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-028.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -24705,7 +24705,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: na-config
   namespace: default
 ---
@@ -24722,7 +24722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: na-metrics-service
   namespace: default
 spec:
@@ -24747,7 +24747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: na
   namespace: default
 spec:
@@ -25041,7 +25041,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: na-metrics-monitor
   namespace: default
 spec:
@@ -25063,7 +25063,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 7Nn
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-029.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -25093,7 +25093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-config
   namespace: default
 ---
@@ -25111,7 +25111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-metrics-reader
 rules:
 - nonResourceURLs:
@@ -25133,7 +25133,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D
 rules:
 - apiGroups:
@@ -25220,7 +25220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-additional-controllers
 rules:
 - apiGroups:
@@ -25308,7 +25308,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25333,7 +25333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25358,7 +25358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-election-role
   namespace: default
 rules:
@@ -25408,7 +25408,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D
   namespace: default
 rules:
@@ -25582,7 +25582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-additional-controllers
   namespace: default
 rules:
@@ -25680,7 +25680,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-rpk-bundle
   namespace: default
 rules:
@@ -25716,7 +25716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-election-role
   namespace: default
 roleRef:
@@ -25742,7 +25742,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D
   namespace: default
 roleRef:
@@ -25768,7 +25768,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-additional-controllers
   namespace: default
 roleRef:
@@ -25794,7 +25794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-rpk-bundle
   namespace: default
 roleRef:
@@ -25820,7 +25820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D-metrics-service
   namespace: default
 spec:
@@ -25846,7 +25846,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: D
   namespace: default
 spec:
@@ -26135,7 +26135,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: spW
   namespace: default
 ---
@@ -26165,7 +26165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: vvvAuBP-config
   namespace: default
 ---
@@ -26182,7 +26182,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: vvvAuBP-metrics-service
   namespace: default
 spec:
@@ -26207,7 +26207,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: vvvAuBP
   namespace: default
 spec:
@@ -26684,7 +26684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Zihc6G
   namespace: default
 ---
@@ -26715,7 +26715,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-config
   namespace: default
 ---
@@ -26733,7 +26733,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -26755,7 +26755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu
 rules:
 - apiGroups:
@@ -26842,7 +26842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-additional-controllers
 rules:
 - apiGroups:
@@ -26930,7 +26930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -26955,7 +26955,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -26980,7 +26980,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-election-role
   namespace: default
 rules:
@@ -27030,7 +27030,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu
   namespace: default
 rules:
@@ -27204,7 +27204,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-additional-controllers
   namespace: default
 rules:
@@ -27302,7 +27302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-rpk-bundle
   namespace: default
 rules:
@@ -27338,7 +27338,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-election-role
   namespace: default
 roleRef:
@@ -27364,7 +27364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu
   namespace: default
 roleRef:
@@ -27390,7 +27390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-additional-controllers
   namespace: default
 roleRef:
@@ -27416,7 +27416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-rpk-bundle
   namespace: default
 roleRef:
@@ -27442,7 +27442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu-metrics-service
   namespace: default
 spec:
@@ -27468,7 +27468,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tDyp0579ogHIu
   namespace: default
 spec:
@@ -27917,7 +27917,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: TmM6fo
   namespace: default
 ---
@@ -27946,7 +27946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Wzr8UxvO-config
   namespace: default
 ---
@@ -27962,7 +27962,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Wzr8UxvO-metrics-service
   namespace: default
 spec:
@@ -27986,7 +27986,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Wzr8UxvO
   namespace: default
 spec:
@@ -28300,7 +28300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Wzr8UxvO-metrics-monitor
   namespace: default
 spec:
@@ -28322,7 +28322,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: P6wEG
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-033.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -28351,7 +28351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-config
   namespace: default
@@ -28369,7 +28369,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-metrics-reader
 rules:
@@ -28391,7 +28391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX
 rules:
@@ -28478,7 +28478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX
 roleRef:
@@ -28503,7 +28503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-election-role
   namespace: default
@@ -28553,7 +28553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX
   namespace: default
@@ -28727,7 +28727,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-rpk-bundle
   namespace: default
@@ -28763,7 +28763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-election-role
   namespace: default
@@ -28789,7 +28789,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX
   namespace: default
@@ -28815,7 +28815,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-rpk-bundle
   namespace: default
@@ -28841,7 +28841,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX-metrics-service
   namespace: default
@@ -28867,7 +28867,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     uUW: Us
   name: 6z0k3NX
   namespace: default
@@ -29312,7 +29312,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     in: IEvkGW7b
   name: ClL0jwLRjj
   namespace: default
@@ -29344,7 +29344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     in: IEvkGW7b
   name: t-config
   namespace: default
@@ -29363,7 +29363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     in: IEvkGW7b
   name: t-metrics-service
   namespace: default
@@ -29390,7 +29390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     in: IEvkGW7b
   name: t
   namespace: default
@@ -29791,7 +29791,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     in: IEvkGW7b
   name: t-metrics-monitor
   namespace: default
@@ -29815,7 +29815,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 6xIMZiuoly3
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       in: IEvkGW7b
 -- testdata/case-035.yaml.golden --
 ---
@@ -29833,7 +29833,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v25.1.1-beta3
     dcuPV: Fy
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 1316QiC
   namespace: default
 ---
@@ -29862,7 +29862,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v25.1.1-beta3
     dcuPV: Fy
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PW6-config
   namespace: default
 ---
@@ -29878,7 +29878,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v25.1.1-beta3
     dcuPV: Fy
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PW6-metrics-service
   namespace: default
 spec:
@@ -29902,7 +29902,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v25.1.1-beta3
     dcuPV: Fy
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PW6
   namespace: default
 spec:
@@ -30343,7 +30343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: a-config
   namespace: default
 ---
@@ -30360,7 +30360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: a-metrics-service
   namespace: default
 spec:
@@ -30385,7 +30385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: a
   namespace: default
 spec:
@@ -30924,7 +30924,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: a-metrics-monitor
   namespace: default
 spec:
@@ -30946,7 +30946,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Z4N6WbZ
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-037.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -30975,7 +30975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     miGH: N7Ko
   name: A8UY-config
   namespace: default
@@ -30993,7 +30993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     miGH: N7Ko
   name: A8UY-metrics-service
   namespace: default
@@ -31019,7 +31019,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     miGH: N7Ko
   name: A8UY
   namespace: default
@@ -31463,7 +31463,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     miGH: N7Ko
   name: A8UY-metrics-monitor
   namespace: default
@@ -31487,7 +31487,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 2rbFmR
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       miGH: N7Ko
 -- testdata/case-038.yaml.golden --
 ---
@@ -31505,7 +31505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: dgtMSpw
@@ -31535,7 +31535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-config
@@ -31552,7 +31552,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-metrics-reader
@@ -31573,7 +31573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -31659,7 +31659,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -31746,7 +31746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -31770,7 +31770,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -31794,7 +31794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-election-role
@@ -31843,7 +31843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -32016,7 +32016,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -32113,7 +32113,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-rpk-bundle
@@ -32148,7 +32148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-election-role
@@ -32173,7 +32173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -32198,7 +32198,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -32223,7 +32223,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-rpk-bundle
@@ -32248,7 +32248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-metrics-service
@@ -32273,7 +32273,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -32676,7 +32676,7 @@ metadata:
     app.kubernetes.io/name: "4"
     app.kubernetes.io/version: v25.1.1-beta3
     chNK6Zz: 5Ii
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: n9s9M-config
   namespace: default
 ---
@@ -32694,7 +32694,7 @@ metadata:
     app.kubernetes.io/name: "4"
     app.kubernetes.io/version: v25.1.1-beta3
     chNK6Zz: 5Ii
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: n9s9M-metrics-service
   namespace: default
 spec:
@@ -32720,7 +32720,7 @@ metadata:
     app.kubernetes.io/name: "4"
     app.kubernetes.io/version: v25.1.1-beta3
     chNK6Zz: 5Ii
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: n9s9M
   namespace: default
 spec:
@@ -33132,7 +33132,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v25.1.1-beta3
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     o7: kFLRHJ8kS
   name: rPim
   namespace: default
@@ -33164,7 +33164,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v25.1.1-beta3
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z-config
   namespace: default
@@ -33183,7 +33183,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v25.1.1-beta3
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z-metrics-service
   namespace: default
@@ -33210,7 +33210,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v25.1.1-beta3
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z
   namespace: default
@@ -33513,7 +33513,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v25.1.1-beta3
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z-metrics-monitor
   namespace: default
@@ -33538,7 +33538,7 @@ spec:
       app.kubernetes.io/name: kam5
       app.kubernetes.io/version: v25.1.1-beta3
       c1ch6r: sk7vUnRJ
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       o7: kFLRHJ8kS
 -- testdata/case-041.yaml.golden --
 ---
@@ -33567,7 +33567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-config
   namespace: default
 ---
@@ -33583,7 +33583,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-metrics-reader
 rules:
 - nonResourceURLs:
@@ -33603,7 +33603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA
 rules:
 - apiGroups:
@@ -33688,7 +33688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-additional-controllers
 rules:
 - apiGroups:
@@ -33774,7 +33774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33797,7 +33797,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33820,7 +33820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-election-role
   namespace: default
 rules:
@@ -33868,7 +33868,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA
   namespace: default
 rules:
@@ -34040,7 +34040,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-additional-controllers
   namespace: default
 rules:
@@ -34136,7 +34136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-election-role
   namespace: default
 roleRef:
@@ -34160,7 +34160,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA
   namespace: default
 roleRef:
@@ -34184,7 +34184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-additional-controllers
   namespace: default
 roleRef:
@@ -34208,7 +34208,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-metrics-service
   namespace: default
 spec:
@@ -34232,7 +34232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA
   namespace: default
 spec:
@@ -34634,7 +34634,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dLmCJ99UDA-metrics-monitor
   namespace: default
 spec:
@@ -34657,7 +34657,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: ATIdy9
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-042.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -34685,7 +34685,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-config
@@ -34703,7 +34703,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-metrics-reader
@@ -34725,7 +34725,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -34812,7 +34812,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -34900,7 +34900,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -34925,7 +34925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -34950,7 +34950,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-election-role
@@ -35000,7 +35000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -35174,7 +35174,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -35272,7 +35272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-election-role
@@ -35298,7 +35298,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -35324,7 +35324,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -35350,7 +35350,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-metrics-service
@@ -35376,7 +35376,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -35936,7 +35936,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     vAU3IVb: K0a
     x: c
   name: I5FRf-metrics-monitor
@@ -35960,7 +35960,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: A
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       vAU3IVb: K0a
       x: c
 -- testdata/case-043.yaml.golden --
@@ -35980,7 +35980,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Kha
   namespace: default
 ---
@@ -36011,7 +36011,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3Xj6U-config
   namespace: default
 ---
@@ -36029,7 +36029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3Xj6U-metrics-service
   namespace: default
 spec:
@@ -36055,7 +36055,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3Xj6U
   namespace: default
 spec:
@@ -36536,7 +36536,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-config
   namespace: default
 ---
@@ -36554,7 +36554,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -36576,7 +36576,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu
 rules:
 - apiGroups:
@@ -36663,7 +36663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -36688,7 +36688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-election-role
   namespace: default
 rules:
@@ -36738,7 +36738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu
   namespace: default
 rules:
@@ -36912,7 +36912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-rpk-bundle
   namespace: default
 rules:
@@ -36948,7 +36948,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-election-role
   namespace: default
 roleRef:
@@ -36974,7 +36974,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu
   namespace: default
 roleRef:
@@ -37000,7 +37000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-rpk-bundle
   namespace: default
 roleRef:
@@ -37026,7 +37026,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-metrics-service
   namespace: default
 spec:
@@ -37052,7 +37052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu
   namespace: default
 spec:
@@ -37625,7 +37625,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Uu-metrics-monitor
   namespace: default
 spec:
@@ -37649,7 +37649,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 23c
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-045.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -37668,7 +37668,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v25.1.1-beta3
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     povH0tOlni: A
   name: 4X8m6P
   namespace: default
@@ -37699,7 +37699,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v25.1.1-beta3
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     povH0tOlni: A
   name: oyGLBa-config
   namespace: default
@@ -37717,7 +37717,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v25.1.1-beta3
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     povH0tOlni: A
   name: oyGLBa-metrics-service
   namespace: default
@@ -37743,7 +37743,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v25.1.1-beta3
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     povH0tOlni: A
   name: oyGLBa
   namespace: default
@@ -38251,7 +38251,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Wmx1ORHBT
   namespace: default
 ---
@@ -38282,7 +38282,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kO-config
   namespace: default
 ---
@@ -38300,7 +38300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kO-metrics-service
   namespace: default
 spec:
@@ -38326,7 +38326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: kO
   namespace: default
 spec:
@@ -38801,7 +38801,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-config
   namespace: default
 ---
@@ -38820,7 +38820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-metrics-reader
 rules:
 - nonResourceURLs:
@@ -38843,7 +38843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d
 rules:
 - apiGroups:
@@ -38931,7 +38931,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-additional-controllers
 rules:
 - apiGroups:
@@ -39020,7 +39020,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39046,7 +39046,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39072,7 +39072,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-election-role
   namespace: default
 rules:
@@ -39123,7 +39123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d
   namespace: default
 rules:
@@ -39298,7 +39298,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-additional-controllers
   namespace: default
 rules:
@@ -39397,7 +39397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-election-role
   namespace: default
 roleRef:
@@ -39424,7 +39424,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d
   namespace: default
 roleRef:
@@ -39451,7 +39451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-additional-controllers
   namespace: default
 roleRef:
@@ -39478,7 +39478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d-metrics-service
   namespace: default
 spec:
@@ -39505,7 +39505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oL1SSfzH9d
   namespace: default
 spec:
@@ -39950,7 +39950,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-config
   namespace: default
 ---
@@ -39968,7 +39968,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-metrics-reader
 rules:
 - nonResourceURLs:
@@ -39990,7 +39990,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre
 rules:
 - apiGroups:
@@ -40077,7 +40077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -40102,7 +40102,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-election-role
   namespace: default
 rules:
@@ -40152,7 +40152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre
   namespace: default
 rules:
@@ -40326,7 +40326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-rpk-bundle
   namespace: default
 rules:
@@ -40362,7 +40362,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-election-role
   namespace: default
 roleRef:
@@ -40388,7 +40388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre
   namespace: default
 roleRef:
@@ -40414,7 +40414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-rpk-bundle
   namespace: default
 roleRef:
@@ -40440,7 +40440,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre-metrics-service
   namespace: default
 spec:
@@ -40466,7 +40466,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: qVYvaMYre
   namespace: default
 spec:
@@ -40936,7 +40936,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tSPxL1Cf1HO9FjR
   namespace: default
 ---
@@ -40966,7 +40966,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-config
   namespace: default
 ---
@@ -40983,7 +40983,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-metrics-reader
 rules:
 - nonResourceURLs:
@@ -41004,7 +41004,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv
 rules:
 - apiGroups:
@@ -41090,7 +41090,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-additional-controllers
 rules:
 - apiGroups:
@@ -41177,7 +41177,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -41201,7 +41201,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -41225,7 +41225,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-election-role
   namespace: default
 rules:
@@ -41274,7 +41274,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv
   namespace: default
 rules:
@@ -41447,7 +41447,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-additional-controllers
   namespace: default
 rules:
@@ -41544,7 +41544,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-election-role
   namespace: default
 roleRef:
@@ -41569,7 +41569,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv
   namespace: default
 roleRef:
@@ -41594,7 +41594,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-additional-controllers
   namespace: default
 roleRef:
@@ -41619,7 +41619,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-metrics-service
   namespace: default
 spec:
@@ -41644,7 +41644,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv
   namespace: default
 spec:
@@ -42104,7 +42104,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v25.1.1-beta3
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RxVwZrtkv-metrics-monitor
   namespace: default
 spec:
@@ -42127,7 +42127,7 @@ spec:
       app.kubernetes.io/name: DFwU
       app.kubernetes.io/version: v25.1.1-beta3
       fuVZ: gcPCqrc0l
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 -- testdata/case-050.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
@@ -42142,7 +42142,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK
   namespace: default
 ---
@@ -42170,7 +42170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-config
   namespace: default
 ---
@@ -42185,7 +42185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-metrics-reader
 rules:
 - nonResourceURLs:
@@ -42204,7 +42204,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK
 rules:
 - apiGroups:
@@ -42409,7 +42409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -42431,7 +42431,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-election-role
   namespace: default
 rules:
@@ -42478,7 +42478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK
   namespace: default
 rules:
@@ -42504,7 +42504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-rpk-bundle
   namespace: default
 rules:
@@ -42537,7 +42537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-election-role
   namespace: default
 roleRef:
@@ -42560,7 +42560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK
   namespace: default
 roleRef:
@@ -42583,7 +42583,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-rpk-bundle
   namespace: default
 roleRef:
@@ -42606,7 +42606,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-metrics-service
   namespace: default
 spec:
@@ -42629,7 +42629,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 6iZG-webhook-service
   namespace: default
 spec:
@@ -42651,7 +42651,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK
   namespace: default
 spec:
@@ -42776,7 +42776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -42801,7 +42801,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: RAyK-selfsigned-issuer
   namespace: default
 spec:
@@ -42884,7 +42884,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W
   namespace: default
 ---
@@ -42912,7 +42912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-config
   namespace: default
 ---
@@ -42927,7 +42927,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-metrics-reader
 rules:
 - nonResourceURLs:
@@ -42946,7 +42946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W
 rules:
 - apiGroups:
@@ -43151,7 +43151,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -43173,7 +43173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-election-role
   namespace: default
 rules:
@@ -43220,7 +43220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W
   namespace: default
 rules:
@@ -43246,7 +43246,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-rpk-bundle
   namespace: default
 rules:
@@ -43279,7 +43279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-election-role
   namespace: default
 roleRef:
@@ -43302,7 +43302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W
   namespace: default
 roleRef:
@@ -43325,7 +43325,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-rpk-bundle
   namespace: default
 roleRef:
@@ -43348,7 +43348,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-metrics-service
   namespace: default
 spec:
@@ -43371,7 +43371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: hsmvzpSm-webhook-service
   namespace: default
 spec:
@@ -43393,7 +43393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W
   namespace: default
 spec:
@@ -43533,7 +43533,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -43558,7 +43558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: tyx5W-selfsigned-issuer
   namespace: default
 spec:
@@ -43641,7 +43641,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fEL2
   namespace: default
 ---
@@ -43669,7 +43669,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-config
   namespace: default
 ---
@@ -43684,7 +43684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-metrics-reader
 rules:
 - nonResourceURLs:
@@ -43703,7 +43703,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS
 rules:
 - apiGroups:
@@ -43908,7 +43908,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -43930,7 +43930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-election-role
   namespace: default
 rules:
@@ -43977,7 +43977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS
   namespace: default
 rules:
@@ -44003,7 +44003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-rpk-bundle
   namespace: default
 rules:
@@ -44036,7 +44036,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-election-role
   namespace: default
 roleRef:
@@ -44059,7 +44059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS
   namespace: default
 roleRef:
@@ -44082,7 +44082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-rpk-bundle
   namespace: default
 roleRef:
@@ -44105,7 +44105,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-metrics-service
   namespace: default
 spec:
@@ -44128,7 +44128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: njC0cLDExDA-webhook-service
   namespace: default
 spec:
@@ -44150,7 +44150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS
   namespace: default
 spec:
@@ -44290,7 +44290,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -44315,7 +44315,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 89IgS-selfsigned-issuer
   namespace: default
 spec:
@@ -44398,7 +44398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0
   namespace: default
 ---
@@ -44428,7 +44428,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-config
   namespace: default
 ---
@@ -44445,7 +44445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-metrics-reader
 rules:
 - nonResourceURLs:
@@ -44466,7 +44466,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0
 rules:
 - apiGroups:
@@ -44673,7 +44673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -44697,7 +44697,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-election-role
   namespace: default
 rules:
@@ -44746,7 +44746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0
   namespace: default
 rules:
@@ -44774,7 +44774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-rpk-bundle
   namespace: default
 rules:
@@ -44809,7 +44809,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-election-role
   namespace: default
 roleRef:
@@ -44834,7 +44834,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0
   namespace: default
 roleRef:
@@ -44859,7 +44859,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-rpk-bundle
   namespace: default
 roleRef:
@@ -44884,7 +44884,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-metrics-service
   namespace: default
 spec:
@@ -44909,7 +44909,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Re-webhook-service
   namespace: default
 spec:
@@ -44933,7 +44933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0
   namespace: default
 spec:
@@ -45058,7 +45058,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -45085,7 +45085,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fRjXK1u0-selfsigned-issuer
   namespace: default
 spec:
@@ -45170,7 +45170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS
   namespace: default
 ---
@@ -45201,7 +45201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-config
   namespace: default
 ---
@@ -45219,7 +45219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-metrics-reader
 rules:
 - nonResourceURLs:
@@ -45241,7 +45241,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS
 rules:
 - apiGroups:
@@ -45449,7 +45449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45474,7 +45474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-election-role
   namespace: default
 rules:
@@ -45524,7 +45524,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS
   namespace: default
 rules:
@@ -45553,7 +45553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-rpk-bundle
   namespace: default
 rules:
@@ -45589,7 +45589,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-election-role
   namespace: default
 roleRef:
@@ -45615,7 +45615,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS
   namespace: default
 roleRef:
@@ -45641,7 +45641,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-rpk-bundle
   namespace: default
 roleRef:
@@ -45667,7 +45667,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-metrics-service
   namespace: default
 spec:
@@ -45693,7 +45693,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: eMNuQ-webhook-service
   namespace: default
 spec:
@@ -45718,7 +45718,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS
   namespace: default
 spec:
@@ -45852,7 +45852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -45880,7 +45880,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2jUS-selfsigned-issuer
   namespace: default
 spec:
@@ -45963,7 +45963,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -45992,7 +45992,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-config
   namespace: default
@@ -46008,7 +46008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-metrics-reader
 rules:
@@ -46028,7 +46028,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM
 rules:
@@ -46234,7 +46234,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM
 roleRef:
@@ -46257,7 +46257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-election-role
   namespace: default
@@ -46305,7 +46305,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -46332,7 +46332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-rpk-bundle
   namespace: default
@@ -46366,7 +46366,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-election-role
   namespace: default
@@ -46390,7 +46390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -46414,7 +46414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-rpk-bundle
   namespace: default
@@ -46438,7 +46438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-metrics-service
   namespace: default
@@ -46462,7 +46462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: hJkIJY5Y-webhook-service
   namespace: default
@@ -46485,7 +46485,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -46611,7 +46611,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: redpanda-serving-cert
   namespace: default
@@ -46637,7 +46637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     kP0Mu: tnINl
   name: WM-selfsigned-issuer
   namespace: default
@@ -46721,7 +46721,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-X2us
   namespace: default
 ---
@@ -46750,7 +46750,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-X2us-config
   namespace: default
 ---
@@ -46766,7 +46766,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-X2us-metrics-service
   namespace: default
 spec:
@@ -46790,7 +46790,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X2us-webhook-service
   namespace: default
 spec:
@@ -46813,7 +46813,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-X2us
   namespace: default
 spec:
@@ -46998,7 +46998,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -47024,7 +47024,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-X2us-selfsigned-issuer
   namespace: default
 spec:
@@ -47108,7 +47108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: n0qMA4h57I5
   namespace: default
@@ -47140,7 +47140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: pEvEye-config
   namespace: default
@@ -47159,7 +47159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: pEvEye-metrics-service
   namespace: default
@@ -47186,7 +47186,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: BdJ-webhook-service
   namespace: default
@@ -47212,7 +47212,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: pEvEye
   namespace: default
@@ -47405,7 +47405,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: redpanda-serving-cert
   namespace: default
@@ -47434,7 +47434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: pEvEye-selfsigned-issuer
   namespace: default
@@ -47487,7 +47487,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jE0q9M4zk: 1A
   name: pEvEye-metrics-monitor
   namespace: default
@@ -47511,7 +47511,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: BdJ
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       jE0q9M4zk: 1A
 ---
 # Source: operator/templates/entry-point.yaml
@@ -47559,7 +47559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2PyZZ8ZNsM
   namespace: default
 ---
@@ -47587,7 +47587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-config
   namespace: default
 ---
@@ -47602,7 +47602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-metrics-reader
 rules:
 - nonResourceURLs:
@@ -47621,7 +47621,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC
 rules:
 - apiGroups:
@@ -47826,7 +47826,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -47848,7 +47848,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-election-role
   namespace: default
 rules:
@@ -47895,7 +47895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC
   namespace: default
 rules:
@@ -47921,7 +47921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-rpk-bundle
   namespace: default
 rules:
@@ -47954,7 +47954,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-election-role
   namespace: default
 roleRef:
@@ -47977,7 +47977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC
   namespace: default
 roleRef:
@@ -48000,7 +48000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-rpk-bundle
   namespace: default
 roleRef:
@@ -48023,7 +48023,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-metrics-service
   namespace: default
 spec:
@@ -48046,7 +48046,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: fgsJm-webhook-service
   namespace: default
 spec:
@@ -48068,7 +48068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC
   namespace: default
 spec:
@@ -48225,7 +48225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -48250,7 +48250,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nLM2irjC-selfsigned-issuer
   namespace: default
 spec:
@@ -48335,7 +48335,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PiQzKZrHGl
   namespace: default
 ---
@@ -48363,7 +48363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-config
   namespace: default
 ---
@@ -48378,7 +48378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-metrics-reader
 rules:
 - nonResourceURLs:
@@ -48397,7 +48397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX
 rules:
 - apiGroups:
@@ -48602,7 +48602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48624,7 +48624,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-election-role
   namespace: default
 rules:
@@ -48671,7 +48671,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX
   namespace: default
 rules:
@@ -48697,7 +48697,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-rpk-bundle
   namespace: default
 rules:
@@ -48730,7 +48730,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-election-role
   namespace: default
 roleRef:
@@ -48753,7 +48753,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX
   namespace: default
 roleRef:
@@ -48776,7 +48776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-rpk-bundle
   namespace: default
 roleRef:
@@ -48799,7 +48799,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-metrics-service
   namespace: default
 spec:
@@ -48822,7 +48822,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: zUC-webhook-service
   namespace: default
 spec:
@@ -48844,7 +48844,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX
   namespace: default
 spec:
@@ -48966,7 +48966,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -48991,7 +48991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-selfsigned-issuer
   namespace: default
 spec:
@@ -49040,7 +49040,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: X374QF3AYX-metrics-monitor
   namespace: default
 spec:
@@ -49062,7 +49062,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: zUC
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -49110,7 +49110,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Fzbi9OkP
   namespace: default
 ---
@@ -49141,7 +49141,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-config
   namespace: default
 ---
@@ -49159,7 +49159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-metrics-reader
 rules:
 - nonResourceURLs:
@@ -49181,7 +49181,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G
 rules:
 - apiGroups:
@@ -49389,7 +49389,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49414,7 +49414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-election-role
   namespace: default
 rules:
@@ -49464,7 +49464,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G
   namespace: default
 rules:
@@ -49493,7 +49493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-rpk-bundle
   namespace: default
 rules:
@@ -49529,7 +49529,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-election-role
   namespace: default
 roleRef:
@@ -49555,7 +49555,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G
   namespace: default
 roleRef:
@@ -49581,7 +49581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-rpk-bundle
   namespace: default
 roleRef:
@@ -49607,7 +49607,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-metrics-service
   namespace: default
 spec:
@@ -49633,7 +49633,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8V1wVzO-webhook-service
   namespace: default
 spec:
@@ -49658,7 +49658,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G
   namespace: default
 spec:
@@ -49961,7 +49961,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -49989,7 +49989,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: G-selfsigned-issuer
   namespace: default
 spec:
@@ -50074,7 +50074,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: Z20j25RfqSp
   namespace: default
@@ -50104,7 +50104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-config
   namespace: default
@@ -50121,7 +50121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-metrics-reader
 rules:
@@ -50142,7 +50142,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA
 rules:
@@ -50349,7 +50349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA
 roleRef:
@@ -50373,7 +50373,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-election-role
   namespace: default
@@ -50422,7 +50422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA
   namespace: default
@@ -50450,7 +50450,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-rpk-bundle
   namespace: default
@@ -50485,7 +50485,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-election-role
   namespace: default
@@ -50510,7 +50510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA
   namespace: default
@@ -50535,7 +50535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-rpk-bundle
   namespace: default
@@ -50560,7 +50560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-metrics-service
   namespace: default
@@ -50585,7 +50585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: JhtIXu-webhook-service
   namespace: default
@@ -50609,7 +50609,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA
   namespace: default
@@ -50738,7 +50738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: redpanda-serving-cert
   namespace: default
@@ -50765,7 +50765,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-selfsigned-issuer
   namespace: default
@@ -50816,7 +50816,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jcF: qXntI
   name: tDaA-metrics-monitor
   namespace: default
@@ -50840,7 +50840,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: JhtIXu
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       jcF: qXntI
 ---
 # Source: operator/templates/entry-point.yaml
@@ -50889,7 +50889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -50920,7 +50920,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-config
@@ -50938,7 +50938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-metrics-reader
@@ -50960,7 +50960,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -51168,7 +51168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -51193,7 +51193,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-election-role
@@ -51243,7 +51243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -51272,7 +51272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-rpk-bundle
@@ -51308,7 +51308,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-election-role
@@ -51334,7 +51334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -51360,7 +51360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-rpk-bundle
@@ -51386,7 +51386,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-metrics-service
@@ -51412,7 +51412,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: ZRaS-webhook-service
@@ -51437,7 +51437,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -51750,7 +51750,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: redpanda-serving-cert
@@ -51778,7 +51778,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-selfsigned-issuer
@@ -51877,7 +51877,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-config
   namespace: default
@@ -51895,7 +51895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-metrics-reader
 rules:
@@ -51917,7 +51917,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5
 rules:
@@ -52125,7 +52125,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5
 roleRef:
@@ -52150,7 +52150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-election-role
   namespace: default
@@ -52200,7 +52200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5
   namespace: default
@@ -52229,7 +52229,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-rpk-bundle
   namespace: default
@@ -52265,7 +52265,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-election-role
   namespace: default
@@ -52291,7 +52291,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5
   namespace: default
@@ -52317,7 +52317,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-rpk-bundle
   namespace: default
@@ -52343,7 +52343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-metrics-service
   namespace: default
@@ -52369,7 +52369,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: ibdE3-webhook-service
   namespace: default
@@ -52394,7 +52394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5
   namespace: default
@@ -52658,7 +52658,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: redpanda-serving-cert
   namespace: default
@@ -52686,7 +52686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     wig: gAae
   name: 41nucs5-selfsigned-issuer
   namespace: default
@@ -52772,7 +52772,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Ev1EfK
   namespace: default
 ---
@@ -52803,7 +52803,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-config
   namespace: default
 ---
@@ -52821,7 +52821,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -52843,7 +52843,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu
 rules:
 - apiGroups:
@@ -53051,7 +53051,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53076,7 +53076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-election-role
   namespace: default
 rules:
@@ -53126,7 +53126,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu
   namespace: default
 rules:
@@ -53155,7 +53155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-rpk-bundle
   namespace: default
 rules:
@@ -53191,7 +53191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-election-role
   namespace: default
 roleRef:
@@ -53217,7 +53217,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu
   namespace: default
 roleRef:
@@ -53243,7 +53243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-rpk-bundle
   namespace: default
 roleRef:
@@ -53269,7 +53269,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-metrics-service
   namespace: default
 spec:
@@ -53295,7 +53295,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Kcp-webhook-service
   namespace: default
 spec:
@@ -53320,7 +53320,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu
   namespace: default
 spec:
@@ -53519,7 +53519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -53547,7 +53547,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: xtpIQu-selfsigned-issuer
   namespace: default
 spec:
@@ -53643,7 +53643,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     yhRLU: bn88A
   name: CbM6ZNJQ-config
   namespace: default
@@ -53660,7 +53660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     yhRLU: bn88A
   name: CbM6ZNJQ-metrics-service
   namespace: default
@@ -53685,7 +53685,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     yhRLU: bn88A
   name: 78-webhook-service
   namespace: default
@@ -53709,7 +53709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     yhRLU: bn88A
   name: CbM6ZNJQ
   namespace: default
@@ -54046,7 +54046,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     yhRLU: bn88A
   name: redpanda-serving-cert
   namespace: default
@@ -54073,7 +54073,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     yhRLU: bn88A
   name: CbM6ZNJQ-selfsigned-issuer
   namespace: default
@@ -54158,7 +54158,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 4s
   namespace: default
 ---
@@ -54187,7 +54187,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oWZxG4ft6-config
   namespace: default
 ---
@@ -54203,7 +54203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oWZxG4ft6-metrics-service
   namespace: default
 spec:
@@ -54227,7 +54227,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 19ztDQ-webhook-service
   namespace: default
 spec:
@@ -54250,7 +54250,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oWZxG4ft6
   namespace: default
 spec:
@@ -54508,7 +54508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -54534,7 +54534,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: oWZxG4ft6-selfsigned-issuer
   namespace: default
 spec:
@@ -54630,7 +54630,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-config
   namespace: default
 ---
@@ -54646,7 +54646,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-metrics-reader
 rules:
 - nonResourceURLs:
@@ -54666,7 +54666,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN
 rules:
 - apiGroups:
@@ -54872,7 +54872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -54895,7 +54895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-election-role
   namespace: default
 rules:
@@ -54943,7 +54943,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN
   namespace: default
 rules:
@@ -54970,7 +54970,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-rpk-bundle
   namespace: default
 rules:
@@ -55004,7 +55004,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-election-role
   namespace: default
 roleRef:
@@ -55028,7 +55028,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN
   namespace: default
 roleRef:
@@ -55052,7 +55052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-rpk-bundle
   namespace: default
 roleRef:
@@ -55076,7 +55076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-metrics-service
   namespace: default
 spec:
@@ -55100,7 +55100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: axjCvWi-webhook-service
   namespace: default
 spec:
@@ -55123,7 +55123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN
   namespace: default
 spec:
@@ -55509,7 +55509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -55535,7 +55535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: PxBN-selfsigned-issuer
   namespace: default
 spec:
@@ -55633,7 +55633,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: CFnO9s-config
   namespace: default
 ---
@@ -55651,7 +55651,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: CFnO9s-metrics-service
   namespace: default
 spec:
@@ -55677,7 +55677,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: bNOJ-webhook-service
   namespace: default
 spec:
@@ -55702,7 +55702,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: CFnO9s
   namespace: default
 spec:
@@ -56125,7 +56125,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -56153,7 +56153,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: CFnO9s-selfsigned-issuer
   namespace: default
 spec:
@@ -56205,7 +56205,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v25.1.1-beta3
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: CFnO9s-metrics-monitor
   namespace: default
 spec:
@@ -56228,7 +56228,7 @@ spec:
       app.kubernetes.io/name: bNOJ
       app.kubernetes.io/version: v25.1.1-beta3
       fYyBJj2Al: 00TYG
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -56278,7 +56278,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 9q
   namespace: default
 ---
@@ -56310,7 +56310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: zLyH-config
   namespace: default
 ---
@@ -56329,7 +56329,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: zLyH-metrics-service
   namespace: default
 spec:
@@ -56356,7 +56356,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: N-webhook-service
   namespace: default
 spec:
@@ -56382,7 +56382,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: zLyH
   namespace: default
 spec:
@@ -56684,7 +56684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -56713,7 +56713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: zLyH-selfsigned-issuer
   namespace: default
 spec:
@@ -56809,7 +56809,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-config
   namespace: default
 ---
@@ -56825,7 +56825,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-metrics-reader
 rules:
 - nonResourceURLs:
@@ -56845,7 +56845,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ
 rules:
 - apiGroups:
@@ -57051,7 +57051,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57074,7 +57074,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-election-role
   namespace: default
 rules:
@@ -57122,7 +57122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ
   namespace: default
 rules:
@@ -57149,7 +57149,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-rpk-bundle
   namespace: default
 rules:
@@ -57183,7 +57183,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-election-role
   namespace: default
 roleRef:
@@ -57207,7 +57207,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ
   namespace: default
 roleRef:
@@ -57231,7 +57231,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-rpk-bundle
   namespace: default
 roleRef:
@@ -57255,7 +57255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-metrics-service
   namespace: default
 spec:
@@ -57279,7 +57279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nUS-webhook-service
   namespace: default
 spec:
@@ -57302,7 +57302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ
   namespace: default
 spec:
@@ -57880,7 +57880,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -57906,7 +57906,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-selfsigned-issuer
   namespace: default
 spec:
@@ -57956,7 +57956,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: m7Z5VmKktJ-metrics-monitor
   namespace: default
 spec:
@@ -57979,7 +57979,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: nUS
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -58043,7 +58043,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-config
   namespace: default
 ---
@@ -58063,7 +58063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-metrics-reader
 rules:
 - nonResourceURLs:
@@ -58087,7 +58087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT
 rules:
 - apiGroups:
@@ -58297,7 +58297,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58324,7 +58324,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-election-role
   namespace: default
 rules:
@@ -58376,7 +58376,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT
   namespace: default
 rules:
@@ -58407,7 +58407,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-election-role
   namespace: default
 roleRef:
@@ -58435,7 +58435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT
   namespace: default
 roleRef:
@@ -58463,7 +58463,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-metrics-service
   namespace: default
 spec:
@@ -58491,7 +58491,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Eg0Oz-webhook-service
   namespace: default
 spec:
@@ -58518,7 +58518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT
   namespace: default
 spec:
@@ -58977,7 +58977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -59007,7 +59007,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-selfsigned-issuer
   namespace: default
 spec:
@@ -59061,7 +59061,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OyOZvn5WT-metrics-monitor
   namespace: default
 spec:
@@ -59086,7 +59086,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Eg0Oz
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -59148,7 +59148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v0: 1iClRDvVO3c
   name: 5GoUVR7T-config
   namespace: default
@@ -59167,7 +59167,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v0: 1iClRDvVO3c
   name: 5GoUVR7T-metrics-service
   namespace: default
@@ -59194,7 +59194,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v0: 1iClRDvVO3c
   name: 8I1Iyd-webhook-service
   namespace: default
@@ -59220,7 +59220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v0: 1iClRDvVO3c
   name: 5GoUVR7T
   namespace: default
@@ -59737,7 +59737,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v0: 1iClRDvVO3c
   name: redpanda-serving-cert
   namespace: default
@@ -59766,7 +59766,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v0: 1iClRDvVO3c
   name: 5GoUVR7T-selfsigned-issuer
   namespace: default
@@ -59854,7 +59854,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: r8KRW4
   namespace: default
 ---
@@ -59887,7 +59887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: IsP97jKm-config
   namespace: default
 ---
@@ -59907,7 +59907,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: IsP97jKm-metrics-service
   namespace: default
 spec:
@@ -59935,7 +59935,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Pt-webhook-service
   namespace: default
 spec:
@@ -59962,7 +59962,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: IsP97jKm
   namespace: default
 spec:
@@ -60457,7 +60457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -60487,7 +60487,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: IsP97jKm-selfsigned-issuer
   namespace: default
 spec:
@@ -60541,7 +60541,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: IsP97jKm-metrics-monitor
   namespace: default
 spec:
@@ -60565,7 +60565,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Pt
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -60625,7 +60625,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dHTgQf-config
   namespace: default
 ---
@@ -60641,7 +60641,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dHTgQf-metrics-service
   namespace: default
 spec:
@@ -60665,7 +60665,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 4MPmeCPMB-webhook-service
   namespace: default
 spec:
@@ -60688,7 +60688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dHTgQf
   namespace: default
 spec:
@@ -61193,7 +61193,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -61219,7 +61219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: dHTgQf-selfsigned-issuer
   namespace: default
 spec:
@@ -61304,7 +61304,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "567"
   namespace: default
 ---
@@ -61333,7 +61333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-config
   namespace: default
 ---
@@ -61349,7 +61349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-metrics-reader
 rules:
 - nonResourceURLs:
@@ -61369,7 +61369,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO
 rules:
 - apiGroups:
@@ -61575,7 +61575,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -61598,7 +61598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-election-role
   namespace: default
 rules:
@@ -61646,7 +61646,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO
   namespace: default
 rules:
@@ -61673,7 +61673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-rpk-bundle
   namespace: default
 rules:
@@ -61707,7 +61707,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-election-role
   namespace: default
 roleRef:
@@ -61731,7 +61731,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO
   namespace: default
 roleRef:
@@ -61755,7 +61755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-rpk-bundle
   namespace: default
 roleRef:
@@ -61779,7 +61779,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-metrics-service
   namespace: default
 spec:
@@ -61803,7 +61803,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8ZgI1VH-webhook-service
   namespace: default
 spec:
@@ -61826,7 +61826,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO
   namespace: default
 spec:
@@ -62252,7 +62252,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -62278,7 +62278,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Hjo9sbxO-selfsigned-issuer
   namespace: default
 spec:
@@ -62375,7 +62375,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-config
@@ -62394,7 +62394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-metrics-reader
@@ -62417,7 +62417,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -62626,7 +62626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -62652,7 +62652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-election-role
@@ -62703,7 +62703,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -62733,7 +62733,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-election-role
@@ -62760,7 +62760,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -62787,7 +62787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-metrics-service
@@ -62814,7 +62814,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: an-webhook-service
@@ -62840,7 +62840,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -63478,7 +63478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: redpanda-serving-cert
@@ -63507,7 +63507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-selfsigned-issuer
@@ -63594,7 +63594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: gFdSAMIO
   namespace: default
@@ -63625,7 +63625,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO-config
   namespace: default
@@ -63643,7 +63643,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO-metrics-reader
 rules:
@@ -63665,7 +63665,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO
 rules:
@@ -63873,7 +63873,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO
 roleRef:
@@ -63898,7 +63898,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO-election-role
   namespace: default
@@ -63948,7 +63948,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO
   namespace: default
@@ -63977,7 +63977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO-election-role
   namespace: default
@@ -64003,7 +64003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO
   namespace: default
@@ -64029,7 +64029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO-metrics-service
   namespace: default
@@ -64055,7 +64055,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: MxF-webhook-service
   namespace: default
@@ -64080,7 +64080,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO
   namespace: default
@@ -64583,7 +64583,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: redpanda-serving-cert
   namespace: default
@@ -64611,7 +64611,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     mNkAknTCpbj0: NCMcS
   name: RQkbO-selfsigned-issuer
   namespace: default
@@ -64698,7 +64698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: K
   namespace: default
 ---
@@ -64728,7 +64728,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-config
   namespace: default
 ---
@@ -64745,7 +64745,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-metrics-reader
 rules:
 - nonResourceURLs:
@@ -64766,7 +64766,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97
 rules:
 - apiGroups:
@@ -64973,7 +64973,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -64997,7 +64997,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-election-role
   namespace: default
 rules:
@@ -65046,7 +65046,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97
   namespace: default
 rules:
@@ -65074,7 +65074,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-rpk-bundle
   namespace: default
 rules:
@@ -65109,7 +65109,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-election-role
   namespace: default
 roleRef:
@@ -65134,7 +65134,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97
   namespace: default
 roleRef:
@@ -65159,7 +65159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-rpk-bundle
   namespace: default
 roleRef:
@@ -65184,7 +65184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-metrics-service
   namespace: default
 spec:
@@ -65209,7 +65209,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: vYy9-webhook-service
   namespace: default
 spec:
@@ -65233,7 +65233,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97
   namespace: default
 spec:
@@ -65720,7 +65720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -65747,7 +65747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 2rNNJQv8k5j97-selfsigned-issuer
   namespace: default
 spec:
@@ -65833,7 +65833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: meK
   namespace: default
 ---
@@ -65861,7 +65861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QClq-config
   namespace: default
 ---
@@ -65876,7 +65876,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QClq-metrics-service
   namespace: default
 spec:
@@ -65899,7 +65899,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: lbhx-webhook-service
   namespace: default
 spec:
@@ -65921,7 +65921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QClq
   namespace: default
 spec:
@@ -66425,7 +66425,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -66450,7 +66450,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QClq-selfsigned-issuer
   namespace: default
 spec:
@@ -66499,7 +66499,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QClq-metrics-monitor
   namespace: default
 spec:
@@ -66521,7 +66521,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: lbhx
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -66571,7 +66571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: Wx
   namespace: default
@@ -66604,7 +66604,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-config
   namespace: default
@@ -66624,7 +66624,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-metrics-reader
 rules:
@@ -66648,7 +66648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP
 rules:
@@ -66858,7 +66858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP
 roleRef:
@@ -66885,7 +66885,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-election-role
   namespace: default
@@ -66937,7 +66937,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP
   namespace: default
@@ -66968,7 +66968,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-election-role
   namespace: default
@@ -66996,7 +66996,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP
   namespace: default
@@ -67024,7 +67024,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-metrics-service
   namespace: default
@@ -67052,7 +67052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: ovez-webhook-service
   namespace: default
@@ -67079,7 +67079,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP
   namespace: default
@@ -67521,7 +67521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: redpanda-serving-cert
   namespace: default
@@ -67551,7 +67551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-selfsigned-issuer
   namespace: default
@@ -67605,7 +67605,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zWv: hIfkuex2B
   name: xxjYziP-metrics-monitor
   namespace: default
@@ -67630,7 +67630,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: ovez
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       zWv: hIfkuex2B
 ---
 # Source: operator/templates/entry-point.yaml
@@ -67678,7 +67678,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 7ZTjb
   namespace: default
 ---
@@ -67709,7 +67709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-config
   namespace: default
 ---
@@ -67727,7 +67727,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-metrics-reader
 rules:
 - nonResourceURLs:
@@ -67749,7 +67749,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk
 rules:
 - apiGroups:
@@ -67957,7 +67957,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -67982,7 +67982,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-election-role
   namespace: default
 rules:
@@ -68032,7 +68032,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk
   namespace: default
 rules:
@@ -68061,7 +68061,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-election-role
   namespace: default
 roleRef:
@@ -68087,7 +68087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk
   namespace: default
 roleRef:
@@ -68113,7 +68113,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-metrics-service
   namespace: default
 spec:
@@ -68139,7 +68139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: zsU8D-webhook-service
   namespace: default
 spec:
@@ -68164,7 +68164,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk
   namespace: default
 spec:
@@ -68689,7 +68689,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -68717,7 +68717,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-selfsigned-issuer
   namespace: default
 spec:
@@ -68769,7 +68769,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: OZHCbAk-metrics-monitor
   namespace: default
 spec:
@@ -68791,7 +68791,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: zsU8D
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -68851,7 +68851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v: pV
   name: JvUUYZNAn-config
   namespace: default
@@ -68868,7 +68868,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v: pV
   name: JvUUYZNAn-metrics-service
   namespace: default
@@ -68893,7 +68893,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v: pV
   name: operator-webhook-service
   namespace: default
@@ -68917,7 +68917,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v: pV
   name: JvUUYZNAn
   namespace: default
@@ -69259,7 +69259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v: pV
   name: redpanda-serving-cert
   namespace: default
@@ -69286,7 +69286,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     v: pV
   name: JvUUYZNAn-selfsigned-issuer
   namespace: default
@@ -69384,7 +69384,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9-config
   namespace: default
 ---
@@ -69401,7 +69401,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9-metrics-reader
 rules:
 - nonResourceURLs:
@@ -69422,7 +69422,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9
 rules:
 - apiGroups:
@@ -69629,7 +69629,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -69653,7 +69653,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9-election-role
   namespace: default
 rules:
@@ -69702,7 +69702,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9
   namespace: default
 rules:
@@ -69730,7 +69730,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9-election-role
   namespace: default
 roleRef:
@@ -69755,7 +69755,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9
   namespace: default
 roleRef:
@@ -69780,7 +69780,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9-metrics-service
   namespace: default
 spec:
@@ -69805,7 +69805,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: AD-webhook-service
   namespace: default
 spec:
@@ -69829,7 +69829,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9
   namespace: default
 spec:
@@ -70378,7 +70378,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -70405,7 +70405,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v25.1.1-beta3
     dRuotY: sUV
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: twuYH9-selfsigned-issuer
   namespace: default
 spec:
@@ -70492,7 +70492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: g
   namespace: default
 ---
@@ -70521,7 +70521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-config
   namespace: default
 ---
@@ -70537,7 +70537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-metrics-reader
 rules:
 - nonResourceURLs:
@@ -70557,7 +70557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn
 rules:
 - apiGroups:
@@ -70763,7 +70763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -70786,7 +70786,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-election-role
   namespace: default
 rules:
@@ -70834,7 +70834,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn
   namespace: default
 rules:
@@ -70861,7 +70861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-rpk-bundle
   namespace: default
 rules:
@@ -70895,7 +70895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-election-role
   namespace: default
 roleRef:
@@ -70919,7 +70919,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn
   namespace: default
 roleRef:
@@ -70943,7 +70943,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-rpk-bundle
   namespace: default
 roleRef:
@@ -70967,7 +70967,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-metrics-service
   namespace: default
 spec:
@@ -70991,7 +70991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: MOjCBp-webhook-service
   namespace: default
 spec:
@@ -71014,7 +71014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn
   namespace: default
 spec:
@@ -71515,7 +71515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -71541,7 +71541,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-selfsigned-issuer
   namespace: default
 spec:
@@ -71591,7 +71591,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Sb2hWn-metrics-monitor
   namespace: default
 spec:
@@ -71614,7 +71614,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: MOjCBp
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -71674,7 +71674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-config
   namespace: default
 ---
@@ -71690,7 +71690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-metrics-reader
 rules:
 - nonResourceURLs:
@@ -71710,7 +71710,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B
 rules:
 - apiGroups:
@@ -71916,7 +71916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -71939,7 +71939,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-election-role
   namespace: default
 rules:
@@ -71987,7 +71987,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B
   namespace: default
 rules:
@@ -72014,7 +72014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-election-role
   namespace: default
 roleRef:
@@ -72038,7 +72038,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B
   namespace: default
 roleRef:
@@ -72062,7 +72062,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-metrics-service
   namespace: default
 spec:
@@ -72086,7 +72086,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: B-webhook-service
   namespace: default
 spec:
@@ -72109,7 +72109,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B
   namespace: default
 spec:
@@ -72603,7 +72603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -72629,7 +72629,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-selfsigned-issuer
   namespace: default
 spec:
@@ -72679,7 +72679,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-B-metrics-monitor
   namespace: default
 spec:
@@ -72701,7 +72701,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: B
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -72750,7 +72750,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: S
   namespace: default
 ---
@@ -72778,7 +72778,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QSmzerg-config
   namespace: default
 ---
@@ -72793,7 +72793,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QSmzerg-metrics-service
   namespace: default
 spec:
@@ -72816,7 +72816,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3SyCJ-webhook-service
   namespace: default
 spec:
@@ -72838,7 +72838,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QSmzerg
   namespace: default
 spec:
@@ -73219,7 +73219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -73244,7 +73244,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QSmzerg-selfsigned-issuer
   namespace: default
 spec:
@@ -73293,7 +73293,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: QSmzerg-metrics-monitor
   namespace: default
 spec:
@@ -73315,7 +73315,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 3SyCJ
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -73375,7 +73375,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-config
@@ -73393,7 +73393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-metrics-reader
@@ -73415,7 +73415,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -73623,7 +73623,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -73648,7 +73648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-election-role
@@ -73698,7 +73698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -73727,7 +73727,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-rpk-bundle
@@ -73763,7 +73763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-election-role
@@ -73789,7 +73789,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -73815,7 +73815,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-rpk-bundle
@@ -73841,7 +73841,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-metrics-service
@@ -73867,7 +73867,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: o2-webhook-service
@@ -73892,7 +73892,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -74309,7 +74309,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: redpanda-serving-cert
@@ -74337,7 +74337,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-selfsigned-issuer
@@ -74438,7 +74438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-config
   namespace: default
@@ -74458,7 +74458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-metrics-reader
 rules:
@@ -74482,7 +74482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
 rules:
@@ -74692,7 +74692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
 roleRef:
@@ -74719,7 +74719,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-election-role
   namespace: default
@@ -74771,7 +74771,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
   namespace: default
@@ -74802,7 +74802,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-election-role
   namespace: default
@@ -74830,7 +74830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
   namespace: default
@@ -74858,7 +74858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-metrics-service
   namespace: default
@@ -74886,7 +74886,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: WqmcFb-webhook-service
   namespace: default
@@ -74913,7 +74913,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
   namespace: default
@@ -75507,7 +75507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: redpanda-serving-cert
   namespace: default
@@ -75537,7 +75537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-selfsigned-issuer
   namespace: default
@@ -75591,7 +75591,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-metrics-monitor
   namespace: default
@@ -75615,7 +75615,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: WqmcFb
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       jHlVD3i0I: Hfqg8dMgdc
 ---
 # Source: operator/templates/entry-point.yaml
@@ -75664,7 +75664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: TxdHR
   namespace: default
 ---
@@ -75692,7 +75692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8WTbb-config
   namespace: default
 ---
@@ -75707,7 +75707,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8WTbb-metrics-service
   namespace: default
 spec:
@@ -75730,7 +75730,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: yHixING-webhook-service
   namespace: default
 spec:
@@ -75752,7 +75752,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8WTbb
   namespace: default
 spec:
@@ -76221,7 +76221,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -76246,7 +76246,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8WTbb-selfsigned-issuer
   namespace: default
 spec:
@@ -76295,7 +76295,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 8WTbb-metrics-monitor
   namespace: default
 spec:
@@ -76317,7 +76317,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: yHixING
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -76367,7 +76367,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: drBf
   namespace: default
@@ -76398,7 +76398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-config
   namespace: default
@@ -76416,7 +76416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-metrics-reader
 rules:
@@ -76438,7 +76438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo
 rules:
@@ -76646,7 +76646,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo
 roleRef:
@@ -76671,7 +76671,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-election-role
   namespace: default
@@ -76721,7 +76721,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo
   namespace: default
@@ -76750,7 +76750,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-rpk-bundle
   namespace: default
@@ -76786,7 +76786,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-election-role
   namespace: default
@@ -76812,7 +76812,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo
   namespace: default
@@ -76838,7 +76838,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-rpk-bundle
   namespace: default
@@ -76864,7 +76864,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-metrics-service
   namespace: default
@@ -76890,7 +76890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: L07-webhook-service
   namespace: default
@@ -76915,7 +76915,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo
   namespace: default
@@ -77351,7 +77351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: redpanda-serving-cert
   namespace: default
@@ -77379,7 +77379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-selfsigned-issuer
   namespace: default
@@ -77431,7 +77431,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     nI2ZSs: 4AI8h
   name: Wo-metrics-monitor
   namespace: default
@@ -77455,7 +77455,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: L07
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       nI2ZSs: 4AI8h
 ---
 # Source: operator/templates/entry-point.yaml
@@ -77505,7 +77505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: 7QeW
@@ -77538,7 +77538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-config
@@ -77558,7 +77558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-metrics-reader
@@ -77582,7 +77582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w
@@ -77792,7 +77792,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w
@@ -77819,7 +77819,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-election-role
@@ -77871,7 +77871,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w
@@ -77902,7 +77902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-election-role
@@ -77930,7 +77930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w
@@ -77958,7 +77958,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-metrics-service
@@ -77986,7 +77986,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: MK-webhook-service
@@ -78013,7 +78013,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w
@@ -78572,7 +78572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: redpanda-serving-cert
@@ -78602,7 +78602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-selfsigned-issuer
@@ -78656,7 +78656,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     t: W
     wH2b: ""
   name: w-metrics-monitor
@@ -78680,7 +78680,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: MK
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       t: W
       wH2b: ""
 ---
@@ -78732,7 +78732,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: LjYLOL6C
   namespace: default
@@ -78765,7 +78765,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-config
   namespace: default
@@ -78785,7 +78785,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-metrics-service
   namespace: default
@@ -78813,7 +78813,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: qv3g-webhook-service
   namespace: default
@@ -78840,7 +78840,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai
   namespace: default
@@ -79327,7 +79327,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: redpanda-serving-cert
   namespace: default
@@ -79357,7 +79357,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-selfsigned-issuer
   namespace: default
@@ -79411,7 +79411,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v25.1.1-beta3
     gi: 9j2
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-metrics-monitor
   namespace: default
@@ -79436,7 +79436,7 @@ spec:
       app.kubernetes.io/name: qv3g
       app.kubernetes.io/version: v25.1.1-beta3
       gi: 9j2
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       zb8lDT9V: olwEfoWZ
 ---
 # Source: operator/templates/entry-point.yaml
@@ -79484,7 +79484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: J2qRpt9
   namespace: default
 ---
@@ -79513,7 +79513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-config
   namespace: default
 ---
@@ -79529,7 +79529,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-metrics-reader
 rules:
 - nonResourceURLs:
@@ -79549,7 +79549,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6
 rules:
 - apiGroups:
@@ -79755,7 +79755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -79778,7 +79778,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-election-role
   namespace: default
 rules:
@@ -79826,7 +79826,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6
   namespace: default
 rules:
@@ -79853,7 +79853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-rpk-bundle
   namespace: default
 rules:
@@ -79887,7 +79887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-election-role
   namespace: default
 roleRef:
@@ -79911,7 +79911,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6
   namespace: default
 roleRef:
@@ -79935,7 +79935,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-rpk-bundle
   namespace: default
 roleRef:
@@ -79959,7 +79959,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-metrics-service
   namespace: default
 spec:
@@ -79983,7 +79983,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Tlv-webhook-service
   namespace: default
 spec:
@@ -80006,7 +80006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6
   namespace: default
 spec:
@@ -80455,7 +80455,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -80481,7 +80481,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-selfsigned-issuer
   namespace: default
 spec:
@@ -80531,7 +80531,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KXsg6-metrics-monitor
   namespace: default
 spec:
@@ -80553,7 +80553,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Tlv
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -80613,7 +80613,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-config
@@ -80631,7 +80631,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-metrics-reader
@@ -80653,7 +80653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -80861,7 +80861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -80886,7 +80886,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-election-role
@@ -80936,7 +80936,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -80965,7 +80965,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-election-role
@@ -80991,7 +80991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -81017,7 +81017,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-metrics-service
@@ -81043,7 +81043,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: DjMfg-webhook-service
@@ -81068,7 +81068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -81528,7 +81528,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: redpanda-serving-cert
@@ -81556,7 +81556,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-selfsigned-issuer
@@ -81645,7 +81645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "02"
   namespace: default
 ---
@@ -81674,7 +81674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-config
   namespace: default
 ---
@@ -81690,7 +81690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-metrics-reader
 rules:
 - nonResourceURLs:
@@ -81710,7 +81710,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "02"
 rules:
 - apiGroups:
@@ -81916,7 +81916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "02"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -81939,7 +81939,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-election-role
   namespace: default
 rules:
@@ -81987,7 +81987,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "02"
   namespace: default
 rules:
@@ -82014,7 +82014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-rpk-bundle
   namespace: default
 rules:
@@ -82048,7 +82048,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-election-role
   namespace: default
 roleRef:
@@ -82072,7 +82072,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "02"
   namespace: default
 roleRef:
@@ -82096,7 +82096,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-rpk-bundle
   namespace: default
 roleRef:
@@ -82120,7 +82120,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-metrics-service
   namespace: default
 spec:
@@ -82144,7 +82144,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: Y-webhook-service
   namespace: default
 spec:
@@ -82167,7 +82167,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: "02"
   namespace: default
 spec:
@@ -82690,7 +82690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -82716,7 +82716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 02-selfsigned-issuer
   namespace: default
 spec:
@@ -82799,7 +82799,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: nNP8R
   namespace: default
 ---
@@ -82829,7 +82829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3SkASoputZl-config
   namespace: default
 ---
@@ -82846,7 +82846,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3SkASoputZl-metrics-service
   namespace: default
 spec:
@@ -82871,7 +82871,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: axov6PJ-webhook-service
   namespace: default
 spec:
@@ -82895,7 +82895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3SkASoputZl
   namespace: default
 spec:
@@ -83344,7 +83344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -83371,7 +83371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: 3SkASoputZl-selfsigned-issuer
   namespace: default
 spec:
@@ -83471,7 +83471,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-config
   namespace: default
 ---
@@ -83491,7 +83491,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-metrics-reader
 rules:
 - nonResourceURLs:
@@ -83515,7 +83515,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi
 rules:
 - apiGroups:
@@ -83725,7 +83725,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -83752,7 +83752,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-election-role
   namespace: default
 rules:
@@ -83804,7 +83804,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi
   namespace: default
 rules:
@@ -83835,7 +83835,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-rpk-bundle
   namespace: default
 rules:
@@ -83873,7 +83873,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-election-role
   namespace: default
 roleRef:
@@ -83901,7 +83901,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi
   namespace: default
 roleRef:
@@ -83929,7 +83929,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-rpk-bundle
   namespace: default
 roleRef:
@@ -83957,7 +83957,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-metrics-service
   namespace: default
 spec:
@@ -83985,7 +83985,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: MkL0HtR-webhook-service
   namespace: default
 spec:
@@ -84012,7 +84012,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi
   namespace: default
 spec:
@@ -84510,7 +84510,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -84540,7 +84540,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v25.1.1-beta3
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: KPhNK5uNi-selfsigned-issuer
   namespace: default
 spec:
@@ -84624,7 +84624,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: L
   namespace: default
 ---
@@ -84653,7 +84653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: iP-config
   namespace: default
 ---
@@ -84669,7 +84669,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: iP-metrics-service
   namespace: default
 spec:
@@ -84693,7 +84693,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: LH-webhook-service
   namespace: default
 spec:
@@ -84716,7 +84716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: iP
   namespace: default
 spec:
@@ -85274,7 +85274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -85300,7 +85300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: iP-selfsigned-issuer
   namespace: default
 spec:
@@ -85385,7 +85385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: vE4AZ
   namespace: default
@@ -85416,7 +85416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-config
   namespace: default
@@ -85434,7 +85434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-metrics-reader
 rules:
@@ -85456,7 +85456,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj
 rules:
@@ -85664,7 +85664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj
 roleRef:
@@ -85689,7 +85689,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-election-role
   namespace: default
@@ -85739,7 +85739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj
   namespace: default
@@ -85768,7 +85768,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-election-role
   namespace: default
@@ -85794,7 +85794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj
   namespace: default
@@ -85820,7 +85820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-metrics-service
   namespace: default
@@ -85846,7 +85846,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: RoJFv-webhook-service
   namespace: default
@@ -85871,7 +85871,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj
   namespace: default
@@ -86420,7 +86420,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: redpanda-serving-cert
   namespace: default
@@ -86448,7 +86448,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-selfsigned-issuer
   namespace: default
@@ -86500,7 +86500,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
     rnKI: dxHr
   name: 5U9oyj-metrics-monitor
   namespace: default
@@ -86525,7 +86525,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: RoJFv
       app.kubernetes.io/version: v25.1.1-beta3
-      helm.sh/chart: operator-v25.1.1-beta3
+      helm.sh/chart: operator-25.1.1-beta3
       rnKI: dxHr
 ---
 # Source: operator/templates/entry-point.yaml
@@ -86573,7 +86573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -86601,7 +86601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -86616,7 +86616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -86635,7 +86635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -86728,7 +86728,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -86813,7 +86813,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -86835,7 +86835,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -86857,7 +86857,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -86904,7 +86904,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -87075,7 +87075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -87170,7 +87170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -87203,7 +87203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -87226,7 +87226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -87249,7 +87249,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -87272,7 +87272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -87295,7 +87295,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -87318,7 +87318,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -87423,7 +87423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-crds
   namespace: default
 spec:
@@ -87491,7 +87491,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -87519,7 +87519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -87534,7 +87534,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -87553,7 +87553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -87646,7 +87646,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -87731,7 +87731,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -87753,7 +87753,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -87775,7 +87775,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -87822,7 +87822,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -87993,7 +87993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -88088,7 +88088,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -88121,7 +88121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -88144,7 +88144,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -88167,7 +88167,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -88190,7 +88190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -88213,7 +88213,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -88236,7 +88236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -88341,7 +88341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-crds
   namespace: default
 spec:
@@ -88408,7 +88408,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -88436,7 +88436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -88451,7 +88451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -88470,7 +88470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -88554,7 +88554,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -88639,7 +88639,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -88661,7 +88661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -88683,7 +88683,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -88730,7 +88730,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -88901,7 +88901,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -88996,7 +88996,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -89029,7 +89029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -89052,7 +89052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -89075,7 +89075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -89098,7 +89098,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -89121,7 +89121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -89144,7 +89144,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -89248,7 +89248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -89276,7 +89276,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -89291,7 +89291,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -89310,7 +89310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -89394,7 +89394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -89479,7 +89479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -89501,7 +89501,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -89523,7 +89523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -89570,7 +89570,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -89741,7 +89741,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -89836,7 +89836,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -89869,7 +89869,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -89892,7 +89892,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -89915,7 +89915,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -89938,7 +89938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -89961,7 +89961,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -89984,7 +89984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -90105,7 +90105,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -90133,7 +90133,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -90148,7 +90148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -90167,7 +90167,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -90251,7 +90251,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -90336,7 +90336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -90358,7 +90358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -90380,7 +90380,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -90427,7 +90427,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -90598,7 +90598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -90693,7 +90693,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -90726,7 +90726,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -90749,7 +90749,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -90772,7 +90772,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -90795,7 +90795,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -90818,7 +90818,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -90841,7 +90841,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -90945,7 +90945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -90973,7 +90973,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -90988,7 +90988,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -91007,7 +91007,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -91091,7 +91091,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -91176,7 +91176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -91198,7 +91198,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -91220,7 +91220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -91267,7 +91267,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -91438,7 +91438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -91533,7 +91533,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -91566,7 +91566,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -91589,7 +91589,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -91612,7 +91612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -91635,7 +91635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -91658,7 +91658,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -91681,7 +91681,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -91785,7 +91785,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -91813,7 +91813,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -91828,7 +91828,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -91847,7 +91847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -92052,7 +92052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -92074,7 +92074,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -92121,7 +92121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -92147,7 +92147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -92180,7 +92180,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -92203,7 +92203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -92226,7 +92226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -92249,7 +92249,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -92272,7 +92272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-webhook-service
   namespace: default
 spec:
@@ -92294,7 +92294,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:
@@ -92403,7 +92403,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -92428,7 +92428,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-selfsigned-issuer
   namespace: default
 spec:
@@ -92511,7 +92511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 ---
@@ -92539,7 +92539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-config
   namespace: default
 ---
@@ -92554,7 +92554,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -92573,7 +92573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 rules:
 - apiGroups:
@@ -92657,7 +92657,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -92742,7 +92742,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -92764,7 +92764,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -92786,7 +92786,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 rules:
@@ -92833,7 +92833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 rules:
@@ -93004,7 +93004,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -93099,7 +93099,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -93132,7 +93132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-election-role
   namespace: default
 roleRef:
@@ -93155,7 +93155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 roleRef:
@@ -93178,7 +93178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -93201,7 +93201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -93224,7 +93224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator-metrics-service
   namespace: default
 spec:
@@ -93247,7 +93247,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v25.1.1-beta3
-    helm.sh/chart: operator-v25.1.1-beta3
+    helm.sh/chart: operator-25.1.1-beta3
   name: operator
   namespace: default
 spec:


### PR DESCRIPTION
The original GHA commit (d4db4300335960c3a1e66339883a038167a181e0) was merged preemptively before it was sufficiently tests.

This commit contains a variety of fixes discovered while testing the original implementation.