### PR TITLE
redpanda: don't crash redpanda on sidecar crashes

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20250625-164512.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250625-164512.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Crashes from the Sidecar container (e.g. due to a temporary API Server outage) no longer forcefully restart the redpanda container.
+time: 2025-06-25T16:45:12.98217-04:00

--- a/.changes/unreleased/operator-Fixed-20250625-164512.yaml
+++ b/.changes/unreleased/operator-Fixed-20250625-164512.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Crashes from the Sidecar container (e.g. due to a temporary API Server outage) no longer forcefully restart the redpanda container.
+time: 2025-06-25T16:45:12.982167-04:00

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -15,6 +15,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"maps"
 	"math/big"
@@ -444,6 +445,48 @@ func TestIntegrationChart(t *testing.T) {
 		assert.NoErrorf(t, kafkaListenerTest(ctx, rpk), "Kafka listener sub test failed")
 		assert.NoErrorf(t, adminListenerTest(ctx, rpk), "Admin listener sub test failed")
 		assert.NoErrorf(t, superuserTest(ctx, rpk, "superuser", "kubernetes-controller"), "Superuser sub test failed")
+	})
+
+	t.Run("sidecar", func(t *testing.T) {
+		env := h.Namespaced(t)
+		ctx := testutil.Context(t)
+
+		release := env.Install(ctx, redpandaChart, helm.InstallOptions{
+			Values: minimalValues(&redpanda.PartialValues{
+				Statefulset: &redpanda.PartialStatefulset{
+					SideCars: &redpanda.PartialSidecars{
+						Args: []string{"--panic-after=5s"},
+					},
+				},
+			}),
+		})
+
+		pods, err := kube.List[corev1.PodList](ctx, env.Ctl(), client.MatchingLabels{
+			"app.kubernetes.io/instance":  release.Name,
+			"app.kubernetes.io/component": release.Chart + "-statefulset",
+		})
+		require.NoError(t, err)
+
+		// Assert that all Pods have a sidecar instance that's panicking based
+		// on their logs and that the panic has NOT triggered a restart of any
+		// container. i.e. Sidecar crashes don't crash redpanda.
+		for _, pod := range pods.Items {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				logStream, err := env.Ctl().Logs(ctx, &pod, corev1.PodLogOptions{
+					Container: "sidecar",
+				})
+				require.NoError(t, err)
+
+				logs, err := io.ReadAll(logStream)
+				require.NoError(t, err)
+
+				require.Contains(t, string(logs), "unhandled panic triggered by --panic-after")
+			}, 5*time.Minute, 5*time.Second)
+
+			for _, container := range pod.Status.ContainerStatuses {
+				require.Zero(t, container.RestartCount)
+			}
+		}
 	})
 }
 

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -828,6 +828,7 @@ func statefulSetContainerSidecar(dot *helmette.Dot) *corev1.Container {
 	values := helmette.Unwrap[Values](dot.Values)
 
 	args := []string{
+		`/redpanda-operator`,
 		`sidecar`,
 		`--redpanda-yaml`,
 		`/etc/redpanda/redpanda.yaml`,
@@ -865,6 +866,8 @@ func statefulSetContainerSidecar(dot *helmette.Dot) *corev1.Container {
 		}...)
 	}
 
+	args = append(args, values.Statefulset.SideCars.Args...)
+
 	volumeMounts := append(
 		CommonMounts(dot),
 		corev1.VolumeMount{
@@ -882,7 +885,7 @@ func statefulSetContainerSidecar(dot *helmette.Dot) *corev1.Container {
 		Name:         "sidecar",
 		Image:        fmt.Sprintf(`%s:%s`, values.Statefulset.SideCars.Image.Repository, values.Statefulset.SideCars.Image.Tag),
 		Command:      []string{`/redpanda-operator`},
-		Args:         args,
+		Args:         append([]string{`supervisor`, `--`}, args...),
 		Env:          append(rpkEnvVars(dot, nil), statefulSetRedpandaEnv()...),
 		VolumeMounts: volumeMounts,
 		ReadinessProbe: &corev1.Probe{

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -620,9 +620,9 @@
 {{- $seen := (dict) -}}
 {{- $deduped := (coalesce nil) -}}
 {{- range $_, $item := $items -}}
-{{- $_963___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
-{{- $_ := (index $_963___ok_11 0) -}}
-{{- $ok_11 := (index $_963___ok_11 1) -}}
+{{- $_964___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
+{{- $_ := (index $_964___ok_11 0) -}}
+{{- $ok_11 := (index $_964___ok_11 1) -}}
 {{- if $ok_11 -}}
 {{- continue -}}
 {{- end -}}
@@ -734,9 +734,9 @@
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1184_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
-{{- $cert := (index $_1184_cert_ok 0) -}}
-{{- $ok := (index $_1184_cert_ok 1) -}}
+{{- $_1185_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
+{{- $cert := (index $_1185_cert_ok 0) -}}
+{{- $ok := (index $_1185_cert_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
@@ -1146,9 +1146,9 @@
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_1633___ok_14 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
-{{- $_ := ((index $_1633___ok_14 0) | float64) -}}
-{{- $ok_14 := (index $_1633___ok_14 1) -}}
+{{- $_1634___ok_14 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
+{{- $_ := ((index $_1634___ok_14 0) | float64) -}}
+{{- $ok_14 := (index $_1634___ok_14 1) -}}
 {{- if $ok_14 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
@@ -1174,9 +1174,9 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
-{{- $_1653_b_15_ok_16 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
-{{- $b_15 := (index $_1653_b_15_ok_16 0) -}}
-{{- $ok_16 := (index $_1653_b_15_ok_16 1) -}}
+{{- $_1654_b_15_ok_16 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
+{{- $b_15 := (index $_1654_b_15_ok_16 0) -}}
+{{- $ok_16 := (index $_1654_b_15_ok_16 1) -}}
 {{- if $ok_16 -}}
 {{- $_ := (set $result $k $b_15) -}}
 {{- continue -}}
@@ -1219,15 +1219,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1698___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1698___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_1698___hasAccessKey 1) -}}
-{{- $_1699___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1699___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_1699___hasSecretKey 1) -}}
-{{- $_1700___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1700___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_1700___hasSharedKey 1) -}}
+{{- $_1699___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1699___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_1699___hasAccessKey 1) -}}
+{{- $_1700___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1700___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_1700___hasSecretKey 1) -}}
+{{- $_1701___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1701___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_1701___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey)))) "r")) -}}
 {{- $envvars = (concat (default (list) $envvars) (list (mustMergeOverwrite (dict "name" "") (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey)))) "r"))))) -}}
@@ -1250,12 +1250,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1736___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1736___containerExists 0) -}}
-{{- $containerExists := (index $_1736___containerExists 1) -}}
-{{- $_1737___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1737___accountExists 0) -}}
-{{- $accountExists := (index $_1737___accountExists 1) -}}
+{{- $_1737___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1737___containerExists 0) -}}
+{{- $containerExists := (index $_1737___containerExists 1) -}}
+{{- $_1738___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1738___accountExists 0) -}}
+{{- $accountExists := (index $_1738___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1266,9 +1266,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1742_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
-{{- $value := (index $_1742_value_ok 0) -}}
-{{- $ok := (index $_1742_value_ok 1) -}}
+{{- $_1743_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
+{{- $value := (index $_1743_value_ok 0) -}}
+{{- $ok := (index $_1743_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -822,7 +822,8 @@ func (t *Tuning) Translate() map[string]any {
 }
 
 type Sidecars struct {
-	Image       Image `json:"image"`
+	Image       Image    `json:"image"`
+	Args        []string `json:"args"`
 	PVCUnbinder struct {
 		Enabled     bool   `json:"enabled"`
 		UnbindAfter string `json:"unbindAfter"`

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -20930,6 +20930,19 @@
         "sideCars": {
           "additionalProperties": false,
           "properties": {
+            "args": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "brokerDecommissioner": {
               "additionalProperties": false,
               "properties": {

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -669,6 +669,9 @@ statefulset:
     image:
       tag: v25.1.1-beta3
       repository: docker.redpanda.com/redpandadata/redpanda-operator
+    # Additional arguments to pass to the sidecar command. Reserved for internal testing.
+    # @ignored
+    args: []
     # The PVCUnbinder helps keep redpanda operational in the event of a tolerable Node or Disk loss event when non-remountable storage,
     # such as `local` or `hostPath`, are used. It does so by monitoring redpanda Pods that are in a "Pending" state for at least the period
     # specified by `unbindAfter`. After this period it will delete the Pod's PVC to re-trigger volume provisioning.

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -285,6 +285,7 @@ type PartialTieredStorageConfig map[string]any
 
 type PartialSidecars struct {
 	Image       *PartialImage "json:\"image,omitempty\""
+	Args        []string      "json:\"args,omitempty\""
 	PVCUnbinder *struct {
 		Enabled     *bool   "json:\"enabled,omitempty\""
 		UnbindAfter *string "json:\"unbindAfter,omitempty\""

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,6 @@
 
           devshells.default = {
             env = [
-              { name = "GOPRIVATE"; value = "github.com/redpanda-data/flux-controller-shim"; }
               { name = "GOROOT"; value = "${pkgs.go_1_24}/share/go"; }
               { name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.32.x)"; }
               { name = "PATH"; eval = "$(pwd)/.build:$PATH"; }

--- a/operator/cmd/bootstrap/bootstrap.go
+++ b/operator/cmd/bootstrap/bootstrap.go
@@ -38,9 +38,8 @@ func Command() *cobra.Command {
 		cloudSecretsAzureKeyVaultURI string
 	)
 	cmd := &cobra.Command{
-		Use:     "bootstrap",
-		Short:   "Configure .bootstrap.yaml based on supplied fixups",
-		Aliases: []string{"configure"},
+		Use:   "bootstrap",
+		Short: "Configure .bootstrap.yaml based on supplied fixups",
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			var cloudExpander *pkgsecrets.CloudExpander

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/ready"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/run"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/sidecar"
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/supervisor"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/version"
 	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
@@ -43,14 +44,15 @@ var (
 
 func init() {
 	rootCmd.AddCommand(
-		configurator.Command(),
 		bootstrap.Command(),
+		configurator.Command(),
+		crd.Command(),
+		ready.Command(),
 		run.Command(),
+		sidecar.Command(),
+		supervisor.Command(),
 		syncclusterconfig.Command(),
 		version.Command(),
-		sidecar.Command(),
-		ready.Command(),
-		crd.Command(),
 	)
 
 	logOptions.BindFlags(rootCmd.PersistentFlags())

--- a/operator/cmd/supervisor/supervisor.go
+++ b/operator/cmd/supervisor/supervisor.go
@@ -1,0 +1,172 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/time/rate"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
+)
+
+func Command() *cobra.Command {
+	var retryBurst int
+	var retryRate time.Duration
+	var gracePeriod time.Duration
+
+	cmd := &cobra.Command{
+		Use:     "supervisor command...",
+		Example: "supervisor --burst-rate=1m -- redpanda-operator sidecar --redpanda-yaml path/on/disk",
+		Short:   "Repeatedly run a given command, akin the supervisord",
+		Long: `supervisor is a stand in for Kubernetes' Sidecar feature.
+It continuously re-runs the provided command, forwarding signals, in a loop until SIGINT is received.
+Subprocess retries are rate limited with token bucket that may be tuned via the --retry-burst and --retry-rate flags.
+The default retry parameters are tuned for a a long running process, such as the sidecar subcommand.`,
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			// As noted by Notify, we're subscribing to all signals and
+			// therefore buffering once per signal for a total of 16.
+			signals := make(chan os.Signal, 16)
+
+			// Looks a bit strange but we're subscribing to all signals _but_
+			// SIGINT and SIGTERM. We reserve those signals for initiating the
+			// graceful shutdown process.
+			signal.Notify(signals)
+			signal.Reset(os.Interrupt, syscall.SIGTERM)
+
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			limiter := rate.NewLimiter(rate.Every(retryRate), retryBurst)
+			runner := Runner{
+				Command:     args,
+				GracePeriod: gracePeriod,
+				Signals:     signals,
+				Stdout:      os.Stdout,
+				Stderr:      os.Stderr,
+			}
+
+			// Loop forever, re-running our child process until the parent
+			// process receives a request to shutdown.
+			for {
+				// We start by consuming a retry "credit" for correctness but
+				// also to fail quickly if the provided retry parameters result
+				// in an unusable limiter.
+				reservation := limiter.Reserve()
+
+				// The API and docs are a bit confusing here as they mention
+				// parameters that's not exposed. OK indicates whether or not
+				// the reservation COULD be granted not if it was. i.e. OK will
+				// be false if retryBurst is < 1.
+				if !reservation.OK() {
+					panic(fmt.Sprintf("invalid retry parameters:\n--retry-burst=%d\n--retry-rate=%s", retryBurst, retryRate))
+				}
+
+				delay := reservation.Delay()
+
+				if delay > 0 {
+					log.Info(ctx, "backing off retries", "delay", delay.String())
+				}
+
+				// Otherwise wait until we have a retry "credit" available.
+				select {
+				case <-ctx.Done():
+					log.Info(ctx, "shutting down")
+					return
+
+				case <-time.After(reservation.Delay()):
+				}
+
+				if !runner.Run(ctx) {
+					return
+				}
+			}
+		},
+	}
+
+	cmd.Flags().IntVar(&retryBurst, "retry-burst", 3, "The `burst` parameter of the token bucket retry. Governs the maximum number of retries before initiating a back off.")
+	cmd.Flags().DurationVar(&retryRate, "retry-rate", 3*time.Minute, "The `rate` parameter of the token bucket retry. Controls the period at which retries attempts are permitted and represents the maximum back off.")
+	cmd.Flags().DurationVar(&gracePeriod, "grace-period", 10*time.Second, "The duration to wait for child processes to terminate upon receiving SIGINT before SIGKILL'ing them. Should be less than the grace period of the Container running this command.")
+
+	return cmd
+}
+
+type Runner struct {
+	Command     []string
+	GracePeriod time.Duration
+	Signals     <-chan os.Signal
+	Stdout      io.Writer
+	Stderr      io.Writer
+}
+
+func (r *Runner) Run(
+	ctx context.Context,
+) (cont bool) {
+	log.Info(ctx, "starting process", "command", r.Command)
+
+	//nolint:gosec // This is running with a users permissions, nothing to exploit here.
+	subprocess := exec.Command(r.Command[0], r.Command[1:]...)
+
+	// Forward all output to this process'
+	subprocess.Stderr = r.Stderr
+	subprocess.Stdout = r.Stdout
+
+	if err := subprocess.Start(); err != nil {
+		log.Error(ctx, err, "failed to start process", "command", r.Command)
+		// If we fail to startup the provided process, don't continue to retry
+		// as it's exceptionally unlikely this type of issue will resolve
+		// itself.
+		return false
+	}
+
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- subprocess.Wait()
+	}()
+
+	for {
+		select {
+		case err := <-doneCh:
+			log.Error(ctx, err, "process exited")
+			return true // Continue to re-run on any process crashes.
+
+		case sig := <-r.Signals:
+			// Forward signals onto our child process.
+			log.Info(ctx, "forwarding signal", "signal", sig)
+			if err := subprocess.Process.Signal(sig); err != nil {
+				log.Error(ctx, err, "failed to forward signal to subprocess", "signal", sig)
+			}
+			continue
+
+		case <-ctx.Done():
+			log.Info(ctx, "terminating process")
+
+			// Initiate the shutdown process by sending SIGTERM to match
+			// Kubernetes' behavior[1] (in most cases).
+			// We fire and forget because the process is going to get killed
+			// one way or another.
+			// [1]: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-stop-signals
+			_ = subprocess.Process.Signal(syscall.SIGTERM)
+
+			// Wait for at most gracePeriod for the process to exit gracefully
+			// before KILL'ing it.
+			select {
+			case <-doneCh:
+				log.Info(ctx, "process gracefully terminated")
+			case <-time.After(r.GracePeriod):
+				_ = subprocess.Process.Kill()
+				log.Info(ctx, "process killed")
+			}
+
+			// If the context has been cancelled, don't continue the loop.
+			return false
+		}
+	}
+}

--- a/operator/cmd/supervisor/supervisor_test.go
+++ b/operator/cmd/supervisor/supervisor_test.go
@@ -1,0 +1,119 @@
+package supervisor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
+)
+
+// script is a bash script that logs our received signals and exits upon
+// receiving 3 in total.
+const script = `
+#!/usr/bin/env bash
+
+signal_count=0
+
+signal_handler() {
+    signal_count=$((signal_count + 1))
+    echo "received: $1"
+
+    if [[ $signal_count -eq 3 || "$1" == "SIGTERM" ]]; then
+        echo "exiting"
+        exit 0
+    fi
+}
+
+# Trap common signals
+trap 'signal_handler SIGTERM' TERM
+trap 'signal_handler SIGINT' INT
+trap 'signal_handler SIGUSR1' USR1
+trap 'signal_handler SIGUSR2' USR2
+trap 'signal_handler SIGHUP' HUP
+
+# Log AFTER traps are established.
+echo "starting"
+
+# Keep script running
+while true; do
+    sleep 0.1
+done
+`
+
+type channelWriter chan<- string
+
+func (w channelWriter) Write(p []byte) (n int, err error) {
+	for _, chunk := range bytes.Split(p, []byte{'\n'}) {
+		if len(chunk) > 0 {
+			w <- string(chunk)
+		}
+	}
+	return len(p), nil
+}
+
+func TestRunner(t *testing.T) {
+	run := func(ctx context.Context, signals chan os.Signal) <-chan string {
+		stdout := make(chan string)
+
+		go func() {
+			r := Runner{
+				Command:     []string{"bash", "-c", script},
+				GracePeriod: 5 * time.Second,
+				Stdout:      channelWriter(stdout),
+				Signals:     signals,
+			}
+
+			cont := r.Run(ctx)
+
+			stdout <- fmt.Sprintf("%v", cont)
+
+			close(stdout)
+		}()
+
+		return stdout
+	}
+
+	t.Run("signal forwarding", func(t *testing.T) {
+		ctx := log.IntoContext(t.Context(), testr.New(t))
+		signals := make(chan os.Signal)
+
+		stdout := run(ctx, signals)
+
+		require.Equal(t, "starting", <-stdout)
+
+		for i := 0; i < 3; i++ {
+			signals <- syscall.SIGHUP
+			assert.Equal(t, "received: SIGHUP", <-stdout)
+		}
+
+		require.Equal(t, "exiting", <-stdout)
+		require.Equal(t, "true", <-stdout)
+	})
+
+	t.Run("graceful termination", func(t *testing.T) {
+		ctx := log.IntoContext(t.Context(), testr.New(t))
+		ctx, cancel := context.WithCancel(ctx)
+		signals := make(chan os.Signal)
+
+		stdout := run(ctx, signals)
+
+		require.Equal(t, "starting", <-stdout)
+
+		cancel()
+
+		require.Equal(t, "received: SIGTERM", <-stdout)
+		require.Equal(t, "exiting", <-stdout)
+
+		// Context cancellation doesn't result in requesting of a retry.
+		require.Equal(t, "false", <-stdout)
+	})
+}

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -50,6 +50,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	golang.org/x/sync v0.14.0
+	golang.org/x/time v0.11.0
 	golang.org/x/tools v0.29.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -309,7 +310,6 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/time v0.11.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/api v0.203.0 // indirect
 	google.golang.org/genproto v0.0.0-20241015192408-796eee8c2d53 // indirect


### PR DESCRIPTION
It's been reported that the redpanda service can be interrupted due to
temporary outages of the Kubernetes API server. This is due to the sidecar
container utilizing the controller-runtime's leader election which
intentionally crashes upon failure to renew its lease.

To prevent such outages from impacting redpanda, this commit implements a
`supervisor` subcommand that wraps the provided command in a retry loop. This
new command is used to wrap the sidecar process, effectively preventing crashes
from impacting redpanda itself.

This strategy was opted for to avoid potential errors in restarting the
controller-runtime's manager after a crash from e.g. shared global state. It
additionally protects redpanda other sources of crashes. Once our floor
Kubernetes version supports [Sidecar
containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)
we will utilize them instead of our own wrapper process.

To aid in testing a hidden `panic-after` flag has been added to the sidecar
container. By setting it and asserting that panics appear in the logs, we can
assert that unexpected crashes do not affect the redpanda container.

Fixes https://github.com/redpanda-data/redpanda-operator/issues/903