### PR TITLE
[release/v2.3.x] kube: improve Ctl struct | redpanda: correct Role and ClusterRole naming

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20250619-113317.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250619-113317.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Corrected naming of `Role`s to use Fullname instead of Name, which ensures they are unique within their namespace.
+time: 2025-06-19T11:33:17.161135-04:00

--- a/.changes/unreleased/charts-redpanda-Fixed-20250619-113526.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250619-113526.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Updated naming of `ClusterRole`s to include the release namespace. This ensures that they are unique per release and permits installing the chart with the same name across different namespaces.
+time: 2025-06-19T11:35:26.699507-04:00

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm/helmtest"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube/kubetest"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 	"github.com/redpanda-data/redpanda-operator/pkg/tlsgeneration"
 	"github.com/redpanda-data/redpanda-operator/pkg/valuesutil"
@@ -1137,5 +1138,79 @@ func TestGoHelmEquivalence(t *testing.T) {
 				assert.Equal(t, helmObjs[i], goObjs[i])
 			}
 		})
+	}
+}
+
+// TestMultiNamespaceInstall verifies that:
+// - Multiple instances of the redpanda chart with different names may be installed in the same instance.
+// - Multiple instances of the redpanda chart with the same name may be installed in different namespaces.
+func TestMultiNamespaceInstall(t *testing.T) {
+	ctx := testutil.Context(t)
+	ctl := kubetest.NewEnv(t)
+	client, err := helm.New(helm.Options{
+		KubeConfig: ctl.RestConfig(),
+	})
+	require.NoError(t, err)
+
+	values := redpanda.PartialValues{
+		// Disable NodePort services to avoid port conflicts.
+		External: &redpanda.PartialExternalConfig{
+			Type: ptr.To(corev1.ServiceTypeLoadBalancer),
+		},
+		// Disable cert-manager integration so we don't have to
+		// install their CRDs.
+		TLS: &redpanda.PartialTLS{
+			Certs: redpanda.PartialTLSCertMap{
+				"default": redpanda.PartialTLSCert{
+					SecretRef: &corev1.LocalObjectReference{
+						Name: "default",
+					},
+				},
+				"external": redpanda.PartialTLSCert{
+					SecretRef: &corev1.LocalObjectReference{
+						Name: "default",
+					},
+				},
+			},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		namespace := fmt.Sprintf("namespace-%d", i)
+
+		require.NoError(t, ctl.Apply(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}))
+
+		for j := 0; j < 2; j++ {
+			_, err := client.Install(ctx, ".", helm.InstallOptions{
+				Name:      fmt.Sprintf("redpanda-%d", j),
+				Namespace: namespace,
+				// Disable all forms of waits / checks. This isn't an actual
+				// cluster, were just verifying that the API server and helm
+				// don't report naming conflicts.
+				NoHooks:       true,
+				NoWait:        true,
+				NoWaitForJobs: true,
+				Timeout:       ptr.To(5 * time.Second),
+				Values:        values,
+			})
+			require.NoError(t, err)
+		}
+
+		// One final check to show that conflicting names will result in an error.
+		_, err := client.Install(ctx, ".", helm.InstallOptions{
+			Name:      "redpanda-0",
+			Namespace: namespace,
+			// Disable all forms of waits / checks. This isn't an actual
+			// cluster, were just verifying that the API server and helm
+			// don't report naming conflicts.
+			NoHooks:       true,
+			NoWait:        true,
+			NoWaitForJobs: true,
+			Timeout:       ptr.To(5 * time.Second),
+			Values:        values,
+		})
+		require.Error(t, err)
 	}
 }

--- a/charts/redpanda/go.sum
+++ b/charts/redpanda/go.sum
@@ -618,6 +618,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/genproto v0.0.0-20241015192408-796eee8c2d53 h1:Df6WuGvthPzc+JiQ/G+m+sNX24kc0aTBqoDN/0yyykE=
 google.golang.org/genproto v0.0.0-20241015192408-796eee8c2d53/go.mod h1:fheguH3Am2dGp1LfXkrvwqC/KlFq8F0nLq3LryOMrrE=
 google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 h1:T6rh4haD3GVYsgEfWExoCZA2o2FmbNyKpTuAxbEFPTg=

--- a/charts/redpanda/helpers.go
+++ b/charts/redpanda/helpers.go
@@ -46,7 +46,11 @@ func ChartLabel(dot *helmette.Dot) string {
 	return cleanForK8s(strings.ReplaceAll(fmt.Sprintf("%s-%s", dot.Chart.Name, dot.Chart.Version), "+", "_"))
 }
 
-// Expand the name of the chart
+// Name returns the name of this chart as specified in Chart.yaml, unless
+// explicitly overridden.
+// Name is effectively static and should not be used for naming of resources.
+// Name is truncated at 63 characters to satisfy Kubernetes field limits
+// and DNS limits.
 func Name(dot *helmette.Dot) string {
 	if override, ok := dot.Values["nameOverride"].(string); ok && override != "" {
 		return cleanForK8s(override)
@@ -54,8 +58,10 @@ func Name(dot *helmette.Dot) string {
 	return cleanForK8s(dot.Chart.Name)
 }
 
-// Create a default fully qualified app name.
-// We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+// Fullname returns the name of this helm release, unless explicitly
+// overridden.
+// Fullname is truncated at 63 characters to satisfy Kubernetes field limits
+// and DNS limits.
 func Fullname(dot *helmette.Dot) string {
 	if override, ok := dot.Values["fullnameOverride"].(string); ok && override != "" {
 		return cleanForK8s(override)

--- a/charts/redpanda/rbac.go
+++ b/charts/redpanda/rbac.go
@@ -39,7 +39,7 @@ func Roles(dot *helmette.Dot) []*rbacv1.Role {
 		role := helmette.FromYaml[rbacv1.Role](dot.Files.Get(file))
 
 		// Populated all chart values on the loaded static Role.
-		role.ObjectMeta.Name = fmt.Sprintf("%s-%s", Name(dot), role.ObjectMeta.Name)
+		role.ObjectMeta.Name = fmt.Sprintf("%s-%s", Fullname(dot), role.ObjectMeta.Name)
 		role.ObjectMeta.Namespace = dot.Release.Namespace
 		role.ObjectMeta.Labels = FullLabels(dot)
 		role.ObjectMeta.Annotations = helmette.Merge(
@@ -73,7 +73,10 @@ func ClusterRoles(dot *helmette.Dot) []*rbacv1.ClusterRole {
 		role := helmette.FromYaml[rbacv1.ClusterRole](dot.Files.Get(file))
 
 		// Populated all chart values on the loaded static Role.
-		role.ObjectMeta.Name = fmt.Sprintf("%s-%s", Fullname(dot), role.ObjectMeta.Name)
+		// For ClusterScoped resources, we include the Namespace to permit
+		// installing multiple releases with the same names into the same
+		// cluster.
+		role.ObjectMeta.Name = cleanForK8s(fmt.Sprintf("%s-%s-%s", Fullname(dot), dot.Release.Namespace, role.ObjectMeta.Name))
 		role.ObjectMeta.Labels = FullLabels(dot)
 		role.ObjectMeta.Annotations = helmette.Merge(
 			map[string]string{},

--- a/charts/redpanda/templates/_helpers.go.tpl
+++ b/charts/redpanda/templates/_helpers.go.tpl
@@ -14,9 +14,9 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_51_override_1_ok_2 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $dot.Values "nameOverride") "")))) "r") -}}
-{{- $override_1 := (index $_51_override_1_ok_2 0) -}}
-{{- $ok_2 := (index $_51_override_1_ok_2 1) -}}
+{{- $_55_override_1_ok_2 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $dot.Values "nameOverride") "")))) "r") -}}
+{{- $override_1 := (index $_55_override_1_ok_2 0) -}}
+{{- $ok_2 := (index $_55_override_1_ok_2 1) -}}
 {{- if (and $ok_2 (ne $override_1 "")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (get (fromJson (include "redpanda.cleanForK8s" (dict "a" (list $override_1)))) "r")) | toJson -}}
@@ -32,9 +32,9 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_61_override_3_ok_4 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $dot.Values "fullnameOverride") "")))) "r") -}}
-{{- $override_3 := (index $_61_override_3_ok_4 0) -}}
-{{- $ok_4 := (index $_61_override_3_ok_4 1) -}}
+{{- $_67_override_3_ok_4 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $dot.Values "fullnameOverride") "")))) "r") -}}
+{{- $override_3 := (index $_67_override_3_ok_4 0) -}}
+{{- $ok_4 := (index $_67_override_3_ok_4 1) -}}
 {{- if (and $ok_4 (ne $override_3 "")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (get (fromJson (include "redpanda.cleanForK8s" (dict "a" (list $override_3)))) "r")) | toJson -}}
@@ -399,9 +399,9 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $version := (trimPrefix "v" (get (fromJson (include "redpanda.Tag" (dict "a" (list $dot)))) "r")) -}}
-{{- $_385_result_err := (list (semverCompare $constraint $version) nil) -}}
-{{- $result := (index $_385_result_err 0) -}}
-{{- $err := (index $_385_result_err 1) -}}
+{{- $_391_result_err := (list (semverCompare $constraint $version) nil) -}}
+{{- $result := (index $_391_result_err 0) -}}
+{{- $err := (index $_391_result_err 1) -}}
 {{- if (ne (toJson $err) "null") -}}
 {{- $_ := (fail $err) -}}
 {{- end -}}
@@ -497,9 +497,9 @@
 {{- $originalKeys := (dict) -}}
 {{- $overrideByKey := (dict) -}}
 {{- range $_, $el := $override -}}
-{{- $_497_key_ok := (get (fromJson (include "_shims.get" (dict "a" (list $el $mergeKey)))) "r") -}}
-{{- $key := (index $_497_key_ok 0) -}}
-{{- $ok := (index $_497_key_ok 1) -}}
+{{- $_503_key_ok := (get (fromJson (include "_shims.get" (dict "a" (list $el $mergeKey)))) "r") -}}
+{{- $key := (index $_503_key_ok 0) -}}
+{{- $ok := (index $_503_key_ok 1) -}}
 {{- if (not $ok) -}}
 {{- continue -}}
 {{- end -}}
@@ -510,13 +510,13 @@
 {{- end -}}
 {{- $merged := (coalesce nil) -}}
 {{- range $_, $el := $original -}}
-{{- $_509_key__ := (get (fromJson (include "_shims.get" (dict "a" (list $el $mergeKey)))) "r") -}}
-{{- $key := (index $_509_key__ 0) -}}
-{{- $_ := (index $_509_key__ 1) -}}
+{{- $_515_key__ := (get (fromJson (include "_shims.get" (dict "a" (list $el $mergeKey)))) "r") -}}
+{{- $key := (index $_515_key__ 0) -}}
+{{- $_ := (index $_515_key__ 1) -}}
 {{- $_ := (set $originalKeys $key true) -}}
-{{- $_511_elOverride_7_ok_8 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $overrideByKey $key (coalesce nil))))) "r") -}}
-{{- $elOverride_7 := (index $_511_elOverride_7_ok_8 0) -}}
-{{- $ok_8 := (index $_511_elOverride_7_ok_8 1) -}}
+{{- $_517_elOverride_7_ok_8 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $overrideByKey $key (coalesce nil))))) "r") -}}
+{{- $elOverride_7 := (index $_517_elOverride_7_ok_8 0) -}}
+{{- $ok_8 := (index $_517_elOverride_7_ok_8 1) -}}
 {{- if $ok_8 -}}
 {{- $merged = (concat (default (list) $merged) (list (get (fromJson (include $mergeFunc (dict "a" (list $el $elOverride_7)))) "r"))) -}}
 {{- else -}}
@@ -527,15 +527,15 @@
 {{- break -}}
 {{- end -}}
 {{- range $_, $el := $override -}}
-{{- $_521_key_ok := (get (fromJson (include "_shims.get" (dict "a" (list $el $mergeKey)))) "r") -}}
-{{- $key := (index $_521_key_ok 0) -}}
-{{- $ok := (index $_521_key_ok 1) -}}
+{{- $_527_key_ok := (get (fromJson (include "_shims.get" (dict "a" (list $el $mergeKey)))) "r") -}}
+{{- $key := (index $_527_key_ok 0) -}}
+{{- $ok := (index $_527_key_ok 1) -}}
 {{- if (not $ok) -}}
 {{- continue -}}
 {{- end -}}
-{{- $_526___ok_9 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $originalKeys $key false)))) "r") -}}
-{{- $_ := (index $_526___ok_9 0) -}}
-{{- $ok_9 := (index $_526___ok_9 1) -}}
+{{- $_532___ok_9 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $originalKeys $key false)))) "r") -}}
+{{- $_ := (index $_532___ok_9 0) -}}
+{{- $ok_9 := (index $_532___ok_9 1) -}}
 {{- if $ok_9 -}}
 {{- continue -}}
 {{- end -}}

--- a/charts/redpanda/templates/_rbac.go.tpl
+++ b/charts/redpanda/templates/_rbac.go.tpl
@@ -12,7 +12,7 @@
 {{- continue -}}
 {{- end -}}
 {{- $role := (get (fromJson (include "_shims.fromYaml" (dict "a" (list ($dot.Files.Get $file))))) "r") -}}
-{{- $_ := (set $role.metadata "name" (printf "%s-%s" (get (fromJson (include "redpanda.Name" (dict "a" (list $dot)))) "r") $role.metadata.name)) -}}
+{{- $_ := (set $role.metadata "name" (printf "%s-%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot)))) "r") $role.metadata.name)) -}}
 {{- $_ := (set $role.metadata "namespace" $dot.Release.Namespace) -}}
 {{- $_ := (set $role.metadata "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot)))) "r")) -}}
 {{- $_ := (set $role.metadata "annotations" (merge (dict) (dict) $values.serviceAccount.annotations $values.rbac.annotations)) -}}
@@ -39,7 +39,7 @@
 {{- continue -}}
 {{- end -}}
 {{- $role := (get (fromJson (include "_shims.fromYaml" (dict "a" (list ($dot.Files.Get $file))))) "r") -}}
-{{- $_ := (set $role.metadata "name" (printf "%s-%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot)))) "r") $role.metadata.name)) -}}
+{{- $_ := (set $role.metadata "name" (get (fromJson (include "redpanda.cleanForK8s" (dict "a" (list (printf "%s-%s-%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot)))) "r") $dot.Release.Namespace $role.metadata.name))))) "r")) -}}
 {{- $_ := (set $role.metadata "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot)))) "r")) -}}
 {{- $_ := (set $role.metadata "annotations" (merge (dict) (dict) $values.serviceAccount.annotations $values.rbac.annotations)) -}}
 {{- $clusterRoles = (concat (default (list) $clusterRoles) (list $role)) -}}

--- a/pkg/helm/flags.go
+++ b/pkg/helm/flags.go
@@ -36,6 +36,10 @@ func ToFlags(flagsStruct any) []string {
 			value = !value.(bool)
 		}
 
+		if field.Type.Kind() == reflect.Pointer && reflect.ValueOf(value).IsNil() {
+			continue
+		}
+
 		if field.Type.Kind() == reflect.String && reflect.ValueOf(value).IsZero() {
 			continue
 		}

--- a/pkg/helm/flags_test.go
+++ b/pkg/helm/flags_test.go
@@ -11,15 +11,18 @@ package helm_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 )
 
 type Flags struct {
-	NoWait        bool `flag:"wait"`
-	NoWaitForJobs bool `flag:"no-wait-for-jobs"`
+	NoWait        bool           `flag:"wait"`
+	NoWaitForJobs bool           `flag:"no-wait-for-jobs"`
+	Timeout       *time.Duration `flag:"timeout"`
 	NotAFlag      string
 	StringFlag    string   `flag:"string-flag"`
 	StringArray   []string `flag:"string-array"`
@@ -66,6 +69,16 @@ func TestToFlags(t *testing.T) {
 				"--string-array=1",
 				"--string-array=2",
 				"--string-array=3",
+			},
+		},
+		{
+			in: Flags{
+				Timeout: ptr.To(time.Hour),
+			},
+			out: []string{
+				"--wait=true",
+				"--no-wait-for-jobs=false",
+				"--timeout=1h0m0s",
 			},
 		},
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -224,21 +224,28 @@ func (c *Client) GetValues(ctx context.Context, release *Release, values any) er
 }
 
 type InstallOptions struct {
-	CreateNamespace bool     `flag:"create-namespace"`
-	Name            string   `flag:"-"`
-	Namespace       string   `flag:"namespace"`
-	Values          any      `flag:"-"`
-	Version         string   `flag:"version"`
-	NoWait          bool     `flag:"wait"`
-	NoWaitForJobs   bool     `flag:"wait-for-jobs"`
-	GenerateName    bool     `flag:"generate-name"`
-	ValuesFile      string   `flag:"values"`
-	Set             []string `flag:"set"`
+	CreateNamespace bool           `flag:"create-namespace"`
+	Name            string         `flag:"-"`
+	Namespace       string         `flag:"namespace"`
+	Values          any            `flag:"-"`
+	Version         string         `flag:"version"`
+	NoHooks         bool           `flag:"no-hooks"`
+	Timeout         *time.Duration `flag:"timeout"`
+	NoWait          bool           `flag:"wait"`
+	NoWaitForJobs   bool           `flag:"wait-for-jobs"`
+	GenerateName    bool           `flag:"generate-name"`
+	ValuesFile      string         `flag:"values"`
+	Set             []string       `flag:"set"`
 }
 
 func (c *Client) Install(ctx context.Context, chart string, opts InstallOptions) (Release, error) {
 	if opts.Name == "" {
 		opts.GenerateName = true
+	}
+
+	if deadline, ok := ctx.Deadline(); ok && opts.Timeout == nil {
+		timeout := time.Until(deadline).Round(time.Second)
+		opts.Timeout = &timeout
 	}
 
 	if opts.Values != nil {

--- a/pkg/kube/ctl.go
+++ b/pkg/kube/ctl.go
@@ -14,9 +14,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -26,15 +28,55 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type (
-	Object    = client.Object
-	ObjectKey = client.ObjectKey
+	Object     = client.Object
+	ObjectList = client.ObjectList
+	ObjectKey  = client.ObjectKey
+
+	InNamespace = client.InNamespace
 )
 
+type Option interface {
+	ApplyToOptions(*Options)
+}
+
+type Options struct {
+	client.Options
+
+	FieldManager string
+}
+
+func (o Options) ApplyToOptions(opts *Options) {
+	if o.Cache != nil {
+		opts.Cache = o.Cache
+	}
+
+	if o.Scheme != nil {
+		opts.Scheme = o.Scheme
+	}
+
+	if o.DryRun != nil {
+		opts.DryRun = o.DryRun
+	}
+
+	if o.HTTPClient != nil {
+		opts.HTTPClient = o.HTTPClient
+	}
+
+	if o.Mapper != nil {
+		opts.Mapper = o.Mapper
+	}
+
+	if o.HTTPClient != nil {
+		opts.HTTPClient = o.HTTPClient
+	}
+}
+
 // FromEnv returns a [Ctl] for the default context in $KUBECONFIG.
-func FromEnv() (*Ctl, error) {
+func FromEnv(opts ...Option) (*Ctl, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
@@ -43,39 +85,42 @@ func FromEnv() (*Ctl, error) {
 		return nil, err
 	}
 
-	c, err := client.New(config, client.Options{})
-	if err != nil {
-		return nil, err
-	}
-
-	return &Ctl{
-		config: config,
-		client: c,
-	}, nil
+	return FromRESTConfig(config, opts...)
 }
 
-func FromConfig(cfg Config) (*Ctl, error) {
+func FromConfig(cfg Config, opts ...Option) (*Ctl, error) {
 	rest, err := ConfigToRest(cfg)
 	if err != nil {
 		return nil, err
 	}
-	return FromRESTConfig(rest)
+	return FromRESTConfig(rest, opts...)
 }
 
-func FromRESTConfig(cfg *RESTConfig) (*Ctl, error) {
-	c, err := client.New(cfg, client.Options{})
+func FromRESTConfig(cfg *RESTConfig, opts ...Option) (*Ctl, error) {
+	var options Options
+	for _, o := range opts {
+		o.ApplyToOptions(&options)
+	}
+
+	c, err := client.New(cfg, options.Options)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Ctl{config: cfg, client: c}, nil
+	fieldManager := options.FieldManager
+	if fieldManager == "" {
+		fieldManager = "*kube.Ctl"
+	}
+
+	return &Ctl{config: cfg, client: c, fieldManager: fieldManager}, nil
 }
 
 // Ctl is a Kubernetes client inspired by the shape of the `kubectl` CLI with a
 // focus on being ergonomic.
 type Ctl struct {
-	config *rest.Config
-	client client.Client
+	config       *rest.Config
+	client       client.Client
+	fieldManager string
 }
 
 // RestConfig returns a deep copy of the [rest.Config] used by this [Ctl].
@@ -95,6 +140,88 @@ func (c *Ctl) Get(ctx context.Context, key ObjectKey, obj Object) error {
 	return nil
 }
 
+// GetAndWait is the equivalent of calling [Ctl.Get] followed by [Ctl.WaitFor].
+func (c *Ctl) GetAndWait(ctx context.Context, key ObjectKey, obj Object, cond CondFn[Object]) error {
+	if err := c.Get(ctx, key, obj); err != nil {
+		return err
+	}
+	return c.WaitFor(ctx, obj, cond)
+}
+
+// List fetches a list of objects into `objs` from Kubernetes.
+// Usage:
+//
+//	var pods corev1.PodList
+//	ctl.List(ctx, &pods)
+func (c *Ctl) List(ctx context.Context, objs client.ObjectList, opts ...client.ListOption) error {
+	if err := c.client.List(ctx, objs, opts...); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// Apply "applies" the provided [Object] via SSA (Server Side Apply).
+func (c *Ctl) Apply(ctx context.Context, obj Object) error {
+	kinds, _, err := c.client.Scheme().ObjectKinds(obj)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	obj.SetManagedFields(nil)
+
+	obj.GetObjectKind().SetGroupVersionKind(kinds[0])
+
+	if err := c.client.Patch(ctx, obj, client.Apply, client.FieldOwner(c.fieldManager)); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// ApplyAndWait is the equivalent of calling [Ctl.Apply] followed by [Ctl.WaitFor].
+func (c *Ctl) ApplyAndWait(ctx context.Context, obj Object, cond CondFn[Object]) error {
+	if err := c.Apply(ctx, obj); err != nil {
+		return err
+	}
+
+	return c.WaitFor(ctx, obj, cond)
+}
+
+// ApplyAll "applies" the all provided [Object] via SSA (Server Side Apply).
+// Individual failures do not abort the entire operation; an aggregated error,
+// if any, is returned.
+func (c *Ctl) ApplyAll(ctx context.Context, objs ...Object) error {
+	var errs []error
+	for _, obj := range objs {
+		if err := c.Apply(ctx, obj); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ApplyAllAndWait is the equivalent of calling [Ctl.ApplyAll] followed by
+// [Ctl.WaitFor] in a loop.
+//
+// If ApplyAll fails, the entire wait loop is aborted.
+//
+// Individual failures in the wait loop do not abort the entire operator; an
+// aggregated error, if any, is returned.
+func (c *Ctl) ApplyAllAndWait(ctx context.Context, cond CondFn[Object], objs ...Object) error {
+	if err := c.ApplyAll(ctx, objs...); err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, obj := range objs {
+		if err := c.WaitFor(ctx, obj, cond); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Create creates the given [Object].
 func (c *Ctl) Create(ctx context.Context, obj Object) error {
 	if err := c.client.Create(ctx, obj); err != nil {
 		return errors.WithStack(err)
@@ -102,11 +229,97 @@ func (c *Ctl) Create(ctx context.Context, obj Object) error {
 	return nil
 }
 
+// CreateAndWait is the equivalent of calling [Ctl.Create] followed by [Ctl.WaitFor].
+func (c *Ctl) CreateAndWait(ctx context.Context, obj Object, cond CondFn[Object]) error {
+	if err := c.Create(ctx, obj); err != nil {
+		return err
+	}
+	return c.WaitFor(ctx, obj, cond)
+}
+
+// Delete initiates the deletion the given [Object].
 func (c *Ctl) Delete(ctx context.Context, obj Object) error {
 	if err := c.client.Delete(ctx, obj); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+// DeleteAndWait is the equivalent of calling [Ctl.Delete] followed by
+// [Ctl.WaitFor] with [IsDeleted].
+func (c *Ctl) DeleteAndWait(ctx context.Context, obj Object) error {
+	if err := c.Delete(ctx, obj); err != nil {
+		return err
+	}
+
+	// Wait for the Object to be removed from the API server.
+	return c.WaitFor(ctx, obj, IsDeleted[Object])
+}
+
+// CondFn is a condition checker for Kubernetes Objects. The provided error is
+// the result of [Ctl.Get] and may be used e.g. to await 404's in Deletes.
+type CondFn[T Object] func(T, error) (bool, error)
+
+// IsDeleted is a [CondFn] that returns true when the err is a 404.
+func IsDeleted[T Object](obj T, err error) (bool, error) {
+	if k8serrors.IsNotFound(err) {
+		return true, nil
+	}
+	return false, err
+}
+
+// WaitFor blocks until `cond` returns true for obj or ctx is cancelled. obj is
+// continuously refreshed via [Ctl.Get] before calling cond. If ctx does not
+// have a deadline a default of 5m will be used.
+func (c *Ctl) WaitFor(ctx context.Context, obj Object, cond CondFn[Object]) error {
+	const timeout = 5 * time.Minute
+	const logEvery = 10 * time.Second
+	logger := log.FromContext(ctx)
+
+	// If ctx doesn't have a deadline, we'll apply the default.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	lastLog := start
+
+	// TODO(chrisseto): We should be able to pull this off obj but Get doesn't
+	// seem to set TypeMeta?
+	kinds, _, err := c.client.Scheme().ObjectKinds(obj)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	gvk := kinds[0]
+
+	for {
+		err := c.Get(ctx, AsKey(obj), obj)
+
+		done, err := cond(obj, err)
+		if err != nil {
+			return err
+		}
+
+		if done {
+			logger.Info("Cond satisfied", "key", AsKey(obj), "gvk", gvk, "waited", time.Since(start))
+			return nil
+		}
+
+		if time.Since(lastLog) >= logEvery {
+			lastLog = time.Now()
+			logger.Info("waiting for Cond", "key", AsKey(obj), "gvk", gvk, "waited", time.Since(start))
+		}
+
+		select {
+		case <-time.After(10 * time.Second):
+			continue
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		}
+	}
 }
 
 type ExecOptions struct {

--- a/pkg/kube/ctl_test.go
+++ b/pkg/kube/ctl_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kube_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube/kubetest"
+	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+)
+
+func TestCtl(t *testing.T) {
+	ctx := testutil.Context(t)
+	ctl := kubetest.NewEnv(t)
+
+	require.NoError(t, ctl.Apply(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hello-world",
+		},
+	}))
+
+	ns, err := kube.Get[corev1.Namespace](ctx, ctl, kube.ObjectKey{Name: "hello-world"})
+	require.NoError(t, err)
+
+	// Cond is explicitly a *Namespace here!
+	require.EqualError(t, kube.WaitFor(ctx, ctl, ns, func(ns *corev1.Namespace, err error) (bool, error) {
+		return false, errors.New("passed through")
+	}), "passed through")
+
+	var seen []string
+	require.NoError(t, kube.ApplyAllAndWait(ctx, ctl, func(cm *corev1.ConfigMap, err error) (bool, error) {
+		seen = append(seen, cm.Name)
+		return true, nil
+	},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "hello-world", Name: "cm-0"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "hello-world", Name: "cm-1"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "hello-world", Name: "cm-2"}},
+	))
+	require.Equal(t, []string{"cm-0", "cm-1", "cm-2"}, seen)
+
+	cms, err := kube.List[corev1.ConfigMapList](ctx, ctl, kube.InNamespace("hello-world"))
+	require.NoError(t, err)
+	require.Len(t, cms.Items, 3)
+}

--- a/pkg/kube/generics.go
+++ b/pkg/kube/generics.go
@@ -16,29 +16,63 @@ import (
 )
 
 // ObjectList is a generic equivalent of [ObjectList].
-type ObjectList[T any] interface {
+type AddrOfObjectList[T any] interface {
 	client.ObjectList
 	*T
 }
 
-// AddrofObject is a helper type constraint for accepting a struct value that
+// AddrOfObject is a helper type constraint for accepting a struct value that
 // implements the Object interface.
+type AddrOfObject[T any] interface {
+	*T
+	client.Object
+}
+
+// AddrofObject is a copy of AddrofObject for backwards compatibility as
+// generic type aliases are currently experimental.
 type AddrofObject[T any] interface {
 	*T
 	client.Object
 }
 
+// ApplyAll is the generic equivalent of [Ctl.ApplyAll].
+func ApplyAll[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, objs ...PT) error {
+	return ctl.ApplyAll(ctx, AsObjects(objs...)...)
+}
+
+// ApplyAllAndWait is the generic equivalent of [Ctl.ApplyAllAndWait].
+func ApplyAllAndWait[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, cond CondFn[PT], objs ...PT) error {
+	return ctl.ApplyAllAndWait(ctx, func(obj Object, err error) (bool, error) {
+		return cond(obj.(PT), err)
+	}, AsObjects(objs...)...)
+}
+
+// Apply is the generic equivalent of [Ctl.Apply].
+func Apply[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, obj PT) error {
+	return ctl.Apply(ctx, obj)
+}
+
+// ApplyAndWait is the generic equivalent of [Ctl.ApplyAndWait]
+func ApplyAndWait[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, obj PT, cond CondFn[PT]) error {
+	return ctl.ApplyAndWait(ctx, obj, func(obj Object, err error) (bool, error) {
+		return cond(obj.(PT), err)
+	})
+}
+
 // List is a generic equivalent of [Ctl.List].
-func List[T any, L ObjectList[T]](ctx context.Context, ctl *Ctl, opts ...client.ListOption) (*T, error) {
+func List[T any, L AddrOfObjectList[T]](ctx context.Context, ctl *Ctl, opts ...client.ListOption) (*T, error) {
 	var list T
-	if err := ctl.client.List(ctx, L(&list), opts...); err != nil {
+	if err := ctl.List(ctx, L(&list), opts...); err != nil {
 		return nil, err
 	}
 	return &list, nil
 }
 
 // Get is a generic equivalent of [Ctl.Get].
-func Get[T any, PT AddrofObject[T]](ctx context.Context, ctl *Ctl, key ObjectKey) (*T, error) {
+//
+//	ns, err := Get[corev1.Namespace](ctx, ctl, ObjectKey{Name: "my-namespace"})
+//	pod, err := Get[corev1.Pod](ctx, ctl, ObjectKey{Namespace: "my-namespace", Name: "my-pod"})
+func Get[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, key ObjectKey) (*T, error) {
 	var obj T
 	if err := ctl.client.Get(ctx, key, PT(&obj)); err != nil {
 		return nil, err
@@ -47,7 +81,7 @@ func Get[T any, PT AddrofObject[T]](ctx context.Context, ctl *Ctl, key ObjectKey
 }
 
 // Get is a generic equivalent of [Ctl.Create].
-func Create[T any, PT AddrofObject[T]](ctx context.Context, ctl *Ctl, obj T) (*T, error) {
+func Create[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, obj T) (*T, error) {
 	if err := ctl.Create(ctx, PT(&obj)); err != nil {
 		return nil, err
 	}
@@ -55,7 +89,7 @@ func Create[T any, PT AddrofObject[T]](ctx context.Context, ctl *Ctl, obj T) (*T
 }
 
 // Get is a generic equivalent of [Ctl.Delete].
-func Delete[T any, PT AddrofObject[T]](ctx context.Context, ctl *Ctl, key ObjectKey) error {
+func Delete[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, key ObjectKey) error {
 	obj := PT(new(T))
 	obj.SetName(key.Name)
 	obj.SetNamespace(key.Namespace)
@@ -63,6 +97,23 @@ func Delete[T any, PT AddrofObject[T]](ctx context.Context, ctl *Ctl, key Object
 	return ctl.client.Delete(ctx, obj)
 }
 
+// WaitFor is the generic equivalent of [Ctl.WaitFor].
+func WaitFor[T any, PT AddrOfObject[T]](ctx context.Context, ctl *Ctl, obj PT, cond CondFn[PT]) error {
+	return ctl.WaitFor(ctx, obj, func(obj Object, err error) (bool, error) {
+		return cond(obj.(PT), err)
+	})
+}
+
 func AsKey(obj Object) ObjectKey {
 	return ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}
+
+// AsObjects converts a slice of a type that implements [Object] into a slice
+// of [Object].
+func AsObjects[T any, PT AddrOfObject[T]](in ...PT) []Object {
+	out := make([]Object, len(in))
+	for i := range in {
+		out[i] = in[i]
+	}
+	return out
 }

--- a/pkg/kube/kubetest/kubetest.go
+++ b/pkg/kube/kubetest/kubetest.go
@@ -25,7 +25,7 @@ const controlPlaneVersion = "1.30.x"
 // NewEnv starts a local kubernetes control plane via [envtest.Environment] and
 // returns a [kube.Ctl] to access it. The provided [testing.T] will be used to
 // shutdown the control plane at the end of the test.
-func NewEnv(t *testing.T) *kube.Ctl {
+func NewEnv(t *testing.T, opts ...kube.Option) *kube.Ctl {
 	// TODO: Would be nice to instead just import setup-envtest but the package
 	// isn't exactly friendly to be used as a library. Alternatively, we could
 	// use nix to provide the etcd and kubeapi-server binaries as that's all
@@ -50,7 +50,7 @@ func NewEnv(t *testing.T) *kube.Ctl {
 		require.NoError(t, env.Stop())
 	})
 
-	ctl, err := kube.FromRESTConfig(cfg)
+	ctl, err := kube.FromRESTConfig(cfg, opts...)
 	require.NoError(t, err)
 
 	return ctl


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [kube: improve Ctl struct](https://github.com/redpanda-data/redpanda-operator/pull/927)
 - [redpanda: correct Role and ClusterRole naming](https://github.com/redpanda-data/redpanda-operator/pull/927)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)