### PR TITLE
[release/v2.4.x] Add "Release On Tag" GHA | Correct "Release on Tag" GHA

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -34,6 +34,39 @@ projects:
 - label: Redpanda Operator
   key: operator
   changelog: operator/CHANGELOG.md
+  replacements:
+    # Update operator's Chart.yaml
+    - path: operator/chart/Chart.yaml
+      find: '^version: .*$'
+      replace: 'version: {{.VersionNoPrefix}}'
+    - path: operator/chart/Chart.yaml
+      find: '^appVersion: .*$'
+      replace: 'appVersion: {{.Version}}'
+    - path: operator/chart/Chart.yaml
+      find: '/redpanda-operator:.*$'
+      replace: '/redpanda-operator:{{.Version}}'
+    # Update golden files of the operator chart itself.
+    - path: operator/chart/testdata/*.golden.txtar
+      find: '/chart: operator-v.*$'
+      replace: '/chart: operator-{{.Version}}'
+    - path: operator/chart/testdata/*.golden.txtar
+      find: '/version: v.*$'
+      replace: '/version: {{.Version}}'
+    # Update references to the operator image in redpanda's values.yaml
+    # The whitespace ensures we update both values without touching the redpanda tag.
+    # It's fragile but all values are checked via unittests.
+    - path: charts/redpanda/values.yaml
+      find: '^      tag: .*$'
+      replace: '      tag: {{.Version}}'
+    - path: charts/redpanda/values.yaml
+      find: '^        tag: .*$'
+      replace: '        tag: {{.Version}}'
+    # Update golden files across the entire repo.
+    # Changie uses go's filepath.Match which doesn't support ** globbing so
+    # there's some repetition here.
+    - path: 'charts/redpanda/testdata/*.golden.txtar'
+      find: 'image: docker.redpanda.com/redpandadata/redpanda-operator:v.*$'
+      replace: 'image: docker.redpanda.com/redpandadata/redpanda-operator:{{.Version}}'
 - label: Redpanda Helm Chart
   key: charts/redpanda
   changelog: charts/redpanda/CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release On Tag
+
+on:
+  push:
+    tags:
+      # Only match tags that look like go module tags.
+      # This way we explicitly ignore our legacy tagging of the operator.
+      - '*/v*'
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        description: "The ref name to process (e.g., 'operator/v1.2.3')"
+        required: false
+        default: ""
+
+jobs:
+  release:
+    name: Create Release on GitHub
+    runs-on: ubuntu-latest
+
+    steps:
+      # for testing purposes and to allow updating of pre-existing releases,
+      # this workflow can be triggered by a tag being pushed or directly. This
+      # step normalized the possible inputs into a single variable.
+      - name: get ref
+        id: get_ref
+        run: |
+          if [[ -n "${{ inputs.ref_name }}" ]]; then
+            tag="${{ inputs.ref_name }}"
+          else
+            tag="${{ github.ref_name }}"
+          fi
+          echo "using ref name: $tag"
+          echo "ref_name=$tag" >> "$github_output"
+
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.get_ref.outputs.ref_name }}
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          github_access_token: ${{ secrets.github_token }}
+
+      # cache the nix store.
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashfiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
+
+      - name: build release name
+        id: release_name
+        run: |
+          # turn refs into slightly friendlier names. e.g. operator/v1.2.3 -> operator: v1.2.3
+          release_name="$(echo "${{ steps.get_ref.outputs.ref_name }}" | sed 's|/v|: v|')"
+          echo "release_name=$release_name" >> "$github_output"
+
+      - name: package helm chart
+        run: |
+          tag="${{ steps.get_ref.outputs.ref_name }}"
+          # extract the directory from the tag (e.g., "operator" from "operator/v1.2.3")
+          dir="$(dirname "$tag")"
+          # search for chart.yaml in $dir or one directory deep (e.g., operator/chart)
+          chart_path=$(find "$dir" -maxdepth 2 -type f -name "chart.yaml" | head -n 1)
+          # exit early if no chart.yaml file is found
+          if [[ -z "$chart_path" ]]; then
+            echo "no chart.yaml found for $tag. skipping step."
+            exit 0
+          fi
+
+          echo "packaging chart at $chart_path"
+          helm package -u "$(dirname "$chart_path")"
+
+      # create github release and upload file
+      - name: create github release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          name: steps.release_name.outputs.release_name
+          tag_name: steps.get_ref.outputs.ref_name
+          draft: false
+          make_latest: false
+          prerelease: ${{ contains(steps.get_ref.outputs.ref_name, '-alpha') || contains(steps.get_ref.outputs.ref_name, '-beta') }}
+          body_path: ".changes/${{ steps.get_ref.outputs.ref_name }}.md" # pull the release body from changie.
+          # if a chart was packaged, we'll upload it to this release preserving helm's naming convention.
+          files: |
+            ./*.tgz
+
+      # todo(chrisseto) trigger an action in the charts repo that updates index.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             tag="${{ github.ref_name }}"
           fi
           echo "using ref name: $tag"
-          echo "ref_name=$tag" >> "$github_output"
+          echo "ref_name=$tag" >> "$GITHUB_OUTPUT"
 
       - name: checkout code
         uses: actions/checkout@v4
@@ -53,35 +53,52 @@ jobs:
         run: |
           # turn refs into slightly friendlier names. e.g. operator/v1.2.3 -> operator: v1.2.3
           release_name="$(echo "${{ steps.get_ref.outputs.ref_name }}" | sed 's|/v|: v|')"
-          echo "release_name=$release_name" >> "$github_output"
+          echo "release_name=$release_name" >> "$GITHUB_OUTPUT"
 
       - name: package helm chart
         run: |
+          set -ex
           tag="${{ steps.get_ref.outputs.ref_name }}"
           # extract the directory from the tag (e.g., "operator" from "operator/v1.2.3")
           dir="$(dirname "$tag")"
           # search for chart.yaml in $dir or one directory deep (e.g., operator/chart)
-          chart_path=$(find "$dir" -maxdepth 2 -type f -name "chart.yaml" | head -n 1)
+          chart_path=$(find "$dir" -maxdepth 2 -type f -name "Chart.yaml" | head -n 1)
           # exit early if no chart.yaml file is found
           if [[ -z "$chart_path" ]]; then
             echo "no chart.yaml found for $tag. skipping step."
             exit 0
           fi
 
+          # Explicitly set the version based on the tag, stripping the leading
+          # v. This is done due to a mishap in managing the operator's version.
+          # All our charts specify `version` without a leading v but the
+          # operator's chart accidentally began doing so when binding version
+          # and appVersion.
+          # We enforce uniformity here, which retroactively corrects this
+          # issue.
+          version="$(basename "$tag")"
+          version="${version#v}"
+
           echo "packaging chart at $chart_path"
-          helm package -u "$(dirname "$chart_path")"
+          helm package -u --version "$version" "$(dirname "$chart_path")"
+
+      - name: reformat change log
+        run: |
+          # Our CHANGE LOGS begin with '## VERSION - DATE', which is
+          # duplicative to include in the GH release body. tail -n +2 will
+          # remove the first line.
+          tail -n +2 .changes/${{ steps.get_ref.outputs.ref_name }}.md > RELEASE_BODY.md
 
       # create github release and upload file
       - name: create github release
-        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
-          name: steps.release_name.outputs.release_name
-          tag_name: steps.get_ref.outputs.ref_name
+          name: ${{ steps.release_name.outputs.release_name }}
+          tag_name: ${{ steps.get_ref.outputs.ref_name }}
           draft: false
           make_latest: false
           prerelease: ${{ contains(steps.get_ref.outputs.ref_name, '-alpha') || contains(steps.get_ref.outputs.ref_name, '-beta') }}
-          body_path: ".changes/${{ steps.get_ref.outputs.ref_name }}.md" # pull the release body from changie.
+          body_path: RELEASE_BODY.md
           # if a chart was packaged, we'll upload it to this release preserving helm's naming convention.
           files: |
             ./*.tgz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,11 +97,12 @@ Releases](https://redpandadata.atlassian.net/projects/K8S?selectedItem=com.atlas
 To release any project in this repository:
 1. Mint the version and its CHANGELOG.md entry via `changie batch -j <project> <version>`
     - If minting a pre-release, specify `-k` to keep the unreleased changes in place for the official release.
+    - Manually review the contents and make any formatting or language adjustments as need be.
 2. Run `task test:unit` and `task lint`, they will report additional required actions, if any.
 4. Commit the resultant diff with the commit message `<project>: cut release <version>` and rebase it into master via a Pull Request.
 5. Tag the above commit with as `<project>/v<version>` with `git tag $(changie latest -j <project>) <commit-sha>`.
 6. Push the tags.
-7. Verify that the Release Workflow ran successfully.
+7. Verify that the [Release Workflow](./.github/workflows/release.yml) ran successfully.
 8. If applicable, mark the newly minted release as the "latest".
 
 ## Nightly build

--- a/operator/chart/Chart.yaml
+++ b/operator/chart/Chart.yaml
@@ -4,8 +4,9 @@ description: Redpanda operator helm chart
 type: application
 
 # The operator helm chart is considered part of the operator itself. Therefore
-# version == appVersion.
-version: v2.4.2
+# version == appVersion. Our charts' versions, don't include a leading `v`, so
+# we match that precedence here.
+version: 2.4.2
 appVersion: v2.4.2
 kubeVersion: ">= 1.25.0-0"
 

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: v2.4.2](https://img.shields.io/badge/Version-v2.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.4.2](https://img.shields.io/badge/AppVersion-v2.4.2-informational?style=flat-square)
+![Version: 2.4.2](https://img.shields.io/badge/Version-2.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.4.2](https://img.shields.io/badge/AppVersion-v2.4.2-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](./values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-config
   namespace: default
 ---
@@ -55,7 +55,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 rules:
 - apiGroups:
@@ -158,7 +158,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -243,7 +243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 rules:
 - apiGroups:
@@ -275,7 +275,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -297,7 +297,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -319,7 +319,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 rules:
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -613,7 +613,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -708,7 +708,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 rules:
@@ -773,7 +773,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -796,7 +796,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -819,7 +819,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -865,7 +865,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 roleRef:
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -911,7 +911,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:
@@ -1264,7 +1264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: S
   namespace: default
 ---
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-config
   namespace: default
 ---
@@ -1307,7 +1307,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY
 rules:
 - apiGroups:
@@ -1410,7 +1410,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-additional-controllers
 rules:
 - apiGroups:
@@ -1495,7 +1495,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-compat
 rules:
 - apiGroups:
@@ -1527,7 +1527,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1549,7 +1549,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1571,7 +1571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1593,7 +1593,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-election-role
   namespace: default
 rules:
@@ -1640,7 +1640,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY
   namespace: default
 rules:
@@ -1865,7 +1865,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-additional-controllers
   namespace: default
 rules:
@@ -1960,7 +1960,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-rpk-bundle
   namespace: default
 rules:
@@ -1993,7 +1993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-compat
   namespace: default
 rules:
@@ -2025,7 +2025,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-election-role
   namespace: default
 roleRef:
@@ -2048,7 +2048,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY
   namespace: default
 roleRef:
@@ -2071,7 +2071,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-additional-controllers
   namespace: default
 roleRef:
@@ -2094,7 +2094,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-rpk-bundle
   namespace: default
 roleRef:
@@ -2117,7 +2117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-compat
   namespace: default
 roleRef:
@@ -2140,7 +2140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-metrics-service
   namespace: default
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY
   namespace: default
 spec:
@@ -2291,7 +2291,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aNfgS0
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: koBY-metrics-monitor
   namespace: default
 spec:
@@ -2313,7 +2313,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: aNfgS0
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -2573,7 +2573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu
   namespace: default
 ---
@@ -2601,7 +2601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-config
   namespace: default
 ---
@@ -2616,7 +2616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -2635,7 +2635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu
 rules:
 - apiGroups:
@@ -2719,7 +2719,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-additional-controllers
 rules:
 - apiGroups:
@@ -2804,7 +2804,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-compat
 rules:
 - apiGroups:
@@ -2836,7 +2836,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2858,7 +2858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2880,7 +2880,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2902,7 +2902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-election-role
   namespace: default
 rules:
@@ -2949,7 +2949,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu
   namespace: default
 rules:
@@ -3174,7 +3174,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-additional-controllers
   namespace: default
 rules:
@@ -3269,7 +3269,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-rpk-bundle
   namespace: default
 rules:
@@ -3302,7 +3302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-compat
   namespace: default
 rules:
@@ -3334,7 +3334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-election-role
   namespace: default
 roleRef:
@@ -3357,7 +3357,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu
   namespace: default
 roleRef:
@@ -3380,7 +3380,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-additional-controllers
   namespace: default
 roleRef:
@@ -3403,7 +3403,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-rpk-bundle
   namespace: default
 roleRef:
@@ -3426,7 +3426,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-compat
   namespace: default
 roleRef:
@@ -3449,7 +3449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu-metrics-service
   namespace: default
 spec:
@@ -3472,7 +3472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: EbX3hB7N
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: WSGbu
   namespace: default
 spec:
@@ -3830,7 +3830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G
   namespace: default
 ---
@@ -3861,7 +3861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-config
   namespace: default
 ---
@@ -3879,7 +3879,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-metrics-reader
 rules:
 - nonResourceURLs:
@@ -3901,7 +3901,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G
 rules:
 - apiGroups:
@@ -3988,7 +3988,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-additional-controllers
 rules:
 - apiGroups:
@@ -4076,7 +4076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-compat
 rules:
 - apiGroups:
@@ -4111,7 +4111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4136,7 +4136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4161,7 +4161,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -4186,7 +4186,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-election-role
   namespace: default
 rules:
@@ -4236,7 +4236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G
   namespace: default
 rules:
@@ -4464,7 +4464,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-additional-controllers
   namespace: default
 rules:
@@ -4562,7 +4562,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-rpk-bundle
   namespace: default
 rules:
@@ -4598,7 +4598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-compat
   namespace: default
 rules:
@@ -4633,7 +4633,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-election-role
   namespace: default
 roleRef:
@@ -4659,7 +4659,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G
   namespace: default
 roleRef:
@@ -4685,7 +4685,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-additional-controllers
   namespace: default
 roleRef:
@@ -4711,7 +4711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-rpk-bundle
   namespace: default
 roleRef:
@@ -4737,7 +4737,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-compat
   namespace: default
 roleRef:
@@ -4763,7 +4763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G-metrics-service
   namespace: default
 spec:
@@ -4789,7 +4789,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: HICN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Dx441G
   namespace: default
 spec:
@@ -5153,7 +5153,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba
   namespace: default
 ---
@@ -5181,7 +5181,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-config
   namespace: default
 ---
@@ -5196,7 +5196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-metrics-reader
 rules:
 - nonResourceURLs:
@@ -5215,7 +5215,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba
 rules:
 - apiGroups:
@@ -5299,7 +5299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-additional-controllers
 rules:
 - apiGroups:
@@ -5384,7 +5384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-compat
 rules:
 - apiGroups:
@@ -5416,7 +5416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5438,7 +5438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5460,7 +5460,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5482,7 +5482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-election-role
   namespace: default
 rules:
@@ -5529,7 +5529,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba
   namespace: default
 rules:
@@ -5754,7 +5754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-additional-controllers
   namespace: default
 rules:
@@ -5849,7 +5849,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-rpk-bundle
   namespace: default
 rules:
@@ -5882,7 +5882,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-compat
   namespace: default
 rules:
@@ -5914,7 +5914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-election-role
   namespace: default
 roleRef:
@@ -5937,7 +5937,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba
   namespace: default
 roleRef:
@@ -5960,7 +5960,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-additional-controllers
   namespace: default
 roleRef:
@@ -5983,7 +5983,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-rpk-bundle
   namespace: default
 roleRef:
@@ -6006,7 +6006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-compat
   namespace: default
 roleRef:
@@ -6029,7 +6029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba-metrics-service
   namespace: default
 spec:
@@ -6052,7 +6052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kzHCtV
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rEba
   namespace: default
 spec:
@@ -6444,7 +6444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: SpE0
   namespace: default
 ---
@@ -6473,7 +6473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-config
   namespace: default
 ---
@@ -6489,7 +6489,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-metrics-reader
 rules:
 - nonResourceURLs:
@@ -6509,7 +6509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z
 rules:
 - apiGroups:
@@ -6594,7 +6594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-additional-controllers
 rules:
 - apiGroups:
@@ -6680,7 +6680,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-compat
 rules:
 - apiGroups:
@@ -6713,7 +6713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6736,7 +6736,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6759,7 +6759,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6782,7 +6782,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-election-role
   namespace: default
 rules:
@@ -6830,7 +6830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z
   namespace: default
 rules:
@@ -7056,7 +7056,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-additional-controllers
   namespace: default
 rules:
@@ -7152,7 +7152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-rpk-bundle
   namespace: default
 rules:
@@ -7186,7 +7186,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-compat
   namespace: default
 rules:
@@ -7219,7 +7219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-election-role
   namespace: default
 roleRef:
@@ -7243,7 +7243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z
   namespace: default
 roleRef:
@@ -7267,7 +7267,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-additional-controllers
   namespace: default
 roleRef:
@@ -7291,7 +7291,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-rpk-bundle
   namespace: default
 roleRef:
@@ -7315,7 +7315,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-compat
   namespace: default
 roleRef:
@@ -7339,7 +7339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z-metrics-service
   namespace: default
 spec:
@@ -7363,7 +7363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BRlD
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kdh6Z
   namespace: default
 spec:
@@ -7727,7 +7727,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -7758,7 +7758,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-config
   namespace: default
@@ -7776,7 +7776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-metrics-reader
 rules:
@@ -7798,7 +7798,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
 rules:
@@ -7885,7 +7885,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
 rules:
@@ -7973,7 +7973,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-compat
 rules:
@@ -8008,7 +8008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
 roleRef:
@@ -8033,7 +8033,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
 roleRef:
@@ -8058,7 +8058,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-compat
 roleRef:
@@ -8083,7 +8083,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-election-role
   namespace: default
@@ -8133,7 +8133,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -8361,7 +8361,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
   namespace: default
@@ -8459,7 +8459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-rpk-bundle
   namespace: default
@@ -8495,7 +8495,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-compat
   namespace: default
@@ -8530,7 +8530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-election-role
   namespace: default
@@ -8556,7 +8556,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -8582,7 +8582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-additional-controllers
   namespace: default
@@ -8608,7 +8608,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-rpk-bundle
   namespace: default
@@ -8634,7 +8634,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-compat
   namespace: default
@@ -8660,7 +8660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B-metrics-service
   namespace: default
@@ -8686,7 +8686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zejbO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wU3MsxN: 4Bn0vQj
   name: WM7nRI7B
   namespace: default
@@ -9070,7 +9070,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em
   namespace: default
 ---
@@ -9099,7 +9099,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-config
   namespace: default
 ---
@@ -9115,7 +9115,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-metrics-reader
 rules:
 - nonResourceURLs:
@@ -9135,7 +9135,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em
 rules:
 - apiGroups:
@@ -9220,7 +9220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-additional-controllers
 rules:
 - apiGroups:
@@ -9306,7 +9306,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-compat
 rules:
 - apiGroups:
@@ -9339,7 +9339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9362,7 +9362,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9385,7 +9385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9408,7 +9408,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-election-role
   namespace: default
 rules:
@@ -9456,7 +9456,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em
   namespace: default
 rules:
@@ -9682,7 +9682,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-additional-controllers
   namespace: default
 rules:
@@ -9778,7 +9778,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-rpk-bundle
   namespace: default
 rules:
@@ -9812,7 +9812,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-compat
   namespace: default
 rules:
@@ -9845,7 +9845,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-election-role
   namespace: default
 roleRef:
@@ -9869,7 +9869,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em
   namespace: default
 roleRef:
@@ -9893,7 +9893,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-additional-controllers
   namespace: default
 roleRef:
@@ -9917,7 +9917,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-rpk-bundle
   namespace: default
 roleRef:
@@ -9941,7 +9941,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-compat
   namespace: default
 roleRef:
@@ -9965,7 +9965,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-metrics-service
   namespace: default
 spec:
@@ -9989,7 +9989,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em
   namespace: default
 spec:
@@ -10100,7 +10100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: di
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Em-metrics-monitor
   namespace: default
 spec:
@@ -10123,7 +10123,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: di
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -10385,7 +10385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QOxZ1
   namespace: default
 ---
@@ -10416,7 +10416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 6yA-config
   namespace: default
 ---
@@ -10434,7 +10434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 6yA-metrics-service
   namespace: default
 spec:
@@ -10460,7 +10460,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ij1lCfI4a
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 6yA
   namespace: default
 spec:
@@ -10815,7 +10815,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: q5hs
   namespace: default
@@ -10847,7 +10847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-config
   namespace: default
@@ -10866,7 +10866,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-metrics-reader
 rules:
@@ -10889,7 +10889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn
 rules:
@@ -10977,7 +10977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
 rules:
@@ -11066,7 +11066,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-compat
 rules:
@@ -11102,7 +11102,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn
 roleRef:
@@ -11128,7 +11128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
 roleRef:
@@ -11154,7 +11154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-compat
 roleRef:
@@ -11180,7 +11180,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-election-role
   namespace: default
@@ -11231,7 +11231,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn
   namespace: default
@@ -11460,7 +11460,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
   namespace: default
@@ -11559,7 +11559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-rpk-bundle
   namespace: default
@@ -11596,7 +11596,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-compat
   namespace: default
@@ -11632,7 +11632,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-election-role
   namespace: default
@@ -11659,7 +11659,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn
   namespace: default
@@ -11686,7 +11686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-additional-controllers
   namespace: default
@@ -11713,7 +11713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-rpk-bundle
   namespace: default
@@ -11740,7 +11740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-compat
   namespace: default
@@ -11767,7 +11767,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn-metrics-service
   namespace: default
@@ -11794,7 +11794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: GNbmN
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     u: yT9Aqc
   name: DBMkVbLNvvZn
   namespace: default
@@ -12172,7 +12172,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs
   namespace: default
 ---
@@ -12202,7 +12202,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-config
   namespace: default
 ---
@@ -12219,7 +12219,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-metrics-reader
 rules:
 - nonResourceURLs:
@@ -12240,7 +12240,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs
 rules:
 - apiGroups:
@@ -12326,7 +12326,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-additional-controllers
 rules:
 - apiGroups:
@@ -12413,7 +12413,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-compat
 rules:
 - apiGroups:
@@ -12447,7 +12447,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12471,7 +12471,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12495,7 +12495,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12519,7 +12519,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-election-role
   namespace: default
 rules:
@@ -12568,7 +12568,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs
   namespace: default
 rules:
@@ -12795,7 +12795,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-additional-controllers
   namespace: default
 rules:
@@ -12892,7 +12892,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-rpk-bundle
   namespace: default
 rules:
@@ -12927,7 +12927,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-compat
   namespace: default
 rules:
@@ -12961,7 +12961,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-election-role
   namespace: default
 roleRef:
@@ -12986,7 +12986,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs
   namespace: default
 roleRef:
@@ -13011,7 +13011,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-additional-controllers
   namespace: default
 roleRef:
@@ -13036,7 +13036,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-rpk-bundle
   namespace: default
 roleRef:
@@ -13061,7 +13061,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-compat
   namespace: default
 roleRef:
@@ -13086,7 +13086,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs-metrics-service
   namespace: default
 spec:
@@ -13111,7 +13111,7 @@ metadata:
     app.kubernetes.io/name: 6n9214EY
     app.kubernetes.io/version: v2.4.2
     gLlqKr: m
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kBI8lEs
   namespace: default
 spec:
@@ -13475,7 +13475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE
   namespace: default
 ---
@@ -13505,7 +13505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-config
   namespace: default
 ---
@@ -13522,7 +13522,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-metrics-reader
 rules:
 - nonResourceURLs:
@@ -13543,7 +13543,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE
 rules:
 - apiGroups:
@@ -13629,7 +13629,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-additional-controllers
 rules:
 - apiGroups:
@@ -13716,7 +13716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-compat
 rules:
 - apiGroups:
@@ -13750,7 +13750,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13774,7 +13774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13798,7 +13798,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13822,7 +13822,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-election-role
   namespace: default
 rules:
@@ -13871,7 +13871,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE
   namespace: default
 rules:
@@ -14098,7 +14098,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-additional-controllers
   namespace: default
 rules:
@@ -14195,7 +14195,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-rpk-bundle
   namespace: default
 rules:
@@ -14230,7 +14230,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-compat
   namespace: default
 rules:
@@ -14264,7 +14264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-election-role
   namespace: default
 roleRef:
@@ -14289,7 +14289,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE
   namespace: default
 roleRef:
@@ -14314,7 +14314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-additional-controllers
   namespace: default
 roleRef:
@@ -14339,7 +14339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-rpk-bundle
   namespace: default
 roleRef:
@@ -14364,7 +14364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-compat
   namespace: default
 roleRef:
@@ -14389,7 +14389,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE-metrics-service
   namespace: default
 spec:
@@ -14414,7 +14414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ubj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: rcE
   namespace: default
 spec:
@@ -14822,7 +14822,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -14853,7 +14853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-config
@@ -14871,7 +14871,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-metrics-reader
@@ -14893,7 +14893,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -14980,7 +14980,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -15068,7 +15068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-compat
@@ -15103,7 +15103,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -15128,7 +15128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -15153,7 +15153,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-compat
@@ -15178,7 +15178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-election-role
@@ -15228,7 +15228,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -15456,7 +15456,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -15554,7 +15554,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-rpk-bundle
@@ -15590,7 +15590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-compat
@@ -15625,7 +15625,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-election-role
@@ -15651,7 +15651,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -15677,7 +15677,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-additional-controllers
@@ -15703,7 +15703,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-rpk-bundle
@@ -15729,7 +15729,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-compat
@@ -15755,7 +15755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07-metrics-service
@@ -15781,7 +15781,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pP
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mOxaE: dEuL
     w49JChsEQqA0: "3"
   name: 7guti07
@@ -16140,7 +16140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI
   namespace: default
 ---
@@ -16168,7 +16168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-config
   namespace: default
 ---
@@ -16183,7 +16183,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-metrics-reader
 rules:
 - nonResourceURLs:
@@ -16202,7 +16202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI
 rules:
 - apiGroups:
@@ -16286,7 +16286,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-additional-controllers
 rules:
 - apiGroups:
@@ -16371,7 +16371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-compat
 rules:
 - apiGroups:
@@ -16403,7 +16403,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16425,7 +16425,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16447,7 +16447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16469,7 +16469,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-election-role
   namespace: default
 rules:
@@ -16516,7 +16516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI
   namespace: default
 rules:
@@ -16741,7 +16741,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-additional-controllers
   namespace: default
 rules:
@@ -16836,7 +16836,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-rpk-bundle
   namespace: default
 rules:
@@ -16869,7 +16869,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-compat
   namespace: default
 rules:
@@ -16901,7 +16901,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-election-role
   namespace: default
 roleRef:
@@ -16924,7 +16924,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI
   namespace: default
 roleRef:
@@ -16947,7 +16947,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-additional-controllers
   namespace: default
 roleRef:
@@ -16970,7 +16970,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-rpk-bundle
   namespace: default
 roleRef:
@@ -16993,7 +16993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-compat
   namespace: default
 roleRef:
@@ -17016,7 +17016,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI-metrics-service
   namespace: default
 spec:
@@ -17039,7 +17039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: E4UR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J5MiI
   namespace: default
 spec:
@@ -17448,7 +17448,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS
   namespace: default
 ---
@@ -17478,7 +17478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-config
   namespace: default
 ---
@@ -17495,7 +17495,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-metrics-reader
 rules:
 - nonResourceURLs:
@@ -17516,7 +17516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS
 rules:
 - apiGroups:
@@ -17602,7 +17602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-additional-controllers
 rules:
 - apiGroups:
@@ -17689,7 +17689,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-compat
 rules:
 - apiGroups:
@@ -17723,7 +17723,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -17747,7 +17747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -17771,7 +17771,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -17795,7 +17795,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-election-role
   namespace: default
 rules:
@@ -17844,7 +17844,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS
   namespace: default
 rules:
@@ -18071,7 +18071,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-additional-controllers
   namespace: default
 rules:
@@ -18168,7 +18168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-rpk-bundle
   namespace: default
 rules:
@@ -18203,7 +18203,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-compat
   namespace: default
 rules:
@@ -18237,7 +18237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-election-role
   namespace: default
 roleRef:
@@ -18262,7 +18262,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS
   namespace: default
 roleRef:
@@ -18287,7 +18287,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-additional-controllers
   namespace: default
 roleRef:
@@ -18312,7 +18312,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-rpk-bundle
   namespace: default
 roleRef:
@@ -18337,7 +18337,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-compat
   namespace: default
 roleRef:
@@ -18362,7 +18362,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS-metrics-service
   namespace: default
 spec:
@@ -18387,7 +18387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xALbe0A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: NofaS
   namespace: default
 spec:
@@ -18754,7 +18754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: g5
   namespace: default
 ---
@@ -18785,7 +18785,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: o2lMoG-config
   namespace: default
 ---
@@ -18803,7 +18803,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: o2lMoG-metrics-service
   namespace: default
 spec:
@@ -18829,7 +18829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qKT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: o2lMoG
   namespace: default
 spec:
@@ -19277,7 +19277,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-config
   namespace: default
 ---
@@ -19293,7 +19293,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-metrics-reader
 rules:
 - nonResourceURLs:
@@ -19313,7 +19313,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R
 rules:
 - apiGroups:
@@ -19398,7 +19398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-compat
 rules:
 - apiGroups:
@@ -19431,7 +19431,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -19454,7 +19454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -19477,7 +19477,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-election-role
   namespace: default
 rules:
@@ -19525,7 +19525,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R
   namespace: default
 rules:
@@ -19751,7 +19751,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-compat
   namespace: default
 rules:
@@ -19784,7 +19784,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-election-role
   namespace: default
 roleRef:
@@ -19808,7 +19808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R
   namespace: default
 roleRef:
@@ -19832,7 +19832,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-compat
   namespace: default
 roleRef:
@@ -19856,7 +19856,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R-metrics-service
   namespace: default
 spec:
@@ -19880,7 +19880,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: TCq
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K9R
   namespace: default
 spec:
@@ -20291,7 +20291,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL
   namespace: default
@@ -20321,7 +20321,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL-config
   namespace: default
@@ -20338,7 +20338,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL-metrics-service
   namespace: default
@@ -20363,7 +20363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5aFk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     pSTEUjYKreNw: j4onXF
   name: f0FlDsNL
   namespace: default
@@ -20841,7 +20841,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: pHzNPjb
   namespace: default
@@ -20871,7 +20871,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-config
   namespace: default
@@ -20888,7 +20888,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-metrics-reader
 rules:
@@ -20909,7 +20909,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O
 rules:
@@ -20995,7 +20995,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-additional-controllers
 rules:
@@ -21082,7 +21082,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-compat
 rules:
@@ -21116,7 +21116,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O
 roleRef:
@@ -21140,7 +21140,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-additional-controllers
 roleRef:
@@ -21164,7 +21164,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-compat
 roleRef:
@@ -21188,7 +21188,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-election-role
   namespace: default
@@ -21237,7 +21237,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O
   namespace: default
@@ -21464,7 +21464,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-additional-controllers
   namespace: default
@@ -21561,7 +21561,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-rpk-bundle
   namespace: default
@@ -21596,7 +21596,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-compat
   namespace: default
@@ -21630,7 +21630,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-election-role
   namespace: default
@@ -21655,7 +21655,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O
   namespace: default
@@ -21680,7 +21680,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-additional-controllers
   namespace: default
@@ -21705,7 +21705,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-rpk-bundle
   namespace: default
@@ -21730,7 +21730,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-compat
   namespace: default
@@ -21755,7 +21755,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-metrics-service
   namespace: default
@@ -21780,7 +21780,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O
   namespace: default
@@ -21991,7 +21991,7 @@ metadata:
     app.kubernetes.io/name: NlE3orKsq9
     app.kubernetes.io/version: v2.4.2
     bKX: d
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     m2Z8Z: wRw
   name: DX7O-metrics-monitor
   namespace: default
@@ -22015,7 +22015,7 @@ spec:
       app.kubernetes.io/name: NlE3orKsq9
       app.kubernetes.io/version: v2.4.2
       bKX: d
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       m2Z8Z: wRw
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
@@ -22276,7 +22276,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh
   namespace: default
 ---
@@ -22307,7 +22307,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-config
   namespace: default
 ---
@@ -22325,7 +22325,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-metrics-reader
 rules:
 - nonResourceURLs:
@@ -22347,7 +22347,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh
 rules:
 - apiGroups:
@@ -22434,7 +22434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-additional-controllers
 rules:
 - apiGroups:
@@ -22522,7 +22522,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-compat
 rules:
 - apiGroups:
@@ -22557,7 +22557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22582,7 +22582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22607,7 +22607,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22632,7 +22632,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-election-role
   namespace: default
 rules:
@@ -22682,7 +22682,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh
   namespace: default
 rules:
@@ -22910,7 +22910,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-additional-controllers
   namespace: default
 rules:
@@ -23008,7 +23008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-rpk-bundle
   namespace: default
 rules:
@@ -23044,7 +23044,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-compat
   namespace: default
 rules:
@@ -23079,7 +23079,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-election-role
   namespace: default
 roleRef:
@@ -23105,7 +23105,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh
   namespace: default
 roleRef:
@@ -23131,7 +23131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-additional-controllers
   namespace: default
 roleRef:
@@ -23157,7 +23157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-rpk-bundle
   namespace: default
 roleRef:
@@ -23183,7 +23183,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-compat
   namespace: default
 roleRef:
@@ -23209,7 +23209,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-metrics-service
   namespace: default
 spec:
@@ -23235,7 +23235,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh
   namespace: default
 spec:
@@ -23367,7 +23367,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "5"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: x8K24mCZYsnh-metrics-monitor
   namespace: default
 spec:
@@ -23389,7 +23389,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: "5"
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -23649,7 +23649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi
   namespace: default
 ---
@@ -23680,7 +23680,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-config
   namespace: default
 ---
@@ -23698,7 +23698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-metrics-reader
 rules:
 - nonResourceURLs:
@@ -23720,7 +23720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi
 rules:
 - apiGroups:
@@ -23807,7 +23807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-additional-controllers
 rules:
 - apiGroups:
@@ -23895,7 +23895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-compat
 rules:
 - apiGroups:
@@ -23930,7 +23930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -23955,7 +23955,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -23980,7 +23980,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -24005,7 +24005,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-election-role
   namespace: default
 rules:
@@ -24055,7 +24055,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi
   namespace: default
 rules:
@@ -24283,7 +24283,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-additional-controllers
   namespace: default
 rules:
@@ -24381,7 +24381,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-rpk-bundle
   namespace: default
 rules:
@@ -24417,7 +24417,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-compat
   namespace: default
 rules:
@@ -24452,7 +24452,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-election-role
   namespace: default
 roleRef:
@@ -24478,7 +24478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi
   namespace: default
 roleRef:
@@ -24504,7 +24504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-additional-controllers
   namespace: default
 roleRef:
@@ -24530,7 +24530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-rpk-bundle
   namespace: default
 roleRef:
@@ -24556,7 +24556,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-compat
   namespace: default
 roleRef:
@@ -24582,7 +24582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-metrics-service
   namespace: default
 spec:
@@ -24608,7 +24608,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi
   namespace: default
 spec:
@@ -24734,7 +24734,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Fk
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: UHlKDi-metrics-monitor
   namespace: default
 spec:
@@ -24756,7 +24756,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Fk
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -25029,7 +25029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-config
   namespace: default
@@ -25046,7 +25046,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-metrics-reader
 rules:
@@ -25067,7 +25067,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
 rules:
@@ -25153,7 +25153,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
 rules:
@@ -25240,7 +25240,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-compat
 rules:
@@ -25274,7 +25274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
 roleRef:
@@ -25298,7 +25298,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
 roleRef:
@@ -25322,7 +25322,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-compat
 roleRef:
@@ -25346,7 +25346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-election-role
   namespace: default
@@ -25395,7 +25395,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
   namespace: default
@@ -25622,7 +25622,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
   namespace: default
@@ -25719,7 +25719,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-rpk-bundle
   namespace: default
@@ -25754,7 +25754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-compat
   namespace: default
@@ -25788,7 +25788,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-election-role
   namespace: default
@@ -25813,7 +25813,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
   namespace: default
@@ -25838,7 +25838,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-additional-controllers
   namespace: default
@@ -25863,7 +25863,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-rpk-bundle
   namespace: default
@@ -25888,7 +25888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-compat
   namespace: default
@@ -25913,7 +25913,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR-metrics-service
   namespace: default
@@ -25938,7 +25938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: IC6CHScZj
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ruSHmUUvOj1: h3BuiPAHIC
   name: wINY4HR
   namespace: default
@@ -26480,7 +26480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 12bwUKO
   namespace: default
@@ -26509,7 +26509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-config
   namespace: default
@@ -26525,7 +26525,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-metrics-reader
 rules:
@@ -26545,7 +26545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: "5"
 rules:
@@ -26630,7 +26630,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-additional-controllers
 rules:
@@ -26716,7 +26716,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-compat
 rules:
@@ -26749,7 +26749,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: "5"
 roleRef:
@@ -26772,7 +26772,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-additional-controllers
 roleRef:
@@ -26795,7 +26795,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-compat
 roleRef:
@@ -26818,7 +26818,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-election-role
   namespace: default
@@ -26866,7 +26866,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: "5"
   namespace: default
@@ -27092,7 +27092,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-additional-controllers
   namespace: default
@@ -27188,7 +27188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-rpk-bundle
   namespace: default
@@ -27222,7 +27222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-compat
   namespace: default
@@ -27255,7 +27255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-election-role
   namespace: default
@@ -27279,7 +27279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: "5"
   namespace: default
@@ -27303,7 +27303,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-additional-controllers
   namespace: default
@@ -27327,7 +27327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-rpk-bundle
   namespace: default
@@ -27351,7 +27351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-compat
   namespace: default
@@ -27375,7 +27375,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: 5-metrics-service
   namespace: default
@@ -27399,7 +27399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZtDuI
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kxvj1aV: un4v2
   name: "5"
   namespace: default
@@ -27783,7 +27783,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf
   namespace: default
 ---
@@ -27816,7 +27816,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-config
   namespace: default
 ---
@@ -27836,7 +27836,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-metrics-reader
 rules:
 - nonResourceURLs:
@@ -27860,7 +27860,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf
 rules:
 - apiGroups:
@@ -27949,7 +27949,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-additional-controllers
 rules:
 - apiGroups:
@@ -28039,7 +28039,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-compat
 rules:
 - apiGroups:
@@ -28076,7 +28076,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28103,7 +28103,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28130,7 +28130,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28157,7 +28157,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-election-role
   namespace: default
 rules:
@@ -28209,7 +28209,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf
   namespace: default
 rules:
@@ -28439,7 +28439,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-additional-controllers
   namespace: default
 rules:
@@ -28539,7 +28539,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-rpk-bundle
   namespace: default
 rules:
@@ -28577,7 +28577,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-compat
   namespace: default
 rules:
@@ -28614,7 +28614,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-election-role
   namespace: default
 roleRef:
@@ -28642,7 +28642,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf
   namespace: default
 roleRef:
@@ -28670,7 +28670,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-additional-controllers
   namespace: default
 roleRef:
@@ -28698,7 +28698,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-rpk-bundle
   namespace: default
 roleRef:
@@ -28726,7 +28726,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-compat
   namespace: default
 roleRef:
@@ -28754,7 +28754,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf-metrics-service
   namespace: default
 spec:
@@ -28782,7 +28782,7 @@ metadata:
     app.kubernetes.io/name: NY
     app.kubernetes.io/version: v2.4.2
     gWL: pM
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sFwgtf
   namespace: default
 spec:
@@ -29354,7 +29354,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-config
   namespace: default
@@ -29370,7 +29370,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-metrics-reader
 rules:
@@ -29390,7 +29390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi
 rules:
@@ -29475,7 +29475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-additional-controllers
 rules:
@@ -29561,7 +29561,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-compat
 rules:
@@ -29594,7 +29594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi
 roleRef:
@@ -29617,7 +29617,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-additional-controllers
 roleRef:
@@ -29640,7 +29640,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-compat
 roleRef:
@@ -29663,7 +29663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-election-role
   namespace: default
@@ -29711,7 +29711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi
   namespace: default
@@ -29937,7 +29937,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-additional-controllers
   namespace: default
@@ -30033,7 +30033,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-rpk-bundle
   namespace: default
@@ -30067,7 +30067,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-compat
   namespace: default
@@ -30100,7 +30100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-election-role
   namespace: default
@@ -30124,7 +30124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi
   namespace: default
@@ -30148,7 +30148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-additional-controllers
   namespace: default
@@ -30172,7 +30172,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-rpk-bundle
   namespace: default
@@ -30196,7 +30196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-compat
   namespace: default
@@ -30220,7 +30220,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi-metrics-service
   namespace: default
@@ -30244,7 +30244,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4waX
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     iW8sRg: to
   name: bi
   namespace: default
@@ -30869,7 +30869,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: a
   namespace: default
 ---
@@ -30900,7 +30900,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-config
   namespace: default
 ---
@@ -30918,7 +30918,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-metrics-reader
 rules:
 - nonResourceURLs:
@@ -30940,7 +30940,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs
 rules:
 - apiGroups:
@@ -31027,7 +31027,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-additional-controllers
 rules:
 - apiGroups:
@@ -31115,7 +31115,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-compat
 rules:
 - apiGroups:
@@ -31150,7 +31150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31175,7 +31175,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31200,7 +31200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31225,7 +31225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-election-role
   namespace: default
 rules:
@@ -31275,7 +31275,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs
   namespace: default
 rules:
@@ -31503,7 +31503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-additional-controllers
   namespace: default
 rules:
@@ -31601,7 +31601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-rpk-bundle
   namespace: default
 rules:
@@ -31637,7 +31637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-compat
   namespace: default
 rules:
@@ -31672,7 +31672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-election-role
   namespace: default
 roleRef:
@@ -31698,7 +31698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs
   namespace: default
 roleRef:
@@ -31724,7 +31724,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-additional-controllers
   namespace: default
 roleRef:
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-rpk-bundle
   namespace: default
 roleRef:
@@ -31776,7 +31776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-compat
   namespace: default
 roleRef:
@@ -31802,7 +31802,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs-metrics-service
   namespace: default
 spec:
@@ -31828,7 +31828,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YCs
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-YCs
   namespace: default
 spec:
@@ -32336,7 +32336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: sA
   namespace: default
 ---
@@ -32367,7 +32367,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: VI1RU-config
   namespace: default
 ---
@@ -32385,7 +32385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: VI1RU-metrics-service
   namespace: default
 spec:
@@ -32411,7 +32411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: VI1RU
   namespace: default
 spec:
@@ -33085,7 +33085,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: blB
   namespace: default
 ---
@@ -33117,7 +33117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-config
   namespace: default
 ---
@@ -33136,7 +33136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-metrics-reader
 rules:
 - nonResourceURLs:
@@ -33159,7 +33159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "2"
 rules:
 - apiGroups:
@@ -33247,7 +33247,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-additional-controllers
 rules:
 - apiGroups:
@@ -33336,7 +33336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-compat
 rules:
 - apiGroups:
@@ -33372,7 +33372,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33398,7 +33398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33424,7 +33424,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33450,7 +33450,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-election-role
   namespace: default
 rules:
@@ -33501,7 +33501,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "2"
   namespace: default
 rules:
@@ -33730,7 +33730,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-additional-controllers
   namespace: default
 rules:
@@ -33829,7 +33829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-rpk-bundle
   namespace: default
 rules:
@@ -33866,7 +33866,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-compat
   namespace: default
 rules:
@@ -33902,7 +33902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-election-role
   namespace: default
 roleRef:
@@ -33929,7 +33929,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "2"
   namespace: default
 roleRef:
@@ -33956,7 +33956,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-additional-controllers
   namespace: default
 roleRef:
@@ -33983,7 +33983,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-rpk-bundle
   namespace: default
 roleRef:
@@ -34010,7 +34010,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-compat
   namespace: default
 roleRef:
@@ -34037,7 +34037,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-metrics-service
   namespace: default
 spec:
@@ -34064,7 +34064,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "2"
   namespace: default
 spec:
@@ -34387,7 +34387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: VhCMS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2-metrics-monitor
   namespace: default
 spec:
@@ -34411,7 +34411,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: VhCMS
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -34673,7 +34673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tIa
   namespace: default
 ---
@@ -34703,7 +34703,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-config
   namespace: default
 ---
@@ -34720,7 +34720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-metrics-reader
 rules:
 - nonResourceURLs:
@@ -34741,7 +34741,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO
 rules:
 - apiGroups:
@@ -34827,7 +34827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-compat
 rules:
 - apiGroups:
@@ -34861,7 +34861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -34885,7 +34885,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -34909,7 +34909,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-election-role
   namespace: default
 rules:
@@ -34958,7 +34958,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO
   namespace: default
 rules:
@@ -35185,7 +35185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-compat
   namespace: default
 rules:
@@ -35219,7 +35219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-election-role
   namespace: default
 roleRef:
@@ -35244,7 +35244,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO
   namespace: default
 roleRef:
@@ -35269,7 +35269,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-compat
   namespace: default
 roleRef:
@@ -35294,7 +35294,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-metrics-service
   namespace: default
 spec:
@@ -35319,7 +35319,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO
   namespace: default
 spec:
@@ -35762,7 +35762,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: z7BRO-metrics-monitor
   namespace: default
 spec:
@@ -35786,7 +35786,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Qi
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -36060,7 +36060,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: na-config
   namespace: default
 ---
@@ -36077,7 +36077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: na-metrics-service
   namespace: default
 spec:
@@ -36102,7 +36102,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: na
   namespace: default
 spec:
@@ -36403,7 +36403,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 7Nn
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: na-metrics-monitor
   namespace: default
 spec:
@@ -36425,7 +36425,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 7Nn
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -36700,7 +36700,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-config
   namespace: default
 ---
@@ -36718,7 +36718,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-metrics-reader
 rules:
 - nonResourceURLs:
@@ -36740,7 +36740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D
 rules:
 - apiGroups:
@@ -36827,7 +36827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-additional-controllers
 rules:
 - apiGroups:
@@ -36915,7 +36915,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-compat
 rules:
 - apiGroups:
@@ -36950,7 +36950,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -36975,7 +36975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37000,7 +37000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37025,7 +37025,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-election-role
   namespace: default
 rules:
@@ -37075,7 +37075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D
   namespace: default
 rules:
@@ -37303,7 +37303,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-additional-controllers
   namespace: default
 rules:
@@ -37401,7 +37401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-rpk-bundle
   namespace: default
 rules:
@@ -37437,7 +37437,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-compat
   namespace: default
 rules:
@@ -37472,7 +37472,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-election-role
   namespace: default
 roleRef:
@@ -37498,7 +37498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D
   namespace: default
 roleRef:
@@ -37524,7 +37524,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-additional-controllers
   namespace: default
 roleRef:
@@ -37550,7 +37550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-rpk-bundle
   namespace: default
 roleRef:
@@ -37576,7 +37576,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-compat
   namespace: default
 roleRef:
@@ -37602,7 +37602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D-metrics-service
   namespace: default
 spec:
@@ -37628,7 +37628,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aYT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: D
   namespace: default
 spec:
@@ -38166,7 +38166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: spW
   namespace: default
 ---
@@ -38196,7 +38196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: vvvAuBP-config
   namespace: default
 ---
@@ -38213,7 +38213,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: vvvAuBP-metrics-service
   namespace: default
 spec:
@@ -38238,7 +38238,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xl0SYd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: vvvAuBP
   namespace: default
 spec:
@@ -38958,7 +38958,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Zihc6G
   namespace: default
 ---
@@ -38989,7 +38989,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-config
   namespace: default
 ---
@@ -39007,7 +39007,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -39029,7 +39029,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu
 rules:
 - apiGroups:
@@ -39116,7 +39116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-additional-controllers
 rules:
 - apiGroups:
@@ -39204,7 +39204,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-compat
 rules:
 - apiGroups:
@@ -39239,7 +39239,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39264,7 +39264,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39289,7 +39289,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39314,7 +39314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-election-role
   namespace: default
 rules:
@@ -39364,7 +39364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu
   namespace: default
 rules:
@@ -39592,7 +39592,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-additional-controllers
   namespace: default
 rules:
@@ -39690,7 +39690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-rpk-bundle
   namespace: default
 rules:
@@ -39726,7 +39726,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-compat
   namespace: default
 rules:
@@ -39761,7 +39761,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-election-role
   namespace: default
 roleRef:
@@ -39787,7 +39787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu
   namespace: default
 roleRef:
@@ -39813,7 +39813,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-additional-controllers
   namespace: default
 roleRef:
@@ -39839,7 +39839,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-rpk-bundle
   namespace: default
 roleRef:
@@ -39865,7 +39865,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-compat
   namespace: default
 roleRef:
@@ -39891,7 +39891,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu-metrics-service
   namespace: default
 spec:
@@ -39917,7 +39917,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pnciO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tDyp0579ogHIu
   namespace: default
 spec:
@@ -40612,7 +40612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: TmM6fo
   namespace: default
 ---
@@ -40641,7 +40641,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Wzr8UxvO-config
   namespace: default
 ---
@@ -40657,7 +40657,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Wzr8UxvO-metrics-service
   namespace: default
 spec:
@@ -40681,7 +40681,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Wzr8UxvO
   namespace: default
 spec:
@@ -40993,7 +40993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P6wEG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Wzr8UxvO-metrics-monitor
   namespace: default
 spec:
@@ -41015,7 +41015,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: P6wEG
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -41289,7 +41289,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-config
   namespace: default
@@ -41307,7 +41307,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-metrics-reader
 rules:
@@ -41329,7 +41329,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX
 rules:
@@ -41416,7 +41416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-compat
 rules:
@@ -41451,7 +41451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX
 roleRef:
@@ -41476,7 +41476,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-compat
 roleRef:
@@ -41501,7 +41501,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-election-role
   namespace: default
@@ -41551,7 +41551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX
   namespace: default
@@ -41779,7 +41779,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-rpk-bundle
   namespace: default
@@ -41815,7 +41815,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-compat
   namespace: default
@@ -41850,7 +41850,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-election-role
   namespace: default
@@ -41876,7 +41876,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX
   namespace: default
@@ -41902,7 +41902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-rpk-bundle
   namespace: default
@@ -41928,7 +41928,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-compat
   namespace: default
@@ -41954,7 +41954,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX-metrics-service
   namespace: default
@@ -41980,7 +41980,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9wjOhT
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     uUW: Us
   name: 6z0k3NX
   namespace: default
@@ -42677,7 +42677,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     in: IEvkGW7b
   name: ClL0jwLRjj
   namespace: default
@@ -42709,7 +42709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     in: IEvkGW7b
   name: t-config
   namespace: default
@@ -42728,7 +42728,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     in: IEvkGW7b
   name: t-metrics-service
   namespace: default
@@ -42755,7 +42755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     in: IEvkGW7b
   name: t
   namespace: default
@@ -43154,7 +43154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6xIMZiuoly3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     in: IEvkGW7b
   name: t-metrics-monitor
   namespace: default
@@ -43178,7 +43178,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 6xIMZiuoly3
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       in: IEvkGW7b
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
@@ -43441,7 +43441,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v2.4.2
     dcuPV: Fy
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 1316QiC
   namespace: default
 ---
@@ -43470,7 +43470,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v2.4.2
     dcuPV: Fy
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PW6-config
   namespace: default
 ---
@@ -43486,7 +43486,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v2.4.2
     dcuPV: Fy
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PW6-metrics-service
   namespace: default
 spec:
@@ -43510,7 +43510,7 @@ metadata:
     app.kubernetes.io/name: k
     app.kubernetes.io/version: v2.4.2
     dcuPV: Fy
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PW6
   namespace: default
 spec:
@@ -44197,7 +44197,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: a-config
   namespace: default
 ---
@@ -44214,7 +44214,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: a-metrics-service
   namespace: default
 spec:
@@ -44239,7 +44239,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: a
   namespace: default
 spec:
@@ -44782,7 +44782,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Z4N6WbZ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: a-metrics-monitor
   namespace: default
 spec:
@@ -44804,7 +44804,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Z4N6WbZ
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -45078,7 +45078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     miGH: N7Ko
   name: A8UY-config
   namespace: default
@@ -45096,7 +45096,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     miGH: N7Ko
   name: A8UY-metrics-service
   namespace: default
@@ -45122,7 +45122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     miGH: N7Ko
   name: A8UY
   namespace: default
@@ -45570,7 +45570,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 2rbFmR
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     miGH: N7Ko
   name: A8UY-metrics-monitor
   namespace: default
@@ -45594,7 +45594,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 2rbFmR
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       miGH: N7Ko
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
@@ -45857,7 +45857,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: dgtMSpw
@@ -45887,7 +45887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-config
@@ -45904,7 +45904,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-metrics-reader
@@ -45925,7 +45925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -46011,7 +46011,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -46098,7 +46098,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-compat
@@ -46132,7 +46132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -46156,7 +46156,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -46180,7 +46180,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-compat
@@ -46204,7 +46204,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-election-role
@@ -46253,7 +46253,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -46480,7 +46480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -46577,7 +46577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-rpk-bundle
@@ -46612,7 +46612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-compat
@@ -46646,7 +46646,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-election-role
@@ -46671,7 +46671,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -46696,7 +46696,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-additional-controllers
@@ -46721,7 +46721,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-rpk-bundle
@@ -46746,7 +46746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-compat
@@ -46771,7 +46771,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE-metrics-service
@@ -46796,7 +46796,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RYuL
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oMSwsE1: VOZ
     x: 4Xx1lbe
   name: fjEnE
@@ -47445,7 +47445,7 @@ metadata:
     app.kubernetes.io/name: "4"
     app.kubernetes.io/version: v2.4.2
     chNK6Zz: 5Ii
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: n9s9M-config
   namespace: default
 ---
@@ -47463,7 +47463,7 @@ metadata:
     app.kubernetes.io/name: "4"
     app.kubernetes.io/version: v2.4.2
     chNK6Zz: 5Ii
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: n9s9M-metrics-service
   namespace: default
 spec:
@@ -47489,7 +47489,7 @@ metadata:
     app.kubernetes.io/name: "4"
     app.kubernetes.io/version: v2.4.2
     chNK6Zz: 5Ii
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: n9s9M
   namespace: default
 spec:
@@ -48147,7 +48147,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v2.4.2
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     o7: kFLRHJ8kS
   name: rPim
   namespace: default
@@ -48179,7 +48179,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v2.4.2
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z-config
   namespace: default
@@ -48198,7 +48198,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v2.4.2
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z-metrics-service
   namespace: default
@@ -48225,7 +48225,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v2.4.2
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z
   namespace: default
@@ -48532,7 +48532,7 @@ metadata:
     app.kubernetes.io/name: kam5
     app.kubernetes.io/version: v2.4.2
     c1ch6r: sk7vUnRJ
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     o7: kFLRHJ8kS
   name: t08KC6rLj4Z-metrics-monitor
   namespace: default
@@ -48557,7 +48557,7 @@ spec:
       app.kubernetes.io/name: kam5
       app.kubernetes.io/version: v2.4.2
       c1ch6r: sk7vUnRJ
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       o7: kFLRHJ8kS
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
@@ -48831,7 +48831,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-config
   namespace: default
 ---
@@ -48847,7 +48847,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-metrics-reader
 rules:
 - nonResourceURLs:
@@ -48867,7 +48867,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA
 rules:
 - apiGroups:
@@ -48952,7 +48952,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-additional-controllers
 rules:
 - apiGroups:
@@ -49038,7 +49038,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-compat
 rules:
 - apiGroups:
@@ -49071,7 +49071,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49094,7 +49094,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49117,7 +49117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49140,7 +49140,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-election-role
   namespace: default
 rules:
@@ -49188,7 +49188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA
   namespace: default
 rules:
@@ -49414,7 +49414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-additional-controllers
   namespace: default
 rules:
@@ -49510,7 +49510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-compat
   namespace: default
 rules:
@@ -49543,7 +49543,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-election-role
   namespace: default
 roleRef:
@@ -49567,7 +49567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA
   namespace: default
 roleRef:
@@ -49591,7 +49591,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-additional-controllers
   namespace: default
 roleRef:
@@ -49615,7 +49615,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-compat
   namespace: default
 roleRef:
@@ -49639,7 +49639,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-metrics-service
   namespace: default
 spec:
@@ -49663,7 +49663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA
   namespace: default
 spec:
@@ -50063,7 +50063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATIdy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dLmCJ99UDA-metrics-monitor
   namespace: default
 spec:
@@ -50086,7 +50086,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: ATIdy9
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -50359,7 +50359,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-config
@@ -50377,7 +50377,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-metrics-reader
@@ -50399,7 +50399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -50486,7 +50486,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -50574,7 +50574,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-compat
@@ -50609,7 +50609,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -50634,7 +50634,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -50659,7 +50659,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-compat
@@ -50684,7 +50684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-election-role
@@ -50734,7 +50734,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -50962,7 +50962,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -51060,7 +51060,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-compat
@@ -51095,7 +51095,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-election-role
@@ -51121,7 +51121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -51147,7 +51147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-additional-controllers
@@ -51173,7 +51173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-compat
@@ -51199,7 +51199,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-metrics-service
@@ -51225,7 +51225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf
@@ -51783,7 +51783,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: A
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     vAU3IVb: K0a
     x: c
   name: I5FRf-metrics-monitor
@@ -51807,7 +51807,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: A
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       vAU3IVb: K0a
       x: c
 ---
@@ -52072,7 +52072,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Kha
   namespace: default
 ---
@@ -52103,7 +52103,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3Xj6U-config
   namespace: default
 ---
@@ -52121,7 +52121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3Xj6U-metrics-service
   namespace: default
 spec:
@@ -52147,7 +52147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3Xj6U
   namespace: default
 spec:
@@ -52874,7 +52874,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-config
   namespace: default
 ---
@@ -52892,7 +52892,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -52914,7 +52914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu
 rules:
 - apiGroups:
@@ -53001,7 +53001,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-compat
 rules:
 - apiGroups:
@@ -53036,7 +53036,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53061,7 +53061,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53086,7 +53086,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-election-role
   namespace: default
 rules:
@@ -53136,7 +53136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu
   namespace: default
 rules:
@@ -53364,7 +53364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-rpk-bundle
   namespace: default
 rules:
@@ -53400,7 +53400,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-compat
   namespace: default
 rules:
@@ -53435,7 +53435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-election-role
   namespace: default
 roleRef:
@@ -53461,7 +53461,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu
   namespace: default
 roleRef:
@@ -53487,7 +53487,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-rpk-bundle
   namespace: default
 roleRef:
@@ -53513,7 +53513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-compat
   namespace: default
 roleRef:
@@ -53539,7 +53539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-metrics-service
   namespace: default
 spec:
@@ -53565,7 +53565,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu
   namespace: default
 spec:
@@ -54145,7 +54145,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 23c
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Uu-metrics-monitor
   namespace: default
 spec:
@@ -54169,7 +54169,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 23c
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -54433,7 +54433,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v2.4.2
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     povH0tOlni: A
   name: 4X8m6P
   namespace: default
@@ -54464,7 +54464,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v2.4.2
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     povH0tOlni: A
   name: oyGLBa-config
   namespace: default
@@ -54482,7 +54482,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v2.4.2
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     povH0tOlni: A
   name: oyGLBa-metrics-service
   namespace: default
@@ -54508,7 +54508,7 @@ metadata:
     app.kubernetes.io/name: WgoV
     app.kubernetes.io/version: v2.4.2
     aqO3ub: Ai5ntG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     povH0tOlni: A
   name: oyGLBa
   namespace: default
@@ -55259,7 +55259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Wmx1ORHBT
   namespace: default
 ---
@@ -55290,7 +55290,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kO-config
   namespace: default
 ---
@@ -55308,7 +55308,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kO-metrics-service
   namespace: default
 spec:
@@ -55334,7 +55334,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 0tSU
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: kO
   namespace: default
 spec:
@@ -56058,7 +56058,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-config
   namespace: default
 ---
@@ -56077,7 +56077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-metrics-reader
 rules:
 - nonResourceURLs:
@@ -56100,7 +56100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d
 rules:
 - apiGroups:
@@ -56188,7 +56188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-additional-controllers
 rules:
 - apiGroups:
@@ -56277,7 +56277,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-compat
 rules:
 - apiGroups:
@@ -56313,7 +56313,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -56339,7 +56339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -56365,7 +56365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -56391,7 +56391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-election-role
   namespace: default
 rules:
@@ -56442,7 +56442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d
   namespace: default
 rules:
@@ -56671,7 +56671,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-additional-controllers
   namespace: default
 rules:
@@ -56770,7 +56770,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-compat
   namespace: default
 rules:
@@ -56806,7 +56806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-election-role
   namespace: default
 roleRef:
@@ -56833,7 +56833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d
   namespace: default
 roleRef:
@@ -56860,7 +56860,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-additional-controllers
   namespace: default
 roleRef:
@@ -56887,7 +56887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-compat
   namespace: default
 roleRef:
@@ -56914,7 +56914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d-metrics-service
   namespace: default
 spec:
@@ -56941,7 +56941,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oL1SSfzH9d
   namespace: default
 spec:
@@ -57629,7 +57629,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-config
   namespace: default
 ---
@@ -57647,7 +57647,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-metrics-reader
 rules:
 - nonResourceURLs:
@@ -57669,7 +57669,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre
 rules:
 - apiGroups:
@@ -57756,7 +57756,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-compat
 rules:
 - apiGroups:
@@ -57791,7 +57791,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57816,7 +57816,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57841,7 +57841,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-election-role
   namespace: default
 rules:
@@ -57891,7 +57891,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre
   namespace: default
 rules:
@@ -58119,7 +58119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-rpk-bundle
   namespace: default
 rules:
@@ -58155,7 +58155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-compat
   namespace: default
 rules:
@@ -58190,7 +58190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-election-role
   namespace: default
 roleRef:
@@ -58216,7 +58216,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre
   namespace: default
 roleRef:
@@ -58242,7 +58242,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-rpk-bundle
   namespace: default
 roleRef:
@@ -58268,7 +58268,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-compat
   namespace: default
 roleRef:
@@ -58294,7 +58294,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre-metrics-service
   namespace: default
 spec:
@@ -58320,7 +58320,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: icwMYEubJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: qVYvaMYre
   namespace: default
 spec:
@@ -59039,7 +59039,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tSPxL1Cf1HO9FjR
   namespace: default
 ---
@@ -59069,7 +59069,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-config
   namespace: default
 ---
@@ -59086,7 +59086,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-metrics-reader
 rules:
 - nonResourceURLs:
@@ -59107,7 +59107,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv
 rules:
 - apiGroups:
@@ -59193,7 +59193,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-additional-controllers
 rules:
 - apiGroups:
@@ -59280,7 +59280,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-compat
 rules:
 - apiGroups:
@@ -59314,7 +59314,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -59338,7 +59338,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -59362,7 +59362,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -59386,7 +59386,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-election-role
   namespace: default
 rules:
@@ -59435,7 +59435,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv
   namespace: default
 rules:
@@ -59662,7 +59662,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-additional-controllers
   namespace: default
 rules:
@@ -59759,7 +59759,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-compat
   namespace: default
 rules:
@@ -59793,7 +59793,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-election-role
   namespace: default
 roleRef:
@@ -59818,7 +59818,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv
   namespace: default
 roleRef:
@@ -59843,7 +59843,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-additional-controllers
   namespace: default
 roleRef:
@@ -59868,7 +59868,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-compat
   namespace: default
 roleRef:
@@ -59893,7 +59893,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-metrics-service
   namespace: default
 spec:
@@ -59918,7 +59918,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv
   namespace: default
 spec:
@@ -60376,7 +60376,7 @@ metadata:
     app.kubernetes.io/name: DFwU
     app.kubernetes.io/version: v2.4.2
     fuVZ: gcPCqrc0l
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RxVwZrtkv-metrics-monitor
   namespace: default
 spec:
@@ -60399,7 +60399,7 @@ spec:
       app.kubernetes.io/name: DFwU
       app.kubernetes.io/version: v2.4.2
       fuVZ: gcPCqrc0l
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/tests/create-topic-with-client-auth.yaml
 apiVersion: v1
@@ -60659,7 +60659,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK
   namespace: default
 ---
@@ -60687,7 +60687,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-config
   namespace: default
 ---
@@ -60702,7 +60702,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-metrics-reader
 rules:
 - nonResourceURLs:
@@ -60721,7 +60721,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK
 rules:
 - apiGroups:
@@ -60926,7 +60926,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -60948,7 +60948,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-election-role
   namespace: default
 rules:
@@ -60995,7 +60995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK
   namespace: default
 rules:
@@ -61021,7 +61021,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-rpk-bundle
   namespace: default
 rules:
@@ -61054,7 +61054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-election-role
   namespace: default
 roleRef:
@@ -61077,7 +61077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK
   namespace: default
 roleRef:
@@ -61100,7 +61100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-rpk-bundle
   namespace: default
 roleRef:
@@ -61123,7 +61123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-metrics-service
   namespace: default
 spec:
@@ -61146,7 +61146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 6iZG-webhook-service
   namespace: default
 spec:
@@ -61168,7 +61168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK
   namespace: default
 spec:
@@ -61291,7 +61291,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -61316,7 +61316,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6iZG
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: RAyK-selfsigned-issuer
   namespace: default
 spec:
@@ -61550,7 +61550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W
   namespace: default
 ---
@@ -61578,7 +61578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-config
   namespace: default
 ---
@@ -61593,7 +61593,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-metrics-reader
 rules:
 - nonResourceURLs:
@@ -61612,7 +61612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W
 rules:
 - apiGroups:
@@ -61817,7 +61817,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -61839,7 +61839,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-election-role
   namespace: default
 rules:
@@ -61886,7 +61886,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W
   namespace: default
 rules:
@@ -61912,7 +61912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-rpk-bundle
   namespace: default
 rules:
@@ -61945,7 +61945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-election-role
   namespace: default
 roleRef:
@@ -61968,7 +61968,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W
   namespace: default
 roleRef:
@@ -61991,7 +61991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-rpk-bundle
   namespace: default
 roleRef:
@@ -62014,7 +62014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-metrics-service
   namespace: default
 spec:
@@ -62037,7 +62037,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: hsmvzpSm-webhook-service
   namespace: default
 spec:
@@ -62059,7 +62059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W
   namespace: default
 spec:
@@ -62197,7 +62197,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -62222,7 +62222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hsmvzpSm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: tyx5W-selfsigned-issuer
   namespace: default
 spec:
@@ -62456,7 +62456,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fEL2
   namespace: default
 ---
@@ -62484,7 +62484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-config
   namespace: default
 ---
@@ -62499,7 +62499,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-metrics-reader
 rules:
 - nonResourceURLs:
@@ -62518,7 +62518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS
 rules:
 - apiGroups:
@@ -62723,7 +62723,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -62745,7 +62745,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-election-role
   namespace: default
 rules:
@@ -62792,7 +62792,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS
   namespace: default
 rules:
@@ -62818,7 +62818,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-rpk-bundle
   namespace: default
 rules:
@@ -62851,7 +62851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-election-role
   namespace: default
 roleRef:
@@ -62874,7 +62874,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS
   namespace: default
 roleRef:
@@ -62897,7 +62897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-rpk-bundle
   namespace: default
 roleRef:
@@ -62920,7 +62920,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-metrics-service
   namespace: default
 spec:
@@ -62943,7 +62943,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: njC0cLDExDA-webhook-service
   namespace: default
 spec:
@@ -62965,7 +62965,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS
   namespace: default
 spec:
@@ -63103,7 +63103,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -63128,7 +63128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: njC0cLDExDA
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 89IgS-selfsigned-issuer
   namespace: default
 spec:
@@ -63362,7 +63362,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0
   namespace: default
 ---
@@ -63392,7 +63392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-config
   namespace: default
 ---
@@ -63409,7 +63409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-metrics-reader
 rules:
 - nonResourceURLs:
@@ -63430,7 +63430,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0
 rules:
 - apiGroups:
@@ -63637,7 +63637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -63661,7 +63661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-election-role
   namespace: default
 rules:
@@ -63710,7 +63710,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0
   namespace: default
 rules:
@@ -63738,7 +63738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-rpk-bundle
   namespace: default
 rules:
@@ -63773,7 +63773,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-election-role
   namespace: default
 roleRef:
@@ -63798,7 +63798,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0
   namespace: default
 roleRef:
@@ -63823,7 +63823,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-rpk-bundle
   namespace: default
 roleRef:
@@ -63848,7 +63848,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-metrics-service
   namespace: default
 spec:
@@ -63873,7 +63873,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Re-webhook-service
   namespace: default
 spec:
@@ -63897,7 +63897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0
   namespace: default
 spec:
@@ -64020,7 +64020,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -64047,7 +64047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Re
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fRjXK1u0-selfsigned-issuer
   namespace: default
 spec:
@@ -64283,7 +64283,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS
   namespace: default
 ---
@@ -64314,7 +64314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-config
   namespace: default
 ---
@@ -64332,7 +64332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-metrics-reader
 rules:
 - nonResourceURLs:
@@ -64354,7 +64354,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS
 rules:
 - apiGroups:
@@ -64562,7 +64562,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -64587,7 +64587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-election-role
   namespace: default
 rules:
@@ -64637,7 +64637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS
   namespace: default
 rules:
@@ -64666,7 +64666,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-rpk-bundle
   namespace: default
 rules:
@@ -64702,7 +64702,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-election-role
   namespace: default
 roleRef:
@@ -64728,7 +64728,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS
   namespace: default
 roleRef:
@@ -64754,7 +64754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-rpk-bundle
   namespace: default
 roleRef:
@@ -64780,7 +64780,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-metrics-service
   namespace: default
 spec:
@@ -64806,7 +64806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: eMNuQ-webhook-service
   namespace: default
 spec:
@@ -64831,7 +64831,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS
   namespace: default
 spec:
@@ -64963,7 +64963,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -64991,7 +64991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: eMNuQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2jUS-selfsigned-issuer
   namespace: default
 spec:
@@ -65225,7 +65225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -65254,7 +65254,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-config
   namespace: default
@@ -65270,7 +65270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-metrics-reader
 rules:
@@ -65290,7 +65290,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM
 rules:
@@ -65496,7 +65496,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM
 roleRef:
@@ -65519,7 +65519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-election-role
   namespace: default
@@ -65567,7 +65567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -65594,7 +65594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-rpk-bundle
   namespace: default
@@ -65628,7 +65628,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-election-role
   namespace: default
@@ -65652,7 +65652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -65676,7 +65676,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-rpk-bundle
   namespace: default
@@ -65700,7 +65700,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-metrics-service
   namespace: default
@@ -65724,7 +65724,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: hJkIJY5Y-webhook-service
   namespace: default
@@ -65747,7 +65747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM
   namespace: default
@@ -65871,7 +65871,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: redpanda-serving-cert
   namespace: default
@@ -65897,7 +65897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: hJkIJY5Y
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     kP0Mu: tnINl
   name: WM-selfsigned-issuer
   namespace: default
@@ -66132,7 +66132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-X2us
   namespace: default
 ---
@@ -66161,7 +66161,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-X2us-config
   namespace: default
 ---
@@ -66177,7 +66177,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-X2us-metrics-service
   namespace: default
 spec:
@@ -66201,7 +66201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X2us-webhook-service
   namespace: default
 spec:
@@ -66224,7 +66224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-X2us
   namespace: default
 spec:
@@ -66407,7 +66407,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -66433,7 +66433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: X2us
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-X2us-selfsigned-issuer
   namespace: default
 spec:
@@ -66668,7 +66668,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: n0qMA4h57I5
   namespace: default
@@ -66700,7 +66700,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: pEvEye-config
   namespace: default
@@ -66719,7 +66719,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: pEvEye-metrics-service
   namespace: default
@@ -66746,7 +66746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: BdJ-webhook-service
   namespace: default
@@ -66772,7 +66772,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: pEvEye
   namespace: default
@@ -66963,7 +66963,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: redpanda-serving-cert
   namespace: default
@@ -66992,7 +66992,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: pEvEye-selfsigned-issuer
   namespace: default
@@ -67045,7 +67045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BdJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jE0q9M4zk: 1A
   name: pEvEye-metrics-monitor
   namespace: default
@@ -67069,7 +67069,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: BdJ
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       jE0q9M4zk: 1A
 ---
 # Source: operator/templates/entry-point.yaml
@@ -67268,7 +67268,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2PyZZ8ZNsM
   namespace: default
 ---
@@ -67296,7 +67296,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-config
   namespace: default
 ---
@@ -67311,7 +67311,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-metrics-reader
 rules:
 - nonResourceURLs:
@@ -67330,7 +67330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC
 rules:
 - apiGroups:
@@ -67535,7 +67535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -67557,7 +67557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-election-role
   namespace: default
 rules:
@@ -67604,7 +67604,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC
   namespace: default
 rules:
@@ -67630,7 +67630,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-rpk-bundle
   namespace: default
 rules:
@@ -67663,7 +67663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-election-role
   namespace: default
 roleRef:
@@ -67686,7 +67686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC
   namespace: default
 roleRef:
@@ -67709,7 +67709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-rpk-bundle
   namespace: default
 roleRef:
@@ -67732,7 +67732,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-metrics-service
   namespace: default
 spec:
@@ -67755,7 +67755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: fgsJm-webhook-service
   namespace: default
 spec:
@@ -67777,7 +67777,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC
   namespace: default
 spec:
@@ -67938,7 +67938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -67963,7 +67963,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fgsJm
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nLM2irjC-selfsigned-issuer
   namespace: default
 spec:
@@ -68199,7 +68199,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PiQzKZrHGl
   namespace: default
 ---
@@ -68227,7 +68227,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-config
   namespace: default
 ---
@@ -68242,7 +68242,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-metrics-reader
 rules:
 - nonResourceURLs:
@@ -68261,7 +68261,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX
 rules:
 - apiGroups:
@@ -68466,7 +68466,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -68488,7 +68488,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-election-role
   namespace: default
 rules:
@@ -68535,7 +68535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX
   namespace: default
 rules:
@@ -68561,7 +68561,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-rpk-bundle
   namespace: default
 rules:
@@ -68594,7 +68594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-election-role
   namespace: default
 roleRef:
@@ -68617,7 +68617,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX
   namespace: default
 roleRef:
@@ -68640,7 +68640,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-rpk-bundle
   namespace: default
 roleRef:
@@ -68663,7 +68663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-metrics-service
   namespace: default
 spec:
@@ -68686,7 +68686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: zUC-webhook-service
   namespace: default
 spec:
@@ -68708,7 +68708,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX
   namespace: default
 spec:
@@ -68828,7 +68828,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -68853,7 +68853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-selfsigned-issuer
   namespace: default
 spec:
@@ -68902,7 +68902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zUC
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: X374QF3AYX-metrics-monitor
   namespace: default
 spec:
@@ -68924,7 +68924,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: zUC
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -69123,7 +69123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Fzbi9OkP
   namespace: default
 ---
@@ -69154,7 +69154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-config
   namespace: default
 ---
@@ -69172,7 +69172,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-metrics-reader
 rules:
 - nonResourceURLs:
@@ -69194,7 +69194,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G
 rules:
 - apiGroups:
@@ -69402,7 +69402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -69427,7 +69427,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-election-role
   namespace: default
 rules:
@@ -69477,7 +69477,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G
   namespace: default
 rules:
@@ -69506,7 +69506,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-rpk-bundle
   namespace: default
 rules:
@@ -69542,7 +69542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-election-role
   namespace: default
 roleRef:
@@ -69568,7 +69568,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G
   namespace: default
 roleRef:
@@ -69594,7 +69594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-rpk-bundle
   namespace: default
 roleRef:
@@ -69620,7 +69620,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-metrics-service
   namespace: default
 spec:
@@ -69646,7 +69646,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8V1wVzO-webhook-service
   namespace: default
 spec:
@@ -69671,7 +69671,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G
   namespace: default
 spec:
@@ -69972,7 +69972,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -70000,7 +70000,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8V1wVzO
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: G-selfsigned-issuer
   namespace: default
 spec:
@@ -70236,7 +70236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: Z20j25RfqSp
   namespace: default
@@ -70266,7 +70266,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-config
   namespace: default
@@ -70283,7 +70283,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-metrics-reader
 rules:
@@ -70304,7 +70304,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA
 rules:
@@ -70511,7 +70511,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA
 roleRef:
@@ -70535,7 +70535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-election-role
   namespace: default
@@ -70584,7 +70584,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA
   namespace: default
@@ -70612,7 +70612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-rpk-bundle
   namespace: default
@@ -70647,7 +70647,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-election-role
   namespace: default
@@ -70672,7 +70672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA
   namespace: default
@@ -70697,7 +70697,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-rpk-bundle
   namespace: default
@@ -70722,7 +70722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-metrics-service
   namespace: default
@@ -70747,7 +70747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: JhtIXu-webhook-service
   namespace: default
@@ -70771,7 +70771,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA
   namespace: default
@@ -70898,7 +70898,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: redpanda-serving-cert
   namespace: default
@@ -70925,7 +70925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-selfsigned-issuer
   namespace: default
@@ -70976,7 +70976,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JhtIXu
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jcF: qXntI
   name: tDaA-metrics-monitor
   namespace: default
@@ -71000,7 +71000,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: JhtIXu
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       jcF: qXntI
 ---
 # Source: operator/templates/entry-point.yaml
@@ -71200,7 +71200,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -71231,7 +71231,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-config
@@ -71249,7 +71249,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-metrics-reader
@@ -71271,7 +71271,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -71479,7 +71479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -71504,7 +71504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-election-role
@@ -71554,7 +71554,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -71583,7 +71583,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-rpk-bundle
@@ -71619,7 +71619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-election-role
@@ -71645,7 +71645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -71671,7 +71671,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-rpk-bundle
@@ -71697,7 +71697,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-metrics-service
@@ -71723,7 +71723,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: ZRaS-webhook-service
@@ -71748,7 +71748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG
@@ -72059,7 +72059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: redpanda-serving-cert
@@ -72087,7 +72087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZRaS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     j: Wmsdb
     uS: h6Fj
   name: 79ioSjMT8KG-selfsigned-issuer
@@ -72337,7 +72337,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-config
   namespace: default
@@ -72355,7 +72355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-metrics-reader
 rules:
@@ -72377,7 +72377,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5
 rules:
@@ -72585,7 +72585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5
 roleRef:
@@ -72610,7 +72610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-election-role
   namespace: default
@@ -72660,7 +72660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5
   namespace: default
@@ -72689,7 +72689,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-rpk-bundle
   namespace: default
@@ -72725,7 +72725,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-election-role
   namespace: default
@@ -72751,7 +72751,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5
   namespace: default
@@ -72777,7 +72777,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-rpk-bundle
   namespace: default
@@ -72803,7 +72803,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-metrics-service
   namespace: default
@@ -72829,7 +72829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: ibdE3-webhook-service
   namespace: default
@@ -72854,7 +72854,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5
   namespace: default
@@ -73122,7 +73122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: redpanda-serving-cert
   namespace: default
@@ -73150,7 +73150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ibdE3
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     wig: gAae
   name: 41nucs5-selfsigned-issuer
   namespace: default
@@ -73387,7 +73387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Ev1EfK
   namespace: default
 ---
@@ -73418,7 +73418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-config
   namespace: default
 ---
@@ -73436,7 +73436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-metrics-reader
 rules:
 - nonResourceURLs:
@@ -73458,7 +73458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu
 rules:
 - apiGroups:
@@ -73666,7 +73666,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -73691,7 +73691,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-election-role
   namespace: default
 rules:
@@ -73741,7 +73741,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu
   namespace: default
 rules:
@@ -73770,7 +73770,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-rpk-bundle
   namespace: default
 rules:
@@ -73806,7 +73806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-election-role
   namespace: default
 roleRef:
@@ -73832,7 +73832,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu
   namespace: default
 roleRef:
@@ -73858,7 +73858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-rpk-bundle
   namespace: default
 roleRef:
@@ -73884,7 +73884,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-metrics-service
   namespace: default
 spec:
@@ -73910,7 +73910,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Kcp-webhook-service
   namespace: default
 spec:
@@ -73935,7 +73935,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu
   namespace: default
 spec:
@@ -74132,7 +74132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -74160,7 +74160,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Kcp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: xtpIQu-selfsigned-issuer
   namespace: default
 spec:
@@ -74407,7 +74407,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     yhRLU: bn88A
   name: CbM6ZNJQ-config
   namespace: default
@@ -74424,7 +74424,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     yhRLU: bn88A
   name: CbM6ZNJQ-metrics-service
   namespace: default
@@ -74449,7 +74449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     yhRLU: bn88A
   name: 78-webhook-service
   namespace: default
@@ -74473,7 +74473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     yhRLU: bn88A
   name: CbM6ZNJQ
   namespace: default
@@ -74811,7 +74811,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     yhRLU: bn88A
   name: redpanda-serving-cert
   namespace: default
@@ -74838,7 +74838,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "78"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     yhRLU: bn88A
   name: CbM6ZNJQ-selfsigned-issuer
   namespace: default
@@ -75074,7 +75074,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 4s
   namespace: default
 ---
@@ -75103,7 +75103,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oWZxG4ft6-config
   namespace: default
 ---
@@ -75119,7 +75119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oWZxG4ft6-metrics-service
   namespace: default
 spec:
@@ -75143,7 +75143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 19ztDQ-webhook-service
   namespace: default
 spec:
@@ -75166,7 +75166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oWZxG4ft6
   namespace: default
 spec:
@@ -75422,7 +75422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -75448,7 +75448,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 19ztDQ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: oWZxG4ft6-selfsigned-issuer
   namespace: default
 spec:
@@ -75695,7 +75695,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-config
   namespace: default
 ---
@@ -75711,7 +75711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-metrics-reader
 rules:
 - nonResourceURLs:
@@ -75731,7 +75731,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN
 rules:
 - apiGroups:
@@ -75937,7 +75937,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -75960,7 +75960,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-election-role
   namespace: default
 rules:
@@ -76008,7 +76008,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN
   namespace: default
 rules:
@@ -76035,7 +76035,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-rpk-bundle
   namespace: default
 rules:
@@ -76069,7 +76069,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-election-role
   namespace: default
 roleRef:
@@ -76093,7 +76093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN
   namespace: default
 roleRef:
@@ -76117,7 +76117,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-rpk-bundle
   namespace: default
 roleRef:
@@ -76141,7 +76141,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-metrics-service
   namespace: default
 spec:
@@ -76165,7 +76165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: axjCvWi-webhook-service
   namespace: default
 spec:
@@ -76188,7 +76188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN
   namespace: default
 spec:
@@ -76572,7 +76572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -76598,7 +76598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axjCvWi
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: PxBN-selfsigned-issuer
   namespace: default
 spec:
@@ -76847,7 +76847,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: CFnO9s-config
   namespace: default
 ---
@@ -76865,7 +76865,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: CFnO9s-metrics-service
   namespace: default
 spec:
@@ -76891,7 +76891,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: bNOJ-webhook-service
   namespace: default
 spec:
@@ -76916,7 +76916,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: CFnO9s
   namespace: default
 spec:
@@ -77340,7 +77340,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -77368,7 +77368,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: CFnO9s-selfsigned-issuer
   namespace: default
 spec:
@@ -77420,7 +77420,7 @@ metadata:
     app.kubernetes.io/name: bNOJ
     app.kubernetes.io/version: v2.4.2
     fYyBJj2Al: 00TYG
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: CFnO9s-metrics-monitor
   namespace: default
 spec:
@@ -77443,7 +77443,7 @@ spec:
       app.kubernetes.io/name: bNOJ
       app.kubernetes.io/version: v2.4.2
       fYyBJj2Al: 00TYG
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -77644,7 +77644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 9q
   namespace: default
 ---
@@ -77676,7 +77676,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: zLyH-config
   namespace: default
 ---
@@ -77695,7 +77695,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: zLyH-metrics-service
   namespace: default
 spec:
@@ -77722,7 +77722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: N-webhook-service
   namespace: default
 spec:
@@ -77748,7 +77748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: zLyH
   namespace: default
 spec:
@@ -78048,7 +78048,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -78077,7 +78077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "N"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: zLyH-selfsigned-issuer
   namespace: default
 spec:
@@ -78324,7 +78324,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-config
   namespace: default
 ---
@@ -78340,7 +78340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-metrics-reader
 rules:
 - nonResourceURLs:
@@ -78360,7 +78360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ
 rules:
 - apiGroups:
@@ -78566,7 +78566,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -78589,7 +78589,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-election-role
   namespace: default
 rules:
@@ -78637,7 +78637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ
   namespace: default
 rules:
@@ -78664,7 +78664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-rpk-bundle
   namespace: default
 rules:
@@ -78698,7 +78698,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-election-role
   namespace: default
 roleRef:
@@ -78722,7 +78722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ
   namespace: default
 roleRef:
@@ -78746,7 +78746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-rpk-bundle
   namespace: default
 roleRef:
@@ -78770,7 +78770,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-metrics-service
   namespace: default
 spec:
@@ -78794,7 +78794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nUS-webhook-service
   namespace: default
 spec:
@@ -78817,7 +78817,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ
   namespace: default
 spec:
@@ -79399,7 +79399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -79425,7 +79425,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-selfsigned-issuer
   namespace: default
 spec:
@@ -79475,7 +79475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nUS
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: m7Z5VmKktJ-metrics-monitor
   namespace: default
 spec:
@@ -79498,7 +79498,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: nUS
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -79713,7 +79713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-config
   namespace: default
 ---
@@ -79733,7 +79733,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-metrics-reader
 rules:
 - nonResourceURLs:
@@ -79757,7 +79757,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT
 rules:
 - apiGroups:
@@ -79967,7 +79967,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -79994,7 +79994,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-election-role
   namespace: default
 rules:
@@ -80046,7 +80046,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT
   namespace: default
 rules:
@@ -80077,7 +80077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-election-role
   namespace: default
 roleRef:
@@ -80105,7 +80105,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT
   namespace: default
 roleRef:
@@ -80133,7 +80133,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-metrics-service
   namespace: default
 spec:
@@ -80161,7 +80161,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Eg0Oz-webhook-service
   namespace: default
 spec:
@@ -80188,7 +80188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT
   namespace: default
 spec:
@@ -80645,7 +80645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -80675,7 +80675,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-selfsigned-issuer
   namespace: default
 spec:
@@ -80729,7 +80729,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Eg0Oz
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OyOZvn5WT-metrics-monitor
   namespace: default
 spec:
@@ -80754,7 +80754,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Eg0Oz
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -80967,7 +80967,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v0: 1iClRDvVO3c
   name: 5GoUVR7T-config
   namespace: default
@@ -80986,7 +80986,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v0: 1iClRDvVO3c
   name: 5GoUVR7T-metrics-service
   namespace: default
@@ -81013,7 +81013,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v0: 1iClRDvVO3c
   name: 8I1Iyd-webhook-service
   namespace: default
@@ -81039,7 +81039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v0: 1iClRDvVO3c
   name: 5GoUVR7T
   namespace: default
@@ -81560,7 +81560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v0: 1iClRDvVO3c
   name: redpanda-serving-cert
   namespace: default
@@ -81589,7 +81589,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8I1Iyd
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v0: 1iClRDvVO3c
   name: 5GoUVR7T-selfsigned-issuer
   namespace: default
@@ -81828,7 +81828,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: r8KRW4
   namespace: default
 ---
@@ -81861,7 +81861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: IsP97jKm-config
   namespace: default
 ---
@@ -81881,7 +81881,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: IsP97jKm-metrics-service
   namespace: default
 spec:
@@ -81909,7 +81909,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Pt-webhook-service
   namespace: default
 spec:
@@ -81936,7 +81936,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: IsP97jKm
   namespace: default
 spec:
@@ -82435,7 +82435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -82465,7 +82465,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: IsP97jKm-selfsigned-issuer
   namespace: default
 spec:
@@ -82519,7 +82519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Pt
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: IsP97jKm-metrics-monitor
   namespace: default
 spec:
@@ -82543,7 +82543,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Pt
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -82754,7 +82754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dHTgQf-config
   namespace: default
 ---
@@ -82770,7 +82770,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dHTgQf-metrics-service
   namespace: default
 spec:
@@ -82794,7 +82794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 4MPmeCPMB-webhook-service
   namespace: default
 spec:
@@ -82817,7 +82817,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dHTgQf
   namespace: default
 spec:
@@ -83326,7 +83326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -83352,7 +83352,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4MPmeCPMB
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: dHTgQf-selfsigned-issuer
   namespace: default
 spec:
@@ -83588,7 +83588,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "567"
   namespace: default
 ---
@@ -83617,7 +83617,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-config
   namespace: default
 ---
@@ -83633,7 +83633,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-metrics-reader
 rules:
 - nonResourceURLs:
@@ -83653,7 +83653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO
 rules:
 - apiGroups:
@@ -83859,7 +83859,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -83882,7 +83882,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-election-role
   namespace: default
 rules:
@@ -83930,7 +83930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO
   namespace: default
 rules:
@@ -83957,7 +83957,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-rpk-bundle
   namespace: default
 rules:
@@ -83991,7 +83991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-election-role
   namespace: default
 roleRef:
@@ -84015,7 +84015,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO
   namespace: default
 roleRef:
@@ -84039,7 +84039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-rpk-bundle
   namespace: default
 roleRef:
@@ -84063,7 +84063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-metrics-service
   namespace: default
 spec:
@@ -84087,7 +84087,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8ZgI1VH-webhook-service
   namespace: default
 spec:
@@ -84110,7 +84110,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO
   namespace: default
 spec:
@@ -84537,7 +84537,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -84563,7 +84563,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8ZgI1VH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Hjo9sbxO-selfsigned-issuer
   namespace: default
 spec:
@@ -84811,7 +84811,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-config
@@ -84830,7 +84830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-metrics-reader
@@ -84853,7 +84853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -85062,7 +85062,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -85088,7 +85088,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-election-role
@@ -85139,7 +85139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -85169,7 +85169,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-election-role
@@ -85196,7 +85196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -85223,7 +85223,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-metrics-service
@@ -85250,7 +85250,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: an-webhook-service
@@ -85276,7 +85276,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N
@@ -85921,7 +85921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: redpanda-serving-cert
@@ -85950,7 +85950,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: an
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     ib: 8cz
     mKZJ: qFJ
   name: 8K2N-selfsigned-issuer
@@ -86188,7 +86188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: gFdSAMIO
   namespace: default
@@ -86219,7 +86219,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO-config
   namespace: default
@@ -86237,7 +86237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO-metrics-reader
 rules:
@@ -86259,7 +86259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO
 rules:
@@ -86467,7 +86467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO
 roleRef:
@@ -86492,7 +86492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO-election-role
   namespace: default
@@ -86542,7 +86542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO
   namespace: default
@@ -86571,7 +86571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO-election-role
   namespace: default
@@ -86597,7 +86597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO
   namespace: default
@@ -86623,7 +86623,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO-metrics-service
   namespace: default
@@ -86649,7 +86649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: MxF-webhook-service
   namespace: default
@@ -86674,7 +86674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO
   namespace: default
@@ -87181,7 +87181,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: redpanda-serving-cert
   namespace: default
@@ -87209,7 +87209,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MxF
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     mNkAknTCpbj0: NCMcS
   name: RQkbO-selfsigned-issuer
   namespace: default
@@ -87447,7 +87447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: K
   namespace: default
 ---
@@ -87477,7 +87477,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-config
   namespace: default
 ---
@@ -87494,7 +87494,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-metrics-reader
 rules:
 - nonResourceURLs:
@@ -87515,7 +87515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97
 rules:
 - apiGroups:
@@ -87722,7 +87722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -87746,7 +87746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-election-role
   namespace: default
 rules:
@@ -87795,7 +87795,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97
   namespace: default
 rules:
@@ -87823,7 +87823,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-rpk-bundle
   namespace: default
 rules:
@@ -87858,7 +87858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-election-role
   namespace: default
 roleRef:
@@ -87883,7 +87883,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97
   namespace: default
 roleRef:
@@ -87908,7 +87908,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-rpk-bundle
   namespace: default
 roleRef:
@@ -87933,7 +87933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-metrics-service
   namespace: default
 spec:
@@ -87958,7 +87958,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: vYy9-webhook-service
   namespace: default
 spec:
@@ -87982,7 +87982,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97
   namespace: default
 spec:
@@ -88467,7 +88467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -88494,7 +88494,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vYy9
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 2rNNJQv8k5j97-selfsigned-issuer
   namespace: default
 spec:
@@ -88731,7 +88731,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: meK
   namespace: default
 ---
@@ -88759,7 +88759,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QClq-config
   namespace: default
 ---
@@ -88774,7 +88774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QClq-metrics-service
   namespace: default
 spec:
@@ -88797,7 +88797,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: lbhx-webhook-service
   namespace: default
 spec:
@@ -88819,7 +88819,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QClq
   namespace: default
 spec:
@@ -89330,7 +89330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -89355,7 +89355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QClq-selfsigned-issuer
   namespace: default
 spec:
@@ -89404,7 +89404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lbhx
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QClq-metrics-monitor
   namespace: default
 spec:
@@ -89426,7 +89426,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: lbhx
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -89627,7 +89627,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: Wx
   namespace: default
@@ -89660,7 +89660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-config
   namespace: default
@@ -89680,7 +89680,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-metrics-reader
 rules:
@@ -89704,7 +89704,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP
 rules:
@@ -89914,7 +89914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP
 roleRef:
@@ -89941,7 +89941,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-election-role
   namespace: default
@@ -89993,7 +89993,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP
   namespace: default
@@ -90024,7 +90024,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-election-role
   namespace: default
@@ -90052,7 +90052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP
   namespace: default
@@ -90080,7 +90080,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-metrics-service
   namespace: default
@@ -90108,7 +90108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: ovez-webhook-service
   namespace: default
@@ -90135,7 +90135,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP
   namespace: default
@@ -90581,7 +90581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: redpanda-serving-cert
   namespace: default
@@ -90611,7 +90611,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-selfsigned-issuer
   namespace: default
@@ -90665,7 +90665,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ovez
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zWv: hIfkuex2B
   name: xxjYziP-metrics-monitor
   namespace: default
@@ -90690,7 +90690,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: ovez
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       zWv: hIfkuex2B
 ---
 # Source: operator/templates/entry-point.yaml
@@ -90889,7 +90889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 7ZTjb
   namespace: default
 ---
@@ -90920,7 +90920,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-config
   namespace: default
 ---
@@ -90938,7 +90938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-metrics-reader
 rules:
 - nonResourceURLs:
@@ -90960,7 +90960,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk
 rules:
 - apiGroups:
@@ -91168,7 +91168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -91193,7 +91193,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-election-role
   namespace: default
 rules:
@@ -91243,7 +91243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk
   namespace: default
 rules:
@@ -91272,7 +91272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-election-role
   namespace: default
 roleRef:
@@ -91298,7 +91298,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk
   namespace: default
 roleRef:
@@ -91324,7 +91324,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-metrics-service
   namespace: default
 spec:
@@ -91350,7 +91350,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: zsU8D-webhook-service
   namespace: default
 spec:
@@ -91375,7 +91375,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk
   namespace: default
 spec:
@@ -91904,7 +91904,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -91932,7 +91932,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-selfsigned-issuer
   namespace: default
 spec:
@@ -91984,7 +91984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zsU8D
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: OZHCbAk-metrics-monitor
   namespace: default
 spec:
@@ -92006,7 +92006,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: zsU8D
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -92217,7 +92217,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v: pV
   name: JvUUYZNAn-config
   namespace: default
@@ -92234,7 +92234,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v: pV
   name: JvUUYZNAn-metrics-service
   namespace: default
@@ -92259,7 +92259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v: pV
   name: operator-webhook-service
   namespace: default
@@ -92283,7 +92283,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v: pV
   name: JvUUYZNAn
   namespace: default
@@ -92626,7 +92626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v: pV
   name: redpanda-serving-cert
   namespace: default
@@ -92653,7 +92653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     v: pV
   name: JvUUYZNAn-selfsigned-issuer
   namespace: default
@@ -92902,7 +92902,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9-config
   namespace: default
 ---
@@ -92919,7 +92919,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9-metrics-reader
 rules:
 - nonResourceURLs:
@@ -92940,7 +92940,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9
 rules:
 - apiGroups:
@@ -93147,7 +93147,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -93171,7 +93171,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9-election-role
   namespace: default
 rules:
@@ -93220,7 +93220,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9
   namespace: default
 rules:
@@ -93248,7 +93248,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9-election-role
   namespace: default
 roleRef:
@@ -93273,7 +93273,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9
   namespace: default
 roleRef:
@@ -93298,7 +93298,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9-metrics-service
   namespace: default
 spec:
@@ -93323,7 +93323,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: AD-webhook-service
   namespace: default
 spec:
@@ -93347,7 +93347,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9
   namespace: default
 spec:
@@ -93897,7 +93897,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -93924,7 +93924,7 @@ metadata:
     app.kubernetes.io/name: AD
     app.kubernetes.io/version: v2.4.2
     dRuotY: sUV
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: twuYH9-selfsigned-issuer
   namespace: default
 spec:
@@ -94162,7 +94162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: g
   namespace: default
 ---
@@ -94191,7 +94191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-config
   namespace: default
 ---
@@ -94207,7 +94207,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-metrics-reader
 rules:
 - nonResourceURLs:
@@ -94227,7 +94227,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn
 rules:
 - apiGroups:
@@ -94433,7 +94433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -94456,7 +94456,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-election-role
   namespace: default
 rules:
@@ -94504,7 +94504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn
   namespace: default
 rules:
@@ -94531,7 +94531,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-rpk-bundle
   namespace: default
 rules:
@@ -94565,7 +94565,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-election-role
   namespace: default
 roleRef:
@@ -94589,7 +94589,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn
   namespace: default
 roleRef:
@@ -94613,7 +94613,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-rpk-bundle
   namespace: default
 roleRef:
@@ -94637,7 +94637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-metrics-service
   namespace: default
 spec:
@@ -94661,7 +94661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: MOjCBp-webhook-service
   namespace: default
 spec:
@@ -94684,7 +94684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn
   namespace: default
 spec:
@@ -95183,7 +95183,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -95209,7 +95209,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-selfsigned-issuer
   namespace: default
 spec:
@@ -95259,7 +95259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MOjCBp
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Sb2hWn-metrics-monitor
   namespace: default
 spec:
@@ -95282,7 +95282,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: MOjCBp
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -95493,7 +95493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-config
   namespace: default
 ---
@@ -95509,7 +95509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-metrics-reader
 rules:
 - nonResourceURLs:
@@ -95529,7 +95529,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B
 rules:
 - apiGroups:
@@ -95735,7 +95735,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -95758,7 +95758,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-election-role
   namespace: default
 rules:
@@ -95806,7 +95806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B
   namespace: default
 rules:
@@ -95833,7 +95833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-election-role
   namespace: default
 roleRef:
@@ -95857,7 +95857,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B
   namespace: default
 roleRef:
@@ -95881,7 +95881,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-metrics-service
   namespace: default
 spec:
@@ -95905,7 +95905,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: B-webhook-service
   namespace: default
 spec:
@@ -95928,7 +95928,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B
   namespace: default
 spec:
@@ -96420,7 +96420,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -96446,7 +96446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-selfsigned-issuer
   namespace: default
 spec:
@@ -96496,7 +96496,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: B
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-B-metrics-monitor
   namespace: default
 spec:
@@ -96518,7 +96518,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: B
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -96718,7 +96718,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: S
   namespace: default
 ---
@@ -96746,7 +96746,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QSmzerg-config
   namespace: default
 ---
@@ -96761,7 +96761,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QSmzerg-metrics-service
   namespace: default
 spec:
@@ -96784,7 +96784,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3SyCJ-webhook-service
   namespace: default
 spec:
@@ -96806,7 +96806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QSmzerg
   namespace: default
 spec:
@@ -97185,7 +97185,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -97210,7 +97210,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QSmzerg-selfsigned-issuer
   namespace: default
 spec:
@@ -97259,7 +97259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3SyCJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: QSmzerg-metrics-monitor
   namespace: default
 spec:
@@ -97281,7 +97281,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: 3SyCJ
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -97492,7 +97492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-config
@@ -97510,7 +97510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-metrics-reader
@@ -97532,7 +97532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -97740,7 +97740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -97765,7 +97765,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-election-role
@@ -97815,7 +97815,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -97844,7 +97844,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-rpk-bundle
@@ -97880,7 +97880,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-election-role
@@ -97906,7 +97906,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -97932,7 +97932,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-rpk-bundle
@@ -97958,7 +97958,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-metrics-service
@@ -97984,7 +97984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: o2-webhook-service
@@ -98009,7 +98009,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ
@@ -98424,7 +98424,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: redpanda-serving-cert
@@ -98452,7 +98452,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     q93: ONPg3F
     rZBEA7mOLYT: iFtHtFH
   name: nJ-selfsigned-issuer
@@ -98704,7 +98704,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-config
   namespace: default
@@ -98724,7 +98724,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-metrics-reader
 rules:
@@ -98748,7 +98748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
 rules:
@@ -98958,7 +98958,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
 roleRef:
@@ -98985,7 +98985,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-election-role
   namespace: default
@@ -99037,7 +99037,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
   namespace: default
@@ -99068,7 +99068,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-election-role
   namespace: default
@@ -99096,7 +99096,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
   namespace: default
@@ -99124,7 +99124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-metrics-service
   namespace: default
@@ -99152,7 +99152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: WqmcFb-webhook-service
   namespace: default
@@ -99179,7 +99179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP
   namespace: default
@@ -99780,7 +99780,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: redpanda-serving-cert
   namespace: default
@@ -99810,7 +99810,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-selfsigned-issuer
   namespace: default
@@ -99864,7 +99864,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WqmcFb
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     jHlVD3i0I: Hfqg8dMgdc
   name: cCP-metrics-monitor
   namespace: default
@@ -99888,7 +99888,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: WqmcFb
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       jHlVD3i0I: Hfqg8dMgdc
 ---
 # Source: operator/templates/entry-point.yaml
@@ -100088,7 +100088,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: TxdHR
   namespace: default
 ---
@@ -100116,7 +100116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8WTbb-config
   namespace: default
 ---
@@ -100131,7 +100131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8WTbb-metrics-service
   namespace: default
 spec:
@@ -100154,7 +100154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: yHixING-webhook-service
   namespace: default
 spec:
@@ -100176,7 +100176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8WTbb
   namespace: default
 spec:
@@ -100649,7 +100649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -100674,7 +100674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8WTbb-selfsigned-issuer
   namespace: default
 spec:
@@ -100723,7 +100723,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: yHixING
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 8WTbb-metrics-monitor
   namespace: default
 spec:
@@ -100745,7 +100745,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: yHixING
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -100946,7 +100946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: drBf
   namespace: default
@@ -100977,7 +100977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-config
   namespace: default
@@ -100995,7 +100995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-metrics-reader
 rules:
@@ -101017,7 +101017,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo
 rules:
@@ -101225,7 +101225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo
 roleRef:
@@ -101250,7 +101250,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-election-role
   namespace: default
@@ -101300,7 +101300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo
   namespace: default
@@ -101329,7 +101329,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-rpk-bundle
   namespace: default
@@ -101365,7 +101365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-election-role
   namespace: default
@@ -101391,7 +101391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo
   namespace: default
@@ -101417,7 +101417,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-rpk-bundle
   namespace: default
@@ -101443,7 +101443,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-metrics-service
   namespace: default
@@ -101469,7 +101469,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: L07-webhook-service
   namespace: default
@@ -101494,7 +101494,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo
   namespace: default
@@ -101934,7 +101934,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: redpanda-serving-cert
   namespace: default
@@ -101962,7 +101962,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-selfsigned-issuer
   namespace: default
@@ -102014,7 +102014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: L07
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     nI2ZSs: 4AI8h
   name: Wo-metrics-monitor
   namespace: default
@@ -102038,7 +102038,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: L07
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       nI2ZSs: 4AI8h
 ---
 # Source: operator/templates/entry-point.yaml
@@ -102239,7 +102239,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: 7QeW
@@ -102272,7 +102272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-config
@@ -102292,7 +102292,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-metrics-reader
@@ -102316,7 +102316,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w
@@ -102526,7 +102526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w
@@ -102553,7 +102553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-election-role
@@ -102605,7 +102605,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w
@@ -102636,7 +102636,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-election-role
@@ -102664,7 +102664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w
@@ -102692,7 +102692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-metrics-service
@@ -102720,7 +102720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: MK-webhook-service
@@ -102747,7 +102747,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w
@@ -103310,7 +103310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: redpanda-serving-cert
@@ -103340,7 +103340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-selfsigned-issuer
@@ -103394,7 +103394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MK
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     t: W
     wH2b: ""
   name: w-metrics-monitor
@@ -103418,7 +103418,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: MK
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       t: W
       wH2b: ""
 ---
@@ -103621,7 +103621,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: LjYLOL6C
   namespace: default
@@ -103654,7 +103654,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-config
   namespace: default
@@ -103674,7 +103674,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-metrics-service
   namespace: default
@@ -103702,7 +103702,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: qv3g-webhook-service
   namespace: default
@@ -103729,7 +103729,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai
   namespace: default
@@ -104220,7 +104220,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: redpanda-serving-cert
   namespace: default
@@ -104250,7 +104250,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-selfsigned-issuer
   namespace: default
@@ -104304,7 +104304,7 @@ metadata:
     app.kubernetes.io/name: qv3g
     app.kubernetes.io/version: v2.4.2
     gi: 9j2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     zb8lDT9V: olwEfoWZ
   name: f3nfwQai-metrics-monitor
   namespace: default
@@ -104329,7 +104329,7 @@ spec:
       app.kubernetes.io/name: qv3g
       app.kubernetes.io/version: v2.4.2
       gi: 9j2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       zb8lDT9V: olwEfoWZ
 ---
 # Source: operator/templates/entry-point.yaml
@@ -104528,7 +104528,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: J2qRpt9
   namespace: default
 ---
@@ -104557,7 +104557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-config
   namespace: default
 ---
@@ -104573,7 +104573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-metrics-reader
 rules:
 - nonResourceURLs:
@@ -104593,7 +104593,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6
 rules:
 - apiGroups:
@@ -104799,7 +104799,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -104822,7 +104822,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-election-role
   namespace: default
 rules:
@@ -104870,7 +104870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6
   namespace: default
 rules:
@@ -104897,7 +104897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-rpk-bundle
   namespace: default
 rules:
@@ -104931,7 +104931,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-election-role
   namespace: default
 roleRef:
@@ -104955,7 +104955,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6
   namespace: default
 roleRef:
@@ -104979,7 +104979,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-rpk-bundle
   namespace: default
 roleRef:
@@ -105003,7 +105003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-metrics-service
   namespace: default
 spec:
@@ -105027,7 +105027,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Tlv-webhook-service
   namespace: default
 spec:
@@ -105050,7 +105050,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6
   namespace: default
 spec:
@@ -105497,7 +105497,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -105523,7 +105523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-selfsigned-issuer
   namespace: default
 spec:
@@ -105573,7 +105573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Tlv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KXsg6-metrics-monitor
   namespace: default
 spec:
@@ -105595,7 +105595,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: Tlv
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -105806,7 +105806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-config
@@ -105824,7 +105824,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-metrics-reader
@@ -105846,7 +105846,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -106054,7 +106054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -106079,7 +106079,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-election-role
@@ -106129,7 +106129,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -106158,7 +106158,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-election-role
@@ -106184,7 +106184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -106210,7 +106210,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-metrics-service
@@ -106236,7 +106236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: DjMfg-webhook-service
@@ -106261,7 +106261,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh
@@ -106728,7 +106728,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: redpanda-serving-cert
@@ -106756,7 +106756,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DjMfg
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     oLWSEoF: Ps5P
     uO6upU7K: lMwbJ
   name: FCXrBjh-selfsigned-issuer
@@ -106996,7 +106996,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "02"
   namespace: default
 ---
@@ -107025,7 +107025,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-config
   namespace: default
 ---
@@ -107041,7 +107041,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-metrics-reader
 rules:
 - nonResourceURLs:
@@ -107061,7 +107061,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "02"
 rules:
 - apiGroups:
@@ -107267,7 +107267,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "02"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -107290,7 +107290,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-election-role
   namespace: default
 rules:
@@ -107338,7 +107338,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "02"
   namespace: default
 rules:
@@ -107365,7 +107365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-rpk-bundle
   namespace: default
 rules:
@@ -107399,7 +107399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-election-role
   namespace: default
 roleRef:
@@ -107423,7 +107423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "02"
   namespace: default
 roleRef:
@@ -107447,7 +107447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-rpk-bundle
   namespace: default
 roleRef:
@@ -107471,7 +107471,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-metrics-service
   namespace: default
 spec:
@@ -107495,7 +107495,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: Y-webhook-service
   namespace: default
 spec:
@@ -107518,7 +107518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: "02"
   namespace: default
 spec:
@@ -108048,7 +108048,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -108074,7 +108074,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "Y"
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 02-selfsigned-issuer
   namespace: default
 spec:
@@ -108308,7 +108308,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: nNP8R
   namespace: default
 ---
@@ -108338,7 +108338,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3SkASoputZl-config
   namespace: default
 ---
@@ -108355,7 +108355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3SkASoputZl-metrics-service
   namespace: default
 spec:
@@ -108380,7 +108380,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: axov6PJ-webhook-service
   namespace: default
 spec:
@@ -108404,7 +108404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3SkASoputZl
   namespace: default
 spec:
@@ -108860,7 +108860,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -108887,7 +108887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: axov6PJ
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: 3SkASoputZl-selfsigned-issuer
   namespace: default
 spec:
@@ -109138,7 +109138,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-config
   namespace: default
 ---
@@ -109158,7 +109158,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-metrics-reader
 rules:
 - nonResourceURLs:
@@ -109182,7 +109182,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi
 rules:
 - apiGroups:
@@ -109392,7 +109392,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109419,7 +109419,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-election-role
   namespace: default
 rules:
@@ -109471,7 +109471,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi
   namespace: default
 rules:
@@ -109502,7 +109502,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-rpk-bundle
   namespace: default
 rules:
@@ -109540,7 +109540,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-election-role
   namespace: default
 roleRef:
@@ -109568,7 +109568,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi
   namespace: default
 roleRef:
@@ -109596,7 +109596,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-rpk-bundle
   namespace: default
 roleRef:
@@ -109624,7 +109624,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-metrics-service
   namespace: default
 spec:
@@ -109652,7 +109652,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: MkL0HtR-webhook-service
   namespace: default
 spec:
@@ -109679,7 +109679,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi
   namespace: default
 spec:
@@ -110175,7 +110175,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -110205,7 +110205,7 @@ metadata:
     app.kubernetes.io/name: MkL0HtR
     app.kubernetes.io/version: v2.4.2
     dwmXsKZoxFp: TZf
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: KPhNK5uNi-selfsigned-issuer
   namespace: default
 spec:
@@ -110440,7 +110440,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: L
   namespace: default
 ---
@@ -110469,7 +110469,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: iP-config
   namespace: default
 ---
@@ -110485,7 +110485,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: iP-metrics-service
   namespace: default
 spec:
@@ -110509,7 +110509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: LH-webhook-service
   namespace: default
 spec:
@@ -110532,7 +110532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: iP
   namespace: default
 spec:
@@ -111097,7 +111097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -111123,7 +111123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: LH
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: iP-selfsigned-issuer
   namespace: default
 spec:
@@ -111359,7 +111359,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: vE4AZ
   namespace: default
@@ -111390,7 +111390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-config
   namespace: default
@@ -111408,7 +111408,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-metrics-reader
 rules:
@@ -111430,7 +111430,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj
 rules:
@@ -111638,7 +111638,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj
 roleRef:
@@ -111663,7 +111663,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-election-role
   namespace: default
@@ -111713,7 +111713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj
   namespace: default
@@ -111742,7 +111742,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-election-role
   namespace: default
@@ -111768,7 +111768,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj
   namespace: default
@@ -111794,7 +111794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-metrics-service
   namespace: default
@@ -111820,7 +111820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: RoJFv-webhook-service
   namespace: default
@@ -111845,7 +111845,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj
   namespace: default
@@ -112395,7 +112395,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: redpanda-serving-cert
   namespace: default
@@ -112423,7 +112423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-selfsigned-issuer
   namespace: default
@@ -112475,7 +112475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RoJFv
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
     rnKI: dxHr
   name: 5U9oyj-metrics-monitor
   namespace: default
@@ -112500,7 +112500,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: RoJFv
       app.kubernetes.io/version: v2.4.2
-      helm.sh/chart: operator-v2.4.2
+      helm.sh/chart: operator-2.4.2
       rnKI: dxHr
 ---
 # Source: operator/templates/entry-point.yaml
@@ -112685,7 +112685,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
--- testdata/default-values.yaml.golden --
+-- testdata/crd-installation.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: v1
@@ -112833,6 +112833,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - update
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112921,38 +112930,6 @@ rules:
 ---
 # Source: operator/templates/entry-point.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations: null
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/instance: operator
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: operator
-    app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
-  name: operator-compat
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - events
-  - limitranges
-  - persistentvolumeclaims
-  - pods
-  - pods/log
-  - replicationcontrollers
-  - resourcequotas
-  - serviceaccounts
-  - services
-  verbs:
-  - get
-  - list
----
-# Source: operator/templates/entry-point.yaml
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations: null
@@ -112990,28 +112967,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: operator-additional-controllers
-subjects:
-- kind: ServiceAccount
-  name: operator
-  namespace: default
----
-# Source: operator/templates/entry-point.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations: null
-  creationTimestamp: null
-  labels:
-    app.kubernetes.io/instance: operator
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: operator
-    app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
-  name: operator-compat
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: operator-compat
 subjects:
 - kind: ServiceAccount
   name: operator
@@ -113076,6 +113031,1890 @@ metadata:
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
     helm.sh/chart: operator-v2.4.2
+  name: operator
+  namespace: default
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-rpk-bundle
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-election-role
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-election-role
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-rpk-bundle
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-rpk-bundle
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/name: operator
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/name: operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --webhook-enabled=false
+        - --namespace=default
+        - --log-level=info
+        - --configurator-tag=v25.1.1-beta3
+        - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
+        command:
+        - /manager
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v25.1.1-beta3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      ephemeralContainers: null
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-v2.4.2
+  name: operator-crds
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - crd
+        command:
+        - /redpanda-operator
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v25.1.1-beta3
+        imagePullPolicy: IfNotPresent
+        name: crd-installation
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: OnFailure
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+=======
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+-- testdata/crd-installation.yaml.golden --
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |-
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: :8081
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: aa9fc693.vectorized.io
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-config
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas/finalizers
+  - schemas/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas/status
+  - schemas/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - schemas
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-election-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator
+  namespace: default
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-additional-controllers
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-rpk-bundle
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-election-role
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-election-role
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-additional-controllers
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-additional-controllers
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-rpk-bundle
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-rpk-bundle
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/name: operator
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/name: operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --webhook-enabled=false
+        - --namespace=default
+        - --log-level=info
+        - --configurator-tag=v25.1.1-beta3
+        - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
+        command:
+        - /manager
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v25.1.1-beta3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      ephemeralContainers: null
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-25.1.1-beta3
+  name: operator-crds
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - crd
+        command:
+        - /redpanda-operator
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v25.1.1-beta3
+        imagePullPolicy: IfNotPresent
+        name: crd-installation
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: OnFailure
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+>>>>>>> b23b0e1f (Correct "Release on Tag" GHA)
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+-- testdata/default-values.yaml.golden --
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |-
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: :8081
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: aa9fc693.vectorized.io
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-config
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas/finalizers
+  - schemas/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas/status
+  - schemas/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - schemas
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-additional-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-compat
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-additional-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-compat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-compat
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
+  name: operator-election-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: null
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -113300,7 +115139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -113395,7 +115234,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -113428,7 +115267,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 rules:
@@ -113460,7 +115299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -113483,7 +115322,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -113506,7 +115345,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -113529,7 +115368,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -113552,7 +115391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 roleRef:
@@ -113575,7 +115414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -113598,7 +115437,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:
@@ -113945,7 +115784,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 ---
@@ -113973,7 +115812,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-config
   namespace: default
 ---
@@ -113988,7 +115827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -114007,7 +115846,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 rules:
 - apiGroups:
@@ -114091,7 +115930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -114176,7 +116015,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 rules:
 - apiGroups:
@@ -114208,7 +116047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -114230,7 +116069,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -114252,7 +116091,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -114274,7 +116113,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 rules:
@@ -114321,7 +116160,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -114546,7 +116385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -114641,7 +116480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -114674,7 +116513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 rules:
@@ -114706,7 +116545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -114729,7 +116568,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -114752,7 +116591,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -114775,7 +116614,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -114798,7 +116637,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 roleRef:
@@ -114821,7 +116660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -114844,7 +116683,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:
@@ -115208,7 +117047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 ---
@@ -115236,7 +117075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-config
   namespace: default
 ---
@@ -115251,7 +117090,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -115270,7 +117109,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 rules:
 - apiGroups:
@@ -115354,7 +117193,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -115439,7 +117278,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 rules:
 - apiGroups:
@@ -115471,7 +117310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -115493,7 +117332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -115515,7 +117354,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -115537,7 +117376,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 rules:
@@ -115584,7 +117423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -115809,7 +117648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -115904,7 +117743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -115937,7 +117776,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 rules:
@@ -115969,7 +117808,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -115992,7 +117831,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -116015,7 +117854,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -116038,7 +117877,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -116061,7 +117900,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 roleRef:
@@ -116084,7 +117923,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -116107,7 +117946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:
@@ -116454,7 +118293,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 ---
@@ -116482,7 +118321,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-config
   namespace: default
 ---
@@ -116497,7 +118336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -116516,7 +118355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 rules:
 - apiGroups:
@@ -116600,7 +118439,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -116685,7 +118524,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 rules:
 - apiGroups:
@@ -116717,7 +118556,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -116739,7 +118578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -116761,7 +118600,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -116783,7 +118622,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 rules:
@@ -116830,7 +118669,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -117055,7 +118894,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -117150,7 +118989,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -117183,7 +119022,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 rules:
@@ -117215,7 +119054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -117238,7 +119077,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -117261,7 +119100,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -117284,7 +119123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -117307,7 +119146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 roleRef:
@@ -117330,7 +119169,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -117353,7 +119192,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:
@@ -117700,7 +119539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 ---
@@ -117728,7 +119567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-config
   namespace: default
 ---
@@ -117743,7 +119582,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -117762,7 +119601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 rules:
 - apiGroups:
@@ -117967,7 +119806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -117989,7 +119828,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 rules:
@@ -118036,7 +119875,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -118062,7 +119901,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -118095,7 +119934,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -118118,7 +119957,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -118141,7 +119980,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -118164,7 +120003,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -118187,7 +120026,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-webhook-service
   namespace: default
 spec:
@@ -118209,7 +120048,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:
@@ -118316,7 +120155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: redpanda-serving-cert
   namespace: default
 spec:
@@ -118341,7 +120180,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-selfsigned-issuer
   namespace: default
 spec:
@@ -118575,7 +120414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 ---
@@ -118603,7 +120442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-config
   namespace: default
 ---
@@ -118618,7 +120457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-reader
 rules:
 - nonResourceURLs:
@@ -118637,7 +120476,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 rules:
 - apiGroups:
@@ -118721,7 +120560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 rules:
 - apiGroups:
@@ -118806,7 +120645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 rules:
 - apiGroups:
@@ -118838,7 +120677,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -118860,7 +120699,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -118882,7 +120721,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -118904,7 +120743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 rules:
@@ -118951,7 +120790,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 rules:
@@ -119176,7 +121015,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 rules:
@@ -119271,7 +121110,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 rules:
@@ -119304,7 +121143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 rules:
@@ -119336,7 +121175,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-election-role
   namespace: default
 roleRef:
@@ -119359,7 +121198,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 roleRef:
@@ -119382,7 +121221,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-additional-controllers
   namespace: default
 roleRef:
@@ -119405,7 +121244,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-rpk-bundle
   namespace: default
 roleRef:
@@ -119428,7 +121267,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-compat
   namespace: default
 roleRef:
@@ -119451,7 +121290,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator-metrics-service
   namespace: default
 spec:
@@ -119474,7 +121313,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
     app.kubernetes.io/version: v2.4.2
-    helm.sh/chart: operator-v2.4.2
+    helm.sh/chart: operator-2.4.2
   name: operator
   namespace: default
 spec:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [Add "Release On Tag" GHA](https://github.com/redpanda-data/redpanda-operator/pull/928)
 - [Correct "Release on Tag" GHA](https://github.com/redpanda-data/redpanda-operator/pull/936)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)