### PR TITLE
[release/v2.3.x] operator: Add option to opt-out from User password generation

### DIFF
--- a/.changes/unreleased/operator-Added-20250630-182854.yaml
+++ b/.changes/unreleased/operator-Added-20250630-182854.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: Added `noGenerate` to `Password`. When `true`, it prevents the operator from generating non-existent Secrets and non-existent Secret keys that are specified via `valueFrom`
+time: 2025-06-30T18:28:54.805625+02:00

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
               { name = "GOROOT"; value = "${pkgs.go_1_23}/share/go"; }
               { name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.29.x)"; }
               { name = "PATH"; eval = "$(pwd)/.build:$PATH"; }
+              { name = "TEST_REDPANDA_VERSION"; eval = "v24.3.16"; }
             ];
 
             # If the version of the installed binary is important make sure to

--- a/operator/api/applyconfiguration/redpanda/v1alpha2/password.go
+++ b/operator/api/applyconfiguration/redpanda/v1alpha2/password.go
@@ -14,8 +14,9 @@ package v1alpha2
 // PasswordApplyConfiguration represents an declarative configuration of the Password type for use
 // with apply.
 type PasswordApplyConfiguration struct {
-	Value     *string                           `json:"value,omitempty"`
-	ValueFrom *PasswordSourceApplyConfiguration `json:"valueFrom,omitempty"`
+	Value      *string                           `json:"value,omitempty"`
+	ValueFrom  *PasswordSourceApplyConfiguration `json:"valueFrom,omitempty"`
+	NoGenerate *bool                             `json:"noGenerate,omitempty"`
 }
 
 // PasswordApplyConfiguration constructs an declarative configuration of the Password type for use with
@@ -37,5 +38,13 @@ func (b *PasswordApplyConfiguration) WithValue(value string) *PasswordApplyConfi
 // If called multiple times, the ValueFrom field is set to the value of the last call.
 func (b *PasswordApplyConfiguration) WithValueFrom(value *PasswordSourceApplyConfiguration) *PasswordApplyConfiguration {
 	b.ValueFrom = value
+	return b
+}
+
+// WithNoGenerate sets the NoGenerate field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NoGenerate field is set to the value of the last call.
+func (b *PasswordApplyConfiguration) WithNoGenerate(value bool) *PasswordApplyConfiguration {
+	b.NoGenerate = &value
 	return b
 }

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -1485,6 +1485,8 @@ Password specifies a password for the user.
 | *`value`* __string__ | Value is a hardcoded value to use for the given password. It should only be used for testing purposes. +
 In production, use ValueFrom. + |  | 
 | *`valueFrom`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-passwordsource[$$PasswordSource$$]__ | ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials. + |  | 
+| *`noGenerate`* __boolean__ | NoGenerate When `true`, prevents the operator from generating non-existent Secrets and non-existent Secret +
+keys that are specified via `valueFrom` + |  | 
 |===
 
 

--- a/operator/api/redpanda/v1alpha2/user_types.go
+++ b/operator/api/redpanda/v1alpha2/user_types.go
@@ -129,6 +129,9 @@ type Password struct {
 	Value string `json:"value,omitempty"`
 	// ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials.
 	ValueFrom *PasswordSource `json:"valueFrom"`
+	// NoGenerate When `true`, prevents the operator from generating non-existent Secrets and non-existent Secret
+	// keys that are specified via `valueFrom`
+	NoGenerate bool `json:"noGenerate,omitempty"`
 }
 
 // Fetch fetches the actual value of a password based on its configuration.

--- a/operator/config/crd/bases/cluster.redpanda.com_users.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_users.yaml
@@ -60,6 +60,11 @@ spec:
                   password:
                     description: Password specifies where a password is read from.
                     properties:
+                      noGenerate:
+                        description: |-
+                          NoGenerate When `true`, prevents the operator from generating non-existent Secrets and non-existent Secret
+                          keys that are specified via `valueFrom`
+                        type: boolean
                       value:
                         description: |-
                           Value is a hardcoded value to use for the given password. It should only be used for testing purposes.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.3.x`:
 - [operator: Add option to opt-out from User password generation](https://github.com/redpanda-data/redpanda-operator/pull/953)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)