### PR TITLE
[release/v25.1.x] release: fix tag pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       # Only match tags that look like go module tags.
       # This way we explicitly ignore our legacy tagging of the operator.
-      - '*/v*'
+      - '**/v*'
   workflow_dispatch:
     inputs:
       ref_name:
@@ -89,7 +89,7 @@ jobs:
           # remove the first line.
           tail -n +2 .changes/${{ steps.get_ref.outputs.ref_name }}.md > RELEASE_BODY.md
 
-      # create github release and upload file
+      # Create github release and upload packaged chart, if any.
       - name: create github release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [release: fix tag pattern](https://github.com/redpanda-data/redpanda-operator/pull/967)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)