### PR TITLE
Annotation FFs and Cluster Config Sync Fixes

### DIFF
--- a/operator/cmd/syncclusterconfig/sync.go
+++ b/operator/cmd/syncclusterconfig/sync.go
@@ -25,9 +25,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"reflect"
-	"slices"
-	"sort"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -98,14 +95,6 @@ If present and not empty, the $%s environment variable will be set as the cluste
 				return err
 			}
 
-			// NB: remove must be an empty slice NOT nil.
-			result, err := client.PatchClusterConfig(ctx, clusterConfig, []string{})
-			if err != nil {
-				return err
-			}
-
-			logger.Info("Updated cluster configuration", "config_version", result.ConfigVersion)
-
 			// NB: It's unclear why this endpoint is being hit. It's preserved
 			// as a historical artifact.
 			// See also: https://github.com/redpanda-data/redpanda-operator/issues/232
@@ -162,11 +151,11 @@ func loadBoostrapYAML(path string) (map[string]any, error) {
 func loadUsersFiles(ctx context.Context, path string) ([]string, error) {
 	files, err := os.ReadDir(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			log.FromContext(ctx).Info(fmt.Sprintf("users directory doesn't exist; skipping: %q", path))
-			return nil, nil
+		if !os.IsNotExist(err) {
+			return nil, err
 		}
-		return nil, err
+		log.FromContext(ctx).Info(fmt.Sprintf("users directory doesn't exist; skipping: %q", path))
+		return nil, nil
 	}
 
 	users := []string{}
@@ -195,16 +184,32 @@ type SyncerMode int
 const (
 	SyncerModeAdditive = SyncerMode(iota)
 	SyncerModeDeclarative
+	SyncerModeDisabled
+
+	maxSyncMode // Not a valid value, used for static checks.
 )
 
 var ErrSyncerMode = errors.New("unrecognised syncer mode")
 
-func StringToMode(m string) (SyncerMode, error) {
+func (m SyncerMode) String() string {
 	switch m {
-	case "additive":
-		return SyncerModeAdditive, nil
-	case "declarative":
-		return SyncerModeDeclarative, nil
+	case SyncerModeAdditive:
+		return "additive"
+	case SyncerModeDeclarative:
+		return "declarative"
+	case SyncerModeDisabled:
+		return "disabled"
+	default:
+		return "SyncerMode(-1)"
+	}
+}
+
+func StringToMode(m string) (SyncerMode, error) {
+	m = strings.ToLower(m)
+	for i := 0; i < int(maxSyncMode); i++ {
+		if m == SyncerMode(i).String() {
+			return SyncerMode(i), nil
+		}
 	}
 	// Let Unwrap identify the concrete error
 	return SyncerModeAdditive, fmt.Errorf("cannot parse %s: %w", m, ErrSyncerMode)
@@ -234,141 +239,184 @@ type ClusterConfigStatus struct {
 // reported by the brokers. If there's a change, it will return the new version
 // of the cluster config.
 func (s *Syncer) Sync(ctx context.Context, desired map[string]any, superusers []string) (*ClusterConfigStatus, error) {
-	equal := s.EqualityCheck
-	if equal == nil {
-		equal = func(_ string, desired, current any) bool {
-			return reflect.DeepEqual(desired, current)
-		}
-	}
 	logger := log.FromContext(ctx)
 
-	s.maybeMergeSuperusers(ctx, desired, superusers)
-
-	current, err := s.Client.Config(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-
-	var added []string
-	var changed []string
-	// NB: toRemove MUST default to an empty array. Otherwise redpanda will reject our request.
-	removed := []string{}
-	upsert := maps.Clone(desired)
-	status, err := s.Client.ClusterConfigStatus(ctx, true)
-	if err != nil {
-		return nil, err
-	}
 	schema, err := s.Client.ClusterConfigSchema(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	// 1. Normalize the desired config.
+	// **All operations that go to redpanda APIs will operate on the normalized value.**
+	// **All operations that go to Kubernetes will operate on the unmodified desired value.**
+	normalized := s.normalizeConfig(ctx, schema, superusers, desired)
+
+	// 2. Compute values to be removed.
+	status, err := s.Client.ClusterConfigStatus(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// NB: toRemove MUST default to an empty array. Otherwise redpanda will reject our request.
+	toRemove := []string{}
+
+	// We need to explicitly mark unknown or invalid properties to remove, because
+	// they will otherwise linger, since AdminAPI.Config does not return those entries.
+	// We always send requests for config status to the leader to avoid inconsistencies
+	// due to config propagation delays.
+	// This list is generally expected to be empty.
+	for i := range status {
+		for _, invalid := range status[i].Invalid {
+			if _, ok := normalized[invalid]; !ok {
+				toRemove = append(toRemove, invalid)
+			}
+		}
+		for _, unknown := range status[i].Unknown {
+			if _, ok := normalized[unknown]; !ok {
+				toRemove = append(toRemove, unknown)
+			}
+		}
+	}
+
+	// If we're operating in declarative mode, we'll remove the any keys that
+	// aren't present in our normalized config.
+	if s.Mode == SyncerModeDeclarative {
+		current, err := s.Client.Config(ctx, false)
+		if err != nil {
+			return nil, err
+		}
+
+		for key := range current {
+			if _, ok := normalized[key]; !ok {
+				toRemove = append(toRemove, key)
+			}
+		}
+	}
+
+	// Intermediate variable to hold the config result if syncing is actually
+	// enabled.
+	configVersion := int64(-1)
+
+	// 3. Actually send the patch to redpanda, if enabled.
+	if s.Mode == SyncerModeDisabled {
+		logger.Info("cluster config synchronization is disabled")
+	} else {
+		result, err := s.Client.PatchClusterConfig(ctx, normalized, toRemove)
+		if err != nil {
+			return nil, err
+		}
+
+		configVersion = int64(result.ConfigVersion)
+		logger.Info("updated cluster configuration", "config_version", result.ConfigVersion, "removed", toRemove)
+	}
+
+	// Compute a hash of configs that might trigger a restart of the cluster.
+	// This incorrectly uses the desired config instead of the one reflected by
+	// the cluster and could technically trigger a restart prior to the config
+	// be set but is historical consistent.
+	// Use of this hash is slated for removal.
 	hashOfConfigsThatNeedRestart, err := hashConfigsThatNeedRestart(desired, schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash config: %w", err)
 	}
-	if s.Mode == SyncerModeDeclarative {
-		for key, value := range current {
-			if currentValue, ok := desired[key]; !ok {
-				removed = append(removed, key)
-			} else if equal(key, value, currentValue) {
-				// No change, leave it be
-				delete(upsert, key)
-			}
-		}
 
-		// We need to explicitly mark unknown or invalid properties to remove, because
-		// they will otherwise linger, since AdminAPI.Config does not return those entries.
-		// We always send requests for config status to the leader to avoid inconsistencies
-		// due to config propagation delays.
-		for i := range status {
-			for _, invalid := range status[i].Invalid {
-				if _, ok := desired[invalid]; !ok {
-					removed = append(removed, invalid)
-				}
-			}
-			for _, unknown := range status[i].Unknown {
-				if _, ok := desired[unknown]; !ok {
-					removed = append(removed, unknown)
-				}
-			}
-		}
-	}
-	for key, value := range upsert {
-		if currentValue, ok := current[key]; !ok {
-			added = append(added, key)
-		} else if !equal(key, value, currentValue) {
-			changed = append(changed, key)
-		}
-	}
-	if len(added) == 0 && len(changed) == 0 && len(removed) == 0 {
-		logger.Info("no cluster config changes to apply")
-		// find the highest config version
-		return &ClusterConfigStatus{
-			Version: slices.MaxFunc(status, func(a, b rpadmin.ConfigStatus) int {
-				return int(a.ConfigVersion - b.ConfigVersion)
-			}).ConfigVersion,
-			NeedsRestart:                  slices.ContainsFunc(status, func(s rpadmin.ConfigStatus) bool { return s.Restart }),
-			PropertiesThatNeedRestartHash: hashOfConfigsThatNeedRestart,
-		}, nil
-	}
-
-	{
-		var keys []string
-		for k := range maps.Keys(desired) {
-			keys = append(keys, k)
-		}
-		sort.Strings(added)
-		sort.Strings(changed)
-		sort.Strings(removed)
-		sort.Strings(keys)
-		logger.Info("updating cluster config", "added", added, "removed", removed, "changed", changed, "config", keys)
-	}
-
-	result, err := s.Client.PatchClusterConfig(ctx, upsert, removed)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Info("updated cluster configuration", "config_version", result.ConfigVersion)
 	status, err = s.Client.ClusterConfigStatus(ctx, true)
 	if err != nil {
 		return nil, err
 	}
+
+	needsRestart := false
+	for _, s := range status {
+		configVersion = max(s.ConfigVersion, configVersion)
+		needsRestart = needsRestart && s.Restart
+	}
+
 	return &ClusterConfigStatus{
-		Version:                       int64(result.ConfigVersion),
-		NeedsRestart:                  slices.ContainsFunc(status, func(s rpadmin.ConfigStatus) bool { return s.Restart }),
+		Version:                       configVersion,
+		NeedsRestart:                  needsRestart,
 		PropertiesThatNeedRestartHash: hashOfConfigsThatNeedRestart,
 	}, nil
 }
 
-func (s *Syncer) maybeMergeSuperusers(ctx context.Context, config map[string]any, superusers []string) {
+func (s *Syncer) normalizeConfig(
+	ctx context.Context,
+	schema rpadmin.ConfigSchema,
+	superusers []string,
+	desired map[string]any,
+) map[string]any {
 	logger := log.FromContext(ctx)
+	normalized := maps.Clone(desired)
 
-	superusersConfig, ok := config[superusersEntry]
-	if !ok {
-		// we have no superusers configuration, so don't do anything
-		logger.Info("Configuration does not contain a 'superusers' entry. Skipping superusers merge.")
-		return
+	if superusers, ok := s.mergeSuperusers(ctx, superusers, desired); ok {
+		// Conversely, if ok is false, we don't need to unset superusers as it
+		// should already be unset.
+		normalized["superusers"] = superusers
 	}
 
-	switch su := superusersConfig.(type) {
-	case []string:
-		superusers = append(superusers, su...)
-	case []any:
-		for _, s := range su {
-			if cast, ok := s.(string); ok {
-				superusers = append(superusers, cast)
-			} else {
-				logger.Info("Unable to cast value from %T to string, skipping.", s)
+	// Redpanda's cluster configs can be aliased. The preferred name is the one
+	// that's listed in the schema (as opposed to being present in an alias
+	// list).
+	for key, schema := range schema {
+		_, hasKey := normalized[key]
+
+		for _, alias := range schema.Aliases {
+			aliased, hasAlias := normalized[alias]
+
+			if !hasKey && hasAlias {
+				logger.Info("renaming aliased config key", "from", alias, "to", key)
+				normalized[key] = aliased
+				delete(normalized, alias)
+			} else if hasKey && hasAlias {
+				logger.Info("dropping aliased key due to non-alias key being provided", "alias", alias, "non-alias", key)
+				delete(normalized, alias)
 			}
 		}
-	default:
-		err := fmt.Errorf("expected superusers entry to be an array of strings, got %T", superusersConfig)
-		logger.Error(err, fmt.Sprintf("Unable to cast superusers entry to array. Skipping superusers merge. Type is: %T", superusersConfig))
-		return
 	}
 
-	config[superusersEntry] = NormalizeSuperusers(superusers)
+	return normalized
+}
+
+func (s *Syncer) mergeSuperusers(ctx context.Context, superusers []string, desired map[string]any) ([]string, bool) {
+	desiredSUs, ok := desired["superusers"]
+	superusers = append(superusers, coherceToSliceOf[string](ctx, desiredSUs)...)
+
+	// return union(desired['superusers'], superusers) and an indication of
+	// whether or not the superusers key should be set or not.
+	//
+	// **Setting the key or not has different implications depending on s.Mode**
+	//
+	// We largely key off the presence, or lack thereof, of the superusers key
+	// in the desired cluster config. If any superusers are provided via other
+	// means, we consider that as an implicit setting of superusers.
+	return NormalizeSuperusers(superusers), ok || len(superusers) > 0
+}
+
+func coherceToSliceOf[T any](ctx context.Context, in any) []T {
+	logger := log.FromContext(ctx)
+
+	switch in := in.(type) {
+	case nil:
+		return nil
+
+	case []T:
+		return in
+
+	case []any:
+		out := make([]T, 0, len(in))
+		for i := 0; i < len(in); i++ {
+			if asT, ok := in[i].(T); ok {
+				out = append(out, asT)
+			} else {
+				logger.Info("unable to cast values from %T to %T; skipping", in[i], asT)
+			}
+		}
+		return out
+
+	default:
+		err := errors.Newf("can't coherce %T to %T", in, make([]T, 1))
+		logger.Error(err, "unhandled type in coherceToSliceOf")
+		return nil
+	}
 }
 
 // hashConfigsThatNeedRestart returns a hash of the config that needs the

--- a/operator/cmd/syncclusterconfig/sync_test.go
+++ b/operator/cmd/syncclusterconfig/sync_test.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,7 @@ func TestSync(t *testing.T) {
 	// No auth is easy, only test on a cluster with auth on admin API.
 	container, err := redpanda.Run(
 		ctx,
-		"docker.redpanda.com/redpandadata/redpanda:v24.2.4",
+		"docker.redpanda.com/redpandadata/redpanda:v25.1.7",
 		// TODO: Upgrade to testcontainers 0.33.0 so we get
 		// WithBootstrapConfig. For whatever reason, it seems to not get along
 		// with CI.
@@ -89,19 +88,21 @@ func TestSync(t *testing.T) {
 	require.NoError(t, err)
 
 	redpandaYAMLPath := testutils.WriteFile(t, "redpanda-*.yaml", rpkConfigBytes)
-	usersTxtYAMLPath := testutils.WriteFile(t, "users-*.txt", []byte(strings.Join([]string{admin, password, saslMechanism}, ":")))
+	usersTXTPath := testutils.WriteFile(t, "users-*.txt", []byte(strings.Join([]string{user, password, saslMechanism}, ":")))
 
 	cases := []struct {
-		Config          map[string]any
-		Expected        map[string]any
-		UsersTXTDir     string
-		DeclarativeMode bool
+		Config      map[string]any
+		Expected    map[string]any
+		UsersTXTDir string
+		Mode        SyncerMode
 	}{
 		{
-			// No superusers entry, the value just gets pulled from
-			// what we initialized in our redpanda.Run call above.
+			// Superusers only set to what is pulled from usersTXT
+			// NB: `user` can't be removed from `superusers` when
+			// `admin_api_require_auth` is enabled as redpanda validates this:
+			// > superusers must contain the user making the change when auth is enabled
 			Config:      map[string]any{},
-			UsersTXTDir: filepath.Dir(usersTxtYAMLPath),
+			UsersTXTDir: filepath.Dir(usersTXTPath),
 			Expected: map[string]any{
 				"admin_api_require_auth": true,
 				"superusers":             []any{user},
@@ -115,9 +116,9 @@ func TestSync(t *testing.T) {
 			// in this test, so all subsequent test cases will have both
 			// superusers.
 			Config: map[string]any{
-				"superusers": []string{user},
+				"superusers": []string{admin},
 			},
-			UsersTXTDir: filepath.Dir(usersTxtYAMLPath),
+			UsersTXTDir: filepath.Dir(usersTXTPath),
 			Expected: map[string]any{
 				"admin_api_require_auth": true,
 				"superusers":             []any{admin, user},
@@ -128,7 +129,6 @@ func TestSync(t *testing.T) {
 				"abort_index_segment_size":      10,
 				"audit_queue_drain_interval_ms": 60,
 			},
-			UsersTXTDir: filepath.Dir(usersTxtYAMLPath),
 			Expected: map[string]any{
 				"abort_index_segment_size":      10,
 				"admin_api_require_auth":        true,
@@ -143,7 +143,6 @@ func TestSync(t *testing.T) {
 			// Showcasing that settings are not unset if/when they're removed.
 			// This is to showcase feature parity with the helm chart's job(s).
 			// Improvements are welcome.
-			UsersTXTDir: filepath.Dir(usersTxtYAMLPath),
 			Expected: map[string]any{
 				"abort_index_segment_size":      10,
 				"admin_api_require_auth":        true,
@@ -155,7 +154,6 @@ func TestSync(t *testing.T) {
 			Config: map[string]any{
 				"audit_queue_drain_interval_ms": 70,
 			},
-			UsersTXTDir: filepath.Dir(usersTxtYAMLPath),
 			Expected: map[string]any{
 				"abort_index_segment_size":      10,
 				"admin_api_require_auth":        true,
@@ -169,7 +167,6 @@ func TestSync(t *testing.T) {
 				// auth is ignored if it's not required.
 				"admin_api_require_auth": false,
 			},
-			UsersTXTDir: filepath.Dir(usersTxtYAMLPath),
 			Expected: map[string]any{
 				"abort_index_segment_size":      10,
 				"audit_queue_drain_interval_ms": 70,
@@ -204,21 +201,31 @@ func TestSync(t *testing.T) {
 		},
 		{
 			// In declarative mode, we'll drop any unspecified configuration
-			Config:          map[string]any{},
-			UsersTXTDir:     os.TempDir() + "/this-path-does-not-exist",
-			DeclarativeMode: true,
-			Expected:        map[string]any{},
+			Config:      map[string]any{},
+			UsersTXTDir: os.TempDir() + "/this-path-does-not-exist",
+			Mode:        SyncerModeDeclarative,
+			Expected:    map[string]any{},
 		},
 		{
-			// Even in declarative mode, the implicit settings from UsersTXT
-			// should still be applied.
+			// Even in declarative mode, the UsersTXT
+			// is still applied.
+			Mode:        SyncerModeDeclarative,
+			UsersTXTDir: filepath.Dir(usersTXTPath),
 			Config: map[string]any{
-				"superusers": []string{user},
+				"superusers": []string{admin},
 			},
-			UsersTXTDir:     filepath.Dir(usersTxtYAMLPath),
-			DeclarativeMode: true,
 			Expected: map[string]any{
 				"superusers": []any{admin, user},
+			},
+		},
+		{
+			Mode: SyncerModeDeclarative,
+			Config: map[string]any{
+				// An aliased config value.
+				"schema_registry_normalize_on_startup": true,
+			},
+			Expected: map[string]any{
+				"schema_registry_always_normalize": true,
 			},
 		},
 	}
@@ -234,9 +241,7 @@ func TestSync(t *testing.T) {
 			"--users-directory", tc.UsersTXTDir,
 			"--redpanda-yaml", redpandaYAMLPath,
 			"--bootstrap-yaml", testutils.WriteFile(t, "bootstrap-*.yaml", configBytes),
-		}
-		if tc.DeclarativeMode {
-			args = append(args, "--mode", "declarative")
+			"--mode", tc.Mode.String(),
 		}
 		cmd.SetArgs(args)
 
@@ -376,10 +381,9 @@ func TestSyncSuperusers(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := maps.Clone(tc.config)
-			s.maybeMergeSuperusers(t.Context(), c, tc.suTxt)
+			merged, _ := s.mergeSuperusers(t.Context(), tc.suTxt, tc.config)
 			if tc.expectArray {
-				assert.Equal(t, []string{"a", "b", "c"}, c[superusersEntry])
+				assert.Equal(t, []string{"a", "b", "c"}, merged)
 			}
 		})
 	}

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/clusterconfiguration"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/feature"
 	pkgsecrets "github.com/redpanda-data/redpanda-operator/operator/pkg/secrets"
 	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
 	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/otelkube"
@@ -44,15 +45,7 @@ import (
 )
 
 const (
-	FinalizerKey                    = "operator.redpanda.com/finalizer"
-	RestartClusterOnConfigChangeKey = "operator.redpanda.com/restart-cluster-on-config-change"
-	SyncerModeKey                   = "operator.redpanda.com/config-sync-mode"
-	SyncerModeDeclarative           = "declarative"
-	SyncerModeAdditive              = "additive" // The default for the moment
-
-	NotManaged = "false"
-
-	managedPath = "/managed"
+	FinalizerKey = "operator.redpanda.com/finalizer"
 
 	revisionPath        = "/revision"
 	componentLabelValue = "redpanda-statefulset"
@@ -169,7 +162,7 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 	logger := log.FromContext(ctx)
 
-	if !isRedpandaManaged(ctx, rp) {
+	if !feature.V2Managed.Get(ctx, rp) {
 		if controllerutil.RemoveFinalizer(rp, FinalizerKey) {
 			if err := r.Client.Update(ctx, rp); err != nil {
 				logger.Error(err, "updating cluster finalizer")
@@ -181,12 +174,22 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		return ctrl.Result{}, nil
 	}
 
+	// Update our Redpanda with any default Annotation FFs. If any changes are
+	// made, persist the changes and immediately requeue to prevent any cache /
+	// resource version synchronization issues.
+	if feature.SetDefaults(ctx, feature.V2Flags, rp) {
+		if err := r.Client.Patch(ctx, rp, client.Apply); err != nil {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	// grab our existing and desired pool resources
 	// so that we can immediately calculate cluster status
 	// from and sync in any subsequent operation that
 	// early returns
 	injectedConfigVersion := ""
-	if rp.Annotations != nil && rp.Annotations[RestartClusterOnConfigChangeKey] == "true" {
+	if feature.RestartOnConfigChange.Get(ctx, rp) {
 		injectedConfigVersion = rp.Status.ConfigVersion
 	}
 	pools, err := r.LifecycleClient.FetchExistingAndDesiredPools(ctx, cluster, injectedConfigVersion)
@@ -613,7 +616,7 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, admin *
 		return "", false, errors.WithStack(err)
 	}
 
-	mode := r.configSyncMode(ctx, rp)
+	mode := feature.ClusterConfigSyncMode.Get(ctx, rp)
 
 	syncer := syncclusterconfig.Syncer{Client: admin, Mode: mode}
 	configStatus, err := syncer.Sync(ctx, config, superusers)
@@ -622,19 +625,6 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, admin *
 	}
 
 	return configStatus.PropertiesThatNeedRestartHash, configStatus.NeedsRestart, nil
-}
-
-func (r *RedpandaReconciler) configSyncMode(ctx context.Context, rp *redpandav1alpha2.Redpanda) syncclusterconfig.SyncerMode {
-	switch strings.ToLower(rp.Annotations[SyncerModeKey]) {
-	case SyncerModeDeclarative:
-		return syncclusterconfig.SyncerModeDeclarative
-	case "", SyncerModeAdditive:
-		return syncclusterconfig.SyncerModeAdditive
-	default:
-		logger := log.FromContext(ctx)
-		logger.Info("unrecognised value %q for %s, syncing config in Additive mode", rp.Annotations[SyncerModeKey], SyncerModeKey)
-		return syncclusterconfig.SyncerModeAdditive
-	}
 }
 
 func (r *RedpandaReconciler) superusersFor(ctx context.Context, rp *redpandav1alpha2.Redpanda) ([]string, error) {
@@ -843,15 +833,4 @@ func validateClusterParameters(rp *redpandav1alpha2.Redpanda) error {
 	}
 
 	return nil
-}
-
-func isRedpandaManaged(ctx context.Context, redpandaCluster *redpandav1alpha2.Redpanda) bool {
-	logger := log.FromContext(ctx)
-
-	managedAnnotationKey := redpandav1alpha2.GroupVersion.Group + managedPath
-	if managed, exists := redpandaCluster.Annotations[managedAnnotationKey]; exists && managed == NotManaged {
-		logger.V(log.TraceLevel).Info(fmt.Sprintf("management is disabled; to enable it, change the '%s' annotation to true or remove it", managedAnnotationKey))
-		return false
-	}
-	return true
 }

--- a/operator/pkg/feature/flag.go
+++ b/operator/pkg/feature/flag.go
@@ -1,0 +1,112 @@
+package feature
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
+)
+
+type FlagBundle int
+
+const (
+	_ FlagBundle = iota
+	V1Flags
+	V2Flags
+
+	maxBundles
+)
+
+var bundles = make([][]*AnnotationFeatureFlag[any], maxBundles-1)
+
+// Register adds the given flag to the provided [FlagBundle] and returns a handle it it.
+// Usage:
+//
+//	var MyFlag = Register(MyBundle, AnnotationFeatureFlag{/* ... */})
+func Register[T any](bundle FlagBundle, flag AnnotationFeatureFlag[T]) *AnnotationFeatureFlag[T] {
+	// NB: FlagBundle are base 1 to prevent silently successes of zero values.
+	// The downside is having to -1 everywhere.
+	bundles[bundle-1] = append(bundles[bundle-1], flag.AsAny())
+	return &flag
+}
+
+type AnnotationGetSetter interface {
+	AnnotationGetter
+	SetAnnotations(map[string]string)
+}
+
+// SetDefaults updates the annotations of obj with the default values all flags,
+// if the flag is not provided, in the given [FlagBundle] and returns a bool
+// indicating whether or not any changes where made.
+func SetDefaults(ctx context.Context, bundle FlagBundle, obj AnnotationGetSetter) bool {
+	flags := bundles[bundle-1]
+
+	annos := obj.GetAnnotations()
+	if annos == nil {
+		annos = make(map[string]string, len(flags))
+	}
+
+	changed := false
+	for _, flag := range flags {
+		if _, ok := annos[flag.Key]; ok {
+			continue
+		}
+
+		annos[flag.Key] = flag.Default
+		changed = true
+	}
+
+	if !changed {
+		return false
+	}
+
+	obj.SetAnnotations(annos)
+	return false
+}
+
+type AnnotationFeatureFlag[T any] struct {
+	Key     string
+	Default string
+	Parse   func(string) (T, error)
+}
+
+func (f *AnnotationFeatureFlag[T]) AsAny() *AnnotationFeatureFlag[any] {
+	return &AnnotationFeatureFlag[any]{
+		Key:     f.Key,
+		Default: f.Default,
+		Parse: func(s string) (any, error) {
+			out, err := f.Parse(s)
+			if err != nil {
+				return nil, err
+			}
+			return any(out), nil
+		},
+	}
+}
+
+type AnnotationGetter interface {
+	GetAnnotations() map[string]string
+}
+
+// Get extracts and parsed the value of this flag from obj. If any errors are
+// encountered, an error is logged and the default is returned.
+func (f *AnnotationFeatureFlag[T]) Get(ctx context.Context, obj AnnotationGetter) T {
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[f.Key]; ok {
+			parsed, err := f.Parse(value)
+			if err == nil {
+				return parsed
+			}
+			log.Error(ctx, err, "failed to parsed annotation; interpreting as default", "default", f.Default, "value", value)
+		}
+	}
+
+	parsed, err := f.Parse(f.Default)
+	if err != nil {
+		panic(errors.Wrapf(err, "failed to parsed default value %q of %q", f.Default, f.Key))
+	}
+
+	return parsed
+}

--- a/operator/pkg/feature/flag_test.go
+++ b/operator/pkg/feature/flag_test.go
@@ -1,0 +1,96 @@
+package feature
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, bundle := range bundles {
+		flags := make(map[string]struct{}, len(bundle))
+		for _, flag := range bundle {
+			// All defaults should successfully parse
+			_, err := flag.Parse(flag.Default)
+			assert.NoErrorf(t, err, "%q's default failed to parse: %q", flag.Key, flag.Default)
+
+			// All flag names must be unique
+			assert.NotContains(t, flag.Key, "%q is a non-unique flag", flag.Key)
+			flags[flag.Key] = struct{}{}
+
+		}
+	}
+}
+
+func TestSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		In      Annotations
+		Out     Annotations
+		Changed bool
+	}{
+		{
+			In: Annotations{},
+			Out: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "true",
+					"operator.redpanda.com/config-sync-mode":                 "additive",
+					"operator.redpanda.com/restart-cluster-on-config-change": "false",
+				},
+			},
+			Changed: true,
+		},
+		{
+			In: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "true",
+					"operator.redpanda.com/config-sync-mode":                 "additive",
+					"operator.redpanda.com/restart-cluster-on-config-change": "false",
+				},
+			},
+			Out: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "true",
+					"operator.redpanda.com/config-sync-mode":                 "additive",
+					"operator.redpanda.com/restart-cluster-on-config-change": "false",
+				},
+			},
+			Changed: false,
+		},
+		{
+			In: Annotations{
+				Annotations: map[string]string{
+					"operator.redpanda.com/config-sync-mode":                 "",
+					"cluster.redpanda.com/managed":                           "",
+					"operator.redpanda.com/restart-cluster-on-config-change": "",
+				},
+			},
+			Out: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "",
+					"operator.redpanda.com/config-sync-mode":                 "",
+					"operator.redpanda.com/restart-cluster-on-config-change": "",
+				},
+			},
+			Changed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		SetDefaults(t.Context(), V2Flags, &tc.In)
+		assert.Equal(t, tc.Out, tc.In)
+	}
+}
+
+type Annotations struct{ Annotations map[string]string }
+
+func (a *Annotations) GetAnnotations() map[string]string {
+	return a.Annotations
+}
+
+func (a *Annotations) SetAnnotations(annos map[string]string) {
+	a.Annotations = annos
+}

--- a/operator/pkg/feature/flags.go
+++ b/operator/pkg/feature/flags.go
@@ -1,0 +1,72 @@
+package feature
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
+)
+
+const (
+	v2Prefix = "cluster.redpanda.com"
+	v1Prefix = "redpanda.vectorized.io"
+)
+
+// V1Managed controls whether a Cluster resource is
+// reconciled or by the cluster controller(s) or not.
+// Valid Value(s): false
+var V1Managed = Register(V1Flags, AnnotationFeatureFlag[bool]{
+	// redpanda.vectorized.io/managed
+	Key:     v2Prefix + "/managed",
+	Default: "true",
+	Parse: func(s string) (bool, error) {
+		return s != "false", nil
+	},
+})
+
+var (
+	// V2Managed controls whether a Redpanda resource is
+	// reconciled or by the redpanda controller(s) or not.
+	// Valid Value(s): false
+	V2Managed = Register(V2Flags, AnnotationFeatureFlag[bool]{
+		// cluster.redpanda.com/managed
+		Key:     v2Prefix + "/managed",
+		Default: "true",
+		Parse: func(s string) (bool, error) {
+			return s != "false", nil
+		},
+	})
+
+	// RestartOnConfigChange controls whether or not the Redpanda controller
+	// will restart a cluster by injecting its cluster config version into its
+	// PodSpec.
+	// Valid Value(s): true
+	RestartOnConfigChange = Register(V2Flags, AnnotationFeatureFlag[bool]{
+		Key:     "operator.redpanda.com/restart-cluster-on-config-change",
+		Default: "false",
+		Parse: func(s string) (bool, error) {
+			return s == "true", nil
+		},
+	})
+
+	// ClusterConfigSyncMode controls how the Redpanda controller
+	// synchronizes the cluster's cluster config.
+	// Valid Value(s):
+	// - additive: Set all keys, don't unset keys not explicit set
+	// - declarative: Set all keys, unset any keys not explicitly set
+	ClusterConfigSyncMode = Register(V2Flags, AnnotationFeatureFlag[syncclusterconfig.SyncerMode]{
+		Key:     "operator.redpanda.com/config-sync-mode",
+		Default: "additive",
+		Parse: func(s string) (syncclusterconfig.SyncerMode, error) {
+			switch strings.ToLower(s) {
+			case "declarative":
+				return syncclusterconfig.SyncerModeDeclarative, nil
+			case "additive":
+				return syncclusterconfig.SyncerModeAdditive, nil
+			default:
+				return syncclusterconfig.SyncerMode(0), errors.Newf("unknown cluster config syncer mode: %q", s)
+			}
+		},
+	})
+)

--- a/operator/pkg/feature/flags.go
+++ b/operator/pkg/feature/flags.go
@@ -1,10 +1,6 @@
 package feature
 
 import (
-	"strings"
-
-	"github.com/cockroachdb/errors"
-
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
 )
 
@@ -55,18 +51,10 @@ var (
 	// Valid Value(s):
 	// - additive: Set all keys, don't unset keys not explicit set
 	// - declarative: Set all keys, unset any keys not explicitly set
+	// - disabled: Don't sync, cluster config at all.
 	ClusterConfigSyncMode = Register(V2Flags, AnnotationFeatureFlag[syncclusterconfig.SyncerMode]{
 		Key:     "operator.redpanda.com/config-sync-mode",
 		Default: "additive",
-		Parse: func(s string) (syncclusterconfig.SyncerMode, error) {
-			switch strings.ToLower(s) {
-			case "declarative":
-				return syncclusterconfig.SyncerModeDeclarative, nil
-			case "additive":
-				return syncclusterconfig.SyncerModeAdditive, nil
-			default:
-				return syncclusterconfig.SyncerMode(0), errors.Newf("unknown cluster config syncer mode: %q", s)
-			}
-		},
+		Parse:   syncclusterconfig.StringToMode,
 	})
 )


### PR DESCRIPTION
#### 96dcebe33f221e56285ae7dcca32b992002143d6 operator: add annotation feature flag system

This commit adds a generic annotation based feature flagging system at
`operator/pkg/feature` to consolidate the existing flags and reduce boiler
plate for future flags.

Notably, this package includes a function `SetDefaults` which will update the
annotations of an object with all the default values of any flags. This makes
it trivial for human operators to identify the set of available "knobs" when
debugging a cluster.


#### ca2938a6d99d05279a0ef013c75cf85e4a18ede8 cluster config sync: fix a lot

Initially this commit was indented to be more scoped but it become a lot easier
to fix all of this in one fell swoop. This commit:
- Fixes a long standing bug where the `syncclusterconfig` command incorrectly
  called `PatchClusterConfig` **twice**.
- Updates syncclusterconfig to handle aliased cluster config properties without
  adversely affecting Kubernetes side hashing.
- Removes the non-functional and generally problematic client side diffing of
  cluster config values.
- Fixes a bug where `superusers` provided via users.txt or other means would be
  ignored if the `superusers` key was not explicitly set.
- Adds a `disabled` syncing mode which may be activated via annotation or CLI flag.

Fixes K8S-679 and K8S-678


