### PR TITLE
[release/v2.4.x] ci: Remove unused Redpanda License secret

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -39,7 +39,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -81,7 +80,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -126,7 +124,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -171,7 +168,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests
@@ -213,7 +209,6 @@ steps:
         json-to-env:
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
-        - secret-id: sdlc/prod/buildkite/redpanda_second_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
     - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
         channel_name: kubernetes-tests

--- a/gen/pipeline/helpers.go
+++ b/gen/pipeline/helpers.go
@@ -91,7 +91,6 @@ func (suite *TestSuite) ToStep() pipeline.Step {
 					secretEnvVars(
 						GITHUB_API_TOKEN, // Required to clone private GH repos (Flux Shims, buildkite slack).
 						REDPANDA_SAMPLE_LICENSE,
-						REDPANDA_SECOND_SAMPLE_LICENSE,
 						SLACK_VBOT_TOKEN, // Used to notify us of build failures in slack.
 					),
 					// Inform us about failures on main.

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -17,10 +17,9 @@ import (
 var (
 	// Known/Permitted environment variables pulled from AWS secret store.
 
-	GITHUB_API_TOKEN               = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
-	REDPANDA_SAMPLE_LICENSE        = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
-	REDPANDA_SECOND_SAMPLE_LICENSE = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_second_sample_license"}
-	SLACK_VBOT_TOKEN               = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}
+	GITHUB_API_TOKEN        = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
+	REDPANDA_SAMPLE_LICENSE = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
+	SLACK_VBOT_TOKEN        = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}
 
 	// Known/Permitted Agent Pools
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [ci: Remove unused Redpanda License secret](https://github.com/redpanda-data/redpanda-operator/pull/982)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)