### PR TITLE
redpanda: use service discovery for client construction

### DIFF
--- a/charts/redpanda/.helmignore
+++ b/charts/redpanda/.helmignore
@@ -26,3 +26,6 @@ README.md.gotmpl
 *.go
 testdata/
 ci/
+
+# dlv debug binaries
+debug.*

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -229,17 +229,9 @@ func TestIntegrationChart(t *testing.T) {
 			Values: partial,
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -304,17 +296,9 @@ func TestIntegrationChart(t *testing.T) {
 			Namespace: env.Namespace(),
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -363,17 +347,9 @@ func TestIntegrationChart(t *testing.T) {
 			Namespace: env.Namespace(),
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -426,17 +402,9 @@ func TestIntegrationChart(t *testing.T) {
 			Namespace: env.Namespace(),
 		})
 
-		rpk := Client{Ctl: env.Ctl(), Release: &rpRelease}
+		rpk := newClient(t, env.Ctl(), &rpRelease, partial)
 
-		dot := &helmette.Dot{
-			Values:  *helmette.UnmarshalInto[*helmette.Values](partial),
-			Release: helmette.Release{Name: rpRelease.Name, Namespace: rpRelease.Namespace},
-			Chart: helmette.Chart{
-				Name: "redpanda",
-			},
-		}
-
-		cleanup, err := rpk.ExposeRedpandaCluster(ctx, dot, w, wErr)
+		cleanup, err := rpk.ExposeRedpandaCluster(ctx, w, wErr)
 		if cleanup != nil {
 			t.Cleanup(cleanup)
 		}
@@ -565,7 +533,7 @@ func TieredStorageSecretRefs(t *testing.T, secret *corev1.Secret) redpanda.Parti
 	}
 }
 
-func kafkaListenerTest(ctx context.Context, rpk Client) error {
+func kafkaListenerTest(ctx context.Context, rpk *Client) error {
 	input := "test-input"
 	topicName := "testTopic"
 	_, err := rpk.CreateTopic(ctx, topicName)
@@ -590,7 +558,7 @@ func kafkaListenerTest(ctx context.Context, rpk Client) error {
 	return nil
 }
 
-func adminListenerTest(ctx context.Context, rpk Client) error {
+func adminListenerTest(ctx context.Context, rpk *Client) error {
 	deadline := time.After(1 * time.Minute)
 	for {
 		select {
@@ -600,7 +568,7 @@ func adminListenerTest(ctx context.Context, rpk Client) error {
 				continue
 			}
 
-			if out["is_healthy"].(bool) {
+			if out.IsHealthy {
 				return nil
 			}
 		case <-deadline:
@@ -611,7 +579,7 @@ func adminListenerTest(ctx context.Context, rpk Client) error {
 	}
 }
 
-func superuserTest(ctx context.Context, rpk Client, superusers ...string) error {
+func superuserTest(ctx context.Context, rpk *Client, superusers ...string) error {
 	deadline := time.After(1 * time.Minute)
 	for {
 		select {
@@ -652,7 +620,7 @@ func equalElements[T comparable](a, b []T) bool {
 	return true
 }
 
-func schemaRegistryListenerTest(ctx context.Context, rpk Client) ([]byte, string, error) {
+func schemaRegistryListenerTest(ctx context.Context, rpk *Client) ([]byte, string, error) {
 	// Test schema registry
 	// Based on https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/
 	formats, err := rpk.QuerySupportedFormats(ctx)
@@ -735,7 +703,7 @@ type HTTPResponse []struct {
 	Offset    int     `json:"offset"`
 }
 
-func httpProxyListenerTest(ctx context.Context, rpk Client) error {
+func httpProxyListenerTest(ctx context.Context, rpk *Client) error {
 	// Test http proxy
 	// Based on https://docs.redpanda.com/current/develop/http-proxy/
 	_, err := rpk.ListTopics(ctx)

--- a/charts/redpanda/client/client.go
+++ b/charts/redpanda/client/client.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package redpanda
+package client
 
 import (
 	"context"
@@ -28,9 +28,12 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
+	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 
 var (
@@ -48,6 +51,13 @@ var (
 	supportedSASLMechanisms = []string{
 		"SCRAM-SHA-256", "SCRAM-SHA-512",
 	}
+
+	// permitOutOfClusterDNS controls whether or not this package will use the
+	// provided dialer to approximate "out of cluster DNS" by constructing a
+	// [net.Resolver] that tunnels into a kube-dns Pod. Building with the
+	// integration build tag will set this flag to true as that's the only
+	// environment we expect to use out of cluster DNS.
+	permitOutOfClusterDNS = false
 )
 
 // DialContextFunc is a function that acts as a dialer for the underlying Kafka client.
@@ -57,16 +67,11 @@ type DialContextFunc = func(ctx context.Context, network, host string) (net.Conn
 // configuration over its internal listeners.
 func AdminClient(dot *helmette.Dot, dialer DialContextFunc, opts ...rpadmin.Opt) (*rpadmin.AdminAPI, error) {
 	values := helmette.Unwrap[redpanda.Values](dot.Values)
-	name := redpanda.Fullname(dot)
-	domain := redpanda.InternalDomain(dot)
-	prefix := "http://"
 
-	var tlsConfig *tls.Config
 	var err error
+	var tlsConfig *tls.Config
 
 	if values.Listeners.Admin.TLS.IsEnabled(&values.TLS) {
-		prefix = "https://"
-
 		tlsConfig, err = tlsConfigFromDot(dot, values.Listeners.Admin.TLS)
 		if err != nil {
 			return nil, err
@@ -88,8 +93,17 @@ func AdminClient(dot *helmette.Dot, dialer DialContextFunc, opts ...rpadmin.Opt)
 		auth = &rpadmin.NopAuth{}
 	}
 
-	hosts := redpanda.ServerList(values.Statefulset.Replicas, prefix, name, domain, values.Listeners.Admin.Port)
+	records, err := srvLookup(dot, dialer, redpanda.InternalAdminAPIPortName)
+	if err != nil {
+		return nil, err
+	}
 
+	hosts := make([]string, len(records))
+	for i, record := range records {
+		hosts[i] = fmt.Sprintf("%s:%d", record.Target, record.Port)
+	}
+
+	// NB: rpadmin automatically infers http or https, if not provided, based on the tlsConfig.
 	client, err := rpadmin.NewAdminAPIWithDialer(hosts, auth, tlsConfig, dialer, opts...)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -102,8 +116,6 @@ func AdminClient(dot *helmette.Dot, dialer DialContextFunc, opts ...rpadmin.Opt)
 // configuration over its internal listeners.
 func SchemaRegistryClient(dot *helmette.Dot, dialer DialContextFunc, opts ...sr.ClientOpt) (*sr.Client, error) {
 	values := helmette.Unwrap[redpanda.Values](dot.Values)
-	name := redpanda.Fullname(dot)
-	domain := redpanda.InternalDomain(dot)
 	prefix := "http://"
 
 	// These transport values come from the TLS client options found here:
@@ -150,7 +162,16 @@ func SchemaRegistryClient(dot *helmette.Dot, dialer DialContextFunc, opts ...sr.
 		copts = append(copts, sr.BasicAuth(username, password))
 	}
 
-	hosts := redpanda.ServerList(values.Statefulset.Replicas, prefix, name, domain, values.Listeners.SchemaRegistry.Port)
+	records, err := srvLookup(dot, dialer, redpanda.InternalAdminAPIPortName)
+	if err != nil {
+		return nil, err
+	}
+
+	hosts := make([]string, len(records))
+	for i, record := range records {
+		hosts[i] = fmt.Sprintf("%s%s:%d", prefix, record.Target, record.Port)
+	}
+
 	copts = append(copts, sr.URLs(hosts...))
 
 	// finally, override any calculated client opts with whatever was
@@ -167,10 +188,16 @@ func SchemaRegistryClient(dot *helmette.Dot, dialer DialContextFunc, opts ...sr.
 // configuration over its internal listeners.
 func KafkaClient(dot *helmette.Dot, dialer DialContextFunc, opts ...kgo.Opt) (*kgo.Client, error) {
 	values := helmette.Unwrap[redpanda.Values](dot.Values)
-	name := redpanda.Fullname(dot)
-	domain := redpanda.InternalDomain(dot)
 
-	brokers := redpanda.ServerList(values.Statefulset.Replicas, "", name, domain, values.Listeners.Kafka.Port)
+	records, err := srvLookup(dot, dialer, redpanda.InternalKafkaPortName)
+	if err != nil {
+		return nil, err
+	}
+
+	brokers := make([]string, len(records))
+	for i, record := range records {
+		brokers[i] = fmt.Sprintf("%s:%d", record.Target, record.Port)
+	}
 
 	opts = append(opts, kgo.SeedBrokers(brokers...))
 
@@ -428,4 +455,90 @@ func wrapTLSDialer(dialer DialContextFunc, config *tls.Config) DialContextFunc {
 		}
 		return tls.Client(conn, config), nil
 	}
+}
+
+// srvLookup performs an SRV DNS lookup on the given helm release as a form of service discovery.
+//
+// As with all forms of service discovery, this method may miss Pods that are
+// temporarily unavailable at the time of invocation.
+//
+// If dialer is nil, this function assumes that it's being executed from within
+// a Kubernetes and performs a DNS query through the default resolver.
+//
+// See also: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records
+func srvLookup(dot *helmette.Dot, dialer DialContextFunc, service string) ([]*net.SRV, error) {
+	// To preserve backwards compatibility of the top level client
+	// constructor's methods, we use a context with a static timeout.
+	// While less than ideal, 30s should be a reasonable upper limit for this method.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// A nil / zero resolver is valid. In the case that dialer is nil, we
+	// assume our DNS requests will go to kube-dns and appropriately resolve.
+	var resolver net.Resolver
+
+	// Otherwise we'll perform an out of cluster DNS query. This code block
+	// will only be executed from our test cases (gated on the integration
+	// build tag). It's a bit sketchy but is technically valid / safe to
+	// run outside of test cases. See the below comments for details.
+	//
+	// NB: It may not always be safe to assume that dialer != nil indicates
+	// execution outside of a cluster.
+	if permitOutOfClusterDNS && dialer != nil {
+		ctl, err := kube.FromRESTConfig(dot.KubeConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		resolver = net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, _network, _address string) (net.Conn, error) {
+				// Querying for k8s-app=kube-dns is a generally accepted / safe
+				// way of finding the kube DNS. We could alternatively find the
+				// kube-dns service and use its label selector.
+				pods, err := kube.List[corev1.PodList](ctx, ctl, client.MatchingLabels{
+					"k8s-app": "kube-dns",
+				}, client.InNamespace(metav1.NamespaceSystem))
+				if err != nil {
+					return nil, err
+				}
+
+				if len(pods.Items) == 0 {
+					return nil, errors.New("failed to locate core DNS Pods for out of cluster DNS queries")
+				}
+
+				pod := pods.Items[0]
+
+				// Fun fact: core-dns and most kube-dns implementations are
+				// exposed over TCP in addition to UDP which makes this method
+				// possible.
+				//
+				// This is where things get fairly sketchy.
+				//
+				// We're ignoring network because kubectl portforward doesn't
+				// support UDP, the standard protocol for DNS, and we're
+				// assuming that kube-dns will accept TCP connections. This is
+				// _generally_ a safe assumption.
+				//
+				// We're ignoring address because we don't want to use the
+				// system supplied name servers and instead go directly to
+				// kube-dns. We're also assuming the kube-dns is serving on
+				// port 53, the standard port for DNS. Yet another generally
+				// correct but not bulletproof assumption.
+				//
+				// Furthermore, this dial call will very likely result in
+				// another DNS query being kicked off through the system
+				// resolver to  initiate the portforward. Again, sketchy but
+				// technically OK.
+				return dialer(ctx, "tcp", fmt.Sprintf("%s.%s:53", pod.Name, pod.Namespace))
+			},
+		}
+	}
+
+	_, records, err := resolver.LookupSRV(ctx, service, "tcp", redpanda.InternalDomain(dot))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return records, nil
 }

--- a/charts/redpanda/client/client_test.go
+++ b/charts/redpanda/client/client_test.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package redpanda
+package client
 
 import (
 	"testing"

--- a/charts/redpanda/client/outofclusterdns_integration.go
+++ b/charts/redpanda/client/outofclusterdns_integration.go
@@ -1,0 +1,7 @@
+//go:build integration
+
+package client
+
+func init() {
+	permitOutOfClusterDNS = true
+}

--- a/charts/redpanda/client_test.go
+++ b/charts/redpanda/client_test.go
@@ -10,7 +10,6 @@
 package redpanda_test
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -19,16 +18,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/portforward"
 	"sigs.k8s.io/yaml"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
@@ -36,10 +38,20 @@ import (
 
 type Client struct {
 	Ctl           *kube.Ctl
-	Release       *helm.Release
-	adminClients  map[string]*portForwardClient
+	dot           *helmette.Dot
 	schemaClients map[string]*portForwardClient
 	proxyClients  map[string]*portForwardClient
+}
+
+func newClient(t *testing.T, ctl *kube.Ctl, release *helm.Release, values any) *Client {
+	dot, err := redpanda.Chart.Dot(
+		ctl.RestConfig(),
+		helmette.Release{Name: release.Name, Namespace: release.Namespace},
+		values,
+	)
+	require.NoError(t, err)
+
+	return &Client{Ctl: ctl, dot: dot}
 }
 
 type portForwardClient struct {
@@ -50,31 +62,9 @@ type portForwardClient struct {
 
 func (c *Client) getStsPod(ctx context.Context, ordinal int) (*corev1.Pod, error) {
 	return kube.Get[corev1.Pod](ctx, c.Ctl, kube.ObjectKey{
-		Name:      fmt.Sprintf("%s-%d", c.Release.Name, ordinal),
-		Namespace: c.Release.Namespace,
+		Name:      fmt.Sprintf("%s-%d", c.dot.Release.Name, ordinal),
+		Namespace: c.dot.Release.Namespace,
 	})
-}
-
-func (c *Client) ClusterConfig(ctx context.Context) (redpanda.ClusterConfig, error) {
-	pod, err := c.getStsPod(ctx, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	var out bytes.Buffer
-	if err := c.Ctl.Exec(ctx, pod, kube.ExecOptions{
-		Command: []string{"bash", "-c", `rpk cluster config export -f /dev/stderr`},
-		Stderr:  &out,
-	}); err != nil {
-		return nil, err
-	}
-
-	var cfg map[string]any
-	if err := yaml.Unmarshal(out.Bytes(), &cfg); err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
 }
 
 func (c *Client) CreateTopic(ctx context.Context, topicName string) (map[string]any, error) {
@@ -144,72 +134,38 @@ func (c *Client) KafkaConsume(ctx context.Context, topicName string) (map[string
 	return event, nil
 }
 
-func (c *Client) GetClusterHealth(ctx context.Context) (map[string]any, error) {
-	pod, err := c.getStsPod(ctx, 0)
+func (c *Client) GetClusterHealth(ctx context.Context) (rpadmin.ClusterHealthOverview, error) {
+	dialer := kube.NewPodDialer(c.Ctl.RestConfig())
+
+	adminClient, err := client.AdminClient(c.dot, dialer.DialContext)
 	if err != nil {
-		return nil, err
+		return rpadmin.ClusterHealthOverview{}, err
 	}
 
-	client := c.adminClients[pod.Name]
+	defer adminClient.Close()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s://127.0.0.1:%d/v1/cluster/health_overview", client.schema, client.exposedPort), nil)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	body, err := io.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if res.StatusCode > 299 {
-		return nil, errors.New("response above 299 HTTP code")
-	}
-
-	var clusterHealth map[string]any
-	if err = json.Unmarshal(body, &clusterHealth); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return clusterHealth, nil
+	return adminClient.GetHealthOverview(ctx)
 }
 
 func (c *Client) GetSuperusers(ctx context.Context) ([]string, error) {
-	pod, err := c.getStsPod(ctx, 0)
+	dialer := kube.NewPodDialer(c.Ctl.RestConfig())
+
+	adminClient, err := client.AdminClient(c.dot, dialer.DialContext)
 	if err != nil {
 		return nil, err
 	}
 
-	var out, eb bytes.Buffer
-	if err = c.Ctl.Exec(ctx, pod, kube.ExecOptions{
-		Command: []string{"bash", "-c", `rpk cluster config get superusers`},
-		Stdout:  &out,
-		Stderr:  &eb,
-	}); err != nil {
+	defer adminClient.Close()
+
+	config, err := adminClient.Config(ctx, false)
+	if err != nil {
 		return nil, err
 	}
 
-	if eb.String() != "" {
-		return nil, errors.New(eb.String())
-	}
-
-	superusers := []string{}
-
-	scanner := bufio.NewScanner(&out)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if !strings.HasPrefix(line, "- ") {
-			continue
-		}
-
-		superusers = append(superusers, strings.TrimSpace(strings.TrimPrefix(line, "- ")))
+	sus := config["superusers"].([]any)
+	superusers := make([]string, len(sus))
+	for i, su := range sus {
+		superusers[i] = su.(string)
 	}
 
 	return superusers, nil
@@ -555,7 +511,7 @@ func (c *Client) RetrieveEventFromTopic(ctx context.Context, topicName string, p
 //
 // As future improvement function could expose all ports for each Redpanda. As possible
 // returned map of Pod name to map of listener and port could be provided.
-func (c *Client) ExposeRedpandaCluster(ctx context.Context, dot *helmette.Dot, out, errOut io.Writer) (func(), error) {
+func (c *Client) ExposeRedpandaCluster(ctx context.Context, out, errOut io.Writer) (func(), error) {
 	pod, err := c.getStsPod(ctx, 0)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -564,10 +520,6 @@ func (c *Client) ExposeRedpandaCluster(ctx context.Context, dot *helmette.Dot, o
 	availablePorts, cleanup, err := c.Ctl.PortForward(ctx, pod, out, errOut)
 	if err != nil {
 		return cleanup, errors.WithStack(err)
-	}
-
-	if c.adminClients == nil {
-		c.adminClients = make(map[string]*portForwardClient)
 	}
 
 	if c.schemaClients == nil {
@@ -583,29 +535,12 @@ func (c *Client) ExposeRedpandaCluster(ctx context.Context, dot *helmette.Dot, o
 		return cleanup, errors.WithStack(err)
 	}
 
-	values := helmette.Unwrap[redpanda.Values](dot.Values)
+	values := helmette.Unwrap[redpanda.Values](c.dot.Values)
 
-	defaultSecretName := fmt.Sprintf("%s-%s-%s", c.Release.Name, "default", "cert")
+	defaultSecretName := fmt.Sprintf("%s-%s-%s", c.dot.Release.Name, "default", "cert")
 
 	secretName := defaultSecretName
-	cert := values.TLS.Certs[values.Listeners.Admin.TLS.Cert]
-	if ref := cert.ClientSecretRef; ref != nil {
-		secretName = ref.Name
-	}
-
-	adminClient, err := c.createClient(ctx,
-		getInternalPort(rpYaml.Redpanda.AdminAPI, availablePorts),
-		isTLSEnabled(rpYaml.Redpanda.AdminAPITLS),
-		isMutualTLSEnabled(rpYaml.Redpanda.AdminAPITLS),
-		secretName)
-	if err != nil {
-		return cleanup, errors.WithStack(err)
-	}
-
-	c.adminClients[pod.Name] = adminClient
-
-	secretName = defaultSecretName
-	cert = values.TLS.Certs[values.Listeners.SchemaRegistry.TLS.Cert]
+	cert := values.TLS.Certs[values.Listeners.SchemaRegistry.TLS.Cert]
 	if ref := cert.ClientSecretRef; ref != nil {
 		secretName = ref.Name
 	}
@@ -691,8 +626,8 @@ func getInternalPort(addresses any, availablePorts []portforward.ForwardedPort) 
 
 func (c *Client) getRedpandaConfig(ctx context.Context) (*config.RedpandaYaml, error) {
 	cm, err := kube.Get[corev1.ConfigMap](ctx, c.Ctl, kube.ObjectKey{
-		Name:      c.Release.Name,
-		Namespace: c.Release.Namespace,
+		Name:      c.dot.Release.Name,
+		Namespace: c.dot.Release.Namespace,
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -724,7 +659,7 @@ func (c *Client) createClient(ctx context.Context, port int, tlsEnabled, mTLSEna
 		schema = "https"
 		s, err := kube.Get[corev1.Secret](ctx, c.Ctl, kube.ObjectKey{
 			Name:      tlsK8SSecretName,
-			Namespace: c.Release.Namespace,
+			Namespace: c.dot.Release.Namespace,
 		})
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -750,7 +685,7 @@ func (c *Client) createClient(ctx context.Context, port int, tlsEnabled, mTLSEna
 			Certificates: certs,
 			RootCAs:      rootCAs,
 			// Available subject alternative names are defined in certs.go
-			ServerName: fmt.Sprintf("%s.%s", c.Release.Name, c.Release.Namespace),
+			ServerName: fmt.Sprintf("%s.%s", c.dot.Release.Name, c.dot.Release.Namespace),
 		},
 		TLSHandshakeTimeout:   10 * time.Second,
 		MaxIdleConns:          100,

--- a/charts/redpanda/service_internal.go
+++ b/charts/redpanda/service_internal.go
@@ -20,6 +20,13 @@ import (
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 )
 
+const (
+	InternalAdminAPIPortName       = "admin"
+	InternalKafkaPortName          = "kafka"
+	InternalSchemaRegistryPortName = "schemaregistry"
+	InternalPandaProxyPortName     = "http"
+)
+
 func MonitoringEnabledLabel(dot *helmette.Dot) map[string]string {
 	values := helmette.Unwrap[Values](dot.Values)
 	return map[string]string{
@@ -36,7 +43,7 @@ func ServiceInternal(dot *helmette.Dot) *corev1.Service {
 	ports := []corev1.ServicePort{}
 
 	ports = append(ports, corev1.ServicePort{
-		Name:        "admin",
+		Name:        InternalAdminAPIPortName,
 		Protocol:    "TCP",
 		AppProtocol: values.Listeners.Admin.AppProtocol,
 		Port:        values.Listeners.Admin.Port,
@@ -45,14 +52,14 @@ func ServiceInternal(dot *helmette.Dot) *corev1.Service {
 
 	if values.Listeners.HTTP.Enabled {
 		ports = append(ports, corev1.ServicePort{
-			Name:       "http",
+			Name:       InternalPandaProxyPortName,
 			Protocol:   "TCP",
 			Port:       values.Listeners.HTTP.Port,
 			TargetPort: intstr.FromInt32(values.Listeners.HTTP.Port),
 		})
 	}
 	ports = append(ports, corev1.ServicePort{
-		Name:       "kafka",
+		Name:       InternalKafkaPortName,
 		Protocol:   "TCP",
 		Port:       values.Listeners.Kafka.Port,
 		TargetPort: intstr.FromInt32(values.Listeners.Kafka.Port),
@@ -65,7 +72,7 @@ func ServiceInternal(dot *helmette.Dot) *corev1.Service {
 	})
 	if values.Listeners.SchemaRegistry.Enabled {
 		ports = append(ports, corev1.ServicePort{
-			Name:       "schemaregistry",
+			Name:       InternalSchemaRegistryPortName,
 			Protocol:   "TCP",
 			Port:       values.Listeners.SchemaRegistry.Port,
 			TargetPort: intstr.FromInt32(values.Listeners.SchemaRegistry.Port),

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -550,7 +550,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (get (fromJson (include "redpanda.ServerList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.admin.port | int))))) "r")) | toJson -}}
+{{- (dict "r" (get (fromJson (include "redpanda.serverList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.admin.port | int))))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -563,12 +563,12 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (get (fromJson (include "redpanda.ServerList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.schemaRegistry.port | int))))) "r")) | toJson -}}
+{{- (dict "r" (get (fromJson (include "redpanda.serverList" (dict "a" (list $replicas "" $fullname $internalDomain ($l.schemaRegistry.port | int))))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "redpanda.ServerList" -}}
+{{- define "redpanda.serverList" -}}
 {{- $replicas := (index .a 0) -}}
 {{- $prefix := (index .a 1) -}}
 {{- $fullname := (index .a 2) -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -888,14 +888,14 @@ func (l *Listeners) CreateSeedServers(replicas int32, fullname, internalDomain s
 }
 
 func (l *Listeners) AdminList(replicas int32, fullname, internalDomain string) []string {
-	return ServerList(replicas, "", fullname, internalDomain, l.Admin.Port)
+	return serverList(replicas, "", fullname, internalDomain, l.Admin.Port)
 }
 
 func (l *Listeners) SchemaRegistryList(replicas int32, fullname, internalDomain string) []string {
-	return ServerList(replicas, "", fullname, internalDomain, l.SchemaRegistry.Port)
+	return serverList(replicas, "", fullname, internalDomain, l.SchemaRegistry.Port)
 }
 
-func ServerList(replicas int32, prefix, fullname, internalDomain string, port int32) []string {
+func serverList(replicas int32, prefix, fullname, internalDomain string, port int32) []string {
 	var result []string
 	for i := int32(0); i < replicas; i++ {
 		result = append(result, fmt.Sprintf("%s%s-%d.%s:%d", prefix, fullname, i, internalDomain, int(port)))

--- a/gen/go.sum
+++ b/gen/go.sum
@@ -538,6 +538,8 @@ github.com/twmb/franz-go/pkg/kadm v1.16.0 h1:STMs1t5lYR5mR974PSiwNzE5TvsosByTp+r
 github.com/twmb/franz-go/pkg/kadm v1.16.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765 h1:+l/P3ExNaY1T5Tft/+zK5r7hiEilgHWS5Cjjh2iZ4ME=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=
 github.com/twmb/tlscfg v1.2.1/go.mod h1:GameEQddljI+8Es373JfQEBvtI4dCTLKWGJbqT2kErs=
 github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 h1:JwtAtbp7r/7QSyGz8mKUbYJBg2+6Cd7OjM8o/GNOcVo=


### PR DESCRIPTION
`redpanda/client` used to generate a static list of hostnames for its various client constructors. This resulted in latent problems with the AdminAPI client as it internally attempts to maintain a mapping of brokerID <-> URL which surface as `failed to map brokerID X to URL`

When scaling a cluster down, e.g. 5 -> 3, the client would be missing 2 broker URLs as `Replicas` would reflect the desired state that had not yet been applied. If the controller leader happened to be on one of these missing broker URLs, the `sendToLeader` method would fail to resolve a URL and deadlock the operator.

This commit updates the `redpanda/client` package to instead build the host list by issuing an SRV DNS query which will reflect the current state of affairs.

SRV was selected over performing a Pod listing as this allows us to avoid re-implementing some unfortunately nuanced logic. Specifically we get to avoid:
- Implementing Pod -> FQDN logic. [^1]
- Implementing Service port -> Container port resolution logic. [^2]
- Implementing Service -> Pod Selector logic. [^3]

[^1]: While we do this elsewhere, I'm aiming to reduce the total number of references to a hardcoded cluster domain.
[^2]: This is surprisingly tricky as ports could be remapped or named on the service and ports are defined per Container not per Pod.
[^3]: This isn't hard. I'm lazy and wanted to avoid two API calls.