### PR TITLE
Fix up the way image overrides work with nodepools and add a compat test

### DIFF
--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -68,7 +68,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           lifecycle:
             postStart:
               exec:
@@ -203,7 +203,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           name: tuning
           resources: {}
           securityContext:
@@ -241,7 +241,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -358,6 +358,831 @@
   status:
     availableReplicas: 0
     replicas: 0
+-- compat-test --
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test
+    namespace: compat-test
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 0
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: compat-test
+        app.kubernetes.io/name: redpanda
+    serviceName: compat-test
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda-statefulset
+          app.kubernetes.io/instance: compat-test
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: redpanda
+          cluster.redpanda.com/broker: "true"
+          helm.sh/chart: redpanda-25.1.1-beta3
+          redpanda.com/poddisruptionbudget: compat-test
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: redpanda-statefulset
+                  app.kubernetes.io/instance: compat-test
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=$(SERVICE_NAME).compat-test.compat-test.svc.cluster.local.:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: redpandadata/redpanda:v25.2.1
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+                "https://${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - compat-test
+          - --redpanda-cluster-name
+          - compat-test
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).compat-test.compat-test.svc.cluster.local.:9644
+          - --no-set-superusers
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: localhost/redpanda-operator:dev
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: redpandadata/redpanda:v25.2.1
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: redpandadata/redpanda:v25.2.1
+          name: redpanda-configurator
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: compat-test-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: localhost/redpanda-operator:dev
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsUser: 101
+        serviceAccountName: compat-test
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: redpanda-statefulset
+              app.kubernetes.io/instance: compat-test
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: compat-test-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: compat-test-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: compat-test-sts-lifecycle
+        - configMap:
+            name: compat-test
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: compat-test-configurator
+          secret:
+            defaultMode: 509
+            secretName: compat-test-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: compat-test
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda-pool
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/nodepool-generation: "0"
+      cluster.redpanda.com/nodepool-name: pool
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-pool
+    namespace: compat-test
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 9
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-pool-statefulset
+        app.kubernetes.io/instance: compat-test
+        app.kubernetes.io/name: redpanda
+    serviceName: compat-test
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda-pool-statefulset
+          app.kubernetes.io/instance: compat-test
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: redpanda
+          azure.workload.identity/use: "true"
+          cloud.redpanda.com/network-loadbalancer-access: "true"
+          cluster.redpanda.com/broker: "true"
+          helm.sh/chart: redpanda-25.1.1-beta3
+          redpanda.com/poddisruptionbudget: compat-test
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.azure.com/agentpool
+                  operator: In
+                  values:
+                  - pool
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: redpanda-node-readiness
+                  operator: DoesNotExist
+              namespaces:
+              - redpanda-node-setup
+              topologyKey: kubernetes.io/hostname
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: redpanda-pool-statefulset
+                  app.kubernetes.io/instance: compat-test
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - args:
+          - --memory=1G
+          - --reserve-memory=1G
+          command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=$(SERVICE_NAME).compat-test.compat-test.svc.cluster.local.:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: foo:bar
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+                "https://${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - compat-test
+          - --redpanda-cluster-name
+          - compat-test
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).compat-test.compat-test.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: localhost/redpanda-operator:dev
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources:
+            requests:
+              cpu: 16m
+              memory: 64Mi
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: redpandadata/redpanda:v25.2.1
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+        - command:
+          - /bin/sh
+          - -c
+          - chown 65534:65534 -R /var/lib/redpanda/data
+          image: public.ecr.aws/docker/library/busybox:1.36-glibc@sha256:e046063223f7eaafbfbc026aa3954d9a31b9f1053ba5db04a4f1fdc97abd8963
+          name: set-datadir-ownership
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 16m
+              memory: 128Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - args:
+          - -c
+          - trap "exit 0" TERM; exec /etc/secrets/fs-validator/scripts/fsValidator.sh
+            xfs & wait $!
+          command:
+          - /bin/sh
+          image: redpandadata/redpanda:v25.2.1
+          name: fs-validator
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 16m
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/secrets/fs-validator/scripts/
+            name: compat-test-fs-validator
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: redpandadata/redpanda:v25.2.1
+          name: redpanda-configurator
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: compat-test-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: localhost/redpanda-operator:dev
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        - name: redpanda-configuraor
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 16m
+              memory: 256Mi
+        nodeSelector:
+          foo: bar
+        priorityClassName: some-priority-class
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+        serviceAccountName: compat-test
+        terminationGracePeriodSeconds: 90
+        tolerations:
+        - key: Some/Toleration
+          operator: Equal
+          value: "true"
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: redpanda-pool-statefulset
+              app.kubernetes.io/instance: compat-test
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: compat-test-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: compat-test-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: compat-test-sts-lifecycle
+        - configMap:
+            name: compat-test-pool
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: compat-test-configurator
+          secret:
+            defaultMode: 509
+            secretName: compat-test-pool-configurator
+        - name: compat-test-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: compat-test-pool-fs-validator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+        - configMap:
+            defaultMode: 420
+            name: redpanda-truststore.crt
+            optional: false
+          name: redpanda-truststore
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: compat-test
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0
 -- nodepool-basic-test --
 - apiVersion: apps/v1
   kind: StatefulSet
@@ -428,7 +1253,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           lifecycle:
             postStart:
               exec:
@@ -563,7 +1388,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           name: tuning
           resources: {}
           securityContext:
@@ -601,7 +1426,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -789,7 +1614,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           lifecycle:
             postStart:
               exec:
@@ -923,7 +1748,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           name: tuning
           resources: {}
           securityContext:
@@ -961,7 +1786,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-operator:v25.2.1
+          image: redpandadata/redpanda:v25.2.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:

--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -948,7 +948,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda:v25.2.1
+          image: foo:bar
           name: tuning
           resources: {}
           securityContext:
@@ -1033,7 +1033,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda:v25.2.1
+          image: foo:bar
           name: redpanda-configurator
           resources: {}
           volumeMounts:

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -1002,6 +1002,1370 @@
             defaultMode: 272
             secretName: basic-test-default-cert
   status: {}
+-- compat-test --
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-external
+    namespace: compat-test
+  spec:
+    externalTrafficPolicy: Local
+    ports:
+    - name: admin-default
+      nodePort: 31644
+      port: 9645
+      protocol: TCP
+      targetPort: 0
+    - name: kafka-default
+      nodePort: 31092
+      port: 9094
+      protocol: TCP
+      targetPort: 0
+    - name: http-default
+      nodePort: 30082
+      port: 8083
+      protocol: TCP
+      targetPort: 0
+    - name: schema-default
+      nodePort: 30081
+      port: 8084
+      protocol: TCP
+      targetPort: 0
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/name: redpanda
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test
+    namespace: compat-test
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: compat-test
+        app.kubernetes.io/name: redpanda
+        redpanda.com/poddisruptionbudget: compat-test
+  status:
+    currentHealthy: 0
+    desiredHealthy: 0
+    disruptionsAllowed: 0
+    expectedPods: 0
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test
+    namespace: compat-test
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+      monitoring.redpanda.com/enabled: "false"
+    name: compat-test
+    namespace: compat-test
+  spec:
+    clusterIP: None
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/name: redpanda
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers: []
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: compat-test-pool-0.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-1.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-2.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-3.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-4.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-5.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-6.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-7.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-8.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers: []
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test
+    namespace: compat-test
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","default_topic_replications":"3","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers: []
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: compat-test-pool-0.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-1.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-2.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-3.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-4.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-5.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-6.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-7.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: compat-test-pool-8.compat-test.compat-test.svc.cluster.local.
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:9644
+          - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:9093
+          - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:8081
+          - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers: []
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-pool
+    namespace: compat-test
+- apiVersion: v1
+  data:
+    profile: |-
+      admin_api:
+        addresses: []
+        tls:
+          ca_file: ca.crt
+      kafka_api:
+        brokers: []
+        tls:
+          ca_file: ca.crt
+      name: default
+      schema_registry:
+        addresses: []
+        tls:
+          ca_file: ca.crt
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-rpk
+    namespace: compat-test
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-default-selfsigned-issuer
+    namespace: compat-test
+  spec:
+    selfSigned: {}
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-default-root-issuer
+    namespace: compat-test
+  spec:
+    ca:
+      secretName: compat-test-default-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-external-selfsigned-issuer
+    namespace: compat-test
+  spec:
+    selfSigned: {}
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-external-root-issuer
+    namespace: compat-test
+  spec:
+    ca:
+      secretName: compat-test-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-default-root-certificate
+    namespace: compat-test
+  spec:
+    commonName: compat-test-default-root-certificate
+    duration: 43800h0m0s
+    isCA: true
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: compat-test-default-selfsigned-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: compat-test-default-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-external-root-certificate
+    namespace: compat-test
+  spec:
+    commonName: compat-test-external-root-certificate
+    duration: 43800h0m0s
+    isCA: true
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: compat-test-external-selfsigned-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: compat-test-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-default-cert
+    namespace: compat-test
+  spec:
+    dnsNames:
+    - compat-test-cluster.compat-test.compat-test.svc.cluster.local
+    - compat-test-cluster.compat-test.compat-test.svc
+    - compat-test-cluster.compat-test.compat-test
+    - '*.compat-test-cluster.compat-test.compat-test.svc.cluster.local'
+    - '*.compat-test-cluster.compat-test.compat-test.svc'
+    - '*.compat-test-cluster.compat-test.compat-test'
+    - compat-test.compat-test.svc.cluster.local
+    - compat-test.compat-test.svc
+    - compat-test.compat-test
+    - '*.compat-test.compat-test.svc.cluster.local'
+    - '*.compat-test.compat-test.svc'
+    - '*.compat-test.compat-test'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: compat-test-default-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: compat-test-default-cert
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-external-cert
+    namespace: compat-test
+  spec:
+    dnsNames:
+    - compat-test-cluster.compat-test.compat-test.svc.cluster.local
+    - compat-test-cluster.compat-test.compat-test.svc
+    - compat-test-cluster.compat-test.compat-test
+    - '*.compat-test-cluster.compat-test.compat-test.svc.cluster.local'
+    - '*.compat-test-cluster.compat-test.compat-test.svc'
+    - '*.compat-test-cluster.compat-test.compat-test'
+    - compat-test.compat-test.svc.cluster.local
+    - compat-test.compat-test.svc
+    - compat-test.compat-test
+    - '*.compat-test.compat-test.svc.cluster.local'
+    - '*.compat-test.compat-test.svc'
+    - '*.compat-test.compat-test'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: compat-test-external-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: compat-test-external-cert
+  status: {}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-rpk-debug-bundle
+    namespace: compat-test
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - endpoints
+    - events
+    - limitranges
+    - persistentvolumeclaims
+    - pods
+    - pods/log
+    - replicationcontrollers
+    - resourcequotas
+    - serviceaccounts
+    - services
+    verbs:
+    - get
+    - list
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-sidecar
+    namespace: compat-test
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-rpk-debug-bundle
+    namespace: compat-test
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: compat-test-rpk-debug-bundle
+  subjects:
+  - kind: ServiceAccount
+    name: compat-test
+    namespace: compat-test
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-sidecar
+    namespace: compat-test
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: compat-test-sidecar
+  subjects:
+  - kind: ServiceAccount
+    name: compat-test
+    namespace: compat-test
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-sts-lifecycle
+    namespace: compat-test
+  stringData:
+    common.sh: |-
+      #!/usr/bin/env bash
+
+      # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+      CURL_URL="https://${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local:9644"
+
+      # commands used throughout
+      CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+      CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+    postStart.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      postStartHook () {
+        set -x
+
+        touch /tmp/postStartHookStarted
+
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Clearing maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        # a 400 here would mean not in maintenance mode
+        until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+            status=$(${CURL_MAINTENANCE_DELETE_CMD})
+            sleep 0.5
+        done
+
+        touch /tmp/postStartHookFinished
+      }
+
+      postStartHook
+      true
+    preStop.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      touch /tmp/preStopHookStarted
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      set -x
+
+      preStopHook () {
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Setting maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        until [ "${status:-}" = '"200"' ]; do
+            status=$(${CURL_MAINTENANCE_PUT_CMD})
+            sleep 0.5
+        done
+
+        until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+            res=$(${CURL_MAINTENANCE_GET_CMD})
+            finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+            draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+            sleep 0.5
+        done
+
+        touch /tmp/preStopHookFinished
+      }
+      preStopHook
+      true
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-configurator
+    namespace: compat-test
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+      BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      ADVERTISED_KAFKA_ADDRESSES=()
+
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      ADVERTISED_HTTP_ADDRESSES=()
+
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-pool-configurator
+    namespace: compat-test
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+      BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      ADVERTISED_KAFKA_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.compat-test.compat-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      ADVERTISED_HTTP_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-pool-fs-validator
+    namespace: compat-test
+  stringData:
+    fsValidator.sh: |-
+      set -e
+      EXPECTED_FS_TYPE=$1
+
+      DATA_DIR="/var/lib/redpanda/data"
+      TEST_FILE="testfile"
+
+      echo "checking data directory exist..."
+      if [ ! -d "${DATA_DIR}" ]; then
+        echo "data directory does not exists, exiting"
+        exit 1
+      fi
+
+      echo "checking filesystem type..."
+      FS_TYPE=$(df -T $DATA_DIR  | tail -n +2 | awk '{print $2}')
+
+      if [ "${FS_TYPE}" != "${EXPECTED_FS_TYPE}" ]; then
+        echo "file system found to be ${FS_TYPE} when expected ${EXPECTED_FS_TYPE}"
+        exit 1
+      fi
+
+      echo "checking if able to create a test file..."
+
+      touch ${DATA_DIR}/${TEST_FILE}
+      result=$(touch ${DATA_DIR}/${TEST_FILE} 2> /dev/null; echo $?)
+      if [ "${result}" != "0" ]; then
+        echo "could not write testfile, may not have write permission"
+        exit 1
+      fi
+
+      echo "checking if able to delete a test file..."
+
+      result=$(rm ${DATA_DIR}/${TEST_FILE} 2> /dev/null; echo $?)
+      if [ "${result}" != "0" ]; then
+        echo "could not delete testfile"
+        exit 1
+      fi
+
+      echo "passed"
+  type: Opaque
+- apiVersion: v1
+  data:
+    config.yaml: |
+      # from .Values.config
+      kafka:
+        brokers:
+        - compat-test-pool-0.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-1.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-2.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-3.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-4.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-5.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-6.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-7.compat-test.compat-test.svc.cluster.local.:9093
+        - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:9093
+        sasl:
+          enabled: false
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+      redpanda:
+        adminApi:
+          enabled: true
+          tls:
+            caFilepath: /etc/tls/certs/default/ca.crt
+            certFilepath: ""
+            enabled: true
+            insecureSkipTlsVerify: false
+            keyFilepath: ""
+          urls:
+          - https://compat-test.compat-test.svc.cluster.local.:9644
+      schemaRegistry:
+        enabled: true
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls: null
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v3.1.0
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: console-3.1.0
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-console
+    namespace: compat-test
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: compat-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v3.1.0
+      cluster.redpanda.com/namespace: compat-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: compat-test
+      helm.sh/chart: console-3.1.0
+      helm.toolkit.fluxcd.io/name: compat-test
+      helm.toolkit.fluxcd.io/namespace: compat-test
+    name: compat-test-console
+    namespace: compat-test
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: compat-test
+        app.kubernetes.io/name: console
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          checksum-redpanda-chart/config: def47a15dd1dd16979c3af7ae1d5b6d089e7bed8cbc3c4d76117406fd336e51b
+          checksum/config: b7b7d58b17bcf1f14e1c411b2e3e3512e69a671bcee204ca7461ddf7035e8f16
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: compat-test
+          app.kubernetes.io/name: console
+      spec:
+        affinity: {}
+        automountServiceAccountToken: false
+        containers:
+        - args:
+          - --config.filepath=/etc/console/configs/config.yaml
+          image: docker.redpanda.com/redpandadata/console:v3.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: console
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /etc/console/configs
+            name: configs
+            readOnly: true
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+        securityContext:
+          fsGroup: 99
+          fsGroupChangePolicy: Always
+          runAsUser: 99
+        serviceAccountName: compat-test-console
+        volumes:
+        - configMap:
+            name: compat-test-console
+          name: configs
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 272
+            secretName: compat-test-default-cert
+  status: {}
 -- nodepool-basic-test --
 - apiVersion: v1
   kind: Service

--- a/operator/internal/lifecycle/testdata/cases.txtar
+++ b/operator/internal/lifecycle/testdata/cases.txtar
@@ -10,3 +10,136 @@ spec:
   sidecarImage:
     tag: dev
     repository: localhost/test
+-- compat-test --
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: compat-test
+spec:
+  clusterSpec:
+    statefulset:
+      replicas: 0
+---
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: NodePool
+metadata:
+  name: pool
+spec:
+  clusterRef:
+    name: compat-test
+  replicas: 9
+  image:
+    repository: foo
+    tag: bar
+  initContainerImage:
+    repository: public.ecr.aws/docker/library/busybox
+    tag: 1.36-glibc@sha256:e046063223f7eaafbfbc026aa3954d9a31b9f1053ba5db04a4f1fdc97abd8963
+  initContainers:
+    setDataDirOwnership:
+      enabled: true
+    fsValidator:
+      enabled: true
+      expectedFS: xfs
+    configurator:
+      additionalCLIArgs:
+      - foo
+      - bar
+      - baz
+  podTemplate:
+    labels:
+      azure.workload.identity/use: "true"
+      cloud.redpanda.com/network-loadbalancer-access: "true"
+    spec:
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 1
+          memory: 1Gi
+      nodeSelector:
+        foo: bar
+      tolerations:
+        - key: Some/Toleration
+          operator: Equal
+          value: "true"
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        # from the kubernetes spec, the following need to be set on a per-container basis
+        # see the difference in https://pkg.go.dev/k8s.io/api@v0.33.3/core/v1#PodSecurityContext
+        # and https://pkg.go.dev/k8s.io/api@v0.33.3/core/v1#SecurityContext
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+      priorityClassName: some-priority-class
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "kubernetes.azure.com/agentpool"
+                operator: "In"
+                values:
+                - pool
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: redpanda-node-readiness
+                operator: DoesNotExist
+            namespaces:
+            - redpanda-node-setup
+            topologyKey: kubernetes.io/hostname
+      volumes:
+      # I see no mounts for this
+      - name: redpanda-truststore
+        configMap:
+          name: redpanda-truststore.crt
+          defaultMode: 0644
+          optional: false
+      containers:
+      - name: sidecar
+        resources:
+          requests:
+            cpu: 16m
+            memory: 64Mi
+      - name: redpanda
+        args:
+          - --memory=1G
+          - --reserve-memory=1G
+      initContainers:
+        - name: fs-validator
+          resources:
+            requests:
+              cpu: 16m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+        - name: set-datadir-ownership
+          command:
+            - /bin/sh
+            - -c
+            - chown 65534:65534 -R /var/lib/redpanda/data
+          resources:
+            requests:
+              cpu: 16m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
+        - name: redpanda-configuraor
+          resources:
+            requests:
+              cpu: 16m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi

--- a/operator/internal/lifecycle/testdata/cases.values.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.values.golden.txtar
@@ -524,6 +524,10 @@ pools:
             requests:
               cpu: 16m
               memory: 256Mi
+        - image: foo:bar
+          name: redpanda-configurator
+        - image: foo:bar
+          name: tuning
         nodeSelector:
           foo: bar
         priorityClassName: some-priority-class
@@ -1044,6 +1048,11 @@ pools:
         containers:
         - image: redpandadata/redpanda:v25.2.1
           name: redpanda
+        initContainers:
+        - image: redpandadata/redpanda:v25.2.1
+          name: redpanda-configurator
+        - image: redpandadata/redpanda:v25.2.1
+          name: tuning
         priorityClassName: ""
         securityContext: {}
         terminationGracePeriodSeconds: 90

--- a/operator/internal/lifecycle/testdata/cases.values.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.values.golden.txtar
@@ -145,7 +145,7 @@ values:
   force: false
   fullnameOverride: ""
   image:
-    repository: redpandadata/redpanda-operator
+    repository: redpandadata/redpanda
     tag: v25.2.1
   license_key: ""
   listeners:
@@ -422,6 +422,590 @@ values:
     enabled: true
   tuning:
     tune_aio_events: true
+-- compat-test --
+pools:
+- Generation: "0"
+  Name: pool
+  Statefulset:
+    additionalRedpandaCmdFlags: []
+    additionalSelectorLabels: {}
+    budget:
+      maxUnavailable: 1
+    initContainerImage:
+      repository: public.ecr.aws/docker/library/busybox
+      tag: 1.36-glibc@sha256:e046063223f7eaafbfbc026aa3954d9a31b9f1053ba5db04a4f1fdc97abd8963
+    initContainers:
+      configurator:
+        additionalCLIArgs:
+        - foo
+        - bar
+        - baz
+      fsValidator:
+        enabled: true
+        expectedFS: xfs
+      setDataDirOwnership:
+        enabled: true
+    podAntiAffinity:
+      custom: {}
+      topologyKey: kubernetes.io/hostname
+      type: hard
+      weight: 100
+    podTemplate:
+      labels:
+        azure.workload.identity/use: "true"
+        cloud.redpanda.com/network-loadbalancer-access: "true"
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.azure.com/agentpool
+                  operator: In
+                  values:
+                  - pool
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: redpanda-node-readiness
+                  operator: DoesNotExist
+              namespaces:
+              - redpanda-node-setup
+              topologyKey: kubernetes.io/hostname
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: '{{ include "redpanda.name" . }}-pool-statefulset'
+                  app.kubernetes.io/instance: '{{ .Release.Name }}'
+                  app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
+              topologyKey: kubernetes.io/hostname
+        containers:
+        - name: sidecar
+          resources:
+            requests:
+              cpu: 16m
+              memory: 64Mi
+        - args:
+          - --memory=1G
+          - --reserve-memory=1G
+          image: foo:bar
+          name: redpanda
+        initContainers:
+        - name: fs-validator
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 16m
+              memory: 256Mi
+        - command:
+          - /bin/sh
+          - -c
+          - chown 65534:65534 -R /var/lib/redpanda/data
+          name: set-datadir-ownership
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 16m
+              memory: 128Mi
+          volumeMounts:
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - name: redpanda-configuraor
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 16m
+              memory: 256Mi
+        nodeSelector:
+          foo: bar
+        priorityClassName: some-priority-class
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        securityContext:
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+        terminationGracePeriodSeconds: 90
+        tolerations:
+        - key: Some/Toleration
+          operator: Equal
+          value: "true"
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: '{{ include "redpanda.name" . }}-pool-statefulset'
+              app.kubernetes.io/instance: '{{ .Release.Name }}'
+              app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - configMap:
+            defaultMode: 420
+            name: redpanda-truststore.crt
+            optional: false
+          name: redpanda-truststore
+    replicas: 9
+    sideCars:
+      args: []
+      brokerDecommissioner:
+        decommissionAfter: 60s
+        decommissionRequeueTimeout: 10s
+        enabled: false
+      configWatcher:
+        enabled: true
+      controllers:
+        createRBAC: true
+        enabled: false
+        healthProbeAddress: :8085
+        image: null
+        metricsAddress: :9082
+        pprofAddress: :9083
+        run:
+        - all
+      image:
+        repository: localhost/redpanda-operator
+        tag: dev
+      pvcUnbinder:
+        enabled: false
+        unbindAfter: 60s
+    updateStrategy:
+      type: RollingUpdate
+values:
+  auditLogging:
+    clientMaxBufferSize: 16777216
+    enabled: false
+    enabledEventTypes: null
+    excludedPrincipals: null
+    excludedTopics: null
+    listener: internal
+    partitions: 12
+    queueDrainIntervalMs: 500
+    queueMaxBufferSizePerShard: 1048576
+    replicationFactor: 0
+  auth:
+    sasl:
+      bootstrapUser:
+        mechanism: SCRAM-SHA-256
+        name: null
+        password: null
+        secretKeyRef: null
+      enabled: false
+      mechanism: SCRAM-SHA-512
+      secretRef: redpanda-users
+      users: []
+  clusterDomain: cluster.local.
+  commonLabels: {}
+  config:
+    cluster: {}
+    extraClusterConfiguration: {}
+    node:
+      crash_loop_limit: 5
+    pandaproxy_client:
+      consumer_heartbeat_interval_ms: 0
+      consumer_rebalance_timeout_ms: 0
+      consumer_request_max_bytes: 0
+      consumer_request_timeout_ms: 0
+      consumer_session_timeout_ms: 0
+      produce_batch_delay_ms: 0
+      produce_batch_record_count: 0
+      produce_batch_size_bytes: 0
+      retries: 0
+      retry_base_backoff_ms: 0
+    rpk: {}
+    schema_registry_client:
+      consumer_heartbeat_interval_ms: 0
+      consumer_rebalance_timeout_ms: 0
+      consumer_request_max_bytes: 0
+      consumer_request_timeout_ms: 0
+      consumer_session_timeout_ms: 0
+      produce_batch_delay_ms: 0
+      produce_batch_record_count: 0
+      produce_batch_size_bytes: 0
+      retries: 0
+      retry_base_backoff_ms: 0
+    tunable:
+      compacted_log_segment_size: 67108864
+      kafka_connection_rate_limit: 1000
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+  console:
+    affinity: {}
+    automountServiceAccountToken: false
+    autoscaling:
+      enabled: false
+      maxReplicas: 100
+      minReplicas: 1
+      targetCPUUtilizationPercentage: 80
+    configmap:
+      create: false
+    deployment:
+      create: false
+    enabled: true
+    fullnameOverride: ""
+    image:
+      pullPolicy: IfNotPresent
+      registry: docker.redpanda.com
+      repository: redpandadata/console
+      tag: ""
+    ingress:
+      enabled: false
+      hosts:
+      - host: chart-example.local
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+    initContainers:
+      extraInitContainers: ""
+    livenessProbe:
+      failureThreshold: 3
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    nameOverride: ""
+    podSecurityContext:
+      fsGroup: 99
+      fsGroupChangePolicy: Always
+      runAsUser: 99
+    priorityClassName: ""
+    readinessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    replicaCount: 1
+    resources: {}
+    secret:
+      authentication:
+        jwtSigningKey: ""
+        oidc: {}
+      create: false
+      kafka: {}
+      license: ""
+      redpanda:
+        adminApi: {}
+      schemaRegistry: {}
+      serde: {}
+    securityContext:
+      runAsNonRoot: true
+    service:
+      port: 8080
+      type: ClusterIP
+    serviceAccount:
+      automountServiceAccountToken: false
+      create: true
+      name: ""
+    strategy: {}
+    tests:
+      enabled: true
+  enterprise:
+    license: ""
+  external:
+    addresses: null
+    annotations: null
+    domain: null
+    enabled: true
+    externalDns: null
+    prefixTemplate: ""
+    service:
+      enabled: true
+    sourceRanges: null
+    type: NodePort
+  force: false
+  fullnameOverride: ""
+  image:
+    repository: redpandadata/redpanda
+    tag: v25.2.1
+  license_key: ""
+  listeners:
+    admin:
+      enabled: false
+      external:
+        default:
+          advertisedPorts:
+          - 31644
+          enabled: null
+          nodePort: null
+          port: 9645
+          tls:
+            cert: external
+            enabled: null
+            requireClientAuth: null
+            trustStore: null
+      port: 9644
+      tls:
+        cert: default
+        enabled: null
+        requireClientAuth: false
+        trustStore: null
+    http:
+      enabled: true
+      external:
+        default:
+          advertisedPorts:
+          - 30082
+          enabled: null
+          nodePort: null
+          port: 8083
+          tls:
+            cert: external
+            enabled: null
+            requireClientAuth: false
+            trustStore: null
+      port: 8082
+      tls:
+        cert: default
+        enabled: null
+        requireClientAuth: false
+        trustStore: null
+    kafka:
+      enabled: false
+      external:
+        default:
+          advertisedPorts:
+          - 31092
+          enabled: null
+          nodePort: null
+          port: 9094
+          tls:
+            cert: external
+            enabled: null
+            requireClientAuth: null
+            trustStore: null
+      port: 9093
+      tls:
+        cert: default
+        enabled: null
+        requireClientAuth: false
+        trustStore: null
+    rpc:
+      port: 33145
+      tls:
+        cert: default
+        enabled: null
+        requireClientAuth: false
+        trustStore: null
+    schemaRegistry:
+      enabled: true
+      external:
+        default:
+          advertisedPorts:
+          - 30081
+          enabled: null
+          nodePort: null
+          port: 8084
+          tls:
+            cert: external
+            enabled: null
+            requireClientAuth: false
+            trustStore: null
+      port: 8081
+      tls:
+        cert: default
+        enabled: null
+        requireClientAuth: false
+        trustStore: null
+  logging:
+    logLevel: info
+    usageStats:
+      clusterId: null
+      enabled: true
+  monitoring:
+    enableHttp2: null
+    enabled: false
+    labels: {}
+    scrapeInterval: 30s
+    tlsConfig: null
+  nameOverride: ""
+  podTemplate:
+    spec:
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 101
+  post_install_job:
+    annotations: null
+    enabled: true
+    labels: null
+    podTemplate:
+      spec:
+        containers:
+        - name: post-install
+          securityContext: {}
+        securityContext: {}
+  rackAwareness:
+    enabled: false
+    nodeAnnotation: topology.kubernetes.io/zone
+  rbac:
+    annotations: {}
+    enabled: true
+    rpkDebugBundle: true
+  resources:
+    cpu:
+      cores: "1"
+      overprovisioned: null
+    memory:
+      container:
+        max: 2560Mi
+        min: null
+      enable_memory_locking: null
+      redpanda: null
+  service: null
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ""
+  statefulset:
+    additionalRedpandaCmdFlags: []
+    additionalSelectorLabels: {}
+    budget:
+      maxUnavailable: 1
+    initContainerImage:
+      repository: busybox
+      tag: latest
+    initContainers:
+      configurator: {}
+      fsValidator:
+        enabled: false
+        expectedFS: xfs
+      setDataDirOwnership:
+        enabled: false
+    podAntiAffinity:
+      custom: {}
+      topologyKey: kubernetes.io/hostname
+      type: hard
+      weight: 100
+    podTemplate:
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: '{{ include "redpanda.name" . }}-statefulset'
+                  app.kubernetes.io/instance: '{{ .Release.Name }}'
+                  app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
+              topologyKey: kubernetes.io/hostname
+        containers:
+        - name: redpanda
+        - name: sidecar
+        initContainers:
+        - name: redpanda-configurator
+        priorityClassName: ""
+        securityContext: {}
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: '{{ include "redpanda.name" . }}-statefulset'
+              app.kubernetes.io/instance: '{{ .Release.Name }}'
+              app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+    replicas: 0
+    sideCars:
+      args:
+      - --no-set-superusers
+      brokerDecommissioner:
+        decommissionAfter: 60s
+        decommissionRequeueTimeout: 10s
+        enabled: false
+      configWatcher:
+        enabled: true
+      controllers:
+        createRBAC: true
+        enabled: false
+        healthProbeAddress: :8085
+        image:
+          repository: localhost/redpanda-operator
+          tag: dev
+        metricsAddress: :9082
+        pprofAddress: :9083
+        run:
+        - all
+      image:
+        repository: localhost/redpanda-operator
+        tag: dev
+      pvcUnbinder:
+        enabled: false
+        unbindAfter: 60s
+    updateStrategy:
+      type: RollingUpdate
+  storage:
+    hostPath: ""
+    persistentVolume:
+      annotations: {}
+      enabled: true
+      labels: {}
+      nameOverwrite: ""
+      size: 20Gi
+      storageClass: ""
+    tiered:
+      config:
+        cloud_storage_cache_size: 5368709120
+        cloud_storage_enable_remote_read: true
+        cloud_storage_enable_remote_write: true
+        cloud_storage_enabled: false
+      credentialsSecretRef:
+        accessKey:
+          configurationKey: cloud_storage_access_key
+          key: ""
+          name: ""
+        secretKey:
+          configurationKey: cloud_storage_secret_key
+          key: ""
+          name: ""
+      hostPath: ""
+      mountType: none
+      persistentVolume:
+        annotations: {}
+        enabled: false
+        labels: {}
+        nameOverwrite: ""
+        size: ""
+        storageClass: ""
+    tieredConfig: null
+    tieredStorageHostPath: ""
+    tieredStoragePersistentVolume: null
+  tests:
+    enabled: true
+  tls:
+    certs:
+      default:
+        applyInternalDNSNames: null
+        caEnabled: true
+        clientSecretRef: null
+        duration: ""
+        enabled: null
+        issuerRef: null
+        secretRef: null
+      external:
+        applyInternalDNSNames: null
+        caEnabled: true
+        clientSecretRef: null
+        duration: ""
+        enabled: null
+        issuerRef: null
+        secretRef: null
+    enabled: true
+  tuning:
+    tune_aio_events: true
 -- nodepool-basic-test --
 pools:
 - Generation: "0"
@@ -457,6 +1041,9 @@ pools:
                   app.kubernetes.io/instance: '{{ .Release.Name }}'
                   app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
               topologyKey: kubernetes.io/hostname
+        containers:
+        - image: redpandadata/redpanda:v25.2.1
+          name: redpanda
         priorityClassName: ""
         securityContext: {}
         terminationGracePeriodSeconds: 90
@@ -640,7 +1227,7 @@ values:
   force: false
   fullnameOverride: ""
   image:
-    repository: redpandadata/redpanda-operator
+    repository: redpandadata/redpanda
     tag: v25.2.1
   license_key: ""
   listeners:

--- a/operator/internal/lifecycle/v2_test.go
+++ b/operator/internal/lifecycle/v2_test.go
@@ -99,7 +99,7 @@ func TestV2ResourceClient(t *testing.T) {
 		CloudSecretsEnabled: false,
 	}
 	redpandaImage := Image{
-		Repository: "redpandadata/redpanda-operator",
+		Repository: "redpandadata/redpanda",
 		Tag:        os.Getenv("TEST_REDPANDA_VERSION"),
 	}
 	sidecarImage := Image{


### PR DESCRIPTION
This adds a compatability test with a more elaborate node pool spec. In the process of adding this, realized that the way we were attempting to override the cluster-level image for the redpanda image on a per-node basis was broken, so added a fix for that.