### PR TITLE
[release/v25.1.x] operator: add annotation feature flag system | cluster config sync: fix a lot | Fix changed bool in default settings

### DIFF
--- a/.changes/unreleased/charts-redpanda-Changed-20250721-133736.yaml
+++ b/.changes/unreleased/charts-redpanda-Changed-20250721-133736.yaml
@@ -1,0 +1,10 @@
+project: charts/redpanda
+kind: Changed
+body: |-
+    Cluster configuration syncing now sends the entire config instead of a minimal patch
+
+      Due to numerous divergences in how the operator, redpanda and their
+      respective underlying YAML serde libraries handle marshalling data, computing
+      a minimal diff has generally resulted in nasty bugs not worth the few bytes
+      and CPU cycles we were initially trying to save.
+time: 2025-07-21T13:37:36.079058-04:00

--- a/.changes/unreleased/charts-redpanda-Fixed-20250721-133951.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20250721-133951.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Cluster configuration synchronization now correctly handles aliased keys such as `schema_registry_normalize_on_startup`.
+time: 2025-07-21T13:39:51.694469-04:00

--- a/.changes/unreleased/operator-Added-20250721-132707.yaml
+++ b/.changes/unreleased/operator-Added-20250721-132707.yaml
@@ -1,0 +1,10 @@
+project: operator
+kind: Added
+body: |-
+    Annotations that function like Feature Flags will now have their default values added to Custom Resources, if they are not already present.
+
+      This behavior is present to alert users of what feature flags exist, what
+      their default values are, and to make it easier to toggle between values. For
+      example, `Redpanda`'s will have `operator.redpanda.com/config-sync-mode:
+      additive` added as an annotation.
+time: 2025-07-21T13:27:07.022609-04:00

--- a/.changes/unreleased/operator-Added-20250721-132928.yaml
+++ b/.changes/unreleased/operator-Added-20250721-132928.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: Add `disabled` to `operator.redpanda.com/config-sync-mode` which completely disabled cluster configuration syncing without blocking the reconciliation loop
+time: 2025-07-21T13:29:28.330497-04:00

--- a/.changes/unreleased/operator-Changed-20250721-133736.yaml
+++ b/.changes/unreleased/operator-Changed-20250721-133736.yaml
@@ -1,0 +1,10 @@
+project: operator
+kind: Changed
+body: |-
+    Cluster configuration syncing now sends the entire config instead of a minimal patch
+
+      Due to numerous divergences in how the operator, redpanda and their
+      respective underlying YAML serde libraries handle marshalling data, computing
+      a minimal diff has generally resulted in nasty bugs not worth the few bytes
+      and CPU cycles we were initially trying to save.
+time: 2025-07-21T13:37:36.079051-04:00

--- a/.changes/unreleased/operator-Fixed-20250721-133951.yaml
+++ b/.changes/unreleased/operator-Fixed-20250721-133951.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Cluster configuration synchronization now correctly handles aliased keys such as `schema_registry_normalize_on_startup`.
+time: 2025-07-21T13:39:51.694468-04:00

--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -44,6 +44,7 @@ import (
 	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/feature"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/networking"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/patch"
@@ -57,10 +58,6 @@ const (
 	FinalizerKey = "operator.redpanda.com/finalizer"
 
 	SecretAnnotationExternalCAKey = "operator.redpanda.com/external-ca"
-
-	NotManaged = "false"
-
-	managedPath = "/managed"
 )
 
 var (
@@ -188,8 +185,10 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
-	isManaged := isRedpandaClusterManaged(log, &vectorizedCluster) && isRedpandaClusterVersionManaged(log, &vectorizedCluster, r.RestrictToRedpandaVersion)
-	if !isManaged {
+	if !feature.V1Managed.Get(ctx, &vectorizedCluster) || !isRedpandaClusterVersionManaged(log, &vectorizedCluster, r.RestrictToRedpandaVersion) {
+		key := feature.V1Managed.Key
+		log.Info(fmt.Sprintf("management is disabled; to enable it, change the '%s' annotation to true or remove it",
+			key))
 		return ctrl.Result{}, nil
 	}
 
@@ -1190,19 +1189,6 @@ func collectClusterPorts(
 	}
 
 	return clusterPorts
-}
-
-func isRedpandaClusterManaged(
-	l logr.Logger, redpandaCluster *vectorizedv1alpha1.Cluster,
-) bool {
-	log := l.WithName("isRedpandaClusterManaged")
-	managedAnnotationKey := vectorizedv1alpha1.GroupVersion.Group + managedPath
-	if managed, exists := redpandaCluster.Annotations[managedAnnotationKey]; exists && managed == NotManaged {
-		log.Info(fmt.Sprintf("management is disabled; to enable it, change the '%s' annotation to true or remove it",
-			managedAnnotationKey))
-		return false
-	}
-	return true
 }
 
 func isRedpandaClusterVersionManaged(

--- a/operator/pkg/feature/flag.go
+++ b/operator/pkg/feature/flag.go
@@ -1,0 +1,112 @@
+package feature
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
+)
+
+type FlagBundle int
+
+const (
+	_ FlagBundle = iota
+	V1Flags
+	V2Flags
+
+	maxBundles
+)
+
+var bundles = make([][]*AnnotationFeatureFlag[any], maxBundles-1)
+
+// Register adds the given flag to the provided [FlagBundle] and returns a handle it it.
+// Usage:
+//
+//	var MyFlag = Register(MyBundle, AnnotationFeatureFlag{/* ... */})
+func Register[T any](bundle FlagBundle, flag AnnotationFeatureFlag[T]) *AnnotationFeatureFlag[T] {
+	// NB: FlagBundle are base 1 to prevent silently successes of zero values.
+	// The downside is having to -1 everywhere.
+	bundles[bundle-1] = append(bundles[bundle-1], flag.AsAny())
+	return &flag
+}
+
+type AnnotationGetSetter interface {
+	AnnotationGetter
+	SetAnnotations(map[string]string)
+}
+
+// SetDefaults updates the annotations of obj with the default values all flags,
+// if the flag is not provided, in the given [FlagBundle] and returns a bool
+// indicating whether or not any changes where made.
+func SetDefaults(ctx context.Context, bundle FlagBundle, obj AnnotationGetSetter) bool {
+	flags := bundles[bundle-1]
+
+	annos := obj.GetAnnotations()
+	if annos == nil {
+		annos = make(map[string]string, len(flags))
+	}
+
+	changed := false
+	for _, flag := range flags {
+		if _, ok := annos[flag.Key]; ok {
+			continue
+		}
+
+		annos[flag.Key] = flag.Default
+		changed = true
+	}
+
+	if !changed {
+		return false
+	}
+
+	obj.SetAnnotations(annos)
+	return false
+}
+
+type AnnotationFeatureFlag[T any] struct {
+	Key     string
+	Default string
+	Parse   func(string) (T, error)
+}
+
+func (f *AnnotationFeatureFlag[T]) AsAny() *AnnotationFeatureFlag[any] {
+	return &AnnotationFeatureFlag[any]{
+		Key:     f.Key,
+		Default: f.Default,
+		Parse: func(s string) (any, error) {
+			out, err := f.Parse(s)
+			if err != nil {
+				return nil, err
+			}
+			return any(out), nil
+		},
+	}
+}
+
+type AnnotationGetter interface {
+	GetAnnotations() map[string]string
+}
+
+// Get extracts and parsed the value of this flag from obj. If any errors are
+// encountered, an error is logged and the default is returned.
+func (f *AnnotationFeatureFlag[T]) Get(ctx context.Context, obj AnnotationGetter) T {
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[f.Key]; ok {
+			parsed, err := f.Parse(value)
+			if err == nil {
+				return parsed
+			}
+			log.Error(ctx, err, "failed to parsed annotation; interpreting as default", "default", f.Default, "value", value)
+		}
+	}
+
+	parsed, err := f.Parse(f.Default)
+	if err != nil {
+		panic(errors.Wrapf(err, "failed to parsed default value %q of %q", f.Default, f.Key))
+	}
+
+	return parsed
+}

--- a/operator/pkg/feature/flag.go
+++ b/operator/pkg/feature/flag.go
@@ -62,7 +62,7 @@ func SetDefaults(ctx context.Context, bundle FlagBundle, obj AnnotationGetSetter
 	}
 
 	obj.SetAnnotations(annos)
-	return false
+	return true
 }
 
 type AnnotationFeatureFlag[T any] struct {

--- a/operator/pkg/feature/flag_test.go
+++ b/operator/pkg/feature/flag_test.go
@@ -1,0 +1,96 @@
+package feature
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, bundle := range bundles {
+		flags := make(map[string]struct{}, len(bundle))
+		for _, flag := range bundle {
+			// All defaults should successfully parse
+			_, err := flag.Parse(flag.Default)
+			assert.NoErrorf(t, err, "%q's default failed to parse: %q", flag.Key, flag.Default)
+
+			// All flag names must be unique
+			assert.NotContains(t, flag.Key, "%q is a non-unique flag", flag.Key)
+			flags[flag.Key] = struct{}{}
+
+		}
+	}
+}
+
+func TestSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		In      Annotations
+		Out     Annotations
+		Changed bool
+	}{
+		{
+			In: Annotations{},
+			Out: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "true",
+					"operator.redpanda.com/config-sync-mode":                 "additive",
+					"operator.redpanda.com/restart-cluster-on-config-change": "false",
+				},
+			},
+			Changed: true,
+		},
+		{
+			In: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "true",
+					"operator.redpanda.com/config-sync-mode":                 "additive",
+					"operator.redpanda.com/restart-cluster-on-config-change": "false",
+				},
+			},
+			Out: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "true",
+					"operator.redpanda.com/config-sync-mode":                 "additive",
+					"operator.redpanda.com/restart-cluster-on-config-change": "false",
+				},
+			},
+			Changed: false,
+		},
+		{
+			In: Annotations{
+				Annotations: map[string]string{
+					"operator.redpanda.com/config-sync-mode":                 "",
+					"cluster.redpanda.com/managed":                           "",
+					"operator.redpanda.com/restart-cluster-on-config-change": "",
+				},
+			},
+			Out: Annotations{
+				Annotations: map[string]string{
+					"cluster.redpanda.com/managed":                           "",
+					"operator.redpanda.com/config-sync-mode":                 "",
+					"operator.redpanda.com/restart-cluster-on-config-change": "",
+				},
+			},
+			Changed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		SetDefaults(t.Context(), V2Flags, &tc.In)
+		assert.Equal(t, tc.Out, tc.In)
+	}
+}
+
+type Annotations struct{ Annotations map[string]string }
+
+func (a *Annotations) GetAnnotations() map[string]string {
+	return a.Annotations
+}
+
+func (a *Annotations) SetAnnotations(annos map[string]string) {
+	a.Annotations = annos
+}

--- a/operator/pkg/feature/flags.go
+++ b/operator/pkg/feature/flags.go
@@ -1,0 +1,72 @@
+package feature
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
+)
+
+const (
+	v2Prefix = "cluster.redpanda.com"
+	v1Prefix = "redpanda.vectorized.io"
+)
+
+// V1Managed controls whether a Cluster resource is
+// reconciled or by the cluster controller(s) or not.
+// Valid Value(s): false
+var V1Managed = Register(V1Flags, AnnotationFeatureFlag[bool]{
+	// redpanda.vectorized.io/managed
+	Key:     v2Prefix + "/managed",
+	Default: "true",
+	Parse: func(s string) (bool, error) {
+		return s != "false", nil
+	},
+})
+
+var (
+	// V2Managed controls whether a Redpanda resource is
+	// reconciled or by the redpanda controller(s) or not.
+	// Valid Value(s): false
+	V2Managed = Register(V2Flags, AnnotationFeatureFlag[bool]{
+		// cluster.redpanda.com/managed
+		Key:     v2Prefix + "/managed",
+		Default: "true",
+		Parse: func(s string) (bool, error) {
+			return s != "false", nil
+		},
+	})
+
+	// RestartOnConfigChange controls whether or not the Redpanda controller
+	// will restart a cluster by injecting its cluster config version into its
+	// PodSpec.
+	// Valid Value(s): true
+	RestartOnConfigChange = Register(V2Flags, AnnotationFeatureFlag[bool]{
+		Key:     "operator.redpanda.com/restart-cluster-on-config-change",
+		Default: "false",
+		Parse: func(s string) (bool, error) {
+			return s == "true", nil
+		},
+	})
+
+	// ClusterConfigSyncMode controls how the Redpanda controller
+	// synchronizes the cluster's cluster config.
+	// Valid Value(s):
+	// - additive: Set all keys, don't unset keys not explicit set
+	// - declarative: Set all keys, unset any keys not explicitly set
+	ClusterConfigSyncMode = Register(V2Flags, AnnotationFeatureFlag[syncclusterconfig.SyncerMode]{
+		Key:     "operator.redpanda.com/config-sync-mode",
+		Default: "additive",
+		Parse: func(s string) (syncclusterconfig.SyncerMode, error) {
+			switch strings.ToLower(s) {
+			case "declarative":
+				return syncclusterconfig.SyncerModeDeclarative, nil
+			case "additive":
+				return syncclusterconfig.SyncerModeAdditive, nil
+			default:
+				return syncclusterconfig.SyncerMode(0), errors.Newf("unknown cluster config syncer mode: %q", s)
+			}
+		},
+	})
+)

--- a/operator/pkg/feature/flags.go
+++ b/operator/pkg/feature/flags.go
@@ -1,10 +1,6 @@
 package feature
 
 import (
-	"strings"
-
-	"github.com/cockroachdb/errors"
-
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/syncclusterconfig"
 )
 
@@ -55,18 +51,10 @@ var (
 	// Valid Value(s):
 	// - additive: Set all keys, don't unset keys not explicit set
 	// - declarative: Set all keys, unset any keys not explicitly set
+	// - disabled: Don't sync, cluster config at all.
 	ClusterConfigSyncMode = Register(V2Flags, AnnotationFeatureFlag[syncclusterconfig.SyncerMode]{
 		Key:     "operator.redpanda.com/config-sync-mode",
 		Default: "additive",
-		Parse: func(s string) (syncclusterconfig.SyncerMode, error) {
-			switch strings.ToLower(s) {
-			case "declarative":
-				return syncclusterconfig.SyncerModeDeclarative, nil
-			case "additive":
-				return syncclusterconfig.SyncerModeAdditive, nil
-			default:
-				return syncclusterconfig.SyncerMode(0), errors.Newf("unknown cluster config syncer mode: %q", s)
-			}
-		},
+		Parse:   syncclusterconfig.StringToMode,
 	})
 )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v25.1.x`:
 - [operator: add annotation feature flag system](https://github.com/redpanda-data/redpanda-operator/pull/1003)
 - [cluster config sync: fix a lot](https://github.com/redpanda-data/redpanda-operator/pull/1003)
 - [Fix changed bool in default settings](https://github.com/redpanda-data/redpanda-operator/pull/1003)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)