### PR TITLE
Fix path to console helm chart for nightly builds

### DIFF
--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -153,7 +153,7 @@ tasks:
       - task: publish:nightly:helm:chart
         vars: {REPO: redpanda-operator-nightly, CHART: operator, DIR: "operator/chart", VERSION: "{{ .OPERATOR_VERSION }}"}
       - task: publish:nightly:helm:chart
-        vars: {REPO: console-unstable, CHART: console, VERSION: "{{ .CONSOLE_CHART_VERSION }}"}
+        vars: {REPO: console-unstable, CHART: console, DIR: "charts/console/chart", VERSION: "{{ .CONSOLE_CHART_VERSION }}"}
 
   publish:nightly:helm:chart:
     run: 'always'


### PR DESCRIPTION
Looks like the path wasn't updated in the helm chart publishing task after the rendered template chart location was moved from `charts/console` to `charts/console/chart`.