### PR TITLE
operator: use default AWS AZ ID topology label key

### DIFF
--- a/operator/cmd/configurator/configurator.go
+++ b/operator/cmd/configurator/configurator.go
@@ -363,7 +363,15 @@ func getZoneLabels(nodeName string) (zone, zoneID string, err error) {
 		return "", "", fmt.Errorf("unable to retrieve node: %w", err)
 	}
 	zone = node.Labels["topology.kubernetes.io/zone"]
-	zoneID = node.Labels["topology.cloud.redpanda.com/zone-id"]
+
+	// With AWS EKS 1.30, the topology.k8s.aws/zone-id label is added to worker nodes. Prefer it
+	// over the redpanda custom label. These zone-id labels are only important for AWS, as we use the zone
+	// label in other cloud providers.
+	zoneID = node.Labels["topology.k8s.aws/zone-id"]
+	if zoneID == "" {
+		zoneID = node.Labels["topology.cloud.redpanda.com/zone-id"]
+	}
+
 	return zone, zoneID, nil
 }
 


### PR DESCRIPTION
With Amazon EKS 1.30, the `topology.k8s.aws/zone-id` label is added to K8s worker nodes, so we don't need to rely on the custom redpanda label set by us in the cloud. This PR enables the operator to use the AWS AZ ID topology label key by default.

Refs:
- https://github.com/kubernetes/cloud-provider-aws/issues/300
- https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-30