### PR TITLE
Add client factory support for v1 CRD for Kafka and SchemaRegistry API Clients

### DIFF
--- a/operator/api/vectorized/v1alpha1/cluster_types.go
+++ b/operator/api/vectorized/v1alpha1/cluster_types.go
@@ -1328,6 +1328,20 @@ func (r *Cluster) SchemaRegistryAPITLS() *SchemaRegistryAPI {
 	return nil
 }
 
+// SchemaRegistryInternalListener returns internal listener.
+func (r *Cluster) SchemaRegistryInternalListener() *SchemaRegistryAPI {
+	if r == nil {
+		return nil
+	}
+	for i := range r.Spec.Configuration.SchemaRegistryAPI {
+		el := &r.Spec.Configuration.SchemaRegistryAPI[i]
+		if el.External == nil || !el.External.Enabled {
+			return el
+		}
+	}
+	return nil
+}
+
 // SchemaRegistryListeners returns all schema registry listeners
 func (r *Cluster) SchemaRegistryListeners() []SchemaRegistryAPI {
 	if r == nil || r.Spec.Configuration.SchemaRegistry == nil {

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -165,6 +165,10 @@ func (c *Factory) KafkaClient(ctx context.Context, obj any, opts ...kgo.Opt) (*k
 		return c.kafkaForCluster(cluster, opts...)
 	}
 
+	if cluster, ok := obj.(*vectorizedv1alpha1.Cluster); ok {
+		return c.kafkaForV1Cluster(cluster)
+	}
+
 	if profile, ok := obj.(*rpkconfig.RpkProfile); ok {
 		return c.kafkaForRPKProfile(profile, opts...)
 	}
@@ -229,6 +233,10 @@ func (c *Factory) SchemaRegistryClient(ctx context.Context, obj any) (*sr.Client
 	// if we pass in a Redpanda cluster, just use it
 	if cluster, ok := obj.(*redpandav1alpha2.Redpanda); ok {
 		return c.schemaRegistryForCluster(cluster)
+	}
+
+	if cluster, ok := obj.(*vectorizedv1alpha1.Cluster); ok {
+		return c.schemaRegistryForV1Cluster(cluster)
 	}
 
 	if profile, ok := obj.(*rpkconfig.RpkProfile); ok {

--- a/operator/pkg/client/v1.go
+++ b/operator/pkg/client/v1.go
@@ -1,0 +1,266 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sasl"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
+	"github.com/twmb/franz-go/pkg/sr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources/certmanager"
+	resourcetypes "github.com/redpanda-data/redpanda-operator/operator/pkg/resources/types"
+	"github.com/redpanda-data/redpanda-operator/pkg/otelutil/log"
+)
+
+var (
+	// NoKafkaAPI signal absence of the internal kafka API endpoint
+	NoKafkaAPI = errors.New("no internal kafka API defined for cluster")
+	// NoSchemaRegistryAPI signal absence of the internal kafka API endpoint
+	NoSchemaRegistryAPI = errors.New("no internal schema registry API defined for cluster")
+)
+
+// newNodePoolInternalKafkaAPI is used to construct a nodepool specific admin API client that talks to the cluster via
+// the internal interface.
+func newNodePoolInternalKafkaAPI(
+	ctx context.Context,
+	k8sClient client.Client,
+	redpandaCluster *vectorizedv1alpha1.Cluster,
+	fqdn string,
+	tlsProvider resourcetypes.AdminTLSConfigProvider,
+	dialer redpanda.DialContextFunc,
+	opts []kgo.Opt,
+	pods ...string,
+) (*kgo.Client, error) {
+	kafkaAPI := redpandaCluster.InternalListener()
+	if kafkaAPI == nil {
+		return nil, NoKafkaAPI
+	}
+
+	var tlsConfig *tls.Config
+	if kafkaAPI.TLS.Enabled {
+		var err error
+		tlsConfig, err = tlsProvider.GetKafkaTLSConfig(ctx, k8sClient)
+		if err != nil {
+			return nil, fmt.Errorf("could not create tls configuration for internal kafka API: %w", err)
+		}
+	}
+
+	kafkaInternalPort := kafkaAPI.Port
+
+	urls := make([]string, 0)
+
+	if len(pods) == 0 {
+		// If none provided, just add a URL for every Pod.
+		var listedPods corev1.PodList
+		err := k8sClient.List(ctx, &listedPods, &client.ListOptions{
+			LabelSelector: labels.ForCluster(redpandaCluster).AsClientSelector(),
+			Namespace:     redpandaCluster.Namespace,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable list pods to infer schema registry API URLs: %w", err)
+		}
+
+		for i := range listedPods.Items {
+			pod := listedPods.Items[i]
+			pods = append(pods, pod.Name)
+		}
+	}
+
+	for _, pod := range pods {
+		urls = append(urls, fmt.Sprintf("%s.%s:%d", pod, fqdn, kafkaInternalPort))
+	}
+
+	opts = append(opts, kgo.SeedBrokers(urls...))
+
+	if tlsConfig != nil {
+		// we can only specify one of DialTLSConfig or Dialer
+		if dialer == nil {
+			opts = append(opts, kgo.DialTLSConfig(tlsConfig))
+		} else {
+			opts = append(opts, kgo.Dialer(wrapTLSDialer(dialer, tlsConfig)))
+		}
+	} else if dialer != nil {
+		opts = append(opts, kgo.Dialer(dialer))
+	}
+
+	var username, password, mechanism string
+	if redpandaCluster.IsSASLOnInternalEnabled() {
+		superuser := resources.NewSuperUsers(k8sClient, redpandaCluster, controller.UnifiedScheme, resources.ScramRPKUsername, resources.RPKSuffix, log.FromContext(ctx))
+		var superuserSecret corev1.Secret
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: superuser.Key().Namespace, Name: superuser.Key().Name}, &superuserSecret); err != nil {
+			return nil, err
+		}
+		username = string(superuserSecret.Data[corev1.BasicAuthUsernameKey])
+		password = string(superuserSecret.Data[corev1.BasicAuthPasswordKey])
+		// this looks hardcoded in the controller, see cluster_controller.go updateUserOnAdminAPI
+		mechanism = rpadmin.ScramSha256
+	}
+
+	if username != "" {
+		opt, err := saslOpt(username, password, mechanism)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+	}
+
+	return kgo.NewClient(opts...)
+}
+
+// newNodePoolInternalSchemaRegistryAPI is used to construct a nodepool specific admin API client that talks to the cluster via
+// the internal interface.
+func newNodePoolInternalSchemaRegistryAPI(
+	ctx context.Context,
+	k8sClient client.Client,
+	redpandaCluster *vectorizedv1alpha1.Cluster,
+	fqdn string,
+	tlsProvider resourcetypes.AdminTLSConfigProvider,
+	dialer redpanda.DialContextFunc,
+	opts []sr.ClientOpt,
+	pods ...string,
+) (*sr.Client, error) {
+	schemaRegistryAPI := redpandaCluster.SchemaRegistryInternalListener()
+	if schemaRegistryAPI == nil {
+		return nil, NoSchemaRegistryAPI
+	}
+
+	// These transport values come from the TLS client options found here:
+	// https://github.com/twmb/franz-go/blob/cea7aa5d803781e5f0162187795482ba1990c729/pkg/sr/clientopt.go#L48-L68
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		DialContext:           dialer,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	if dialer == nil {
+		transport.DialContext = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+	}
+
+	prefix := "http://"
+
+	var tlsConfig *tls.Config
+	if schemaRegistryAPI.TLS != nil && schemaRegistryAPI.TLS.Enabled {
+		var err error
+		tlsConfig, err = tlsProvider.GetSchemaTLSConfig(ctx, k8sClient)
+		if err != nil {
+			return nil, fmt.Errorf("could not create tls configuration for internal schema registry API: %w", err)
+		}
+		prefix = "https://"
+		transport.TLSClientConfig = tlsConfig
+	}
+
+	copts := []sr.ClientOpt{sr.HTTPClient(&http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
+	})}
+
+	var username, password string
+	if redpandaCluster.IsSASLOnInternalEnabled() {
+		superuser := resources.NewSuperUsers(k8sClient, redpandaCluster, controller.UnifiedScheme, resources.ScramRPKUsername, resources.RPKSuffix, log.FromContext(ctx))
+		var superuserSecret corev1.Secret
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: superuser.Key().Namespace, Name: superuser.Key().Name}, &superuserSecret); err != nil {
+			return nil, err
+		}
+		username = string(superuserSecret.Data[corev1.BasicAuthUsernameKey])
+		password = string(superuserSecret.Data[corev1.BasicAuthPasswordKey])
+	}
+
+	if username != "" {
+		copts = append(copts, sr.BasicAuth(username, password))
+	}
+
+	schemaRegistryInternalPort := schemaRegistryAPI.Port
+
+	urls := make([]string, 0)
+
+	if len(pods) == 0 {
+		// If none provided, just add a URL for every Pod.
+		var listedPods corev1.PodList
+		err := k8sClient.List(ctx, &listedPods, &client.ListOptions{
+			LabelSelector: labels.ForCluster(redpandaCluster).AsClientSelector(),
+			Namespace:     redpandaCluster.Namespace,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable list pods to infer admin API URLs: %w", err)
+		}
+
+		for i := range listedPods.Items {
+			pod := listedPods.Items[i]
+			pods = append(pods, pod.Name)
+		}
+	}
+
+	for _, pod := range pods {
+		urls = append(urls, fmt.Sprintf("%s%s.%s:%d", prefix, pod, fqdn, schemaRegistryInternalPort))
+	}
+
+	copts = append(copts, sr.URLs(urls...))
+
+	// finally, override any calculated client opts with whatever was
+	// passed in
+	return sr.NewClient(append(copts, opts...)...)
+}
+
+func v1ClusterCerts(ctx context.Context, k8sClient client.Client, cluster *vectorizedv1alpha1.Cluster) (string, *certmanager.ClusterCertificates, error) {
+	headlessSvc := resources.NewHeadlessService(k8sClient, cluster, controller.UnifiedScheme, nil, log.FromContext(ctx))
+	clusterSvc := resources.NewClusterService(k8sClient, cluster, controller.UnifiedScheme, nil, log.FromContext(ctx))
+	fqdn := headlessSvc.HeadlessServiceFQDN("cluster.local")
+	clusterFQDN := clusterSvc.ServiceFQDN("cluster.local")
+	certs, err := certmanager.NewClusterCertificates(ctx, cluster, certmanager.KeyStoreKey(cluster), k8sClient, fqdn, clusterFQDN, controller.UnifiedScheme, log.FromContext(ctx))
+	if err != nil {
+		return "", nil, err
+	}
+	return fqdn, certs, nil
+}
+
+func saslOpt(user, password, mechanism string) (kgo.Opt, error) {
+	var m sasl.Mechanism
+	switch mechanism {
+	case "SCRAM-SHA-256", "SCRAM-SHA-512":
+		scram := scram.Auth{User: user, Pass: password}
+
+		switch mechanism {
+		case "SCRAM-SHA-256":
+			m = scram.AsSha256Mechanism()
+		case "SCRAM-SHA-512":
+			m = scram.AsSha512Mechanism()
+		}
+	default:
+		return nil, fmt.Errorf("unhandled SASL mechanism: %s", mechanism)
+	}
+
+	return kgo.SASL(m), nil
+}

--- a/operator/pkg/resources/certmanager/pki.go
+++ b/operator/pkg/resources/certmanager/pki.go
@@ -53,7 +53,7 @@ func NewPki(
 	scheme *runtime.Scheme,
 	logger logr.Logger,
 ) (*PkiReconciler, error) {
-	cc, err := NewClusterCertificates(ctx, pandaCluster, keyStoreKey(pandaCluster), client, fqdn, clusterFQDN, scheme, logger)
+	cc, err := NewClusterCertificates(ctx, pandaCluster, KeyStoreKey(pandaCluster), client, fqdn, clusterFQDN, scheme, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func NewPki(
 	}, nil
 }
 
-func keyStoreKey(pandaCluster *vectorizedv1alpha1.Cluster) types.NamespacedName {
+func KeyStoreKey(pandaCluster *vectorizedv1alpha1.Cluster) types.NamespacedName {
 	return types.NamespacedName{Name: keystoreName(pandaCluster.Name), Namespace: pandaCluster.Namespace}
 }
 
@@ -71,7 +71,7 @@ func keyStoreKey(pandaCluster *vectorizedv1alpha1.Cluster) types.NamespacedName 
 func (r *PkiReconciler) Ensure(ctx context.Context) error {
 	toApply := []resources.Resource{}
 
-	keystoreSecret := NewKeystoreSecretResource(r.Client, r.scheme, r.pandaCluster, keyStoreKey(r.pandaCluster), r.logger)
+	keystoreSecret := NewKeystoreSecretResource(r.Client, r.scheme, r.pandaCluster, KeyStoreKey(r.pandaCluster), r.logger)
 
 	toApply = append(toApply, keystoreSecret)
 	res, err := r.clusterCertificates.Resources(ctx)
@@ -93,7 +93,7 @@ func (r *PkiReconciler) Ensure(ctx context.Context) error {
 }
 
 func (r *PkiReconciler) Key() types.NamespacedName {
-	return keyStoreKey(r.pandaCluster)
+	return KeyStoreKey(r.pandaCluster)
 }
 
 // StatefulSetVolumeProvider returns volume provider for all TLS certificates

--- a/operator/pkg/resources/resource_integration_test.go
+++ b/operator/pkg/resources/resource_integration_test.go
@@ -661,3 +661,15 @@ func (TestAdminTLSConfigProvider) GetTLSConfig(
 ) (*tls.Config, error) {
 	return nil, nil
 }
+
+func (TestAdminTLSConfigProvider) GetKafkaTLSConfig(
+	ctx context.Context, k8sClient client.Reader,
+) (*tls.Config, error) {
+	return nil, nil
+}
+
+func (TestAdminTLSConfigProvider) GetSchemaTLSConfig(
+	ctx context.Context, k8sClient client.Reader,
+) (*tls.Config, error) {
+	return nil, nil
+}

--- a/operator/pkg/resources/types/tls_types.go
+++ b/operator/pkg/resources/types/tls_types.go
@@ -36,6 +36,8 @@ type BrokerTLSConfigProvider interface {
 // AdminTLSConfigProvider returns TLS config for admin API
 type AdminTLSConfigProvider interface {
 	GetTLSConfig(ctx context.Context, k8sClient client.Reader) (*tls.Config, error)
+	GetKafkaTLSConfig(ctx context.Context, k8sClient client.Reader) (*tls.Config, error)
+	GetSchemaTLSConfig(ctx context.Context, k8sClient client.Reader) (*tls.Config, error)
 }
 
 // TLSMountPoint defines paths to be mounted


### PR DESCRIPTION
This is an attempt to begin some of the underlying work necessary to get some of our existing CRDs (i.e. User/Topic/Schema and soon to be ShadowLink) supported by our v1 CRD. I took an extremely rough stab at trying to set up the proper mechanisms for fetching cert material in initializing TLS connections as well as SASL auth, but I'm not entirely sure if I did so correctly due to lack of familiarity with the v1 design.

Going to add you on @birdayz since you added the factory initialization support for the admin API previously and have a sense as to how these things generally should work, but feel free to toss this to someone else if you don't have the cycles. The main thing I need eyes on is the TLS/auth initialization mechanisms translating from v1 cluster --> config.