### PR TITLE
Fix up backport labels and token

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -6,6 +6,6 @@
   "targetBranchChoices": ["release/v25.1.x", "release/v2.4.x", "release/v2.3.x"],
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v(\\d+).(\\d+).\\d+$": "release/v$1.$2.x"
+    "^v(\\d+).(\\d+).x$": "release/v$1.$2.x"
   }
 }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.5.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Info log
         if: ${{ success() }}


### PR DESCRIPTION
Messed up something slightly with the backporting fixes, this should fix things. The process of backporting becomes just tag your PR with the label of the `.x` branch you want to target for backports