### PR TITLE
[WIP] Use v25 rendering pipeline in operator

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -195,9 +195,8 @@ require (
 	github.com/redpanda-data/common-go/net v0.1.0 // indirect
 	github.com/redpanda-data/common-go/secrets v0.1.3 // indirect
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 // indirect
-	github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 // indirect
-	github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 // indirect
-	github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7 // indirect
+	github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.1.0 // indirect
+	github.com/redpanda-data/redpanda-operator/charts/redpanda/v25 v25.0.0 // indirect
 	github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0 // indirect
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -720,14 +720,8 @@ github.com/redpanda-data/common-go/secrets v0.1.3 h1:VRo+OFS4Zgb2UMvwcIuUujdMhAP
 github.com/redpanda-data/common-go/secrets v0.1.3/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
-github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 h1:aSlJX+HNh9C9NKA0+xp9DfYwfVs1fp4tkFaZS9DUkXM=
-github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:o6FEj/SPoAxl6Rn1X9+XO1tlzSl2V64vAiBDgHntfVc=
-github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 h1:HIkLbEDKeCALHFytZdHfeWYo/9JMa1yh4QlsIlhlsB8=
-github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:Sof2HY8U+RLesHJInGLoqhUMzN8iN8gUHXALbROsew8=
 github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.1.0 h1:6jvBn+Xr1+62BEFSHoKxayRM/Xt9hp6O5nhnE368ge4=
 github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.1.0/go.mod h1:y/8tR/cBC11uDPvjosxT8DAxnuSlPWtEzVYeCAqa4K4=
-github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7 h1:D7ME2mDh8/e14VEAj0cIZQfVgyuluHz8Nw9yhZbcKVo=
-github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7/go.mod h1:D8MfzGr+oPWOUNnDEezKSJyHRKvDpGb6NZS0bJdQnds=
 github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0 h1:IV2Ic66JDKPtCnNU4Kn1naJlzZmhl0izRj17qgTCo20=
 github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0/go.mod h1:usCpPzzzhgtPrRTiUQOzFqGmukce8U0SrzEeX2ONDFE=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 h1:SbcvWTYFEbH5+NQOl1To5jppEa8RCK1HAkRNfhdUGLg=

--- a/charts/redpanda/chart/templates/_render_state.go.tpl
+++ b/charts/redpanda/chart/templates/_render_state.go.tpl
@@ -10,16 +10,16 @@
 {{- break -}}
 {{- end -}}
 {{- $secretName := (printf "%s-bootstrap-user" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r")) -}}
-{{- $_97_existing_1_ok_2 := (get (fromJson (include "_shims.lookup" (dict "a" (list "v1" "Secret" $r.Release.Namespace $secretName)))) "r") -}}
-{{- $existing_1 := (index $_97_existing_1_ok_2 0) -}}
-{{- $ok_2 := (index $_97_existing_1_ok_2 1) -}}
+{{- $_98_existing_1_ok_2 := (get (fromJson (include "_shims.lookup" (dict "a" (list "v1" "Secret" $r.Release.Namespace $secretName)))) "r") -}}
+{{- $existing_1 := (index $_98_existing_1_ok_2 0) -}}
+{{- $ok_2 := (index $_98_existing_1_ok_2 1) -}}
 {{- if $ok_2 -}}
 {{- $_ := (set $existing_1 "immutable" true) -}}
 {{- $_ := (set $r "BootstrapUserSecret" $existing_1) -}}
 {{- $selector := (get (fromJson (include "redpanda.BootstrapUser.SecretKeySelector" (dict "a" (list $r.Values.auth.sasl.bootstrapUser (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
-{{- $_114_data_3_found_4 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $existing_1.data $selector.key (coalesce nil))))) "r") -}}
-{{- $data_3 := (index $_114_data_3_found_4 0) -}}
-{{- $found_4 := (index $_114_data_3_found_4 1) -}}
+{{- $_115_data_3_found_4 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $existing_1.data $selector.key (coalesce nil))))) "r") -}}
+{{- $data_3 := (index $_115_data_3_found_4 0) -}}
+{{- $found_4 := (index $_115_data_3_found_4 1) -}}
 {{- if $found_4 -}}
 {{- $_ := (set $r "BootstrapUserPassword" (toString $data_3)) -}}
 {{- end -}}
@@ -32,9 +32,9 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- if $r.Release.IsUpgrade -}}
-{{- $_129_existing_5_ok_6 := (get (fromJson (include "_shims.lookup" (dict "a" (list "apps/v1" "StatefulSet" $r.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
-{{- $existing_5 := (index $_129_existing_5_ok_6 0) -}}
-{{- $ok_6 := (index $_129_existing_5_ok_6 1) -}}
+{{- $_130_existing_5_ok_6 := (get (fromJson (include "_shims.lookup" (dict "a" (list "apps/v1" "StatefulSet" $r.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
+{{- $existing_5 := (index $_130_existing_5_ok_6 0) -}}
+{{- $ok_6 := (index $_130_existing_5_ok_6 1) -}}
 {{- if (and $ok_6 (gt ((get (fromJson (include "_shims.len" (dict "a" (list $existing_5.spec.template.metadata.labels)))) "r") | int) (0 | int))) -}}
 {{- $_ := (set $r "StatefulSetPodLabels" $existing_5.spec.template.metadata.labels) -}}
 {{- $_ := (set $r "StatefulSetSelector" $existing_5.spec.selector.matchLabels) -}}

--- a/charts/redpanda/chart/templates/_statefulset.go.tpl
+++ b/charts/redpanda/chart/templates/_statefulset.go.tpl
@@ -305,7 +305,7 @@
 {{- $mounts = (concat (default (list) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" $name "mountPath" $cacheDir)))) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" `set-tiered-storage-cache-dir-ownership` "image" (printf `%s:%s` $state.Values.statefulset.initContainerImage.repository $state.Values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `mkdir -p %s; chown %d:%d -R %s` $cacheDir $uid $gid $cacheDir)) "securityContext" (mustMergeOverwrite (dict) (dict "runAsUser" (0 | int64) "runAsGroup" (0 | int64))) "volumeMounts" $mounts))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "set-tiered-storage-cache-dir-ownership" "image" (printf `%s:%s` $state.Values.statefulset.initContainerImage.repository $state.Values.statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `mkdir -p %s; chown %d:%d -R %s` $cacheDir $uid $gid $cacheDir)) "securityContext" (mustMergeOverwrite (dict) (dict "runAsUser" (0 | int64) "runAsGroup" (0 | int64))) "volumeMounts" $mounts))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/chart/templates/_values.go.tpl
+++ b/charts/redpanda/chart/templates/_values.go.tpl
@@ -151,13 +151,13 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- if (and (ne (toJson $rr.limits) "null") (ne (toJson $rr.requests) "null")) -}}
-{{- $_424_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.requests) "cpu" "0")))) "r") -}}
-{{- $cpuReq := (index $_424_cpuReq_ok 0) -}}
-{{- $ok := (index $_424_cpuReq_ok 1) -}}
+{{- $_439_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.requests) "cpu" "0")))) "r") -}}
+{{- $cpuReq := (index $_439_cpuReq_ok 0) -}}
+{{- $ok := (index $_439_cpuReq_ok 1) -}}
 {{- if (not $ok) -}}
-{{- $_426_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.limits) "cpu" "0")))) "r") -}}
-{{- $cpuReq = (index $_426_cpuReq_ok 0) -}}
-{{- $ok = (index $_426_cpuReq_ok 1) -}}
+{{- $_441_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.limits) "cpu" "0")))) "r") -}}
+{{- $cpuReq = (index $_441_cpuReq_ok 0) -}}
+{{- $ok = (index $_441_cpuReq_ok 1) -}}
 {{- end -}}
 {{- if (and $ok (lt ((get (fromJson (include "_shims.resource_MilliValue" (dict "a" (list $cpuReq)))) "r") | int64) (1000 | int64))) -}}
 {{- $_is_returning = true -}}
@@ -184,13 +184,13 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- if (and (ne (toJson $rr.limits) "null") (ne (toJson $rr.requests) "null")) -}}
-{{- $_450_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.requests) "cpu" "0")))) "r") -}}
-{{- $cpuReq := (index $_450_cpuReq_ok 0) -}}
-{{- $ok := (index $_450_cpuReq_ok 1) -}}
+{{- $_465_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.requests) "cpu" "0")))) "r") -}}
+{{- $cpuReq := (index $_465_cpuReq_ok 0) -}}
+{{- $ok := (index $_465_cpuReq_ok 1) -}}
 {{- if (not $ok) -}}
-{{- $_452_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.limits) "cpu" "0")))) "r") -}}
-{{- $cpuReq = (index $_452_cpuReq_ok 0) -}}
-{{- $ok = (index $_452_cpuReq_ok 1) -}}
+{{- $_467_cpuReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.limits) "cpu" "0")))) "r") -}}
+{{- $cpuReq = (index $_467_cpuReq_ok 0) -}}
+{{- $ok = (index $_467_cpuReq_ok 1) -}}
 {{- end -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
@@ -222,13 +222,13 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- if (and (ne (toJson $rr.limits) "null") (ne (toJson $rr.requests) "null")) -}}
-{{- $_509_memReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.requests) "memory" "0")))) "r") -}}
-{{- $memReq := (index $_509_memReq_ok 0) -}}
-{{- $ok := (index $_509_memReq_ok 1) -}}
+{{- $_524_memReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.requests) "memory" "0")))) "r") -}}
+{{- $memReq := (index $_524_memReq_ok 0) -}}
+{{- $ok := (index $_524_memReq_ok 1) -}}
 {{- if (not $ok) -}}
-{{- $_511_memReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.limits) "memory" "0")))) "r") -}}
-{{- $memReq = (index $_511_memReq_ok 0) -}}
-{{- $ok = (index $_511_memReq_ok 1) -}}
+{{- $_526_memReq_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list ($rr.limits) "memory" "0")))) "r") -}}
+{{- $memReq = (index $_526_memReq_ok 0) -}}
+{{- $ok = (index $_526_memReq_ok 1) -}}
 {{- end -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
@@ -304,9 +304,9 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $conf := (get (fromJson (include "redpanda.Storage.GetTieredStorageConfig" (dict "a" (list $s)))) "r") -}}
-{{- $_629_b_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $conf "cloud_storage_enabled" (coalesce nil))))) "r") -}}
-{{- $b := (index $_629_b_ok 0) -}}
-{{- $ok := (index $_629_b_ok 1) -}}
+{{- $_644_b_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $conf "cloud_storage_enabled" (coalesce nil))))) "r") -}}
+{{- $b := (index $_644_b_ok 0) -}}
+{{- $ok := (index $_644_b_ok 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $ok (get (fromJson (include "_shims.typeassertion" (dict "a" (list "bool" $b)))) "r"))) | toJson -}}
 {{- break -}}
@@ -350,18 +350,18 @@
 {{- $state := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_657_dir_7_ok_8 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $state.Values.config.node "cloud_storage_cache_directory") "")))) "r") -}}
-{{- $dir_7 := (index $_657_dir_7_ok_8 0) -}}
-{{- $ok_8 := (index $_657_dir_7_ok_8 1) -}}
+{{- $_672_dir_7_ok_8 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $state.Values.config.node "cloud_storage_cache_directory") "")))) "r") -}}
+{{- $dir_7 := (index $_672_dir_7_ok_8 0) -}}
+{{- $ok_8 := (index $_672_dir_7_ok_8 1) -}}
 {{- if $ok_8 -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $dir_7) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- $tieredConfig := (get (fromJson (include "redpanda.Storage.GetTieredStorageConfig" (dict "a" (list $state.Values.storage)))) "r") -}}
-{{- $_666_dir_9_ok_10 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $tieredConfig "cloud_storage_cache_directory") "")))) "r") -}}
-{{- $dir_9 := (index $_666_dir_9_ok_10 0) -}}
-{{- $ok_10 := (index $_666_dir_9_ok_10 1) -}}
+{{- $_681_dir_9_ok_10 := (get (fromJson (include "_shims.typetest" (dict "a" (list "string" (index $tieredConfig "cloud_storage_cache_directory") "")))) "r") -}}
+{{- $dir_9 := (index $_681_dir_9_ok_10 0) -}}
+{{- $ok_10 := (index $_681_dir_9_ok_10 1) -}}
 {{- if $ok_10 -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $dir_9) | toJson -}}
@@ -461,9 +461,9 @@
 {{- $result := (dict) -}}
 {{- $s := (toJson $t) -}}
 {{- $tune := (fromJson $s) -}}
-{{- $_812_m_ok := (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $tune (coalesce nil))))) "r") -}}
-{{- $m := (index $_812_m_ok 0) -}}
-{{- $ok := (index $_812_m_ok 1) -}}
+{{- $_827_m_ok := (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $tune (coalesce nil))))) "r") -}}
+{{- $m := (index $_827_m_ok 0) -}}
+{{- $ok := (index $_827_m_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (dict)) | toJson -}}
@@ -639,9 +639,9 @@
 {{- $seen := (dict) -}}
 {{- $deduped := (coalesce nil) -}}
 {{- range $_, $item := $items -}}
-{{- $_971___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
-{{- $_ := (index $_971___ok_11 0) -}}
-{{- $ok_11 := (index $_971___ok_11 1) -}}
+{{- $_986___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
+{{- $_ := (index $_986___ok_11 0) -}}
+{{- $ok_11 := (index $_986___ok_11 1) -}}
 {{- if $ok_11 -}}
 {{- continue -}}
 {{- end -}}
@@ -753,9 +753,9 @@
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1192_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
-{{- $cert := (index $_1192_cert_ok 0) -}}
-{{- $ok := (index $_1192_cert_ok 1) -}}
+{{- $_1207_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
+{{- $cert := (index $_1207_cert_ok 0) -}}
+{{- $ok := (index $_1207_cert_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
@@ -1165,9 +1165,9 @@
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_1641___ok_14 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
-{{- $_ := ((index $_1641___ok_14 0) | float64) -}}
-{{- $ok_14 := (index $_1641___ok_14 1) -}}
+{{- $_1656___ok_14 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
+{{- $_ := ((index $_1656___ok_14 0) | float64) -}}
+{{- $ok_14 := (index $_1656___ok_14 1) -}}
 {{- if $ok_14 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
@@ -1193,9 +1193,9 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
-{{- $_1661_b_15_ok_16 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
-{{- $b_15 := (index $_1661_b_15_ok_16 0) -}}
-{{- $ok_16 := (index $_1661_b_15_ok_16 1) -}}
+{{- $_1676_b_15_ok_16 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
+{{- $b_15 := (index $_1676_b_15_ok_16 0) -}}
+{{- $ok_16 := (index $_1676_b_15_ok_16 1) -}}
 {{- if $ok_16 -}}
 {{- $_ := (set $result $k $b_15) -}}
 {{- continue -}}
@@ -1238,15 +1238,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1706___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1706___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_1706___hasAccessKey 1) -}}
-{{- $_1707___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1707___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_1707___hasSecretKey 1) -}}
-{{- $_1708___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1708___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_1708___hasSharedKey 1) -}}
+{{- $_1721___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1721___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_1721___hasAccessKey 1) -}}
+{{- $_1722___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1722___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_1722___hasSecretKey 1) -}}
+{{- $_1723___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1723___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_1723___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey)))) "r")) -}}
 {{- $envvars = (concat (default (list) $envvars) (list (mustMergeOverwrite (dict "name" "") (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey)))) "r"))))) -}}
@@ -1269,12 +1269,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1744___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1744___containerExists 0) -}}
-{{- $containerExists := (index $_1744___containerExists 1) -}}
-{{- $_1745___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1745___accountExists 0) -}}
-{{- $accountExists := (index $_1745___accountExists 1) -}}
+{{- $_1759___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1759___containerExists 0) -}}
+{{- $containerExists := (index $_1759___containerExists 1) -}}
+{{- $_1760___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1760___accountExists 0) -}}
+{{- $accountExists := (index $_1760___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1285,9 +1285,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1750_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
-{{- $value := (index $_1750_value_ok 0) -}}
-{{- $ok := (index $_1750_value_ok 1) -}}
+{{- $_1765_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
+{{- $value := (index $_1765_value_ok 0) -}}
+{{- $ok := (index $_1765_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -991,7 +991,8 @@ func TestLabels(t *testing.T) {
 		}, helmValues)
 		require.NoError(t, err)
 
-		state := redpanda.RenderStateFromDot(dot)
+		state, err := redpanda.RenderStateFromDot(dot)
+		require.NoError(t, err)
 
 		manifests, err := client.Template(ctx, "./chart", helm.TemplateOptions{
 			Name:      dot.Release.Name,

--- a/charts/redpanda/client_test.go
+++ b/charts/redpanda/client_test.go
@@ -51,7 +51,8 @@ func newClient(t *testing.T, ctl *kube.Ctl, release *helm.Release, values any) *
 	)
 	require.NoError(t, err)
 
-	state := redpanda.RenderStateFromDot(dot)
+	state, err := redpanda.RenderStateFromDot(dot)
+	require.NoError(t, err)
 
 	return &Client{Ctl: ctl, state: state}
 }

--- a/charts/redpanda/render_state_test.go
+++ b/charts/redpanda/render_state_test.go
@@ -104,7 +104,8 @@ func TestCertificates(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			state := RenderStateFromDot(dot)
+			state, err := RenderStateFromDot(dot)
+			require.NoError(t, err)
 
 			actualRootCertName, actualRootCertKey, actualClientCertName := certificatesFor(state, c.CertificateName)
 			require.Equal(t, c.ExpectedRootCertName, actualRootCertName)

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -344,7 +344,7 @@ func statefulSetInitContainerTuning(state *RenderState) *corev1.Container {
 	}
 
 	return &corev1.Container{
-		Name:  "tuning",
+		Name:  RedpandaTuningContainerName,
 		Image: fmt.Sprintf("%s:%s", state.Values.Image.Repository, Tag(state)),
 		Command: []string{
 			`/bin/bash`,
@@ -377,7 +377,7 @@ func statefulSetInitContainerSetDataDirOwnership(state *RenderState) *corev1.Con
 	uid, gid := securityContextUidGid(state, "set-datadir-ownership")
 
 	return &corev1.Container{
-		Name:  "set-datadir-ownership",
+		Name:  SetDataDirectoryOwnershipContainerName,
 		Image: fmt.Sprintf("%s:%s", state.Values.Statefulset.InitContainerImage.Repository, state.Values.Statefulset.InitContainerImage.Tag),
 		Command: []string{
 			`/bin/sh`,
@@ -452,7 +452,7 @@ func statefulSetInitContainerFSValidator(state *RenderState) *corev1.Container {
 	}
 
 	return &corev1.Container{
-		Name:    "fs-validator",
+		Name:    FSValidatorContainerName,
 		Image:   fmt.Sprintf("%s:%s", state.Values.Image.Repository, Tag(state)),
 		Command: []string{`/bin/sh`},
 		Args: []string{
@@ -499,7 +499,7 @@ func statefulSetInitContainerSetTieredStorageCacheDirOwnership(state *RenderStat
 	}
 
 	return &corev1.Container{
-		Name:  `set-tiered-storage-cache-dir-ownership`,
+		Name:  SetTieredStorageCacheOwnershipContainerName,
 		Image: fmt.Sprintf(`%s:%s`, state.Values.Statefulset.InitContainerImage.Repository, state.Values.Statefulset.InitContainerImage.Tag),
 		Command: []string{
 			`/bin/sh`,
@@ -845,7 +845,7 @@ func statefulSetContainerSidecar(state *RenderState) *corev1.Container {
 	)
 
 	return &corev1.Container{
-		Name:         "sidecar",
+		Name:         SidecarContainerName,
 		Image:        fmt.Sprintf(`%s:%s`, state.Values.Statefulset.SideCars.Image.Repository, state.Values.Statefulset.SideCars.Image.Tag),
 		Command:      []string{`/redpanda-operator`},
 		Args:         append([]string{`supervisor`, `--`}, args...),

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -39,6 +39,9 @@ const (
 	// RedpandaContainerName is the user facing name of the redpanda container
 	// in the redpanda StatefulSet.
 	RedpandaContainerName = "redpanda"
+	// SidecarContainerName is the user facing name of the sidecar container
+	// in the redpanda StatefulSet.
+	SidecarContainerName = "sidecar"
 	// PostUpgradeContainerName is the user facing name of the post-install
 	// job's container.
 	PostInstallContainerName = "post-install"
@@ -48,6 +51,18 @@ const (
 	// RedpandaConfiguratorContainerName is the user facing name of the
 	// redpanda-configurator init container in the redpanda StatefulSet.
 	RedpandaConfiguratorContainerName = "redpanda-configurator"
+	// RedpandaTuningContainerName is the user facing name of the
+	// tuning init container in the redpanda StatefulSet.
+	RedpandaTuningContainerName = "tuning"
+	// SetDataDirectoryOwnershipContainerName is the user facing name of the
+	// set-datadir-ownership init container in the redpanda StatefulSet.
+	SetDataDirectoryOwnershipContainerName = "set-datadir-ownership"
+	// SetTieredStorageCacheOwnershipContainerName is the user facing name of the
+	// set-tiered-storage-cache-dir-ownership init container in the redpanda StatefulSet.
+	SetTieredStorageCacheOwnershipContainerName = "set-tiered-storage-cache-dir-ownership"
+	// FSValidatorContainerName is the user facing name of the
+	// fs-validator init container in the redpanda StatefulSet.
+	FSValidatorContainerName = "fs-validator"
 
 	// certificateMountPoint is a common mount point for any TLS certificate
 	// defined as external truststore or as certificate that would be

--- a/gen/go.sum
+++ b/gen/go.sum
@@ -510,12 +510,6 @@ github.com/redpanda-data/common-go/secrets v0.1.3 h1:VRo+OFS4Zgb2UMvwcIuUujdMhAP
 github.com/redpanda-data/common-go/secrets v0.1.3/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
-github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 h1:aSlJX+HNh9C9NKA0+xp9DfYwfVs1fp4tkFaZS9DUkXM=
-github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:o6FEj/SPoAxl6Rn1X9+XO1tlzSl2V64vAiBDgHntfVc=
-github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 h1:HIkLbEDKeCALHFytZdHfeWYo/9JMa1yh4QlsIlhlsB8=
-github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:Sof2HY8U+RLesHJInGLoqhUMzN8iN8gUHXALbROsew8=
-github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7 h1:D7ME2mDh8/e14VEAj0cIZQfVgyuluHz8Nw9yhZbcKVo=
-github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7/go.mod h1:D8MfzGr+oPWOUNnDEezKSJyHRKvDpGb6NZS0bJdQnds=
 github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0 h1:IV2Ic66JDKPtCnNU4Kn1naJlzZmhl0izRj17qgTCo20=
 github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0/go.mod h1:usCpPzzzhgtPrRTiUQOzFqGmukce8U0SrzEeX2ONDFE=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 h1:SbcvWTYFEbH5+NQOl1To5jppEa8RCK1HAkRNfhdUGLg=

--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 
-	redpandav5 "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	redpandav5 "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )

--- a/operator/api/redpanda/v1alpha2/redpanda_types_test.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/redpanda-operator/charts/console/v3"
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"

--- a/operator/chart/chart_test.go
+++ b/operator/chart/chart_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/cmd/run"

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/redpanda-data/common-go/secrets v0.1.3
 	github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20
 	github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.1.0
-	github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7
+	github.com/redpanda-data/redpanda-operator/charts/redpanda/v25 v25.0.0
 	github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0
-	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250328114403-0fc6b9d24a38
+	github.com/redpanda-data/redpanda-operator/pkg v0.0.0-20250528175436-e8cca0053dc6
 	github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/scalalang2/golang-fifo v1.0.2
@@ -246,8 +246,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22 // indirect
-	github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 // indirect
-	github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rubenv/sql-migrate v1.8.0 // indirect

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -707,14 +707,8 @@ github.com/redpanda-data/common-go/secrets v0.1.3 h1:VRo+OFS4Zgb2UMvwcIuUujdMhAP
 github.com/redpanda-data/common-go/secrets v0.1.3/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20 h1:+zsE3W1V86k2sjAGWOySIlF0xn5R1aXXQBaIdr80F48=
 github.com/redpanda-data/console/backend v0.0.0-20240303221210-05d5d9e85f20/go.mod h1:DC42/3+k5PefSo4IalYbDN3yRZrVFP0b69+gC/NwGd4=
-github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8 h1:aSlJX+HNh9C9NKA0+xp9DfYwfVs1fp4tkFaZS9DUkXM=
-github.com/redpanda-data/redpanda-operator/charts/connectors v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:o6FEj/SPoAxl6Rn1X9+XO1tlzSl2V64vAiBDgHntfVc=
-github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8 h1:HIkLbEDKeCALHFytZdHfeWYo/9JMa1yh4QlsIlhlsB8=
-github.com/redpanda-data/redpanda-operator/charts/console v0.0.0-20250407180246-dc814fb6b3b8/go.mod h1:Sof2HY8U+RLesHJInGLoqhUMzN8iN8gUHXALbROsew8=
 github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.1.0 h1:6jvBn+Xr1+62BEFSHoKxayRM/Xt9hp6O5nhnE368ge4=
 github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.1.0/go.mod h1:y/8tR/cBC11uDPvjosxT8DAxnuSlPWtEzVYeCAqa4K4=
-github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7 h1:D7ME2mDh8/e14VEAj0cIZQfVgyuluHz8Nw9yhZbcKVo=
-github.com/redpanda-data/redpanda-operator/charts/redpanda/v5 v5.10.5-0.20250813202210-1c00a87f10f7/go.mod h1:D8MfzGr+oPWOUNnDEezKSJyHRKvDpGb6NZS0bJdQnds=
 github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0 h1:IV2Ic66JDKPtCnNU4Kn1naJlzZmhl0izRj17qgTCo20=
 github.com/redpanda-data/redpanda-operator/gotohelm v1.1.0/go.mod h1:usCpPzzzhgtPrRTiUQOzFqGmukce8U0SrzEeX2ONDFE=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 h1:SbcvWTYFEbH5+NQOl1To5jppEa8RCK1HAkRNfhdUGLg=

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -39,7 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
@@ -988,7 +988,8 @@ func TestPostInstallUpgradeJobIndex(t *testing.T) {
 	dot, err := redpandachart.Chart.Dot(nil, helmette.Release{}, map[string]any{})
 	require.NoError(t, err)
 
-	job := redpandachart.PostInstallUpgradeJob(dot)
+	state := &redpandachart.RenderState{Dot: dot, Values: helmette.Unwrap[redpandachart.Values](dot.Values), Chart: &dot.Chart, Files: &dot.Files, Release: &dot.Release}
+	job := redpandachart.PostInstallUpgradeJob(state)
 
 	// Assert that index 0 is the envsubst container as that's what
 	// `clusterConfigfor` utilizes.

--- a/operator/internal/controller/vectorized/cluster_controller.go
+++ b/operator/internal/controller/vectorized/cluster_controller.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/feature"

--- a/operator/internal/controller/vectorized/cluster_controller_test.go
+++ b/operator/internal/controller/vectorized/cluster_controller_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"

--- a/operator/internal/lifecycle/v2_node_pools.go
+++ b/operator/internal/lifecycle/v2_node_pools.go
@@ -11,15 +11,18 @@ package lifecycle
 
 import (
 	"context"
+	"encoding/json"
 
 	appsv1 "k8s.io/api/apps/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	redpandav1alpha3 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha3"
 	"github.com/redpanda-data/redpanda-operator/pkg/kube"
 )
 
@@ -96,33 +99,14 @@ func (m *V2NodePoolRenderer) Render(ctx context.Context, cluster *ClusterWithPoo
 		spec.Statefulset.InitContainers.Configurator.AdditionalCLIArgs = m.cloudSecrets.AdditionalConfiguratorArgs()
 	}
 
-	// TODO: upgrade the chart to redpanda/v25 by performing a conversion of
-	// v1alpha2 to it's values here.
-	rendered, err := redpanda.Chart.Render(m.kubeConfig, helmette.Release{
-		Namespace: cluster.Namespace,
-		Name:      cluster.GetHelmReleaseName(),
-		Service:   "Helm",
-		IsUpgrade: true,
-	}, spec)
+	state, err := constructRenderState(m.kubeConfig, cluster.Namespace, cluster.GetHelmReleaseName(), spec, cluster.NodePools)
 	if err != nil {
 		return nil, err
 	}
 
-	resources := []*appsv1.StatefulSet{}
-
-	// filter out non-nodepools
-	for _, object := range rendered {
-		if isNodePool(object) {
-			resources = append(resources, object.(*appsv1.StatefulSet))
-		}
-	}
-
-	return resources, nil
+	return redpanda.RenderNodePools(state)
 }
 
-// isNodePool returns whether or not the object passed to it should be considered a node pool.
-// For now, this concrete implementation just looks for any StatefulSets and says that they are a
-// node pool.
 func isNodePool(object client.Object) bool {
 	_, ok := object.(*appsv1.StatefulSet)
 	return ok
@@ -145,4 +129,254 @@ func defaultImage(base *redpandav1alpha2.RedpandaImage, default_ Image) *redpand
 		Repository: ptr.To(ptr.Deref(base.Repository, default_.Repository)),
 		Tag:        ptr.To(ptr.Deref(base.Tag, default_.Tag)),
 	}
+}
+
+func constructRenderState(config *kube.RESTConfig, namespace, release string, spec *redpandav1alpha2.RedpandaClusterSpec, pools []*redpandav1alpha3.NodePool) (*redpanda.RenderState, error) {
+	dot, err := redpanda.Chart.Dot(config, helmette.Release{
+		Namespace: namespace,
+		Name:      release,
+		Service:   "Helm",
+		IsUpgrade: true,
+	}, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return redpanda.RenderStateFromDot(dot, func(values redpanda.Values) error {
+		if values.PodTemplate.Spec == nil {
+			values.PodTemplate.Spec = &applycorev1.PodSpecApplyConfiguration{}
+		}
+		if spec.NodeSelector != nil {
+			values.PodTemplate.Spec.NodeSelector = spec.NodeSelector
+		}
+		if spec.Affinity != nil {
+			if values.PodTemplate.Spec.Affinity == nil {
+				values.PodTemplate.Spec.Affinity = &applycorev1.AffinityApplyConfiguration{}
+			}
+			if err := convertJSON(spec.Affinity, values.PodTemplate.Spec.Affinity); err != nil {
+				return err
+			}
+		}
+		if spec.Tolerations != nil {
+			if values.PodTemplate.Spec.Tolerations == nil {
+				values.PodTemplate.Spec.Tolerations = []applycorev1.TolerationApplyConfiguration{}
+			}
+			if err := convertJSON(spec.Tolerations, &values.PodTemplate.Spec.Tolerations); err != nil {
+				return err
+			}
+		}
+		if spec.ImagePullSecrets != nil {
+			if values.PodTemplate.Spec.ImagePullSecrets == nil {
+				values.PodTemplate.Spec.ImagePullSecrets = []applycorev1.LocalObjectReferenceApplyConfiguration{}
+			}
+			if err := convertJSON(spec.ImagePullSecrets, &values.PodTemplate.Spec.ImagePullSecrets); err != nil {
+				return err
+			}
+		}
+		if spec.Statefulset != nil {
+			if values.Statefulset.PodTemplate.Spec == nil {
+				values.Statefulset.PodTemplate.Spec = &applycorev1.PodSpecApplyConfiguration{}
+			}
+			if values.Statefulset.PodTemplate.Spec.Containers == nil {
+				values.Statefulset.PodTemplate.Spec.Containers = []applycorev1.ContainerApplyConfiguration{}
+			}
+			if values.Statefulset.PodTemplate.Spec.InitContainers == nil {
+				values.Statefulset.PodTemplate.Spec.InitContainers = []applycorev1.ContainerApplyConfiguration{}
+			}
+
+			redpandaContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.Containers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.RedpandaContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.RedpandaContainerName),
+			})
+			sidecarContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.Containers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.SidecarContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.SidecarContainerName),
+			})
+			configuratorContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.RedpandaConfiguratorContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.RedpandaConfiguratorContainerName),
+			})
+			tuningContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.RedpandaTuningContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.RedpandaTuningContainerName),
+			})
+			setDataDirectoryContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.SetDataDirectoryOwnershipContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.SetDataDirectoryOwnershipContainerName),
+			})
+			setTieredStorageDirectoryContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.SetTieredStorageCacheOwnershipContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.SetTieredStorageCacheOwnershipContainerName),
+			})
+			fsValidatorContainer := firstOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
+				return ptr.Deref(c.Name, "") == redpanda.FSValidatorContainerName
+			}, applycorev1.ContainerApplyConfiguration{
+				Name: ptr.To(redpanda.FSValidatorContainerName),
+			})
+
+			if spec.Statefulset.Annotations != nil {
+				values.Statefulset.PodTemplate.Annotations = spec.Statefulset.Annotations
+			}
+			if spec.Statefulset.LivenessProbe != nil {
+				if err := convertJSON(spec.Statefulset.LivenessProbe, redpandaContainer.LivenessProbe); err != nil {
+					return err
+				}
+			}
+			if spec.Statefulset.StartupProbe != nil {
+				if err := convertJSON(spec.Statefulset.StartupProbe, redpandaContainer.StartupProbe); err != nil {
+					return err
+				}
+			}
+			if spec.Statefulset.ReadinessProbe != nil {
+				if err := convertJSON(spec.Statefulset.ReadinessProbe, sidecarContainer.ReadinessProbe); err != nil {
+					return err
+				}
+			}
+			if spec.Statefulset.PodAffinity != nil {
+				if values.Statefulset.PodTemplate.Spec.Affinity == nil {
+					values.Statefulset.PodTemplate.Spec.Affinity = &applycorev1.AffinityApplyConfiguration{}
+				}
+				if err := convertJSON(spec.Statefulset.PodAffinity, values.Statefulset.PodTemplate.Spec.Affinity); err != nil {
+					return err
+				}
+			}
+			if spec.Statefulset.NodeSelector != nil {
+				values.Statefulset.PodTemplate.Spec.NodeSelector = spec.Statefulset.NodeSelector
+			}
+			if spec.Statefulset.PriorityClassName != nil {
+				values.Statefulset.PodTemplate.Spec.PriorityClassName = spec.Statefulset.PriorityClassName
+			}
+			if spec.Statefulset.Tolerations != nil {
+				tolerations := []applycorev1.TolerationApplyConfiguration{}
+				if err := convertJSON(spec.Statefulset.Tolerations, &tolerations); err != nil {
+					return err
+				}
+				values.Statefulset.PodTemplate.Spec.Tolerations = append(values.Statefulset.PodTemplate.Spec.Tolerations, tolerations...)
+			}
+			if spec.Statefulset.TopologySpreadConstraints != nil {
+				topologyContraints := []applycorev1.TopologySpreadConstraintApplyConfiguration{}
+				if err := convertJSON(spec.Statefulset.TopologySpreadConstraints, &topologyContraints); err != nil {
+					return err
+				}
+				values.Statefulset.PodTemplate.Spec.TopologySpreadConstraints = append(values.Statefulset.PodTemplate.Spec.TopologySpreadConstraints, topologyContraints...)
+			}
+			if spec.Statefulset.TerminationGracePeriodSeconds != nil {
+				values.Statefulset.PodTemplate.Spec.TerminationGracePeriodSeconds = ptr.To[int64](int64(*spec.Statefulset.TerminationGracePeriodSeconds))
+			}
+
+			// TODO: handle these fields as they seem to have been converted from a string to a raw extension array
+			// if spec.Statefulset.ExtraVolumes != nil {
+			// 	if values.Statefulset.PodTemplate.Spec.Volumes == nil {
+			// 		values.Statefulset.PodTemplate.Spec.Volumes = []applycorev1.VolumeApplyConfiguration{}
+			// 	}
+			// 	if err := convertJSON(spec.Statefulset.ExtraVolumes, &values.Statefulset.PodTemplate.Spec.Volumes); err != nil {
+			// 		return err
+			// 	}
+			// }
+
+			if spec.Statefulset.InitContainers != nil {
+				if spec.Statefulset.InitContainers.ExtraInitContainers != nil {
+					extraContainers := []applycorev1.ContainerApplyConfiguration{}
+					if err := convertJSON(spec.Statefulset.InitContainers.ExtraInitContainers, &extraContainers); err != nil {
+						return err
+					}
+					values.Statefulset.PodTemplate.Spec.InitContainers = append(values.Statefulset.PodTemplate.Spec.InitContainers, extraContainers...)
+				}
+
+				if spec.Statefulset.InitContainers.Configurator != nil {
+					if spec.Statefulset.InitContainers.Configurator.Resources != nil {
+						if err := convertJSON(spec.Statefulset.InitContainers.Configurator.Resources, configuratorContainer.Resources); err != nil {
+							return err
+						}
+					}
+					// TODO: volume mounts as they go from a string to an array
+				}
+				if spec.Statefulset.InitContainers.Tuning != nil {
+					if spec.Statefulset.InitContainers.Tuning.Resources != nil {
+						if err := convertJSON(spec.Statefulset.InitContainers.Tuning.Resources, tuningContainer.Resources); err != nil {
+							return err
+						}
+					}
+					// TODO: volume mounts as they go from a string to an array
+				}
+				if spec.Statefulset.InitContainers.SetDataDirOwnership != nil {
+					if spec.Statefulset.InitContainers.SetDataDirOwnership.Resources != nil {
+						if err := convertJSON(spec.Statefulset.InitContainers.SetDataDirOwnership.Resources, setDataDirectoryContainer.Resources); err != nil {
+							return err
+						}
+					}
+					// TODO: volume mounts as they go from a string to an array
+				}
+				if spec.Statefulset.InitContainers.SetTieredStorageCacheDirOwnership != nil {
+					if spec.Statefulset.InitContainers.SetTieredStorageCacheDirOwnership.Resources != nil {
+						if err := convertJSON(spec.Statefulset.InitContainers.SetTieredStorageCacheDirOwnership.Resources, setTieredStorageDirectoryContainer.Resources); err != nil {
+							return err
+						}
+					}
+					// TODO: volume mounts as they go from a string to an array
+				}
+				if spec.Statefulset.InitContainers.FsValidator != nil {
+					if spec.Statefulset.InitContainers.FsValidator.Resources != nil {
+						if err := convertJSON(spec.Statefulset.InitContainers.FsValidator.Resources, fsValidatorContainer.Resources); err != nil {
+							return err
+						}
+					}
+					// TODO: volume mounts as they go from a string to an array
+				}
+
+				// TODO: extra init container conversion as it goes from a string to array
+				// statefulset.initContainers.extraInitContainers -> statefulset.podTemplate.spec.initContainers
+			}
+
+			if spec.Statefulset.SideCars != nil {
+				if spec.Statefulset.SideCars.ConfigWatcher != nil {
+					// TODO: extra volume mounts as they go from a string to an array
+					// statefulset.sidecars.configWatcher.extraVolumeMounts -> statefulset.podTemplate.spec.containers[*].volumeMounts
+					if spec.Statefulset.SideCars.ConfigWatcher.Resources != nil {
+						if err := convertJSON(spec.Statefulset.SideCars.ConfigWatcher.Resources, sidecarContainer.Resources); err != nil {
+							return err
+						}
+					}
+
+					if spec.Statefulset.SideCars.ConfigWatcher.SecurityContext != nil {
+						if sidecarContainer.SecurityContext == nil {
+							sidecarContainer.SecurityContext = &applycorev1.SecurityContextApplyConfiguration{}
+						}
+						if err := convertJSON(spec.Statefulset.SideCars.ConfigWatcher.SecurityContext, sidecarContainer.SecurityContext); err != nil {
+							return err
+						}
+					}
+
+					// TODO: should we handle sidecars.controllers.resources/securityContext? the controllers and sidecar are the same container
+					// TODO: handle extra volume mounts as they go from a string to an array
+					// statefulset.sidecars.configWatcher.extraVolumeMounts -> statefulset.podTemplate.spec.containers[*].volumeMounts
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func convertJSON(from, to any) error {
+	data, err := json.Marshal(from)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, to)
+}
+
+func firstOrInit[T any](slice *[]T, cond func(T) bool, v T) *T {
+	for _, entry := range *slice {
+		if cond(entry) {
+			return &entry
+		}
+	}
+	*slice = append(*slice, v)
+	return &v
 }

--- a/operator/internal/lifecycle/v2_test.go
+++ b/operator/internal/lifecycle/v2_test.go
@@ -27,7 +27,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/yaml"
 
-	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5"
+	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"

--- a/operator/pkg/admin/admin.go
+++ b/operator/pkg/admin/admin.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"

--- a/operator/pkg/client/cluster.go
+++ b/operator/pkg/client/cluster.go
@@ -17,7 +17,8 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
@@ -31,7 +32,11 @@ func (c *Factory) redpandaAdminForCluster(cluster *redpandav1alpha2.Redpanda) (*
 		return nil, err
 	}
 
-	client, err := redpanda.AdminClient(dot, c.dialer, rpadmin.ClientTimeout(c.adminClientTimeout))
+	state, err := redpandachart.RenderStateFromDot(dot)
+	if err != nil {
+		return nil, err
+	}
+	client, err := redpanda.AdminClient(state, c.dialer, rpadmin.ClientTimeout(c.adminClientTimeout))
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +77,11 @@ func (c *Factory) schemaRegistryForCluster(cluster *redpandav1alpha2.Redpanda) (
 		return nil, err
 	}
 
-	client, err := redpanda.SchemaRegistryClient(dot, c.dialer)
+	state, err := redpandachart.RenderStateFromDot(dot)
+	if err != nil {
+		return nil, err
+	}
+	client, err := redpanda.SchemaRegistryClient(state, c.dialer)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +103,11 @@ func (c *Factory) kafkaForCluster(cluster *redpandav1alpha2.Redpanda, opts ...kg
 		return nil, err
 	}
 
-	client, err := redpanda.KafkaClient(dot, c.dialer, opts...)
+	state, err := redpandachart.RenderStateFromDot(dot)
+	if err != nil {
+		return nil, err
+	}
+	client, err := redpanda.KafkaClient(state, c.dialer, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/acls"

--- a/operator/pkg/client/spec_tls.go
+++ b/operator/pkg/client/spec_tls.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"net"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
 )

--- a/operator/pkg/console/admin.go
+++ b/operator/pkg/console/admin.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"

--- a/operator/pkg/console/sasl.go
+++ b/operator/pkg/console/sasl.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -34,7 +34,7 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/clusterconfiguration"

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"

--- a/operator/pkg/resources/statefulset_update_test.go
+++ b/operator/pkg/resources/statefulset_update_test.go
@@ -32,7 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"

--- a/operator/webhooks/redpanda/validate_enterprise_test.go
+++ b/operator/webhooks/redpanda/validate_enterprise_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v5/client"
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	vectorizedcontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"


### PR DESCRIPTION
## Description

This builds off of https://github.com/redpanda-data/redpanda-operator/pull/1054 and does essentially two things:

1. upgrades the operator logic to leverage the local chart and `RenderState`
2. plumbs in the conversion routines based on the 25.1.1 redpanda chart changelog, namely:

- nodeSelector -> podTemplate.spec.nodeSelector
- affinity -> podTemplate.spec.affinity
- tolerations -> podTemplate.spec.tolerations
- imagePullSecrets -> podTemplate.spec.imagePullSecrets
- statefulset.annotations -> statefulset.podTemplate.annotations
- statefulset.startupProbe -> statefulset.podTemplate.spec.containers[0].startupProbe
- statefulset.livenessProbe -> statefulset.podTemplate.spec.containers[0].livenessProbe
- statefulset.readinessProbe -> statefulset.podTemplate.spec.containers[1].readinessProbe
- statefulset.podAffinity -> statefulset.podTemplate.spec.affinity.podAffinity
- statefulset.nodeSelector -> statefulset.podTemplate.spec.nodeSelector
- statefulset.priorityClassName -> statefulset.podTemplate.spec.priorityClassName
- statefulset.tolerations -> statefulset.podTemplate.spec.tolerations
- statefulset.topologySpreadConstraints -> statefulset.podTemplate.spec.topologySpreadConstraints
- statefulset.terminationGracePeriodSeconds -> statefulset.podTemplate.spec.terminationGracePeriodSeconds
- statefulset.extraVolumes -> statefulset.podTemplate.spec.volumes
- statefulset.extraVolumesMounts -> statefulset.podTemplate.spec.containers[*].volumeMounts
- statefulset.initContainers.*.extraVolumesMounts -> statefulset.podTemplate.spec.initContainers[*].volumeMounts
- statefulset.initContainers.*.resources -> statefulset.podTemplate.spec.initContainers[*].resources
- statefulset.initContainers.extraInitContainers -> statefulset.podTemplate.spec.initContainers
- statefulset.sidecars.configWatcher.extraVolumeMounts -> statefulset.podTemplate.spec.containers[*].volumeMounts
- statefulset.sidecars.configWatcher.resources -> statefulset.podTemplate.spec.containers[*].resources
- statefulset.sidecars.configWatcher.securityContext -> statefulset.podTemplate.spec.containers[*].securityContext
- statefulset.sidecars.controllers.resources -> statefulset.podTemplate.spec.containers[*].resources
- statefulset.sidecars.controllers.securityContext -> statefulset.podTemplate.spec.containers[*].securityContext
- statefulset.sidecars.extraVolumeMounts -> statefulset.podTemplate.spec.containers[*].volumeMounts
- statefulset.sidecars.resources -> statefulset.podTemplate.spec.containers[*].resources
- statefulset.sidecars.securityContext -> statefulset.podTemplate.spec.containers[*].securityContext

It does this by using manually updating the unwrapped/defaulted `Values` on the RenderState with the CRD spec after the state has been constructed.

Things that this this explicitly doesn't do yet -- client-based memoization of RenderState fields rather than delegating to `helmetted.Lookup`.

## Note

I'm marking this a WIP due to having to figure out some fields arounds `extraVolumes` and `extraVolumeMounts` which, at first blush, appear to be string pointers when on the `Values` pod spec, they are structured arrays.
