### PR TITLE
[release/v25.1.x] v1: fix admin-api TLS mounting

### DIFF
--- a/operator/pkg/resources/certmanager/type_helpers.go
+++ b/operator/pkg/resources/certmanager/type_helpers.go
@@ -606,7 +606,7 @@ func (cc *ClusterCertificates) Volumes() (
 		mountPoints.AdminAPI.NodeCertMountDir,
 		adminAPIClientCAVolName,
 		mountPoints.AdminAPI.ClientCAMountDir,
-		true,
+		cc.adminAPI.selfSignedNodeCertificate,
 		true,
 	)
 	vols = append(vols, vol...)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [v1: fix admin-api TLS mounting](https://github.com/redpanda-data/redpanda-operator/pull/939)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)