### PR TITLE
v1: fix admin-api TLS mounting

### DIFF
--- a/operator/pkg/resources/certmanager/type_helpers.go
+++ b/operator/pkg/resources/certmanager/type_helpers.go
@@ -606,7 +606,7 @@ func (cc *ClusterCertificates) Volumes() (
 		mountPoints.AdminAPI.NodeCertMountDir,
 		adminAPIClientCAVolName,
 		mountPoints.AdminAPI.ClientCAMountDir,
-		true,
+		cc.adminAPI.selfSignedNodeCertificate,
 		true,
 	)
 	vols = append(vols, vol...)


### PR DESCRIPTION
There was a problem when the admin API was configured with an external listener with public TLS for transport and client certificates for authentication, the last one using a self-signed certificate (I'm not sure if this last part is needed, I think there was some assumption in the code that the admin API transport TLS certificate is always self-signed).

The configuration I set on the cluster admin API is:

```yaml
    adminApi:
    - external: {}
      port: 9644
      tls: {}
    - external:
        enabled: true
        subdomain: yyy.fmc.ign.cloud.redpanda.com
      port: 30303
      tls:
        clientCACertRef:
          apiGroup: ""
          kind: Secret
          name: rp-yyy-admin-api-client-ca
        enabled: true
        nodeSecretRef:
          apiVersion: v1
          kind: Secret
          name: rp-yyy-redpanda
          namespace: redpanda
        requireClientAuth: true
```

In particular, the `rp-yyy-redpanda` secret is a publicly available certificate from LetsEncrypt, and it does not contain the `ca.crt` section.

But, when the operator mounts this to the pod, the pod contains the following snippet:

```yaml
volumes:
  - name: tlsadmincert
    secret:
      defaultMode: 420
      items:
      - key: tls.key
        path: tls.key
      - key: tls.crt
        path: tls.crt
      - key: ca.crt
        path: ca.crt
      secretName: rp-yyy-redpanda
```

And it does not start for mount errors:

```
Warning  FailedMount  15s (x15 over 14m)  kubelet            MountVolume.SetUp failed for volume "tlsadmincert" : references non-existent secret key: ca.crt
```

After the fix, I built an operator image and deployed it in the cloud environment. The release worked and I'm able to call it with a proper key pair:

```shell
% curl -s --key client.key --cert client.crt https://admin-xxx.yyy.fmc.ign.cloud.redpanda.com:30303/v1/cluster/health_overview | jq 
{
  "is_healthy": true,
  "unhealthy_reasons": [],
  "controller_id": 0,
  "all_nodes": [
    0,
    1,
    2
  ],
  "nodes_down": [],
  "leaderless_partitions": [],
  "leaderless_count": 0,
  "under_replicated_partitions": [],
  "under_replicated_count": 0,
  "bytes_in_cloud_storage": 5388031
}
```

While the same does not work without keys:

```shell
% curl https://admin-xxx.yyy.fmc.ign.cloud.redpanda.com:30303/v1/cluster/health_overview | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) LibreSSL SSL_read: LibreSSL/3.3.6: error:1404C45C:SSL routines:ST_OK:reason(1116), errno 0
```
