### PR TITLE
ci: Remove unused Redpanda License secret

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -43,7 +43,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -89,7 +88,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -138,7 +136,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -188,7 +185,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -237,7 +233,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests

--- a/gen/pipeline/helpers.go
+++ b/gen/pipeline/helpers.go
@@ -105,7 +105,6 @@ func (suite *TestSuite) ToStep() pipeline.Step {
 					secretEnvVars(
 						GITHUB_API_TOKEN, // Required to clone private GH repos (Flux Shims, buildkite slack).
 						REDPANDA_SAMPLE_LICENSE,
-						REDPANDA_SECOND_SAMPLE_LICENSE,
 						SLACK_VBOT_TOKEN, // Used to notify us of build failures in slack.
 					),
 					// Inform us about failures on main.

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -17,10 +17,9 @@ import (
 var (
 	// Known/Permitted environment variables pulled from AWS secret store.
 
-	GITHUB_API_TOKEN               = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
-	REDPANDA_SAMPLE_LICENSE        = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
-	REDPANDA_SECOND_SAMPLE_LICENSE = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_second_sample_license"}
-	SLACK_VBOT_TOKEN               = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}
+	GITHUB_API_TOKEN        = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
+	REDPANDA_SAMPLE_LICENSE = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
+	SLACK_VBOT_TOKEN        = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}
 
 	// Known/Permitted Agent Pools
 


### PR DESCRIPTION
There was unexpected secret removal from AWS Secret Manager which causes our pipeline to suddenly fail on all front. The secret was restored only for one week. This commit needs to be backported to all release branches and rebased on any outstanding PRs (feature branches).