### PR TITLE
gotohelm: support passing method references

### DIFF
--- a/.changes/unreleased/gotohelm-Added-20250829-120047.yaml
+++ b/.changes/unreleased/gotohelm-Added-20250829-120047.yaml
@@ -1,0 +1,17 @@
+project: gotohelm
+kind: Added
+body: |-
+    Added support for passing method references.
+
+      The following code (sans the Printf) now transpiles successfully.
+
+      ```go
+      type S struct {Value int}
+      func (s *S) GetValue() int {return s.Value}
+
+      s := S{Value: 10}
+      ref := s.GetValue
+
+      fmt.Printf("%d", ref()) // 10
+      ```
+time: 2025-08-29T12:00:47.078209-04:00

--- a/charts/redpanda/chart/templates/_helpers.go.tpl
+++ b/charts/redpanda/chart/templates/_helpers.go.tpl
@@ -454,9 +454,9 @@
 {{- $overrideSpec = (mustMergeOverwrite (dict) (dict)) -}}
 {{- end -}}
 {{- $merged := (merge (dict) (mustMergeOverwrite (dict) (dict "metadata" (mustMergeOverwrite (dict) (dict "labels" $overrides.labels "annotations" $overrides.annotations)) "spec" $overrideSpec)) $original) -}}
-{{- $_ := (set $merged.spec "initContainers" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.spec.initContainers $overrideSpec.initContainers "name" "redpanda.mergeContainer")))) "r")) -}}
-{{- $_ := (set $merged.spec "containers" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.spec.containers $overrideSpec.containers "name" "redpanda.mergeContainer")))) "r")) -}}
-{{- $_ := (set $merged.spec "volumes" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.spec.volumes $overrideSpec.volumes "name" "redpanda.mergeVolume")))) "r")) -}}
+{{- $_ := (set $merged.spec "initContainers" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.spec.initContainers $overrideSpec.initContainers "name" (list "redpanda.mergeContainer"))))) "r")) -}}
+{{- $_ := (set $merged.spec "containers" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.spec.containers $overrideSpec.containers "name" (list "redpanda.mergeContainer"))))) "r")) -}}
+{{- $_ := (set $merged.spec "volumes" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.spec.volumes $overrideSpec.volumes "name" (list "redpanda.mergeVolume"))))) "r")) -}}
 {{- if (eq (toJson $merged.metadata.labels) "null") -}}
 {{- $_ := (set $merged.metadata "labels" (dict)) -}}
 {{- end -}}
@@ -509,7 +509,7 @@
 {{- $elOverride_5 := (index $_500_elOverride_5_ok_6 0) -}}
 {{- $ok_6 := (index $_500_elOverride_5_ok_6 1) -}}
 {{- if $ok_6 -}}
-{{- $merged = (concat (default (list) $merged) (list (get (fromJson (include $mergeFunc (dict "a" (list $el $elOverride_5)))) "r"))) -}}
+{{- $merged = (concat (default (list) $merged) (list (get (fromJson (include (first $mergeFunc) (dict "a" (concat (rest $mergeFunc) (list $el $elOverride_5))))) "r"))) -}}
 {{- else -}}
 {{- $merged = (concat (default (list) $merged) (list $el)) -}}
 {{- end -}}
@@ -580,8 +580,8 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $merged := (merge (dict) $override $original) -}}
-{{- $_ := (set $merged "env" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.env $override.env "name" "redpanda.mergeEnvVar")))) "r")) -}}
-{{- $_ := (set $merged "volumeMounts" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.volumeMounts $override.volumeMounts "name" "redpanda.mergeVolumeMount")))) "r")) -}}
+{{- $_ := (set $merged "env" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.env $override.env "name" (list "redpanda.mergeEnvVar"))))) "r")) -}}
+{{- $_ := (set $merged "volumeMounts" (get (fromJson (include "redpanda.mergeSliceBy" (dict "a" (list $original.volumeMounts $override.volumeMounts "name" (list "redpanda.mergeVolumeMount"))))) "r")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $merged) | toJson -}}
 {{- break -}}

--- a/gotohelm/ast.go
+++ b/gotohelm/ast.go
@@ -150,8 +150,9 @@ func (c *Cast) Write(w io.Writer) {
 }
 
 type Call struct {
-	FuncName  Node
-	Arguments []Node
+	FuncName     Node
+	Encapsulator Node
+	Arguments    []Node
 }
 
 func litCall(funcName string, args ...Node) *Call {
@@ -159,12 +160,17 @@ func litCall(funcName string, args ...Node) *Call {
 }
 
 func (c *Call) Write(w io.Writer) {
+	encapsulator := c.Encapsulator
+	if encapsulator == nil {
+		encapsulator = Literal("list")
+	}
+
 	args := &DictLiteral{
 		KeysValues: []*KeyValue{
 			{
 				Key: Quoted("a"),
 				Value: &BuiltInCall{
-					Func:      Literal("list"),
+					Func:      encapsulator,
 					Arguments: c.Arguments,
 				},
 			},

--- a/gotohelm/testdata/src/example/syntax/_syntax.syntax.tpl
+++ b/gotohelm/testdata/src/example/syntax/_syntax.syntax.tpl
@@ -94,7 +94,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "syntax.TestStruct.Multiplayer" -}}
+{{- define "syntax.TestStruct.Multiply" -}}
 {{- $ts := (index .a 0) -}}
 {{- $input := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
@@ -135,7 +135,7 @@
 {{- $_ := (get (fromJson (include "syntax.TestStruct.MutateString" (dict "a" (list $f "Change string")))) "r") -}}
 {{- $_ := (get (fromJson (include "syntax.TestStruct.DoNotMutateString" (dict "a" (list (deepCopy $f) "do not change")))) "r") -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (get (fromJson (include "syntax.TestStruct.InstanceMethod" (dict "a" (list $t)))) "r") (get (fromJson (include "syntax.TestStruct.InstanceMethod" (dict "a" (list $f)))) "r") ((get (fromJson (include "syntax.TestStruct.Double" (dict "a" (list $t (2 | int))))) "r") | int) ((get (fromJson (include "syntax.TestStruct.Double" (dict "a" (list $t (4 | int))))) "r") | int) ((get (fromJson (include "syntax.TestStruct.Multiplayer" (dict "a" (list $t (6 | int))))) "r") | int) ((get (fromJson (include "syntax.TestStruct.Multiplayer" (dict "a" (list $f (6 | int))))) "r") | int) (get (fromJson (include "syntax.TestStruct.String" (dict "a" (list (deepCopy $t) "one" "two")))) "r") (eq $f.SomeString "Change string"))) | toJson -}}
+{{- (dict "r" (list (get (fromJson (include "syntax.TestStruct.InstanceMethod" (dict "a" (list $t)))) "r") (get (fromJson (include "syntax.TestStruct.InstanceMethod" (dict "a" (list $f)))) "r") ((get (fromJson (include "syntax.TestStruct.Double" (dict "a" (list $t (2 | int))))) "r") | int) ((get (fromJson (include "syntax.TestStruct.Double" (dict "a" (list $t (4 | int))))) "r") | int) ((get (fromJson (include "syntax.TestStruct.Multiply" (dict "a" (list $t (6 | int))))) "r") | int) ((get (fromJson (include "syntax.TestStruct.Multiply" (dict "a" (list $f (6 | int))))) "r") | int) (get (fromJson (include "syntax.TestStruct.String" (dict "a" (list (deepCopy $t) "one" "two")))) "r") (eq $f.SomeString "Change string"))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -316,8 +316,36 @@
 {{- define "syntax.funcArgs" -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
+{{- $sThunk := (mustMergeOverwrite (dict "Val" "") (dict "Val" "wow!")) -}}
+{{- $sThunkThunk := (list "syntax.thunk.Thunk" $sThunk) -}}
+{{- $sThunkImmutableThunk := (list "syntax.thunk.ImmutableThunk" (deepCopy $sThunk)) -}}
+{{- $_ := (set $sThunk "Val" "wow! Mutation") -}}
+{{- $throughVar := (list "syntax.hello") -}}
+{{- $depThroughVar := (list "aaacommon.SharedConstant") -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (get (fromJson (include "syntax.sliceOf" (dict "a" (list (5 | int) "syntax.ident")))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (10 | int) "syntax.hello")))) "r"))) | toJson -}}
+{{- (dict "r" (list (get (fromJson (include (first $depThroughVar) (dict "a" (concat (rest $depThroughVar) (list))))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (5 | int) (list "syntax.ident"))))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (10 | int) (list "syntax.hello"))))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (10 | int) $throughVar)))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (10 | int) $sThunkThunk)))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (10 | int) $sThunkImmutableThunk)))) "r") (get (fromJson (include "syntax.sliceOf" (dict "a" (list (10 | int) (list "syntax.thunk.Thunk" $sThunk))))) "r"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "syntax.thunk.Thunk" -}}
+{{- $t := (index .a 0) -}}
+{{- $_ := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" $t.Val) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "syntax.thunk.ImmutableThunk" -}}
+{{- $t := (index .a 0) -}}
+{{- $_ := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" $t.Val) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -329,7 +357,7 @@
 {{- $_is_returning := false -}}
 {{- $r := (coalesce nil) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) ($l|int) (1|int) -}}
-{{- $r = (concat (default (list) $r) (list (get (fromJson (include $fn (dict "a" (list $i)))) "r"))) -}}
+{{- $r = (concat (default (list) $r) (list (get (fromJson (include (first $fn) (dict "a" (concat (rest $fn) (list $i))))) "r"))) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/gotohelm/testdata/src/example/syntax/syntax.go
@@ -109,7 +109,7 @@ func (ts *TestStruct) Double(input int) int {
 	return input * 2
 }
 
-func (ts *TestStruct) Multiplayer(input int) int {
+func (ts *TestStruct) Multiply(input int) int {
 	return input * ts.Mult
 }
 
@@ -139,8 +139,8 @@ func instanceMethod() any {
 		f.InstanceMethod(),
 		t.Double(2),
 		t.Double(4),
-		t.Multiplayer(6),
-		f.Multiplayer(6),
+		t.Multiply(6),
+		f.Multiply(6),
 		t.String("one", "two"),
 		f.SomeString == "Change string",
 	}
@@ -335,11 +335,36 @@ func appends() [][]int {
 func funcArgs() []any {
 	// Showcase support for first class functions!
 	// NOTE: Closures are NOT supported.
+
+	sThunk := thunk[string]{Val: "wow!"}
+	sThunkThunk := sThunk.Thunk
+	sThunkImmutableThunk := sThunk.ImmutableThunk
+	sThunk.Val = "wow! Mutation"
+
+	throughVar := hello
+	depThroughVar := aaacommon.SharedConstant
+
 	return []any{
+		depThroughVar(),
 		sliceOf(5, ident),
 		sliceOf(10, hello),
+		sliceOf(10, throughVar),
+		sliceOf(10, sThunkThunk),
+		sliceOf(10, sThunkImmutableThunk),
+		sliceOf(10, sThunk.Thunk),
 	}
+}
 
+type thunk[T any] struct {
+	Val T
+}
+
+func (t *thunk[T]) Thunk(_ int) T {
+	return t.Val
+}
+
+func (t thunk[T]) ImmutableThunk(_ int) T {
+	return t.Val
 }
 
 func sliceOf[T any](l int, fn func(int) T) []T {

--- a/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -110,7 +110,7 @@ func (ts *TestStruct) Double(input int) int {
 	return input * 2
 }
 
-func (ts *TestStruct) Multiplayer(input int) int {
+func (ts *TestStruct) Multiply(input int) int {
 	return input * ts.Mult
 }
 
@@ -140,8 +140,8 @@ func instanceMethod() any {
 		f.InstanceMethod(),
 		t.Double(2),
 		t.Double(4),
-		t.Multiplayer(6),
-		f.Multiplayer(6),
+		t.Multiply(6),
+		f.Multiply(6),
 		t.String("one", "two"),
 		f.SomeString == "Change string",
 	}
@@ -336,11 +336,36 @@ func appends() [][]int {
 func funcArgs() []any {
 	// Showcase support for first class functions!
 	// NOTE: Closures are NOT supported.
+
+	sThunk := thunk[string]{Val: "wow!"}
+	sThunkThunk := sThunk.Thunk
+	sThunkImmutableThunk := sThunk.ImmutableThunk
+	sThunk.Val = "wow! Mutation"
+
+	throughVar := hello
+	depThroughVar := aaacommon.SharedConstant
+
 	return []any{
+		depThroughVar(),
 		sliceOf(5, ident),
 		sliceOf(10, hello),
+		sliceOf(10, throughVar),
+		sliceOf(10, sThunkThunk),
+		sliceOf(10, sThunkImmutableThunk),
+		sliceOf(10, sThunk.Thunk),
 	}
+}
 
+type thunk[T any] struct {
+	Val T
+}
+
+func (t *thunk[T]) Thunk(_ int) T {
+	return t.Val
+}
+
+func (t thunk[T]) ImmutableThunk(_ int) T {
+	return t.Val
 }
 
 func sliceOf[T any](l int, fn func(int) T) []T {


### PR DESCRIPTION
Add support for pseudo-closures by capturing method receivers when assigning them to a variable.

This change builds on prior support of first class functions by changing the "storage" of methods to a slice of the template name and additional arguments. e.g.:

```go
func myFunc() {}
type myStruct struct {}
func (*myStruct) myFunc() {}

s := myStruct{}
_ := s.myFunc // Store as ["namespace.myStruct.myFunc", $s]
_ := myFunc   // Stored as ["namespace.myFunc"]
```