### PR TITLE
Add Azure configuration options for tiered storage

### DIFF
--- a/charts/redpanda/chart/values.schema.json
+++ b/charts/redpanda/chart/values.schema.json
@@ -21164,6 +21164,18 @@
                 "cloud_storage_azure_adls_port": {
                   "type": "integer"
                 },
+                "cloud_storage_azure_container": {
+                  "type": "string"
+                },
+                "cloud_storage_azure_managed_identity_id": {
+                  "type": "string"
+                },
+                "cloud_storage_azure_shared_key": {
+                  "type": "string"
+                },
+                "cloud_storage_azure_storage_account": {
+                  "type": "string"
+                },
                 "cloud_storage_bucket": {
                   "type": "string"
                 },
@@ -21185,7 +21197,7 @@
                   ]
                 },
                 "cloud_storage_credentials_source": {
-                  "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata)$",
+                  "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata)$",
                   "type": "string"
                 },
                 "cloud_storage_disable_tls": {
@@ -21353,6 +21365,18 @@
             "cloud_storage_azure_adls_port": {
               "type": "integer"
             },
+            "cloud_storage_azure_container": {
+              "type": "string"
+            },
+            "cloud_storage_azure_managed_identity_id": {
+              "type": "string"
+            },
+            "cloud_storage_azure_shared_key": {
+              "type": "string"
+            },
+            "cloud_storage_azure_storage_account": {
+              "type": "string"
+            },
             "cloud_storage_bucket": {
               "type": "string"
             },
@@ -21374,7 +21398,7 @@
               ]
             },
             "cloud_storage_credentials_source": {
-              "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata)$",
+              "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata)$",
               "type": "string"
             },
             "cloud_storage_disable_tls": {

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -1793,21 +1793,25 @@ func (c TieredStorageConfig) Translate(creds *TieredStorageCredentials) (map[str
 // +gotohelm:ignore=true
 func (TieredStorageConfig) JSONSchema() *jsonschema.Schema {
 	type schema struct {
-		CloudStorageEnabled            bool   `json:"cloud_storage_enabled" jsonschema:"required"`
-		CloudStorageAccessKey          string `json:"cloud_storage_access_key"`
-		CloudStorageSecretKey          string `json:"cloud_storage_secret_key"`
-		CloudStorageAPIEndpoint        string `json:"cloud_storage_api_endpoint"`
-		CloudStorageAPIEndpointPort    int    `json:"cloud_storage_api_endpoint_port"`
-		CloudStorageAzureADLSEndpoint  string `json:"cloud_storage_azure_adls_endpoint"`
-		CloudStorageAzureADLSPort      int    `json:"cloud_storage_azure_adls_port"`
-		CloudStorageBucket             string `json:"cloud_storage_bucket"`
-		CloudStorageCacheCheckInterval int    `json:"cloud_storage_cache_check_interval"`
+		CloudStorageEnabled                bool   `json:"cloud_storage_enabled" jsonschema:"required"`
+		CloudStorageAccessKey              string `json:"cloud_storage_access_key"`
+		CloudStorageSecretKey              string `json:"cloud_storage_secret_key"`
+		CloudStorageAPIEndpoint            string `json:"cloud_storage_api_endpoint"`
+		CloudStorageAPIEndpointPort        int    `json:"cloud_storage_api_endpoint_port"`
+		CloudStorageAzureADLSEndpoint      string `json:"cloud_storage_azure_adls_endpoint"`
+		CloudStorageAzureADLSPort          int    `json:"cloud_storage_azure_adls_port"`
+		CloudStorageAzureContainer         string `json:"cloud_storage_azure_container"`
+		CloudStorageAzureManagedIdentityID string `json:"cloud_storage_azure_managed_identity_id"`
+		CloudStorageAzureStorageAccount    string `json:"cloud_storage_azure_storage_account"`
+		CloudStorageAzureSharedKey         string `json:"cloud_storage_azure_shared_key"`
+		CloudStorageBucket                 string `json:"cloud_storage_bucket"`
+		CloudStorageCacheCheckInterval     int    `json:"cloud_storage_cache_check_interval"`
 		// CloudStorageCacheDirectory is a node config property unlike
 		// everything else in this struct. It should instead be set via
 		// `config.node`.
 		CloudStorageCacheDirectory              string            `json:"cloud_storage_cache_directory" jsonschema:"deprecated"`
 		CloudStorageCacheSize                   *ResourceQuantity `json:"cloud_storage_cache_size"`
-		CloudStorageCredentialsSource           string            `json:"cloud_storage_credentials_source" jsonschema:"pattern=^(config_file|aws_instance_metadata|sts|gcp_instance_metadata)$"`
+		CloudStorageCredentialsSource           string            `json:"cloud_storage_credentials_source" jsonschema:"pattern=^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata)$"`
 		CloudStorageDisableTLS                  bool              `json:"cloud_storage_disable_tls"`
 		CloudStorageEnableRemoteRead            bool              `json:"cloud_storage_enable_remote_read"`
 		CloudStorageEnableRemoteWrite           bool              `json:"cloud_storage_enable_remote_write"`


### PR DESCRIPTION
https://github.com/redpanda-data/redpanda-operator/pull/1099 points out that we're missing the ability to set `azure_vm_instance_metadata` in our rendering code/helm chart. Following [our docs](https://docs.redpanda.com/25.1/manage/tiered-storage/#configure-object-storage) for configuring tiered storage (make sure you're selecting the "Azure" option), looks like we're missing a few other fields as well. It looks like these are already fields in our `Redpanda` CRD, so my guess is this is mainly affecting helm chart users due to the schema validation that happens during a helm install.