### PR TITLE
Drop the critical configuration hash annotation

### DIFF
--- a/.changes/unreleased/operator-Removed-20250813-154834.yaml
+++ b/.changes/unreleased/operator-Removed-20250813-154834.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Removed
+body: The vectorized operator used to use a `centralized-configuration-hash` annotation to drive statefulset restarts. This is now directly performed on the basis of the RP admin API reporting "Needs Restart" for its cluster configuration status. Related annotations are dropped.
+time: 2025-08-13T15:48:34.953961+01:00

--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -253,7 +253,6 @@ func (r *ClusterReconciler) Reconcile(
 	}
 
 	ar.configMap(cfg)
-	cm := ar.getConfigMap(cfg)
 	if err = ar.statefulSet(cfg); err != nil {
 		return ctrl.Result{}, fmt.Errorf("creating statefulsets: %w", err)
 	}
@@ -309,7 +308,6 @@ func (r *ClusterReconciler) Reconcile(
 		ctx,
 		&vectorizedCluster,
 		cfg,
-		cm,
 		stSets,
 		pki,
 		ar.getHeadlessServiceFQDN(),

--- a/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
+++ b/operator/internal/controller/vectorized/cluster_controller_attached_resources.go
@@ -183,11 +183,6 @@ func (a *attachedResources) configMap(cfg *clusterconfiguration.CombinedCfg) {
 	a.order = append(a.order, configMap)
 }
 
-func (a *attachedResources) getConfigMap(cfg *clusterconfiguration.CombinedCfg) *resources.ConfigMapResource {
-	a.configMap(cfg)
-	return a.items[configMap].(*resources.ConfigMapResource)
-}
-
 func (a *attachedResources) headlessService() {
 	// if already initialized, exit immediately
 	if _, ok := a.items[headlessService]; ok {

--- a/operator/internal/controller/vectorized/cluster_controller_configuration.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration.go
@@ -48,7 +48,6 @@ func (r *ClusterReconciler) reconcileConfiguration(
 	ctx context.Context,
 	redpandaCluster *vectorizedv1alpha1.Cluster,
 	cfg *clusterconfiguration.CombinedCfg,
-	configMapResource *resources.ConfigMapResource,
 	statefulSetResources []*resources.StatefulSetResource,
 	pki *certmanager.PkiReconciler,
 	fqdn string,
@@ -82,11 +81,6 @@ func (r *ClusterReconciler) reconcileConfiguration(
 		return 0, errorWithContext(err, "error while creating the concrete configuration")
 	}
 
-	lastAppliedCriticalConfigurationHash, err := r.getOrInitLastAppliedCriticalConfiguration(ctx, configMapResource, cfg, schema)
-	if err != nil {
-		return 0, errorWithContext(err, "could not load the last applied configuration")
-	}
-
 	// Checking if the feature is active because in the initial stages of cluster creation, it takes time for the feature to be activated
 	// and the API returns the same error (400) that is returned in case of malformed input, which causes a stop of the reconciliation
 	var centralConfigActive bool
@@ -104,36 +98,6 @@ func (r *ClusterReconciler) reconcileConfiguration(
 	if err != nil || !patchSuccess {
 		// patchSuccess=false indicates an error set on the condition that should not be propagated (but we terminate reconciliation anyway)
 		return 0, err
-	}
-
-	// TODO a failure and restart here (after successful patch, before setting the last applied configuration) may lead to inconsistency if the user
-	// changes the CR in the meantime (e.g. removing a field), since we applied a config to the cluster but did not store the information anywhere else.
-	// A possible fix is doing a two-phase commit (first stage commit on configmap, then apply it to the cluster, with possibility to recover on failure),
-	// but it seems overkill given that the case is rare and requires cooperation from the user.
-
-	for _, statefulSetResource := range statefulSetResources {
-		if statefulSetResource == nil {
-			continue
-		}
-		hash, hashChanged, err := r.checkCentralizedConfigurationHashChange(ctx, redpandaCluster, cfg, schema, lastAppliedCriticalConfigurationHash, statefulSetResource)
-		if err != nil {
-			return 0, err
-		} else if hashChanged {
-			// Definitely needs restart
-			log.Info("Centralized configuration hash has changed")
-			if err = statefulSetResource.SetCentralizedConfigurationHashInCluster(ctx, hash); err != nil {
-				return 0, errorWithContext(err, "could not update config hash on statefulset")
-			}
-		}
-	}
-
-	// Now we can mark the new lastAppliedCriticalConfiguration for next update
-	hash, err := cfg.GetCriticalClusterConfigHash(ctx, schema)
-	if err != nil {
-		return 0, errorWithContext(err, "could not concretize critical configuration to store last applied configuration in the cluster")
-	}
-	if err = configMapResource.SetAnnotationForCluster(ctx, resources.LastAppliedCriticalConfigurationAnnotationKey, &hash); err != nil {
-		return 0, errorWithContext(err, "could not store last applied configuration in the cluster")
 	}
 
 	// Synchronized status with cluster, including triggering a restart if needed
@@ -174,36 +138,6 @@ func (r *ClusterReconciler) ratelimitCondition(rp *vectorizedv1alpha1.Cluster, c
 
 	recheckAfter := r.configurationReassertionPeriod() - time.Since(cond.LastTransitionTime.Time)
 	return max(0, recheckAfter)
-}
-
-// getOrInitLastAppliedCriticalConfiguration gets the last applied critical configuration hash to the cluster or creates it when missing.
-//
-// This is needed because the controller will later use that annotation to drive the restart of stateful sets.
-// A missing annotation indicates a cluster where centralized configuration has just been primed using the
-// contents of the .bootstrap.yaml file, so we freeze its current content (early in the reconciliation cycle) so that
-// subsequent patches are computed correctly.
-func (r *ClusterReconciler) getOrInitLastAppliedCriticalConfiguration(
-	ctx context.Context,
-	configMapResource *resources.ConfigMapResource,
-	cfg *clusterconfiguration.CombinedCfg,
-	schema rpadmin.ConfigSchema,
-) (string, error) {
-	lastApplied, cmPresent, err := configMapResource.GetAnnotationFromCluster(ctx, resources.LastAppliedCriticalConfigurationAnnotationKey)
-	if err != nil {
-		return "", err
-	}
-	if !cmPresent || lastApplied != nil {
-		return *lastApplied, nil
-	}
-
-	hash, err := cfg.GetCriticalClusterConfigHash(ctx, schema)
-	if err != nil {
-		return "", err
-	}
-	if err := configMapResource.SetAnnotationForCluster(ctx, resources.LastAppliedCriticalConfigurationAnnotationKey, &hash); err != nil {
-		return "", err
-	}
-	return hash, nil
 }
 
 func (r *ClusterReconciler) applyPatchIfNeeded(
@@ -304,33 +238,6 @@ func (r *ClusterReconciler) ensureConditionPresent(
 		return true, nil
 	}
 	return false, nil
-}
-
-func (r *ClusterReconciler) checkCentralizedConfigurationHashChange(
-	ctx context.Context,
-	redpandaCluster *vectorizedv1alpha1.Cluster,
-	cfg *clusterconfiguration.CombinedCfg,
-	schema rpadmin.ConfigSchema,
-	lastAppliedHash string,
-	statefulSetResource *resources.StatefulSetResource,
-) (hash string, changed bool, err error) {
-	hash, err = cfg.GetCriticalClusterConfigHash(ctx, schema)
-	if err != nil {
-		return "", false, newErrorWithContext(redpandaCluster.Namespace, redpandaCluster.Name)(err, "could not compute hash of the new configuration")
-	}
-
-	oldHash, err := statefulSetResource.GetCentralizedConfigurationHashFromCluster(ctx)
-	if err != nil {
-		return "", false, err
-	}
-
-	if oldHash == "" {
-		// Annotation not yet set on the statefulset (e.g. first time we change config).
-		// We check a diff against last applied configuration to avoid triggering a restart when not needed.
-		oldHash = lastAppliedHash
-	}
-
-	return hash, hash != oldHash, nil
 }
 
 func (r *ClusterReconciler) synchronizeStatusWithCluster(

--- a/operator/pkg/clusterconfiguration/configuration_cluster.go
+++ b/operator/pkg/clusterconfiguration/configuration_cluster.go
@@ -2,7 +2,6 @@ package clusterconfiguration
 
 import (
 	"context"
-	"crypto/md5" //nolint:gosec // this is not encrypting secure info
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -242,28 +241,4 @@ func (c *clusterCfg) Reify(ctx context.Context, reader k8sclient.Reader, cloudEx
 	}
 	c.concrete = properties
 	return properties, nil
-}
-
-// criticalClusterConfigurationHash is a short-term helper to handle checking of cluster configuration.
-// It hashes only properties that require a restart.
-func criticalClusterConfigurationHash(
-	concreteCfg map[string]any,
-	schema rpadmin.ConfigSchema,
-) (string, error) {
-	// Ignore cluster properties that don't require restart
-	criticalCfg := make(map[string]any)
-	for k, v := range concreteCfg {
-		// Unknown properties should be ignored as they might be user errors
-		if meta, ok := schema[k]; ok && meta.NeedsRestart {
-			criticalCfg[k] = v
-		}
-	}
-	// Hash this using the json-marshalled format.
-	buf, err := json.Marshal(criticalCfg)
-	if err != nil {
-		return "", err
-	}
-	// We keep using md5 for having the same format as node hash
-	md5Hash := md5.Sum(buf) //nolint:gosec // this is not encrypting secure info
-	return fmt.Sprintf("%x", md5Hash), nil
 }

--- a/operator/pkg/clusterconfiguration/configuration_combined.go
+++ b/operator/pkg/clusterconfiguration/configuration_combined.go
@@ -310,22 +310,6 @@ func (c *CombinedCfg) ReifyClusterConfiguration(
 	return c.Cluster.Reify(ctx, c.reader, c.cloudExpander, schema)
 }
 
-// GetCriticalClusterConfigHash returns md5 hash of the cluster configuration,
-// considering only those elements that are declared to require a restart according
-// to the supplied schema.
-func (c *CombinedCfg) GetCriticalClusterConfigHash(
-	ctx context.Context,
-	schema rpadmin.ConfigSchema,
-) (string, error) {
-	// Concretise the node configuration, weed out anything that would cause
-	// a useless sts restart, and return the resulting hash.
-	clusterConfig, err := c.ReifyClusterConfiguration(ctx, schema)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	return criticalClusterConfigurationHash(clusterConfig, schema)
-}
-
 // clone supplies a serialisation-backed object cloning mechanism for cases where
 // the underlying type doesn't supply a `.Clone()` mechanism.
 func clone[T any](val T) (T, error) {

--- a/operator/pkg/resources/resource.go
+++ b/operator/pkg/resources/resource.go
@@ -140,7 +140,6 @@ func Update(
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 		patch.IgnorePDBSelector(),
 		utils.IgnoreAnnotation(redpandaAnnotatorKey),
-		utils.IgnoreAnnotation(LastAppliedCriticalConfigurationAnnotationKey),
 	}
 	annotator := patch.NewAnnotator(redpandaAnnotatorKey)
 	patchResult, err := patch.NewPatchMaker(annotator, &patch.K8sStrategicMergePatcher{}, &patch.BaseJSONMergePatcher{}).Calculate(current, modified, opts...)
@@ -205,16 +204,7 @@ func prepareResourceForUpdate(current runtime.Object, modified client.Object) {
 	case *corev1.ServiceAccount:
 		sa := t
 		sa.Secrets = current.(*corev1.ServiceAccount).Secrets
-	// Additional cases due to controller using update instead of patch
-	case *corev1.ConfigMap:
-		cm := t
-		if ann, ok := current.(*corev1.ConfigMap).Annotations[LastAppliedCriticalConfigurationAnnotationKey]; ok {
-			// We always ignore this annotation during normal reconciliation
-			if cm.Annotations == nil {
-				cm.Annotations = make(map[string]string)
-			}
-			cm.Annotations[LastAppliedCriticalConfigurationAnnotationKey] = ann
-		}
+		// Additional cases due to controller using update instead of patch
 	}
 }
 

--- a/operator/pkg/resources/statefulset_update.go
+++ b/operator/pkg/resources/statefulset_update.go
@@ -91,14 +91,6 @@ func (r *StatefulSetResource) runUpdate(
 ) error {
 	log := r.logger.WithName("runUpdate").WithValues("nodepool", r.nodePool.Name)
 
-	// Keep existing central config hash annotation during standard reconciliation
-	if ann, ok := current.Spec.Template.Annotations[CentralizedConfigurationHashAnnotationKey]; ok {
-		if modified.Spec.Template.Annotations == nil {
-			modified.Spec.Template.Annotations = make(map[string]string)
-		}
-		modified.Spec.Template.Annotations[CentralizedConfigurationHashAnnotationKey] = ann
-	}
-
 	// Check if we should run update on this specific STS.
 
 	log.V(logger.DebugLevel).Info("Checking that we should update")
@@ -637,7 +629,6 @@ func (r *StatefulSetResource) shouldUpdate(
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 		utils.IgnoreAnnotation(redpandaAnnotatorKey),
 		utils.IgnoreAnnotation(labels.NodePoolSpecKey),
-		utils.IgnoreAnnotation(CentralizedConfigurationHashAnnotationKey),
 	}
 	patchResult, err := patch.NewPatchMaker(patch.NewAnnotator(redpandaAnnotatorKey), &patch.K8sStrategicMergePatcher{}, &patch.BaseJSONMergePatcher{}).Calculate(current, modified, opts...)
 	if err != nil || patchResult.IsEmpty() {


### PR DESCRIPTION
This was probably introduced to work around bugs with the configuration reconciliation failing to get individual pods to restart.

Now that those are addressed, the `centralized-configuration-hash` annotation can be completely dropped from statefulsets; relying on RP to report when it needs a restart due to configuration changes is far more robust.