### PR TITLE
*: stop leaking (most) etcd procs

### DIFF
--- a/operator/internal/testutils/setup_envtest.go
+++ b/operator/internal/testutils/setup_envtest.go
@@ -43,7 +43,18 @@ func (e *RedpandaTestEnv) StartRedpandaTestEnv(withWebhook bool) (*rest.Config, 
 			Paths: []string{filepath.Join(configPath, "webhook")},
 		}
 	}
+
 	cfg, err := e.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	// Ideally we'd plumb in testing.T here to ensure that clean up is run.
+	// This seems to run ~80% of the time which is a dramatic improvement.
+	runtime.AddCleanup(cfg, func(e *RedpandaTestEnv) {
+		_ = e.Stop()
+	}, e)
+
 	return cfg, err
 }
 

--- a/pkg/kube/envexpander_test.go
+++ b/pkg/kube/envexpander_test.go
@@ -28,6 +28,8 @@ func TestEnvExpander(t *testing.T) {
 	cfg, err := env.Start()
 	require.NoError(t, err)
 
+	t.Cleanup(func() { _ = env.Stop() })
+
 	c, err := client.New(cfg, client.Options{})
 	require.NoError(t, err)
 


### PR DESCRIPTION
The majority of usages of `RedpandaTestEnv` leak `etcd` and `kube-apiserver` processes. This slowly bogs down machines running tests as part of their development loop.

The ideal fix would be to plumb a testing.T into it and hook into cleanup but the widespread usage makes refactoring quite tedious.

This commit instead attaches a finalizer to the returned `*rest.Config` which drops the leaked procs by > 50% (~10 leaks vs ~30). The leakage will vary across runs and is made worse by test failures. Never the less this is an improvement.