### PR TITLE
operator: don't overwrite init container image

### DIFF
--- a/.changes/unreleased/operator-Fixed-20250916-122401.yaml
+++ b/.changes/unreleased/operator-Fixed-20250916-122401.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: '`spec.clusterSpec.initContainerImage` is not longer incorrectly set to the redpanda image.'
+time: 2025-09-16T12:24:01.008607-04:00

--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -362,3 +362,381 @@
   status:
     availableReplicas: 0
     replicas: 0
+-- chown-datadir --
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir
+    namespace: chown-datadir
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: chown-datadir
+        app.kubernetes.io/name: redpanda
+    serviceName: chown-datadir
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda-statefulset
+          app.kubernetes.io/instance: chown-datadir
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: redpanda
+          helm.sh/chart: redpanda-5.10.4
+          redpanda.com/poddisruptionbudget: chown-datadir
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: redpanda-statefulset
+                  app.kubernetes.io/instance: chown-datadir
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=$(SERVICE_NAME).chown-datadir.chown-datadir.svc.cluster.local.:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v25.1.7
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+                "https://${SERVICE_NAME}.chown-datadir.chown-datadir.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 101
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.chown-datadir.chown-datadir.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - chown-datadir
+          - --redpanda-cluster-name
+          - chown-datadir
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).chown-datadir.chown-datadir.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: localhost/redpanda-operator:dev
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          securityContext: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: docker.redpanda.com/redpandadata/redpanda:v25.1.7
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+        - command:
+          - /bin/sh
+          - -c
+          - chown 101:101 -R /var/lib/redpanda/data
+          image: busybox:latest
+          name: set-datadir-ownership
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v25.1.7
+          name: redpanda-configurator
+          resources: {}
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 101
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: chown-datadir-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: localhost/redpanda-operator:dev
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+        serviceAccountName: chown-datadir
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: redpanda-statefulset
+              app.kubernetes.io/instance: chown-datadir
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: chown-datadir-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: chown-datadir-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: chown-datadir-sts-lifecycle
+        - configMap:
+            name: chown-datadir
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: chown-datadir-configurator
+          secret:
+            defaultMode: 509
+            secretName: chown-datadir-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: chown-datadir
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -1051,3 +1051,1056 @@
     type: ClusterIP
   status:
     loadBalancer: {}
+-- chown-datadir --
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-external
+    namespace: chown-datadir
+  spec:
+    externalTrafficPolicy: Local
+    ports:
+    - name: admin-default
+      nodePort: 31644
+      port: 9645
+      protocol: TCP
+      targetPort: 0
+    - name: kafka-default
+      nodePort: 31092
+      port: 9094
+      protocol: TCP
+      targetPort: 0
+    - name: http-default
+      nodePort: 30082
+      port: 8083
+      protocol: TCP
+      targetPort: 0
+    - name: schema-default
+      nodePort: 30081
+      port: 8084
+      protocol: TCP
+      targetPort: 0
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/name: redpanda
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir
+    namespace: chown-datadir
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: chown-datadir
+        app.kubernetes.io/name: redpanda
+        redpanda.com/poddisruptionbudget: chown-datadir
+  status:
+    currentHealthy: 0
+    desiredHealthy: 0
+    disruptionsAllowed: 0
+    expectedPods: 0
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir
+    namespace: chown-datadir
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+      monitoring.redpanda.com/enabled: "false"
+    name: chown-datadir
+    namespace: chown-datadir
+  spec:
+    clusterIP: None
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/name: redpanda
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","default_topic_replications":"3","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.
+          port: 9093
+        - address: chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.
+          port: 9093
+        - address: chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.
+          port: 9093
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.
+            port: 33145
+        - host:
+            address: chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.
+            port: 33145
+        - host:
+            address: chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.:9644
+          - chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.:9644
+          - chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.:9093
+          - chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.:9093
+          - chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.:8081
+          - chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.:8081
+          - chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.
+          port: 9093
+        - address: chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.
+          port: 9093
+        - address: chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.
+          port: 9093
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir
+    namespace: chown-datadir
+- apiVersion: v1
+  data:
+    profile: |-
+      admin_api:
+        addresses:
+        - chown-datadir-0:31644
+        - chown-datadir-1:31644
+        - chown-datadir-2:31644
+        tls:
+          ca_file: ca.crt
+      kafka_api:
+        brokers:
+        - chown-datadir-0:31092
+        - chown-datadir-1:31092
+        - chown-datadir-2:31092
+        tls:
+          ca_file: ca.crt
+      name: default
+      schema_registry:
+        addresses:
+        - chown-datadir-0:30081
+        - chown-datadir-1:30081
+        - chown-datadir-2:30081
+        tls:
+          ca_file: ca.crt
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-rpk
+    namespace: chown-datadir
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-default-selfsigned-issuer
+    namespace: chown-datadir
+  spec:
+    selfSigned: {}
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-default-root-issuer
+    namespace: chown-datadir
+  spec:
+    ca:
+      secretName: chown-datadir-default-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-external-selfsigned-issuer
+    namespace: chown-datadir
+  spec:
+    selfSigned: {}
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-external-root-issuer
+    namespace: chown-datadir
+  spec:
+    ca:
+      secretName: chown-datadir-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-default-root-certificate
+    namespace: chown-datadir
+  spec:
+    commonName: chown-datadir-default-root-certificate
+    duration: 43800h0m0s
+    isCA: true
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: chown-datadir-default-selfsigned-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: chown-datadir-default-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-external-root-certificate
+    namespace: chown-datadir
+  spec:
+    commonName: chown-datadir-external-root-certificate
+    duration: 43800h0m0s
+    isCA: true
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: chown-datadir-external-selfsigned-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: chown-datadir-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-default-cert
+    namespace: chown-datadir
+  spec:
+    dnsNames:
+    - chown-datadir-cluster.chown-datadir.chown-datadir.svc.cluster.local
+    - chown-datadir-cluster.chown-datadir.chown-datadir.svc
+    - chown-datadir-cluster.chown-datadir.chown-datadir
+    - '*.chown-datadir-cluster.chown-datadir.chown-datadir.svc.cluster.local'
+    - '*.chown-datadir-cluster.chown-datadir.chown-datadir.svc'
+    - '*.chown-datadir-cluster.chown-datadir.chown-datadir'
+    - chown-datadir.chown-datadir.svc.cluster.local
+    - chown-datadir.chown-datadir.svc
+    - chown-datadir.chown-datadir
+    - '*.chown-datadir.chown-datadir.svc.cluster.local'
+    - '*.chown-datadir.chown-datadir.svc'
+    - '*.chown-datadir.chown-datadir'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: chown-datadir-default-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: chown-datadir-default-cert
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-external-cert
+    namespace: chown-datadir
+  spec:
+    dnsNames:
+    - chown-datadir-cluster.chown-datadir.chown-datadir.svc.cluster.local
+    - chown-datadir-cluster.chown-datadir.chown-datadir.svc
+    - chown-datadir-cluster.chown-datadir.chown-datadir
+    - '*.chown-datadir-cluster.chown-datadir.chown-datadir.svc.cluster.local'
+    - '*.chown-datadir-cluster.chown-datadir.chown-datadir.svc'
+    - '*.chown-datadir-cluster.chown-datadir.chown-datadir'
+    - chown-datadir.chown-datadir.svc.cluster.local
+    - chown-datadir.chown-datadir.svc
+    - chown-datadir.chown-datadir
+    - '*.chown-datadir.chown-datadir.svc.cluster.local'
+    - '*.chown-datadir.chown-datadir.svc'
+    - '*.chown-datadir.chown-datadir'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: chown-datadir-external-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: chown-datadir-external-cert
+  status: {}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-rpk-debug-bundle
+    namespace: chown-datadir
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - endpoints
+    - events
+    - limitranges
+    - persistentvolumeclaims
+    - pods
+    - pods/log
+    - replicationcontrollers
+    - resourcequotas
+    - serviceaccounts
+    - services
+    verbs:
+    - get
+    - list
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-sidecar
+    namespace: chown-datadir
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-rpk-debug-bundle
+    namespace: chown-datadir
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: chown-datadir-rpk-debug-bundle
+  subjects:
+  - kind: ServiceAccount
+    name: chown-datadir
+    namespace: chown-datadir
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-sidecar
+    namespace: chown-datadir
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: chown-datadir-sidecar
+  subjects:
+  - kind: ServiceAccount
+    name: chown-datadir
+    namespace: chown-datadir
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-sts-lifecycle
+    namespace: chown-datadir
+  stringData:
+    common.sh: |-
+      #!/usr/bin/env bash
+
+      # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+      CURL_URL="https://${SERVICE_NAME}.chown-datadir.chown-datadir.svc.cluster.local:9644"
+
+      # commands used throughout
+      CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+      CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+    postStart.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      postStartHook () {
+        set -x
+
+        touch /tmp/postStartHookStarted
+
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Clearing maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        # a 400 here would mean not in maintenance mode
+        until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+            status=$(${CURL_MAINTENANCE_DELETE_CMD})
+            sleep 0.5
+        done
+
+        touch /tmp/postStartHookFinished
+      }
+
+      postStartHook
+      true
+    preStop.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      touch /tmp/preStopHookStarted
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      set -x
+
+      preStopHook () {
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Setting maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        until [ "${status:-}" = '"200"' ]; do
+            status=$(${CURL_MAINTENANCE_PUT_CMD})
+            sleep 0.5
+        done
+
+        until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+            res=$(${CURL_MAINTENANCE_GET_CMD})
+            finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+            draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+            sleep 0.5
+        done
+
+        touch /tmp/preStopHookFinished
+      }
+      preStopHook
+      true
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: redpanda-5.10.4
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-configurator
+    namespace: chown-datadir
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+      BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.chown-datadir.chown-datadir.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      ADVERTISED_KAFKA_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.chown-datadir.chown-datadir.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      ADVERTISED_HTTP_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+  type: Opaque
+- apiVersion: v1
+  data:
+    config.yaml: |
+      # from .Values.console.config
+      kafka:
+        brokers:
+        - chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.:9093
+        - chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.:9093
+        - chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.:9093
+        sasl:
+          enabled: false
+        schemaRegistry:
+          enabled: true
+          tls:
+            caFilepath: /etc/tls/certs/default/ca.crt
+            certFilepath: ""
+            enabled: true
+            insecureSkipTlsVerify: false
+            keyFilepath: ""
+          urls:
+          - https://chown-datadir-0.chown-datadir.chown-datadir.svc.cluster.local.:8081
+          - https://chown-datadir-1.chown-datadir.chown-datadir.svc.cluster.local.:8081
+          - https://chown-datadir-2.chown-datadir.chown-datadir.svc.cluster.local.:8081
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+      redpanda:
+        adminApi:
+          enabled: true
+          tls:
+            caFilepath: /etc/tls/certs/default/ca.crt
+            certFilepath: ""
+            enabled: true
+            insecureSkipTlsVerify: false
+            keyFilepath: ""
+          urls:
+          - https://chown-datadir.chown-datadir.svc.cluster.local.:9644
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-console
+    namespace: chown-datadir
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-console
+    namespace: chown-datadir
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: chown-datadir
+        app.kubernetes.io/name: console
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          checksum-redpanda-chart/config: 6ebf49f3ef56e0306722fbdb2c2fcd455b17f1bf89ae6d85d0cedcaf64f89e6c
+          checksum/config: 4e5f7d808b9f6bf7323f22007d1a2a891597deec3eb09a83e674a1d48fd50d20
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: chown-datadir
+          app.kubernetes.io/name: console
+      spec:
+        affinity: {}
+        automountServiceAccountToken: false
+        containers:
+        - args:
+          - --config.filepath=/etc/console/configs/config.yaml
+          image: docker.redpanda.com/redpandadata/console:v2.8.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: console
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /etc/console/configs
+            name: configs
+            readOnly: true
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+        securityContext:
+          fsGroup: 99
+          runAsUser: 99
+        serviceAccountName: chown-datadir-console
+        volumes:
+        - configMap:
+            name: chown-datadir-console
+          name: configs
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 272
+            secretName: chown-datadir-default-cert
+  status: {}
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-console
+    namespace: chown-datadir
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: console
+      app.kubernetes.io/version: v2.8.0
+      cluster.redpanda.com/namespace: chown-datadir
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: chown-datadir
+      helm.sh/chart: console-0.7.31
+      helm.toolkit.fluxcd.io/name: chown-datadir
+      helm.toolkit.fluxcd.io/namespace: chown-datadir
+    name: chown-datadir-console
+    namespace: chown-datadir
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 0
+    selector:
+      app.kubernetes.io/instance: chown-datadir
+      app.kubernetes.io/name: console
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/operator/internal/lifecycle/testdata/cases.txtar
+++ b/operator/internal/lifecycle/testdata/cases.txtar
@@ -1,1 +1,9 @@
 -- basic-test --
+
+-- chown-datadir --
+spec:
+  clusterSpec:
+    statefulSet:
+      initContainers:
+        setDataDirOwnership:
+          enabled: true

--- a/operator/internal/lifecycle/v2_node_pools.go
+++ b/operator/internal/lifecycle/v2_node_pools.go
@@ -53,10 +53,6 @@ func (m *V2NodePoolRenderer) Render(ctx context.Context, cluster *ClusterWithPoo
 		spec.Statefulset = &redpandav1alpha2.Statefulset{}
 	}
 
-	if spec.Statefulset.InitContainerImage == nil {
-		spec.Statefulset.InitContainerImage = &redpandav1alpha2.InitContainerImage{}
-	}
-
 	if spec.Statefulset.SideCars == nil {
 		spec.Statefulset.SideCars = &redpandav1alpha2.SideCars{}
 	}
@@ -93,14 +89,6 @@ func (m *V2NodePoolRenderer) Render(ctx context.Context, cluster *ClusterWithPoo
 
 	if spec.Statefulset.SideCars.Controllers.Image.Repository == nil {
 		spec.Statefulset.SideCars.Controllers.Image.Repository = &m.image.Repository
-	}
-
-	if spec.Statefulset.InitContainerImage.Tag == nil {
-		spec.Statefulset.InitContainerImage.Tag = &m.image.Tag
-	}
-
-	if spec.Statefulset.InitContainerImage.Repository == nil {
-		spec.Statefulset.InitContainerImage.Repository = &m.image.Repository
 	}
 
 	// If not explicitly specified, set the initContainer flags for the bootstrap


### PR DESCRIPTION
Prior to this change the operator was incorrectly overwriting `.statefulSet.initContainerImage` with the redpanda image.

This commit removes the overwriting and adds a basic unit test.

[K8S-716](https://redpandadata.atlassian.net/browse/K8S-716)

[K8S-716]: https://redpandadata.atlassian.net/browse/K8S-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ