### PR TITLE
operator: Remove obsolete operator helm chart changelog entry

### DIFF
--- a/.changes/operator/v2.3.9-24.3.11.md
+++ b/.changes/operator/v2.3.9-24.3.11.md
@@ -30,3 +30,7 @@
   if correct FullNameOverride is not provided and handled the same way for both
   client creation and render function.
 * The Redpanda license was not set by operator. Now it will be set in the first reconciliation. After initial setup the consequent license re-set will be reconciled after client-go cache resync timeout (default 10h).
+### Removed
+* [CHART] The [`kube-prometheus-stack`](https://prometheus-community.github.io/helm-charts) subchart has been removed.
+
+  This integration was not being up kept and most use cases will be better served by deploying this chart themselves.

--- a/.changes/unreleased/operator-Removed-20250327-130201.yaml
+++ b/.changes/unreleased/operator-Removed-20250327-130201.yaml
@@ -1,7 +1,0 @@
-project: charts/operator
-kind: Removed
-body: |-
-    The [`kube-prometheus-stack`](https://prometheus-community.github.io/helm-charts) subchart has been removed.
-
-      This integration was not being up kept and most use cases will be better served by deploying this chart themselves.
-time: 2025-03-27T13:02:01.084713-04:00

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -80,6 +80,10 @@ This is required to ensure that a pre-existing sts can roll over to new configur
   if correct FullNameOverride is not provided and handled the same way for both
   client creation and render function.
 * The Redpanda license was not set by operator. Now it will be set in the first reconciliation. After initial setup the consequent license re-set will be reconciled after client-go cache resync timeout (default 10h).
+### Removed
+* [CHART] The [`kube-prometheus-stack`](https://prometheus-community.github.io/helm-charts) subchart has been removed.
+
+  This integration was not being up kept and most use cases will be better served by deploying this chart themselves.
 
 ## v2.3.8-24.3.6 - 2025-03-05
 ### Fixed


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda-operator/commit/cec9d133 commit only one of the bullet points was moved from unreleased Operator helm chart CHANGELOG.md to operator CHANGELOG.md. In this commit already released, change is added to changelog and file removed from an unreleased file list.