### PR TITLE
Add vcluster support to harpoon

### DIFF
--- a/harpoon/features/stub.feature
+++ b/harpoon/features/stub.feature
@@ -1,4 +1,4 @@
-@isolated
+@vcluster @isolated
 Feature: stub
   Scenario Outline: templated stub
     Given there is a stub

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -100,6 +100,7 @@ func SuiteBuilderFromFlags() *SuiteBuilder {
 	}
 
 	builder.RegisterTag("isolated", -1000, isolatedTag)
+	builder.RegisterTag("vcluster", -2000, vclusterTag)
 
 	return builder
 }

--- a/harpoon/tags.go
+++ b/harpoon/tags.go
@@ -17,3 +17,8 @@ func isolatedTag(ctx context.Context, t TestingT, args ...string) context.Contex
 	t.IsolateNamespace(ctx)
 	return ctx
 }
+
+func vclusterTag(ctx context.Context, t TestingT, args ...string) context.Context {
+	t.VCluster(ctx)
+	return ctx
+}

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -53,6 +53,7 @@ type TestingT interface {
 	AddNode(ctx context.Context, name string)
 
 	IsolateNamespace(ctx context.Context) string
+	VCluster(ctx context.Context) string
 
 	InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions)
 	UpgradeHelmChart(ctx context.Context, repo, chart, release string, options helm.UpgradeOptions)

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -31,10 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/vcluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/otelkube"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/pkg/vcluster"
 )
 
 type Env struct {
@@ -94,7 +94,7 @@ func New(t *testing.T, options Options) *Env {
 	config := host.RESTConfig()
 
 	if !options.SkipVCluster {
-		cluster, err = vcluster.New(ctx, host)
+		cluster, err = vcluster.New(ctx, host.RESTConfig())
 		require.NoError(t, err)
 		config = cluster.RESTConfig()
 	}

--- a/pkg/vcluster/vcluster_test.go
+++ b/pkg/vcluster/vcluster_test.go
@@ -16,10 +16,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/vcluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+	"github.com/redpanda-data/redpanda-operator/pkg/vcluster"
 )
 
 func TestIntegrationVCluster(t *testing.T) {
@@ -30,7 +30,7 @@ func TestIntegrationVCluster(t *testing.T) {
 	host, err := k3d.GetShared()
 	require.NoError(t, err)
 
-	cluster, err := vcluster.New(ctx, host)
+	cluster, err := vcluster.New(ctx, host.RESTConfig())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
This adds vcluster support to harpoon. It adds both a tag that can be used for individual features or a helper that can be used on a teating.T for swapping into a vcluster, similar to what we've done for namespace isolation in our acceptance tests. I will plumb this into the acceptance tests once this lands and is backported (as at least v25.1.x should be using a local require override).