### PR TITLE
Make ordering of statefulset processing consistent in rendering

### DIFF
--- a/charts/redpanda/chart/templates/_configmap.go.tpl
+++ b/charts/redpanda/chart/templates/_configmap.go.tpl
@@ -468,8 +468,8 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $brokerList := (list) -}}
-{{- range $_, $i := untilStep (((0 | int) | int)|int) (($state.Values.statefulset.replicas | int)|int) (1|int) -}}
-{{- $brokerList = (concat (default (list) $brokerList) (list (dict "address" (printf "%s-%d.%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $state)))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $state)))) "r")) "port" ($state.Values.listeners.kafka.port | int)))) -}}
+{{- range $_, $broker := (get (fromJson (include "redpanda.BrokerList" (dict "a" (list $state -1)))) "r") -}}
+{{- $brokerList = (concat (default (list) $brokerList) (list (dict "address" $broker "port" ($state.Values.listeners.kafka.port | int)))) -}}
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -490,9 +490,9 @@ func rpkSchemaRegistryClientTLSConfiguration(state *RenderState) map[string]any 
 // Kafka API interactions.
 func kafkaClient(state *RenderState) map[string]any {
 	brokerList := []map[string]any{}
-	for i := int32(0); i < state.Values.Statefulset.Replicas; i++ {
+	for _, broker := range BrokerList(state, -1) {
 		brokerList = append(brokerList, map[string]any{
-			"address": fmt.Sprintf("%s-%d.%s", Fullname(state), i, InternalDomain(state)),
+			"address": broker,
 			"port":    state.Values.Listeners.Kafka.Port,
 		})
 	}

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -11,7 +11,8 @@ package conversion
 
 import (
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -52,9 +53,8 @@ func ConvertV2ToRenderState(config *kube.RESTConfig, defaulters *V2Defaulters, c
 		if err != nil {
 			return err
 		}
-		sort.SliceStable(renderedPools, func(i, j int) bool {
-			poolA, poolB := pools[i], pools[j]
-			return poolA.Name < poolB.Name
+		slices.SortStableFunc(renderedPools, func(poolA, poolB redpanda.Pool) int {
+			return strings.Compare(poolA.Name, poolB.Name)
 		})
 		state.Pools = renderedPools
 		return nil

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -11,6 +11,7 @@ package conversion
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/cockroachdb/errors"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -47,11 +48,15 @@ func ConvertV2ToRenderState(config *kube.RESTConfig, defaulters *V2Defaulters, c
 		if err := convertV2Fields(state, &state.Values, spec); err != nil {
 			return err
 		}
-		pools, err := convertV2NodepoolsToPools(pools, defaulters)
+		renderedPools, err := convertV2NodepoolsToPools(pools, defaulters)
 		if err != nil {
 			return err
 		}
-		state.Pools = pools
+		sort.SliceStable(renderedPools, func(i, j int) bool {
+			poolA, poolB := pools[i], pools[j]
+			return poolA.Name < poolB.Name
+		})
+		state.Pools = renderedPools
 		return nil
 	})
 }

--- a/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.pools.golden.txtar
@@ -1554,26 +1554,26 @@
   metadata:
     creationTimestamp: null
     labels:
-      app.kubernetes.io/component: redpanda-basic
+      app.kubernetes.io/component: redpanda-basic-a
       app.kubernetes.io/instance: nodepool-basic-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: redpanda
       cluster.redpanda.com/namespace: nodepool-basic-test
       cluster.redpanda.com/nodepool-generation: "0"
-      cluster.redpanda.com/nodepool-name: basic
+      cluster.redpanda.com/nodepool-name: basic-a
       cluster.redpanda.com/operator: v2
       cluster.redpanda.com/owner: nodepool-basic-test
       helm.sh/chart: redpanda-25.1.1-beta3
       helm.toolkit.fluxcd.io/name: nodepool-basic-test
       helm.toolkit.fluxcd.io/namespace: nodepool-basic-test
-    name: nodepool-basic-test-basic
+    name: nodepool-basic-test-basic-a
     namespace: nodepool-basic-test
   spec:
     podManagementPolicy: Parallel
     replicas: 1
     selector:
       matchLabels:
-        app.kubernetes.io/component: redpanda-basic-statefulset
+        app.kubernetes.io/component: redpanda-basic-a-statefulset
         app.kubernetes.io/instance: nodepool-basic-test
         app.kubernetes.io/name: redpanda
     serviceName: nodepool-basic-test
@@ -1583,7 +1583,7 @@
           config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
         creationTimestamp: null
         labels:
-          app.kubernetes.io/component: redpanda-basic-statefulset
+          app.kubernetes.io/component: redpanda-basic-a-statefulset
           app.kubernetes.io/instance: nodepool-basic-test
           app.kubernetes.io/managed-by: Helm
           app.kubernetes.io/name: redpanda
@@ -1596,7 +1596,367 @@
             requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app.kubernetes.io/component: redpanda-basic-statefulset
+                  app.kubernetes.io/component: redpanda-basic-a-statefulset
+                  app.kubernetes.io/instance: nodepool-basic-test
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=$(SERVICE_NAME).nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: redpandadata/redpanda:v25.2.1
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+                "https://${SERVICE_NAME}.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - nodepool-basic-test
+          - --redpanda-cluster-name
+          - nodepool-basic-test
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: localhost/redpanda-operator:dev
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: redpandadata/redpanda:v25.2.1
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: redpandadata/redpanda:v25.2.1
+          name: redpanda-configurator
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: nodepool-basic-test-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: localhost/redpanda-operator:dev
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsUser: 101
+        serviceAccountName: nodepool-basic-test
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: redpanda-basic-a-statefulset
+              app.kubernetes.io/instance: nodepool-basic-test
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: nodepool-basic-test-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: nodepool-basic-test-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: nodepool-basic-test-sts-lifecycle
+        - configMap:
+            name: nodepool-basic-test-basic-a
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: nodepool-basic-test-configurator
+          secret:
+            defaultMode: 509
+            secretName: nodepool-basic-test-basic-a-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: nodepool-basic-test
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda-basic-b
+      app.kubernetes.io/instance: nodepool-basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: nodepool-basic-test
+      cluster.redpanda.com/nodepool-generation: "0"
+      cluster.redpanda.com/nodepool-name: basic-b
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: nodepool-basic-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: nodepool-basic-test
+      helm.toolkit.fluxcd.io/namespace: nodepool-basic-test
+    name: nodepool-basic-test-basic-b
+    namespace: nodepool-basic-test
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: redpanda-basic-b-statefulset
+        app.kubernetes.io/instance: nodepool-basic-test
+        app.kubernetes.io/name: redpanda
+    serviceName: nodepool-basic-test
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/component: redpanda-basic-b-statefulset
+          app.kubernetes.io/instance: nodepool-basic-test
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/name: redpanda
+          cluster.redpanda.com/broker: "true"
+          helm.sh/chart: redpanda-25.1.1-beta3
+          redpanda.com/poddisruptionbudget: nodepool-basic-test
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: redpanda-basic-b-statefulset
                   app.kubernetes.io/instance: nodepool-basic-test
                   app.kubernetes.io/name: redpanda
               topologyKey: kubernetes.io/hostname
@@ -1840,7 +2200,7 @@
         topologySpreadConstraints:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/component: redpanda-basic-statefulset
+              app.kubernetes.io/component: redpanda-basic-b-statefulset
               app.kubernetes.io/instance: nodepool-basic-test
               app.kubernetes.io/name: redpanda
           maxSkew: 1
@@ -1860,14 +2220,14 @@
             defaultMode: 509
             secretName: nodepool-basic-test-sts-lifecycle
         - configMap:
-            name: nodepool-basic-test-basic
+            name: nodepool-basic-test-basic-b
           name: base-config
         - emptyDir: {}
           name: config
         - name: nodepool-basic-test-configurator
           secret:
             defaultMode: 509
-            secretName: nodepool-basic-test-basic-configurator
+            secretName: nodepool-basic-test-basic-b-configurator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -2612,7 +2612,10 @@
             address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
             port: 33145
         - host:
-            address: nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
             port: 33145
       rpk:
         additional_start_flags:
@@ -2625,7 +2628,8 @@
           - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
           - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
           - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
-          - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
         enable_memory_locking: false
@@ -2634,7 +2638,8 @@
           - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
           - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
           - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
-          - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
         overprovisioned: false
@@ -2643,7 +2648,8 @@
           - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
           - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
           - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
-          - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
         tune_aio_events: true
@@ -2798,7 +2804,10 @@
             address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
             port: 33145
         - host:
-            address: nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
             port: 33145
       rpk:
         additional_start_flags:
@@ -2811,7 +2820,8 @@
           - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
           - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
           - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
-          - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
         enable_memory_locking: false
@@ -2820,7 +2830,8 @@
           - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
           - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
           - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
-          - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
         overprovisioned: false
@@ -2829,7 +2840,8 @@
           - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
           - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
           - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
-          - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
           tls:
             ca_file: /etc/tls/certs/default/ca.crt
         tune_aio_events: true
@@ -2880,7 +2892,199 @@
       helm.sh/chart: redpanda-25.1.1-beta3
       helm.toolkit.fluxcd.io/name: nodepool-basic-test
       helm.toolkit.fluxcd.io/namespace: nodepool-basic-test
-    name: nodepool-basic-test-basic
+    name: nodepool-basic-test-basic-a
+    namespace: nodepool-basic-test
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+        - host:
+            address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: nodepool-basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: nodepool-basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: nodepool-basic-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: nodepool-basic-test
+      helm.toolkit.fluxcd.io/namespace: nodepool-basic-test
+    name: nodepool-basic-test-basic-b
     namespace: nodepool-basic-test
 - apiVersion: v1
   data:
@@ -3435,7 +3639,57 @@
       helm.sh/chart: redpanda-25.1.1-beta3
       helm.toolkit.fluxcd.io/name: nodepool-basic-test
       helm.toolkit.fluxcd.io/namespace: nodepool-basic-test
-    name: nodepool-basic-test-basic-configurator
+    name: nodepool-basic-test-basic-a-configurator
+    namespace: nodepool-basic-test
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+      BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      ADVERTISED_KAFKA_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      ADVERTISED_HTTP_ADDRESSES=()
+
+      PREFIX_TEMPLATE=""
+      ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: nodepool-basic-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/namespace: nodepool-basic-test
+      cluster.redpanda.com/operator: v2
+      cluster.redpanda.com/owner: nodepool-basic-test
+      helm.sh/chart: redpanda-25.1.1-beta3
+      helm.toolkit.fluxcd.io/name: nodepool-basic-test
+      helm.toolkit.fluxcd.io/namespace: nodepool-basic-test
+    name: nodepool-basic-test-basic-b-configurator
     namespace: nodepool-basic-test
   stringData:
     configurator.sh: |-
@@ -3479,7 +3733,8 @@
         - nodepool-basic-test-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
         - nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
         - nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
-        - nodepool-basic-test-basic-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+        - nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
+        - nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.:9093
         sasl:
           enabled: false
         tls:
@@ -3554,8 +3809,8 @@
     template:
       metadata:
         annotations:
-          checksum-redpanda-chart/config: c8747073736e14d3b974e100efbe332bd74486e237db9575ae7d656b9e96d23a
-          checksum/config: d9fc3f8f7b446030171b8864f5b0662576038207416c2fc15e7a21941bf609eb
+          checksum-redpanda-chart/config: a6e927c774a415450f34487df5734a6e7068a2ad3f7a5c1006cbc20348b472c0
+          checksum/config: 608c992c254e4dcbc1326de93d9d2ce8f9601710e38c342c2aa25d25a8b1d186
         creationTimestamp: null
         labels:
           app.kubernetes.io/instance: nodepool-basic-test

--- a/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.resources.golden.txtar
@@ -1178,7 +1178,25 @@
           enabled: true
           require_client_auth: false
           truststore_file: /etc/tls/certs/default/ca.crt
-        brokers: []
+        brokers:
+        - address: compat-test-pool-0.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-1.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-2.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-3.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-4.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-5.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-6.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-7.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-8.compat-test.compat-test.svc.cluster.local.
+          port: 9093
       redpanda:
         admin:
         - address: 0.0.0.0
@@ -1333,7 +1351,25 @@
           enabled: true
           require_client_auth: false
           truststore_file: /etc/tls/certs/default/ca.crt
-        brokers: []
+        brokers:
+        - address: compat-test-pool-0.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-1.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-2.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-3.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-4.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-5.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-6.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-7.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-8.compat-test.compat-test.svc.cluster.local.
+          port: 9093
   kind: ConfigMap
   metadata:
     creationTimestamp: null
@@ -1382,7 +1418,25 @@
           enabled: true
           require_client_auth: false
           truststore_file: /etc/tls/certs/default/ca.crt
-        brokers: []
+        brokers:
+        - address: compat-test-pool-0.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-1.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-2.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-3.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-4.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-5.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-6.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-7.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-8.compat-test.compat-test.svc.cluster.local.
+          port: 9093
       redpanda:
         admin:
         - address: 0.0.0.0
@@ -1537,7 +1591,25 @@
           enabled: true
           require_client_auth: false
           truststore_file: /etc/tls/certs/default/ca.crt
-        brokers: []
+        brokers:
+        - address: compat-test-pool-0.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-1.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-2.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-3.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-4.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-5.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-6.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-7.compat-test.compat-test.svc.cluster.local.
+          port: 9093
+        - address: compat-test-pool-8.compat-test.compat-test.svc.cluster.local.
+          port: 9093
   kind: ConfigMap
   metadata:
     creationTimestamp: null
@@ -2549,6 +2621,10 @@
           port: 9093
         - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
+        - address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
       redpanda:
         admin:
         - address: 0.0.0.0
@@ -2685,6 +2761,10 @@
         - address: nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
         - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
   kind: ConfigMap
   metadata:
@@ -2741,6 +2821,10 @@
           port: 9093
         - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
+        - address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
       redpanda:
         admin:
         - address: 0.0.0.0
@@ -2877,6 +2961,10 @@
         - address: nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
         - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
   kind: ConfigMap
   metadata:
@@ -2933,6 +3021,10 @@
           port: 9093
         - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
+        - address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
       redpanda:
         admin:
         - address: 0.0.0.0
@@ -3069,6 +3161,10 @@
         - address: nodepool-basic-test-1.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
         - address: nodepool-basic-test-2.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-a-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
+          port: 9093
+        - address: nodepool-basic-test-basic-b-0.nodepool-basic-test.nodepool-basic-test.svc.cluster.local.
           port: 9093
   kind: ConfigMap
   metadata:

--- a/operator/internal/lifecycle/testdata/cases.txtar
+++ b/operator/internal/lifecycle/testdata/cases.txtar
@@ -4,12 +4,19 @@
 apiVersion: cluster.redpanda.com/v1alpha2
 kind: NodePool
 metadata:
-  name: basic
+  name: basic-b
 spec:
   replicas: 1
   sidecarImage:
     tag: dev
     repository: localhost/test
+---
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: NodePool
+metadata:
+  name: basic-a
+spec:
+  replicas: 1
 -- compat-test --
 apiVersion: cluster.redpanda.com/v1alpha2
 kind: Redpanda

--- a/operator/internal/lifecycle/testdata/cases.values.golden.txtar
+++ b/operator/internal/lifecycle/testdata/cases.values.golden.txtar
@@ -1024,7 +1024,7 @@ values:
 -- nodepool-basic-test --
 pools:
 - Generation: "0"
-  Name: basic
+  Name: basic-a
   Statefulset:
     additionalRedpandaCmdFlags: []
     additionalSelectorLabels: {}
@@ -1052,7 +1052,7 @@ pools:
             requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app.kubernetes.io/component: '{{ include "redpanda.name" . }}-basic-statefulset'
+                  app.kubernetes.io/component: '{{ include "redpanda.name" . }}-basic-a-statefulset'
                   app.kubernetes.io/instance: '{{ .Release.Name }}'
                   app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
               topologyKey: kubernetes.io/hostname
@@ -1070,7 +1070,86 @@ pools:
         topologySpreadConstraints:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/component: '{{ include "redpanda.name" . }}-basic-statefulset'
+              app.kubernetes.io/component: '{{ include "redpanda.name" . }}-basic-a-statefulset'
+              app.kubernetes.io/instance: '{{ .Release.Name }}'
+              app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+    replicas: 1
+    sideCars:
+      args: []
+      brokerDecommissioner:
+        decommissionAfter: 60s
+        decommissionRequeueTimeout: 10s
+        enabled: false
+      configWatcher:
+        enabled: true
+      controllers:
+        createRBAC: true
+        enabled: false
+        healthProbeAddress: :8085
+        image: null
+        metricsAddress: :9082
+        pprofAddress: :9083
+        run:
+        - all
+      image:
+        repository: localhost/redpanda-operator
+        tag: dev
+      pvcUnbinder:
+        enabled: false
+        unbindAfter: 60s
+    updateStrategy:
+      type: RollingUpdate
+- Generation: "0"
+  Name: basic-b
+  Statefulset:
+    additionalRedpandaCmdFlags: []
+    additionalSelectorLabels: {}
+    budget:
+      maxUnavailable: 1
+    initContainerImage:
+      repository: busybox
+      tag: latest
+    initContainers:
+      configurator: {}
+      fsValidator:
+        enabled: false
+        expectedFS: xfs
+      setDataDirOwnership:
+        enabled: false
+    podAntiAffinity:
+      custom: {}
+      topologyKey: kubernetes.io/hostname
+      type: hard
+      weight: 100
+    podTemplate:
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: '{{ include "redpanda.name" . }}-basic-b-statefulset'
+                  app.kubernetes.io/instance: '{{ .Release.Name }}'
+                  app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
+              topologyKey: kubernetes.io/hostname
+        containers:
+        - image: redpandadata/redpanda:v25.2.1
+          name: redpanda
+        initContainers:
+        - image: redpandadata/redpanda:v25.2.1
+          name: redpanda-configurator
+        - image: redpandadata/redpanda:v25.2.1
+          name: tuning
+        priorityClassName: ""
+        securityContext: {}
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: '{{ include "redpanda.name" . }}-basic-b-statefulset'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
               app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
           maxSkew: 1


### PR DESCRIPTION
This makes sure that the node pools have a consistent ordering when we iterate across them in our rendering code. In some tests with 3 node pools we were getting odd bootstrapping errors (this should really be handled in core) where the ordering of the `bootstrap_servers` in the distinct `redpanda.yaml` files needs to match exactly:

```
ERROR 2025-09-17 22:28:39,556 [shard 0:main] cluster - cluster_discovery.cc:329 - seed server list mismatch, local: {
  addr: {host: redpanda-broker-blue-c-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145},
  addr: {host: redpanda-broker-blue-a-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145},
  addr: {host: redpanda-broker-blue-b-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145}
},
  {host: redpanda-broker-blue-a-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145}:
    {
      {host: redpanda-broker-blue-b-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145},
      {host: redpanda-broker-blue-c-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145},
      {host: redpanda-broker-blue-a-0.redpanda-broker.redpanda.svc.cluster.local, port: 33145}
    }
```

In addition I found a place where we were still constructing some clients in the rpk configuration with the old non-nodepool aware replica iteration. So I fixed that too.