### PR TITLE
[release/v2.4.x] redpanda: fix rbac gating of sidecar controllers

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20250717-155155.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250717-155155.yaml
@@ -1,0 +1,7 @@
+project: charts/redpanda
+kind: Fixed
+body: |-
+    `ClusterRole`s for the PVCUnbinder and BrokerDecommissioner are now enabled / disabled when their respective controller is enabled / disabled.
+
+      Previously `ClusterRole`s were always generated and could only be disabled by setting `.statefulset.sideCars.controllers.createRBAC=false` which rendered the sidecar inoperable.
+time: 2025-07-17T15:51:55.231105-04:00

--- a/.changes/unreleased/operator-Fixed-20250717-155155.yaml
+++ b/.changes/unreleased/operator-Fixed-20250717-155155.yaml
@@ -1,0 +1,7 @@
+project: operator
+kind: Fixed
+body: |-
+    `ClusterRole`s for the PVCUnbinder and BrokerDecommissioner are now enabled / disabled when their respective controller is enabled / disabled.
+
+      Previously `ClusterRole`s were always generated and could only be disabled by setting `statefulset.sideCars.controllers.createRBAC` to `false` which rendered the sidecar inoperable.
+time: 2025-07-17T15:51:55.231101-04:00

--- a/charts/redpanda/rbac.go
+++ b/charts/redpanda/rbac.go
@@ -25,8 +25,8 @@ func Roles(dot *helmette.Dot) []*rbacv1.Role {
 	// path of static role definition -> Enabled
 	mapping := map[string]bool{
 		"files/sidecar.Role.yaml":          values.RBAC.Enabled && values.Statefulset.SideCars.Controllers.CreateRBAC,
-		"files/pvcunbinder.Role.yaml":      values.RBAC.Enabled && values.Statefulset.SideCars.Controllers.CreateRBAC,
-		"files/decommission.Role.yaml":     values.RBAC.Enabled && values.Statefulset.SideCars.Controllers.CreateRBAC,
+		"files/pvcunbinder.Role.yaml":      values.Statefulset.SideCars.ShouldCreateRBAC() && values.Statefulset.SideCars.PVCUnbinderEnabled(),
+		"files/decommission.Role.yaml":     values.Statefulset.SideCars.ShouldCreateRBAC() && values.Statefulset.SideCars.BrokerDecommissionerEnabled(),
 		"files/rpk-debug-bundle.Role.yaml": values.RBAC.Enabled && values.RBAC.RPKDebugBundle,
 	}
 
@@ -59,8 +59,8 @@ func ClusterRoles(dot *helmette.Dot) []*rbacv1.ClusterRole {
 
 	// path of static ClusterRole definition -> Enabled
 	mapping := map[string]bool{
-		"files/pvcunbinder.ClusterRole.yaml":    values.RBAC.Enabled && values.Statefulset.SideCars.Controllers.CreateRBAC,
-		"files/decommission.ClusterRole.yaml":   values.RBAC.Enabled && values.Statefulset.SideCars.Controllers.CreateRBAC,
+		"files/pvcunbinder.ClusterRole.yaml":    values.Statefulset.SideCars.ShouldCreateRBAC() && values.Statefulset.SideCars.PVCUnbinderEnabled(),
+		"files/decommission.ClusterRole.yaml":   values.Statefulset.SideCars.ShouldCreateRBAC() && values.Statefulset.SideCars.BrokerDecommissionerEnabled(),
 		"files/rack-awareness.ClusterRole.yaml": values.RBAC.Enabled && values.RackAwareness.Enabled,
 	}
 

--- a/charts/redpanda/templates/_rbac.go.tpl
+++ b/charts/redpanda/templates/_rbac.go.tpl
@@ -5,7 +5,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $mapping := (dict "files/sidecar.Role.yaml" (and $values.rbac.enabled $values.statefulset.sideCars.controllers.createRBAC) "files/pvcunbinder.Role.yaml" (and $values.rbac.enabled $values.statefulset.sideCars.controllers.createRBAC) "files/decommission.Role.yaml" (and $values.rbac.enabled $values.statefulset.sideCars.controllers.createRBAC) "files/rpk-debug-bundle.Role.yaml" (and $values.rbac.enabled $values.rbac.rpkDebugBundle)) -}}
+{{- $mapping := (dict "files/sidecar.Role.yaml" (and $values.rbac.enabled $values.statefulset.sideCars.controllers.createRBAC) "files/pvcunbinder.Role.yaml" (and (get (fromJson (include "redpanda.Sidecars.ShouldCreateRBAC" (dict "a" (list $values.statefulset.sideCars)))) "r") (get (fromJson (include "redpanda.Sidecars.PVCUnbinderEnabled" (dict "a" (list $values.statefulset.sideCars)))) "r")) "files/decommission.Role.yaml" (and (get (fromJson (include "redpanda.Sidecars.ShouldCreateRBAC" (dict "a" (list $values.statefulset.sideCars)))) "r") (get (fromJson (include "redpanda.Sidecars.BrokerDecommissionerEnabled" (dict "a" (list $values.statefulset.sideCars)))) "r")) "files/rpk-debug-bundle.Role.yaml" (and $values.rbac.enabled $values.rbac.rpkDebugBundle)) -}}
 {{- $roles := (coalesce nil) -}}
 {{- range $file, $enabled := $mapping -}}
 {{- if (not $enabled) -}}
@@ -32,7 +32,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $mapping := (dict "files/pvcunbinder.ClusterRole.yaml" (and $values.rbac.enabled $values.statefulset.sideCars.controllers.createRBAC) "files/decommission.ClusterRole.yaml" (and $values.rbac.enabled $values.statefulset.sideCars.controllers.createRBAC) "files/rack-awareness.ClusterRole.yaml" (and $values.rbac.enabled $values.rackAwareness.enabled)) -}}
+{{- $mapping := (dict "files/pvcunbinder.ClusterRole.yaml" (and (get (fromJson (include "redpanda.Sidecars.ShouldCreateRBAC" (dict "a" (list $values.statefulset.sideCars)))) "r") (get (fromJson (include "redpanda.Sidecars.PVCUnbinderEnabled" (dict "a" (list $values.statefulset.sideCars)))) "r")) "files/decommission.ClusterRole.yaml" (and (get (fromJson (include "redpanda.Sidecars.ShouldCreateRBAC" (dict "a" (list $values.statefulset.sideCars)))) "r") (get (fromJson (include "redpanda.Sidecars.BrokerDecommissionerEnabled" (dict "a" (list $values.statefulset.sideCars)))) "r")) "files/rack-awareness.ClusterRole.yaml" (and $values.rbac.enabled $values.rackAwareness.enabled)) -}}
 {{- $clusterRoles := (coalesce nil) -}}
 {{- range $file, $enabled := $mapping -}}
 {{- if (not $enabled) -}}

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -482,6 +482,26 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "redpanda.Sidecars.PVCUnbinderEnabled" -}}
+{{- $s := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (and $s.controllers.enabled $s.pvcUnbinder.enabled)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Sidecars.BrokerDecommissionerEnabled" -}}
+{{- $s := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (and $s.controllers.enabled $s.brokerDecommissioner.enabled)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda.Sidecars.ShouldCreateRBAC" -}}
 {{- $s := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
@@ -620,9 +640,9 @@
 {{- $seen := (dict) -}}
 {{- $deduped := (coalesce nil) -}}
 {{- range $_, $item := $items -}}
-{{- $_1064___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
-{{- $_ := (index $_1064___ok_11 0) -}}
-{{- $ok_11 := (index $_1064___ok_11 1) -}}
+{{- $_1072___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
+{{- $_ := (index $_1072___ok_11 0) -}}
+{{- $ok_11 := (index $_1072___ok_11 1) -}}
 {{- if $ok_11 -}}
 {{- continue -}}
 {{- end -}}
@@ -734,9 +754,9 @@
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1285_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
-{{- $cert := (index $_1285_cert_ok 0) -}}
-{{- $ok := (index $_1285_cert_ok 1) -}}
+{{- $_1293_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
+{{- $cert := (index $_1293_cert_ok 0) -}}
+{{- $ok := (index $_1293_cert_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
@@ -1165,9 +1185,9 @@
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_1748___ok_14 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
-{{- $_ := ((index $_1748___ok_14 0) | float64) -}}
-{{- $ok_14 := (index $_1748___ok_14 1) -}}
+{{- $_1756___ok_14 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
+{{- $_ := ((index $_1756___ok_14 0) | float64) -}}
+{{- $ok_14 := (index $_1756___ok_14 1) -}}
 {{- if $ok_14 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
@@ -1193,9 +1213,9 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
-{{- $_1768_b_15_ok_16 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
-{{- $b_15 := (index $_1768_b_15_ok_16 0) -}}
-{{- $ok_16 := (index $_1768_b_15_ok_16 1) -}}
+{{- $_1776_b_15_ok_16 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
+{{- $b_15 := (index $_1776_b_15_ok_16 0) -}}
+{{- $ok_16 := (index $_1776_b_15_ok_16 1) -}}
 {{- if $ok_16 -}}
 {{- $_ := (set $result $k $b_15) -}}
 {{- continue -}}
@@ -1238,15 +1258,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1813___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1813___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_1813___hasAccessKey 1) -}}
-{{- $_1814___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1814___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_1814___hasSecretKey 1) -}}
-{{- $_1815___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1815___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_1815___hasSharedKey 1) -}}
+{{- $_1821___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1821___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_1821___hasAccessKey 1) -}}
+{{- $_1822___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1822___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_1822___hasSecretKey 1) -}}
+{{- $_1823___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1823___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_1823___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey)))) "r")) -}}
 {{- $envvars = (concat (default (list) $envvars) (list (mustMergeOverwrite (dict "name" "") (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey)))) "r"))))) -}}
@@ -1269,12 +1289,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1851___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1851___containerExists 0) -}}
-{{- $containerExists := (index $_1851___containerExists 1) -}}
-{{- $_1852___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1852___accountExists 0) -}}
-{{- $accountExists := (index $_1852___accountExists 1) -}}
+{{- $_1859___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1859___containerExists 0) -}}
+{{- $containerExists := (index $_1859___containerExists 1) -}}
+{{- $_1860___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1860___accountExists 0) -}}
+{{- $accountExists := (index $_1860___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1285,9 +1305,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1857_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
-{{- $value := (index $_1857_value_ok 0) -}}
-{{- $ok := (index $_1857_value_ok 1) -}}
+{{- $_1865_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
+{{- $value := (index $_1865_value_ok 0) -}}
+{{- $ok := (index $_1865_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -94,7 +94,7 @@ tls:
 -- disable-cert-manager-overriding-defaults --
 # ASSERT-NO-ERROR
 # ASSERT-GOLDEN
-# ASSERT-NO-CERTIFICATES
+# ASSERT-NO-GVK ["cert-manager.io/v1", "Certificate"]
 # ASSERT-STATEFULSET-ALL-VOLUMES-ARE-USED
 tls:
   certs:
@@ -108,7 +108,7 @@ tls:
 -- disable-cert-manger-fully-specified --
 # ASSERT-NO-ERROR
 # ASSERT-GOLDEN
-# ASSERT-NO-CERTIFICATES
+# ASSERT-NO-GVK ["cert-manager.io/v1", "Certificate"]
 # ASSERT-STATEFULSET-ALL-VOLUMES-ARE-USED
 listeners:
   http:
@@ -1561,3 +1561,26 @@ config:
       externalSecretRefSelector:
         name: my-external-secret
         optional: true
+    external_opt_raw:
+      externalSecretRefSelector:
+        name: my-external-secret
+        optional: true
+      useRawValue: true
+
+-- umbrella-disableable-clusterroles --
+# ASSERT-NO-ERROR
+# ASSERT-NO-GVK ["rbac.authorization.k8s.io/v1", "ClusterRole"]
+statefulset:
+  sideCars:
+    controllers:
+      enabled: false
+
+-- itemized-disableable-clusterroles --
+# ASSERT-NO-ERROR
+# ASSERT-NO-GVK ["rbac.authorization.k8s.io/v1", "ClusterRole"]
+statefulset:
+  sideCars:
+    brokerDecommissioner:
+      enabled: false
+    pvcUnbinder:
+      enabled: false

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -947,6 +947,14 @@ type Sidecars struct {
 	} `json:"controllers"`
 }
 
+func (s *Sidecars) PVCUnbinderEnabled() bool {
+	return s.Controllers.Enabled && s.PVCUnbinder.Enabled
+}
+
+func (s *Sidecars) BrokerDecommissionerEnabled() bool {
+	return s.Controllers.Enabled && s.BrokerDecommissioner.Enabled
+}
+
 func (s *Sidecars) ShouldCreateRBAC() bool {
 	return (s.Controllers.Enabled && s.Controllers.CreateRBAC) || s.AdditionalSidecarControllersEnabled()
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v2.4.x`:
 - [redpanda: fix rbac gating of sidecar controllers](https://github.com/redpanda-data/redpanda-operator/pull/995)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)