### PR TITLE
require acceptance tests to pass

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -139,7 +139,7 @@ steps:
     retry:
       automatic:
         limit: 3
-    soft_fail: true
+    soft_fail: false
     timeout_in_minutes: 60
   - continue_on_failure: true
     wait: null

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -184,4 +184,9 @@ tasks:
       vars:
         GO_TEST_RUNNER:
           ref: .GO_TEST_RUNNER
+        # Acceptance tests only run from the acceptance package. Limiting the
+        # scope cuts a substantial amount of time off running this task and
+        # makes the output stream instead of being buffered.
+        MOD: "acceptance"
+        PKG: "."
         CLI_ARGS: '{{.CLI_ARGS}} -run "^TestAcceptance" -timeout 35m -tags acceptance'

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -4,6 +4,7 @@ go 1.23.8
 
 require (
 	github.com/cucumber/godog v0.14.1
+	github.com/fluxcd/source-controller/api v1.2.3
 	github.com/go-logr/logr v1.4.2
 	github.com/prometheus/common v0.55.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
@@ -76,6 +77,7 @@ require (
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fluxcd/helm-controller/api v0.37.2 // indirect
+	github.com/fluxcd/pkg/apis/acl v0.1.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.2.0 // indirect
 	github.com/fluxcd/pkg/apis/meta v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -200,7 +200,6 @@ github.com/fluxcd/pkg/apis/kustomize v1.2.0 h1:vkVs+OumxaWso0jNCqdgFFfMHdh+qtZhy
 github.com/fluxcd/pkg/apis/kustomize v1.2.0/go.mod h1:VF7tR/WuVFeum+HaMTHwp+eCtsHiiQlY6ihgqtAnW/M=
 github.com/fluxcd/pkg/apis/meta v1.2.0 h1:O766PzGAdMdQKybSflGL8oV0+GgCNIkdsxfalRyzeO8=
 github.com/fluxcd/pkg/apis/meta v1.2.0/go.mod h1:fU/Az9AoVyIxC0oI4ihG0NVMNnvrcCzdEym3wxjIQsc=
-github.com/fluxcd/source-controller v1.2.3 h1:g+lleTMyaS2yPfOHuXGJIjQLyiIPjPxM1/m59vwMdgs=
 github.com/fluxcd/source-controller/api v1.2.3 h1:71mXv3Qg9HEhcpqOq1ObmoE+P/HuZNaAvxfI7dqZMo8=
 github.com/fluxcd/source-controller/api v1.2.3/go.mod h1:5gaIVVH7hgb8p3HKFp8P6hGmZEC8fKSt4EcrG3g5vZI=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -42,7 +42,7 @@ var suites = []TestSuite{
 	},
 	{
 		Name:     "acceptance",
-		Required: false,
+		Required: true,
 		Timeout:  time.Hour,
 		Retry:    ptr.To(3),
 	},

--- a/harpoon/internal/testing/kubectl.go
+++ b/harpoon/internal/testing/kubectl.go
@@ -100,7 +100,9 @@ func KubectlDelete(ctx context.Context, fileOrDirectory string, options ...*Kube
 		mergedOptions = mergedOptions.merge(option)
 	}
 
-	return kubectl(ctx, mergedOptions, "delete", "-f", fileOrDirectory, "--ignore-not-found=true")
+	// Most objects should cleanly delete in < 1m, anything longer generally
+	// indicates something being stuck on a finalizer.
+	return kubectl(ctx, mergedOptions, "delete", "-f", fileOrDirectory, "--ignore-not-found=true", "--timeout=90s")
 }
 
 func KubectlApply(ctx context.Context, fileOrDirectory string, options ...*KubectlOptions) (string, error) {


### PR DESCRIPTION
Prior to this commit, the acceptance suite wasn't required to pass for this branch. Running the tests locally would suddenly hang without activity or output, similar to their behavior in CI. (Though the output in CI was fairly confusing due to go-dog's formatting.)

This commit fixes the hanging issue by clearing out the `HelmRepository` created by the operator. This resource caused the CRD uninstallation hook to hang due to a finalize being present and the operator being uninstalled ahead of CRD removal.

Additionally, this commit makes the acceptance suite as required once again as it was otherwise passing successfully.

(cherry picked from commit 54b718339e4bbbd2230bd25ab0d8e0f8e00a10c0)