### PR TITLE
redpanda/client: fix schema registry client

### DIFF
--- a/charts/redpanda/client/client.go
+++ b/charts/redpanda/client/client.go
@@ -162,7 +162,7 @@ func SchemaRegistryClient(dot *helmette.Dot, dialer DialContextFunc, opts ...sr.
 		copts = append(copts, sr.BasicAuth(username, password))
 	}
 
-	records, err := srvLookup(dot, dialer, redpanda.InternalAdminAPIPortName)
+	records, err := srvLookup(dot, dialer, redpanda.InternalSchemaRegistryPortName)
 	if err != nil {
 		return nil, err
 	}

--- a/charts/redpanda/client/outofclusterdns_integration.go
+++ b/charts/redpanda/client/outofclusterdns_integration.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || acceptance
 
 package client
 


### PR DESCRIPTION
This commit corrects a typo in 0d805848bc39370787edd687a198dffcef551f5a where `SchemaRegistryClient` was incorrectly referencing the AdminAPI port.

It adds regression tests by replacing the old portforwarding tests with the SchemaRegistryClient method.

Additionally it allows out of cluster DNS when either the `integration` OR `acceptance` build tags are specified as our acceptance suite uses these helpers.