### PR TITLE
redpanda: use service discovery for client construction

### DIFF
--- a/charts/redpanda/.helmignore
+++ b/charts/redpanda/.helmignore
@@ -26,3 +26,6 @@ README.md.gotmpl
 *.go
 testdata/
 ci/
+
+# dlv debug binaries
+debug.*

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -171,17 +171,9 @@ func TestIntegrationChart(t *testing.T) {
 			Values: partial,
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -246,17 +238,9 @@ func TestIntegrationChart(t *testing.T) {
 			Namespace: env.Namespace(),
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -305,17 +289,9 @@ func TestIntegrationChart(t *testing.T) {
 			Namespace: env.Namespace(),
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -368,17 +344,9 @@ func TestIntegrationChart(t *testing.T) {
 			Namespace: env.Namespace(),
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -507,7 +475,7 @@ func TieredStorageSecretRefs(t *testing.T, secret *corev1.Secret) redpanda.Parti
 	}
 }
 
-func kafkaListenerTest(ctx context.Context, rpk Client) error {
+func kafkaListenerTest(ctx context.Context, rpk *Client) error {
 	input := "test-input"
 	topicName := "testTopic"
 	_, err := rpk.CreateTopic(ctx, topicName)
@@ -532,7 +500,7 @@ func kafkaListenerTest(ctx context.Context, rpk Client) error {
 	return nil
 }
 
-func adminListenerTest(ctx context.Context, rpk Client) error {
+func adminListenerTest(ctx context.Context, rpk *Client) error {
 	deadline := time.After(1 * time.Minute)
 	for {
 		select {
@@ -542,7 +510,7 @@ func adminListenerTest(ctx context.Context, rpk Client) error {
 				continue
 			}
 
-			if out["is_healthy"].(bool) {
+			if out.IsHealthy {
 				return nil
 			}
 		case <-deadline:
@@ -553,7 +521,7 @@ func adminListenerTest(ctx context.Context, rpk Client) error {
 	}
 }
 
-func superuserTest(ctx context.Context, rpk Client, superusers ...string) error {
+func superuserTest(ctx context.Context, rpk *Client, superusers ...string) error {
 	deadline := time.After(1 * time.Minute)
 	for {
 		select {
@@ -594,7 +562,7 @@ func equalElements[T comparable](a, b []T) bool {
 	return true
 }
 
-func schemaRegistryListenerTest(ctx context.Context, rpk Client) ([]byte, string, error) {
+func schemaRegistryListenerTest(ctx context.Context, rpk *Client) ([]byte, string, error) {
 	// Test schema registry
 	// Based on https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/
 	formats, err := rpk.QuerySupportedFormats(ctx)
@@ -677,7 +645,7 @@ type HTTPResponse []struct {
 	Offset    int     `json:"offset"`
 }
 
-func httpProxyListenerTest(ctx context.Context, rpk Client) error {
+func httpProxyListenerTest(ctx context.Context, rpk *Client) error {
 	// Test http proxy
 	// Based on https://docs.redpanda.com/current/develop/http-proxy/
 	_, err := rpk.ListTopics(ctx)

--- a/charts/redpanda/client/client_test.go
+++ b/charts/redpanda/client/client_test.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package redpanda
+package client
 
 import (
 	"testing"

--- a/charts/redpanda/client/outofclusterdns_integration.go
+++ b/charts/redpanda/client/outofclusterdns_integration.go
@@ -1,0 +1,7 @@
+//go:build integration
+
+package client
+
+func init() {
+	permitOutOfClusterDNS = true
+}

--- a/charts/redpanda/client_test.go
+++ b/charts/redpanda/client_test.go
@@ -10,7 +10,6 @@
 package redpanda_test
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -19,16 +18,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/portforward"
 	"sigs.k8s.io/yaml"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
@@ -36,10 +38,20 @@ import (
 
 type Client struct {
 	Ctl           *kube.Ctl
-	Release       *helm.Release
-	adminClients  map[string]*portForwardClient
+	dot           *helmette.Dot
 	schemaClients map[string]*portForwardClient
 	proxyClients  map[string]*portForwardClient
+}
+
+func newClient(t *testing.T, ctl *kube.Ctl, release *helm.Release, values any) *Client {
+	dot, err := redpanda.Chart.Dot(
+		ctl.RestConfig(),
+		helmette.Release{Name: release.Name, Namespace: release.Namespace},
+		values,
+	)
+	require.NoError(t, err)
+
+	return &Client{Ctl: ctl, dot: dot}
 }
 
 type portForwardClient struct {
@@ -50,31 +62,9 @@ type portForwardClient struct {
 
 func (c *Client) getStsPod(ctx context.Context, ordinal int) (*corev1.Pod, error) {
 	return kube.Get[corev1.Pod](ctx, c.Ctl, kube.ObjectKey{
-		Name:      fmt.Sprintf("%s-%d", c.Release.Name, ordinal),
-		Namespace: c.Release.Namespace,
+		Name:      fmt.Sprintf("%s-%d", c.dot.Release.Name, ordinal),
+		Namespace: c.dot.Release.Namespace,
 	})
-}
-
-func (c *Client) ClusterConfig(ctx context.Context) (redpanda.ClusterConfig, error) {
-	pod, err := c.getStsPod(ctx, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	var out bytes.Buffer
-	if err := c.Ctl.Exec(ctx, pod, kube.ExecOptions{
-		Command: []string{"bash", "-c", `rpk cluster config export -f /dev/stderr`},
-		Stderr:  &out,
-	}); err != nil {
-		return nil, err
-	}
-
-	var cfg map[string]any
-	if err := yaml.Unmarshal(out.Bytes(), &cfg); err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
 }
 
 func (c *Client) CreateTopic(ctx context.Context, topicName string) (map[string]any, error) {
@@ -144,72 +134,38 @@ func (c *Client) KafkaConsume(ctx context.Context, topicName string) (map[string
 	return event, nil
 }
 
-func (c *Client) GetClusterHealth(ctx context.Context) (map[string]any, error) {
-	pod, err := c.getStsPod(ctx, 0)
+func (c *Client) GetClusterHealth(ctx context.Context) (rpadmin.ClusterHealthOverview, error) {
+	dialer := kube.NewPodDialer(c.Ctl.RestConfig())
+
+	adminClient, err := client.AdminClient(c.dot, dialer.DialContext)
 	if err != nil {
-		return nil, err
+		return rpadmin.ClusterHealthOverview{}, err
 	}
 
-	client := c.adminClients[pod.Name]
+	defer adminClient.Close()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s://127.0.0.1:%d/v1/cluster/health_overview", client.schema, client.exposedPort), nil)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	body, err := io.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if res.StatusCode > 299 {
-		return nil, errors.New("response above 299 HTTP code")
-	}
-
-	var clusterHealth map[string]any
-	if err = json.Unmarshal(body, &clusterHealth); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return clusterHealth, nil
+	return adminClient.GetHealthOverview(ctx)
 }
 
 func (c *Client) GetSuperusers(ctx context.Context) ([]string, error) {
-	pod, err := c.getStsPod(ctx, 0)
+	dialer := kube.NewPodDialer(c.Ctl.RestConfig())
+
+	adminClient, err := client.AdminClient(c.dot, dialer.DialContext)
 	if err != nil {
 		return nil, err
 	}
 
-	var out, eb bytes.Buffer
-	if err = c.Ctl.Exec(ctx, pod, kube.ExecOptions{
-		Command: []string{"bash", "-c", `rpk cluster config get superusers`},
-		Stdout:  &out,
-		Stderr:  &eb,
-	}); err != nil {
+	defer adminClient.Close()
+
+	config, err := adminClient.Config(ctx, false)
+	if err != nil {
 		return nil, err
 	}
 
-	if eb.String() != "" {
-		return nil, errors.New(eb.String())
-	}
-
-	superusers := []string{}
-
-	scanner := bufio.NewScanner(&out)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if !strings.HasPrefix(line, "- ") {
-			continue
-		}
-
-		superusers = append(superusers, strings.TrimSpace(strings.TrimPrefix(line, "- ")))
+	sus := config["superusers"].([]any)
+	superusers := make([]string, len(sus))
+	for i, su := range sus {
+		superusers[i] = su.(string)
 	}
 
 	return superusers, nil
@@ -555,7 +511,7 @@ func (c *Client) RetrieveEventFromTopic(ctx context.Context, topicName string, p
 //
 // As future improvement function could expose all ports for each Redpanda. As possible
 // returned map of Pod name to map of listener and port could be provided.
-func (c *Client) ExposeRedpandaCluster(ctx context.Context, dot *helmette.Dot, out, errOut io.Writer) (func(), error) {
+func (c *Client) ExposeRedpandaCluster(ctx context.Context, out, errOut io.Writer) (func(), error) {
 	pod, err := c.getStsPod(ctx, 0)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -564,10 +520,6 @@ func (c *Client) ExposeRedpandaCluster(ctx context.Context, dot *helmette.Dot, o
 	availablePorts, cleanup, err := c.Ctl.PortForward(ctx, pod, out, errOut)
 	if err != nil {
 		return cleanup, errors.WithStack(err)
-	}
-
-	if c.adminClients == nil {
-		c.adminClients = make(map[string]*portForwardClient)
 	}
 
 	if c.schemaClients == nil {
@@ -583,29 +535,12 @@ func (c *Client) ExposeRedpandaCluster(ctx context.Context, dot *helmette.Dot, o
 		return cleanup, errors.WithStack(err)
 	}
 
-	values := helmette.Unwrap[redpanda.Values](dot.Values)
+	values := helmette.Unwrap[redpanda.Values](c.dot.Values)
 
-	defaultSecretName := fmt.Sprintf("%s-%s-%s", c.Release.Name, "default", "cert")
+	defaultSecretName := fmt.Sprintf("%s-%s-%s", c.dot.Release.Name, "default", "cert")
 
 	secretName := defaultSecretName
-	cert := values.TLS.Certs[values.Listeners.Admin.TLS.Cert]
-	if ref := cert.ClientSecretRef; ref != nil {
-		secretName = ref.Name
-	}
-
-	adminClient, err := c.createClient(ctx,
-		getInternalPort(rpYaml.Redpanda.AdminAPI, availablePorts),
-		isTLSEnabled(rpYaml.Redpanda.AdminAPITLS),
-		isMutualTLSEnabled(rpYaml.Redpanda.AdminAPITLS),
-		secretName)
-	if err != nil {
-		return cleanup, errors.WithStack(err)
-	}
-
-	c.adminClients[pod.Name] = adminClient
-
-	secretName = defaultSecretName
-	cert = values.TLS.Certs[values.Listeners.SchemaRegistry.TLS.Cert]
+	cert := values.TLS.Certs[values.Listeners.SchemaRegistry.TLS.Cert]
 	if ref := cert.ClientSecretRef; ref != nil {
 		secretName = ref.Name
 	}
@@ -691,8 +626,8 @@ func getInternalPort(addresses any, availablePorts []portforward.ForwardedPort) 
 
 func (c *Client) getRedpandaConfig(ctx context.Context) (*config.RedpandaYaml, error) {
 	cm, err := kube.Get[corev1.ConfigMap](ctx, c.Ctl, kube.ObjectKey{
-		Name:      c.Release.Name,
-		Namespace: c.Release.Namespace,
+		Name:      c.dot.Release.Name,
+		Namespace: c.dot.Release.Namespace,
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -724,7 +659,7 @@ func (c *Client) createClient(ctx context.Context, port int, tlsEnabled, mTLSEna
 		schema = "https"
 		s, err := kube.Get[corev1.Secret](ctx, c.Ctl, kube.ObjectKey{
 			Name:      tlsK8SSecretName,
-			Namespace: c.Release.Namespace,
+			Namespace: c.dot.Release.Namespace,
 		})
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -750,7 +685,7 @@ func (c *Client) createClient(ctx context.Context, port int, tlsEnabled, mTLSEna
 			Certificates: certs,
 			RootCAs:      rootCAs,
 			// Available subject alternative names are defined in certs.go
-			ServerName: fmt.Sprintf("%s.%s", c.Release.Name, c.Release.Namespace),
+			ServerName: fmt.Sprintf("%s.%s", c.dot.Release.Name, c.dot.Release.Namespace),
 		},
 		TLSHandshakeTimeout:   10 * time.Second,
 		MaxIdleConns:          100,

--- a/charts/redpanda/service_internal.go
+++ b/charts/redpanda/service_internal.go
@@ -20,6 +20,13 @@ import (
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 )
 
+const (
+	InternalAdminAPIPortName       = "admin"
+	InternalKafkaPortName          = "kafka"
+	InternalSchemaRegistryPortName = "schemaregistry"
+	InternalPandaProxyPortName     = "http"
+)
+
 func MonitoringEnabledLabel(dot *helmette.Dot) map[string]string {
 	values := helmette.Unwrap[Values](dot.Values)
 	return map[string]string{
@@ -36,7 +43,7 @@ func ServiceInternal(dot *helmette.Dot) *corev1.Service {
 	ports := []corev1.ServicePort{}
 
 	ports = append(ports, corev1.ServicePort{
-		Name:        "admin",
+		Name:        InternalAdminAPIPortName,
 		Protocol:    "TCP",
 		AppProtocol: values.Listeners.Admin.AppProtocol,
 		Port:        values.Listeners.Admin.Port,
@@ -45,14 +52,14 @@ func ServiceInternal(dot *helmette.Dot) *corev1.Service {
 
 	if values.Listeners.HTTP.Enabled {
 		ports = append(ports, corev1.ServicePort{
-			Name:       "http",
+			Name:       InternalPandaProxyPortName,
 			Protocol:   "TCP",
 			Port:       values.Listeners.HTTP.Port,
 			TargetPort: intstr.FromInt32(values.Listeners.HTTP.Port),
 		})
 	}
 	ports = append(ports, corev1.ServicePort{
-		Name:       "kafka",
+		Name:       InternalKafkaPortName,
 		Protocol:   "TCP",
 		Port:       values.Listeners.Kafka.Port,
 		TargetPort: intstr.FromInt32(values.Listeners.Kafka.Port),
@@ -65,7 +72,7 @@ func ServiceInternal(dot *helmette.Dot) *corev1.Service {
 	})
 	if values.Listeners.SchemaRegistry.Enabled {
 		ports = append(ports, corev1.ServicePort{
-			Name:       "schemaregistry",
+			Name:       InternalSchemaRegistryPortName,
 			Protocol:   "TCP",
 			Port:       values.Listeners.SchemaRegistry.Port,
 			TargetPort: intstr.FromInt32(values.Listeners.SchemaRegistry.Port),

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -550,7 +550,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (get (fromJson (include "redpanda.ServerList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.admin.port | int))))) "r")) | toJson -}}
+{{- (dict "r" (get (fromJson (include "redpanda.serverList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.admin.port | int))))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -563,12 +563,12 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (get (fromJson (include "redpanda.ServerList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.schemaRegistry.port | int))))) "r")) | toJson -}}
+{{- (dict "r" (get (fromJson (include "redpanda.serverList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.schemaRegistry.port | int))))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "redpanda.ServerList" -}}
+{{- define "redpanda.serverList" -}}
 {{- $replicas := (index .a 0) -}}
 {{- $prefix := (index .a 1) -}}
 {{- $fullname := (index .a 2) -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -988,14 +988,14 @@ func (l *Listeners) CreateSeedServers(replicas int32, fullname, internalDomain s
 }
 
 func (l *Listeners) AdminList(replicas int32, fullname, internalDomain string) []string {
-	return ServerList(replicas, "", fullname, internalDomain, l.Admin.Port)
+	return serverList(replicas, "", fullname, internalDomain, l.Admin.Port)
 }
 
 func (l *Listeners) SchemaRegistryList(replicas int32, fullname, internalDomain string) []string {
-	return ServerList(replicas, "", fullname, internalDomain, l.SchemaRegistry.Port)
+	return serverList(replicas, "", fullname, internalDomain, l.SchemaRegistry.Port)
 }
 
-func ServerList(replicas int32, prefix, fullname, internalDomain string, port int32) []string {
+func serverList(replicas int32, prefix, fullname, internalDomain string, port int32) []string {
 	var result []string
 	for i := int32(0); i < replicas; i++ {
 		result = append(result, fmt.Sprintf("%s%s-%d.%s:%d", prefix, fullname, i, internalDomain, int(port)))

--- a/gen/go.sum
+++ b/gen/go.sum
@@ -431,6 +431,10 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8FpXnUmvQbwNM=
+github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
+github.com/redpanda-data/common-go/rpadmin v0.1.14-0.20250425125657-8ab73f3ad62e h1:0kdPPgbSCZ8XX6K/51x61/9cas2/sXj8UgdoiLJnOqQ=
+github.com/redpanda-data/common-go/rpadmin v0.1.14-0.20250425125657-8ab73f3ad62e/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
 github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 h1:aSlJX+HNh9C9NKA0+xp9DfYwfVs1fp4tkFaZS9DUkXM=
 github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:o6FEj/SPoAxl6Rn1X9+XO1tlzSl2V64vAiBDgHntfVc=
 github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 h1:HIkLbEDKeCALHFytZdHfeWYo/9JMa1yh4QlsIlhlsB8=
@@ -453,6 +457,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sethgrid/pester v1.2.0 h1:adC9RS29rRUef3rIKWPOuP1Jm3/MmB6ke+OhE5giENI=
+github.com/sethgrid/pester v1.2.0/go.mod h1:hEUINb4RqvDxtoCaU0BNT/HV4ig5kfgOasrf1xcvr0A=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -497,6 +503,8 @@ github.com/twmb/franz-go/pkg/kadm v1.12.0 h1:I8P/gpXFzhl73QcAYmJu+1fOXvrynyH/MAo
 github.com/twmb/franz-go/pkg/kadm v1.12.0/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
+github.com/twmb/franz-go/pkg/sr v1.2.0 h1:zYr0Ly7KLFfeCGaSr8teN6LvAVeYVrZoUsyyPHTYB+M=
+github.com/twmb/franz-go/pkg/sr v1.2.0/go.mod h1:gpd2Xl5/prkj3gyugcL+rVzagjaxFqMgvKMYcUlrpDw=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=
 github.com/twmb/tlscfg v1.2.1/go.mod h1:GameEQddljI+8Es373JfQEBvtI4dCTLKWGJbqT2kErs=
 github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 h1:JwtAtbp7r/7QSyGz8mKUbYJBg2+6Cd7OjM8o/GNOcVo=


### PR DESCRIPTION
`redpanda/client` used to generate a static list of hostnames for its various client constructors. This resulted in latent problems with the AdminAPI client as it internally attempts to maintain a mapping of brokerID <-> URL which surface as `failed to map brokerID X to URL`

When scaling a cluster down, e.g. 5 -> 3, the client would be missing 2 broker URLs as `Replicas` would reflect the desired state that had not yet been applied. If the controller leader happened to be on one of these missing broker URLs, the `sendToLeader` method would fail to resolve a URL and deadlock the operator.

This commit updates the `redpanda/client` package to instead build the host list by issuing an SRV DNS query which will reflect the current state of affairs.

SRV was selected over performing a Pod listing as this allows us to avoid re-implementing some unfortunately nuanced logic. Specifically we get to avoid:
- Implementing Pod -> FQDN logic. [^1]
- Implementing Service port -> Container port resolution logic. [^2]
- Implementing Service -> Pod Selector logic. [^3]

[^1]: While we do this elsewhere, I'm aiming to reduce the total number of references to a hardcoded cluster domain.
[^2]: This is surprisingly tricky as ports could be remapped or named on the service and ports are defined per Container not per Pod.
[^3]: This isn't hard. I'm lazy and wanted to avoid two API calls.