### PR TITLE
[Node Pools] Fix rendering code for tuning init container

### DIFF
--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -567,27 +567,6 @@
         - command:
           - /bin/bash
           - -c
-          - rpk redpanda tune all
-          image: redpandadata/redpanda:v25.2.1
-          name: tuning
-          resources: {}
-          securityContext:
-            capabilities:
-              add:
-              - SYS_RESOURCE
-            privileged: true
-            runAsGroup: 0
-            runAsUser: 0
-          volumeMounts:
-          - mountPath: /etc/tls/certs/default
-            name: redpanda-default-cert
-          - mountPath: /etc/tls/certs/external
-            name: redpanda-external-cert
-          - mountPath: /etc/redpanda
-            name: base-config
-        - command:
-          - /bin/bash
-          - -c
           - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
             & wait $!
           env:
@@ -949,27 +928,6 @@
             name: kube-api-access
             readOnly: true
         initContainers:
-        - command:
-          - /bin/bash
-          - -c
-          - rpk redpanda tune all
-          image: foo:bar
-          name: tuning
-          resources: {}
-          securityContext:
-            capabilities:
-              add:
-              - SYS_RESOURCE
-            privileged: true
-            runAsGroup: 0
-            runAsUser: 0
-          volumeMounts:
-          - mountPath: /etc/tls/certs/default
-            name: redpanda-default-cert
-          - mountPath: /etc/tls/certs/external
-            name: redpanda-external-cert
-          - mountPath: /etc/redpanda
-            name: base-config
         - command:
           - /bin/sh
           - -c

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -1306,7 +1306,6 @@
           - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:8081
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
-        tune_aio_events: true
       schema_registry:
         schema_registry_api:
         - address: 0.0.0.0
@@ -1510,7 +1509,6 @@
           - compat-test-pool-8.compat-test.compat-test.svc.cluster.local.:8081
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
-        tune_aio_events: true
       schema_registry:
         schema_registry_api:
         - address: 0.0.0.0

--- a/operator/internal/lifecycle/testdata/cases.txtar
+++ b/operator/internal/lifecycle/testdata/cases.txtar
@@ -17,6 +17,8 @@ metadata:
   name: compat-test
 spec:
   clusterSpec:
+    tuning:
+      tune_aio_events: false
     statefulset:
       replicas: 0
       sideCars:

--- a/operator/internal/lifecycle/testdata/cases.values.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.values.golden.txtar
@@ -530,8 +530,6 @@ pools:
               memory: 256Mi
         - image: foo:bar
           name: redpanda-configurator
-        - image: foo:bar
-          name: tuning
         nodeSelector:
           foo: bar
         priorityClassName: some-priority-class
@@ -1019,8 +1017,7 @@ values:
         issuerRef: null
         secretRef: null
     enabled: true
-  tuning:
-    tune_aio_events: true
+  tuning: {}
 -- nodepool-basic-test --
 pools:
 - Generation: "0"


### PR DESCRIPTION
We were accidentally looking at a stock default `values` template when initializing node pools, causing us not to honor the cluster-specified value for disabling some global stuff like tuning. This fixes that by passing along the already normalized values to the nodepool function and using that for reflecting on non-`values.Statefulset` fields.