### PR TITLE
[release/v2.4.x] operator: Add option to disable cluster configuration in sidecar

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250625-101214.yaml
+++ b/.changes/unreleased/operator-Fixed-20250625-101214.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Setting of the `superuser` cluster configuration is now solely controlled by the operator and now correctly includes the `kubernetes-controller` bootstrap user.
+time: 2025-06-25T10:14:14.143026+02:00

--- a/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
@@ -1031,6 +1031,8 @@ type ClusterConfiguration vectorizedv1alpha1.ClusterConfiguration
 // SideCars configures the additional sidecar containers that run alongside the main Redpanda container in the Pod.
 type SideCars struct {
 	Image *RedpandaImage `json:"image,omitempty"`
+	// +hidefromdoc
+	Args []string `json:"args,omitempty"`
 	// Configures the `config-watcher` sidecar. The `config-watcher` sidecar polls the Secret resource in `auth.sasl.secretRef` for changes and triggers a rolling upgrade to add the new superusers to the Redpanda cluster.
 	ConfigWatcher *ConfigWatcher `json:"configWatcher,omitempty"`
 	RpkStatus     *SideCarObj    `json:"rpkStatus,omitempty"`

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -2711,6 +2711,7 @@ SideCars configures the additional sidecar containers that run alongside the mai
 |===
 | Field | Description | Default | Validation
 | *`image`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaimage[$$RedpandaImage$$]__ |  |  | 
+
 | *`configWatcher`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-configwatcher[$$ConfigWatcher$$]__ | Configures the `config-watcher` sidecar. The `config-watcher` sidecar polls the Secret resource in `auth.sasl.secretRef` for changes and triggers a rolling upgrade to add the new superusers to the Redpanda cluster. + |  | 
 | *`rpkStatus`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-sidecarobj[$$SideCarObj$$]__ |  |  | 
 | *`controllers`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-rpcontrollers[$$RPControllers$$]__ |  |  | 

--- a/operator/api/redpanda/v1alpha2/zz_generated.deepcopy.go
+++ b/operator/api/redpanda/v1alpha2/zz_generated.deepcopy.go
@@ -3565,6 +3565,11 @@ func (in *SideCars) DeepCopyInto(out *SideCars) {
 		*out = new(RedpandaImage)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ConfigWatcher != nil {
 		in, out := &in.ConfigWatcher, &out.ConfigWatcher
 		*out = new(ConfigWatcher)

--- a/operator/cmd/sidecar/sidecar.go
+++ b/operator/cmd/sidecar/sidecar.go
@@ -49,6 +49,7 @@ func Command() *cobra.Command {
 		redpandaYAMLPath           string
 		usersDirectoryPath         string
 		watchUsers                 bool
+		noSetSuperusers            bool
 		runDecommissioner          bool
 		runBrokerProbe             bool
 		brokerProbeShutdownTimeout time.Duration
@@ -78,6 +79,7 @@ func Command() *cobra.Command {
 				redpandaYAMLPath,
 				usersDirectoryPath,
 				watchUsers,
+				noSetSuperusers,
 				runDecommissioner,
 				runBrokerProbe,
 				brokerProbeShutdownTimeout,
@@ -109,7 +111,9 @@ func Command() *cobra.Command {
 
 	// users flags
 	cmd.Flags().BoolVar(&watchUsers, "watch-users", false, "Specifies if the sidecar should watch and configure superusers based on a mounted users file.")
+	cmd.Flags().BoolVar(&noSetSuperusers, "no-set-superusers", false, "Specifies if the sidecar should sync the superuser cluster configuration with watched users or not")
 	cmd.Flags().StringVar(&usersDirectoryPath, "users-directory", "/etc/secrets/users/", "Path to users directory where secrets are mounted.")
+	cmd.Flags().MarkHidden("no-set-superusers") // nolint:gosec
 
 	// broker probe flags
 	cmd.Flags().BoolVar(&runBrokerProbe, "run-broker-probe", false, "Specifies if the sidecar should run the health probe.")
@@ -142,6 +146,7 @@ func Run(
 	redpandaYAMLPath string,
 	usersDirectoryPath string,
 	watchUsers bool,
+	noSetSuperusers bool,
 	runDecommissioner bool,
 	runBrokerProbe bool,
 	brokerProbeShutdownTimeout time.Duration,
@@ -245,6 +250,7 @@ func Run(
 		watcher := configwatcher.NewConfigWatcher(mgr.GetLogger(), true,
 			configwatcher.WithRedpandaConfigPath(redpandaYAMLPath),
 			configwatcher.WithUsersDirectory(usersDirectoryPath),
+			configwatcher.WithSkipClusterConfigurationSync(noSetSuperusers),
 		)
 		if err := mgr.Add(watcher); err != nil {
 			setupLog.Error(err, "unable to run config watcher")

--- a/operator/cmd/syncclusterconfig/superusers.go
+++ b/operator/cmd/syncclusterconfig/superusers.go
@@ -1,0 +1,55 @@
+package syncclusterconfig
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// NormalizeSuperusers de-duplicates and sorts the superusers
+func NormalizeSuperusers(entries []string) []string {
+	var sorted sort.StringSlice
+
+	if len(entries) == 0 {
+		return []string{}
+	}
+
+	unique := make(map[string]struct{})
+	for _, value := range entries {
+		if _, ok := unique[value]; !ok {
+			sorted = append(sorted, value)
+		}
+		unique[value] = struct{}{}
+	}
+
+	sorted.Sort()
+
+	return sorted
+}
+
+// LoadUsersFile parses super users file (Format: USER_NAME:PASSWORD:SASL_MECHANISM_TYPE) and returns list of user names
+func LoadUsersFile(ctx context.Context, filename string, usersFile []byte) []string {
+	scanner := bufio.NewScanner(bytes.NewReader(usersFile))
+
+	users := []string{}
+
+	i := 0
+	for scanner.Scan() {
+		i++
+
+		line := scanner.Text()
+		tokens := strings.Split(line, ":")
+		if len(tokens) != 2 && len(tokens) != 3 {
+			log.FromContext(ctx).Info(fmt.Sprintf("Skipping malformatted line number %d in file %q", i, filename))
+			continue
+		}
+		users = append(users, tokens[0])
+	}
+
+	return users
+}

--- a/operator/cmd/syncclusterconfig/sync_test.go
+++ b/operator/cmd/syncclusterconfig/sync_test.go
@@ -348,36 +348,36 @@ func TestSyncSuperusers(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		config      map[string]any
-		suTxt       string
+		suTxt       []string
 		expectArray bool
 	}{
 		{
 			name:   "no superusers",
 			config: map[string]any{},
-			suTxt:  "a::\nb::",
+			suTxt:  []string{"a", "b"},
 			// TODO: this should probably insert `a` and `b` as superusers; we don't hit this in v2 at present.
 		},
 		{
 			name:        "[]any superusers",
 			config:      map[string]any{superusersEntry: []any{"b", "c"}},
-			suTxt:       "a::\nb::",
+			suTxt:       []string{"a", "b"},
 			expectArray: true,
 		},
 		{
 			name:        "[]string superusers",
 			config:      map[string]any{superusersEntry: []string{"b", "c"}},
-			suTxt:       "a::\nb::",
+			suTxt:       []string{"a", "b"},
 			expectArray: true,
 		},
 		{
 			name:   "bad superusers",
 			config: map[string]any{superusersEntry: "broken"},
-			suTxt:  "a::\nb::",
+			suTxt:  []string{"a", "b"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := maps.Clone(tc.config)
-			s.maybeMergeSuperusers(context.TODO(), c, map[string][]byte{"x": []byte(tc.suTxt)})
+			s.maybeMergeSuperusers(context.TODO(), c, tc.suTxt)
 			if tc.expectArray {
 				assert.Equal(t, []string{"a", "b", "c"}, c[superusersEntry])
 			}

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -18874,6 +18874,10 @@ spec:
                         description: Defines the additional sidecar containers that
                           run alongside the main Redpanda container in the Pod.
                         properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
                           configWatcher:
                             description: Configures the `config-watcher` sidecar.
                               The `config-watcher` sidecar polls the Secret resource
@@ -39281,6 +39285,10 @@ spec:
                         description: Defines the additional sidecar containers that
                           run alongside the main Redpanda container in the Pod.
                         properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
                           configWatcher:
                             description: Configures the `config-watcher` sidecar.
                               The `config-watcher` sidecar polls the Secret resource

--- a/operator/crd-docs-templates/gv_details.tpl
+++ b/operator/crd-docs-templates/gv_details.tpl
@@ -1,0 +1,19 @@
+{{- define "gvDetails" -}}
+{{- $gv := . -}}
+[id="{{ asciidocGroupVersionID $gv | asciidocRenderAnchorID }}"]
+=== {{ $gv.GroupVersionString }}
+
+{{ $gv.Doc }}
+
+{{- if $gv.Kinds  }}
+.Resource Types
+{{- range $gv.SortedKinds }}
+- {{ $gv.TypeForKind . | asciidocRenderTypeLink }}
+{{- end }}
+{{ end }}
+
+{{ range $gv.SortedTypes }}
+{{ template "type" . }}
+{{ end }}
+
+{{- end -}}

--- a/operator/crd-docs-templates/gv_list.tpl
+++ b/operator/crd-docs-templates/gv_list.tpl
@@ -1,0 +1,19 @@
+{{- define "gvList" -}}
+{{- $groupVersions := . -}}
+
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+== API Reference
+
+.Packages
+{{- range $groupVersions }}
+- {{ asciidocRenderGVLink . }}
+{{- end }}
+
+{{ range $groupVersions }}
+{{ template "gvDetails" . }}
+{{ end }}
+
+{{- end -}}

--- a/operator/crd-docs-templates/type.tpl
+++ b/operator/crd-docs-templates/type.tpl
@@ -1,0 +1,48 @@
+{{- define "type" -}}
+{{- $type := . -}}
+{{- if asciidocShouldRenderType $type -}}
+
+[id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
+==== {{ $type.Name  }}
+
+{{ if $type.IsAlias }}_Underlying type:_ _{{ asciidocRenderTypeLink $type.UnderlyingType  }}_{{ end }}
+
+{{ $type.Doc }}
+
+{{ if $type.Validation -}}
+.Validation:
+{{- range $type.Validation }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
+{{ if $type.References -}}
+.Appears In:
+****
+{{- range $type.SortedReferences }}
+- {{ asciidocRenderTypeLink . }}
+{{- end }}
+****
+{{- end }}
+
+{{ if $type.Members -}}
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+{{ if $type.GVK -}}
+| *`apiVersion`* __string__ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}` | |
+| *`kind`* __string__ | `{{ $type.GVK.Kind }}` | |
+{{ end -}}
+
+{{ range $type.Members -}}
+{{ with .Markers.hidefromdoc -}}
+{{ else -}}
+| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }} | {{ .Default }} | {{ range .Validation -}} {{ asciidocRenderValidation . }} +
+{{ end -}}
+{{ end }}
+{{ end -}}
+|===
+{{ end -}}
+
+{{- end -}}
+{{- end -}}

--- a/operator/crd-docs-templates/type_members.tpl
+++ b/operator/crd-docs-templates/type_members.tpl
@@ -1,0 +1,8 @@
+{{- define "type_members" -}}
+{{- $field := . -}}
+{{- if eq $field.Name "metadata" -}}
+Refer to Kubernetes API documentation for fields of `metadata`.
+{{ else -}}
+{{ asciidocRenderFieldDoc $field.Doc }}
+{{- end -}}
+{{- end -}}

--- a/operator/crd-ref-docs-config.yaml
+++ b/operator/crd-ref-docs-config.yaml
@@ -4,6 +4,9 @@ processor:
   - 'Migration$'
   ignoreFields:
   - 'migration$'
+  customMarkers:
+  - name: "hidefromdoc"
+    target: field
 
 render:
   kubernetesVersion: 1.28

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -309,10 +309,7 @@ func (s *RedpandaControllerSuite) TestClusterSettings() {
 			In: map[string]any{
 				"enable_transactions":         true,
 				"enable_schema_id_validation": "none",
-				// TODO: Minor bug in the helm chart here, setting superusers
-				// in cluster.config results in the bootstrap users getting
-				// excluded.
-				// "superusers":                  []any{"jimbob"},
+				//"superusers":                  []any{"jimbob"},
 			},
 			Expected: map[string]any{
 				"admin_api_require_auth":    true,
@@ -358,7 +355,9 @@ func (s *RedpandaControllerSuite) TestClusterSettings() {
 					return int(a.ConfigVersion - b.ConfigVersion)
 				}).ConfigVersion
 
-				assert.Greater(t, currVersion, initialVersion, "expected config version to increase")
+				// Only operator should change cluster configuration once. If there is any other party that changes
+				// Redpanda cluster configuration, it is unexpected and should be investigated.
+				assert.Equal(t, initialVersion+1, currVersion, "current config version should increase only by one")
 
 				assert.False(t, slices.ContainsFunc(st, func(cs rpadmin.ConfigStatus) bool {
 					return cs.Restart

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -126,7 +126,8 @@ tasks:
       crd-ref-docs \
       --config crd-ref-docs-config.yaml \
       --source-path ./api/redpanda/v1alpha2/ \
-      --output-path ./api/redpanda/v1alpha2/testdata/crd-docs.adoc
+      --output-path ./api/redpanda/v1alpha2/testdata/crd-docs.adoc \
+      --templates-dir=./crd-docs-templates/
 
   fetch-latest-redpanda:
     desc: fetch the latest redpanda release and tag it localhost/redpanda:dev


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [operator: Add option to disable cluster configuration in sidecar](https://github.com/redpanda-data/redpanda-operator/pull/938)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)