### PR TITLE
operator: Fix User management using Kafka listener

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250730-185359.yaml
+++ b/.changes/unreleased/operator-Fixed-20250730-185359.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fix SCRAM users using Kafka protocol
+time: 2025-07-30T18:53:59.63905+02:00

--- a/acceptance/features/user-crds.feature
+++ b/acceptance/features/user-crds.feature
@@ -71,6 +71,13 @@ Feature: User CRDs
       cluster:
         clusterRef:
           name: sasl
+      authentication:
+        type: scram-sha-512
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: travis-password
+              key: password
       authorization:
         acls:
         - type: allow


### PR DESCRIPTION
As new Redpanda 25.2.1 will allow managing SCRAM users using kafka listener (`DescribeUserSCRAMCredentials`). The creation and deletion of User had a bug in how to not provide all fileds. That Kafka protocol is different between Apache Kafka and Redpanda.

(cherry picked from commit 65d63741e61b0ea67ad4b09f68f8c6bdcf19d38e)

This commit was picked from https://github.com/redpanda-data/redpanda-operator/pull/1016 which should have been applied to `main` as well as `v25.1`.