### PR TITLE
Add expanded acceptance tests for Users, Topics, Roles, and Schemas

### DIFF
--- a/acceptance/clusters/vectorized/basic/cluster.yaml
+++ b/acceptance/clusters/vectorized/basic/cluster.yaml
@@ -1,12 +1,11 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: sasl
+  name: basic
 spec:
   image: "redpandadata/redpanda"
   version: "v25.2.1"
   replicas: 1
-  enableSasl: true
   resources:
     requests:
       cpu: "100m"

--- a/acceptance/features/vectorized-schema-crds.feature
+++ b/acceptance/features/vectorized-schema-crds.feature
@@ -1,0 +1,100 @@
+@cluster:vectorized/basic
+Feature: Vectorized Schema CRDs
+  Background: Vectorized Cluster available
+    Given vectorized cluster "basic" is available
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage customer profile vectorized schema (Avro)
+    Given there is no schema "customer-profile" in vectorized cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: customer-profile
+    spec:
+      cluster:
+        clusterRef:
+          group: redpanda.vectorized.io
+          kind: Cluster
+          name: basic
+      schemaType: avro
+      compatibilityLevel: Backward
+      text: |
+        {
+          "type": "record",
+          "name": "CustomerProfile",
+          "fields": [
+            { "type": "string", "name": "customer_id" },
+            { "type": "string", "name": "name" },
+            { "type": "int", "name": "age" }
+          ]
+        }
+    """
+    And schema "customer-profile" is successfully synced
+    Then I should be able to check compatibility against "customer-profile" in vectorized cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage product catalog vectorized schema (Protobuf)
+    Given there is no schema "product-catalog" in vectorized cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: product-catalog
+    spec:
+      cluster:
+        clusterRef:
+          group: redpanda.vectorized.io
+          kind: Cluster
+          name: basic
+      schemaType: protobuf
+      compatibilityLevel: Backward
+      text: |
+        syntax = "proto3";
+
+        message Product {
+          int32 product_id = 1;
+          string product_name = 2;
+          double price = 3;
+          string category = 4;
+        }
+    """
+    And schema "product-catalog" is successfully synced
+    Then I should be able to check compatibility against "product-catalog" in vectorized cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage order event vectorized schema (JSON)
+    Given there is no schema "order-event" in vectorized cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: order-event
+    spec:
+      cluster:
+        clusterRef:
+          group: redpanda.vectorized.io
+          kind: Cluster
+          name: basic
+      schemaType: json
+      compatibilityLevel: None
+      text: |
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "order_id": { "type": "string" },
+            "total": { "type": "number" }
+          },
+          "required": ["order_id", "total"],
+          "additionalProperties": false
+        }
+    """
+    And schema "order-event" is successfully synced
+    Then I should be able to check compatibility against "order-event" in vectorized cluster "basic"

--- a/acceptance/features/vectorized-topic-crds.feature
+++ b/acceptance/features/vectorized-topic-crds.feature
@@ -1,0 +1,26 @@
+@cluster:vectorized/basic
+Feature: Vectorized Topic CRDs
+  Background: Vectorized Cluster available
+    Given vectorized cluster "basic" is available
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage vectorized topics
+    Given there is no topic "topic1" in vectorized cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Topic
+    metadata:
+      name: topic1
+    spec:
+      cluster:
+        clusterRef:
+          group: redpanda.vectorized.io
+          kind: Cluster
+          name: basic
+      partitions: 1
+      replicationFactor: 1
+    """
+    And topic "topic1" is successfully synced
+    Then I should be able to produce and consume from "topic1" in vectorized cluster "basic"

--- a/acceptance/features/vectorized-user-crds.feature
+++ b/acceptance/features/vectorized-user-crds.feature
@@ -1,0 +1,87 @@
+@cluster:vectorized/sasl
+Feature: Vectorized User CRDs
+  Background: Vectorized Cluster available
+    Given vectorized cluster "sasl" is available
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage vectorized users
+    Given there is no user "bob" in vectorized cluster "sasl"
+    And there is no user "james" in vectorized cluster "sasl"
+    And there is no user "alice" in vectorized cluster "sasl"
+    When I create CRD-based users for vectorized cluster "sasl":
+      | name  | password | mechanism     | acls |
+      | bob   |          | SCRAM-SHA-256 |      |
+      | james |          | SCRAM-SHA-512 |      |
+      | alice | qwerty   | SCRAM-SHA-512 |      |
+    Then "bob" should exist and be able to authenticate to the vectorized "sasl" cluster
+    And "james" should exist and be able to authenticate to the vectorized "sasl" cluster
+    And "alice" should exist and be able to authenticate to the vectorized "sasl" cluster
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage authentication-only vectorized users
+    Given there is no user "jason" in vectorized cluster "sasl"
+    And there are already the following ACLs in vectorized cluster "sasl":
+      | user   | acls |
+      | jason  | [{"type":"allow","resource":{"type":"cluster"},"operations":["Read"]}] |
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: User
+    metadata:
+      name: jason
+    spec:
+      cluster:
+        clusterRef:
+          group: redpanda.vectorized.io
+          kind: Cluster
+          name: sasl
+      authentication:
+        type: scram-sha-512
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: jason-password
+              key: password
+    """
+    And user "jason" is successfully synced
+    And I delete the CRD user "jason"
+    Then there should be ACLs in the vectorized cluster "sasl" for user "jason"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage authorization-only vectorized users
+    Given there are the following pre-existing users in vectorized cluster "sasl"
+      | name    | password | mechanism     |
+      | travis  | password | SCRAM-SHA-256 |
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: User
+    metadata:
+      name: travis
+    spec:
+      cluster:
+        clusterRef:
+          group: redpanda.vectorized.io
+          kind: Cluster
+          name: sasl
+      authentication:
+        type: scram-sha-512
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: travis-password
+              key: password
+      authorization:
+        acls:
+        - type: allow
+          resource:
+            type: topic
+            name: some-topic
+            patternType: prefixed
+          operations: [Read]
+    """
+    And user "travis" is successfully synced
+    And I delete the CRD user "travis"
+    Then "travis" should be able to authenticate to the vectorized "sasl" cluster with password "password" and mechanism "SCRAM-SHA-256"

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -137,6 +137,10 @@ func ClusterTag(ctx context.Context, t framework.TestingT, args ...string) conte
 	require.Greater(t, len(args), 0, "clusters tags can only be used with additional arguments")
 	name := args[0]
 
+	if variant := t.Variant(); variant != "" {
+		name = filepath.Join(variant, name)
+	}
+
 	t.Logf("Installing cluster %q", name)
 	t.ApplyManifest(ctx, filepath.Join("clusters", name))
 	t.Logf("Finished installing cluster %q", name)

--- a/acceptance/steps/cluster.go
+++ b/acceptance/steps/cluster.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
-	"strings"
 	"time"
 
 	"github.com/redpanda-data/common-go/rpadmin"
@@ -29,9 +28,7 @@ import (
 )
 
 func checkClusterAvailability(ctx context.Context, t framework.TestingT, version, clusterName string) {
-	version = strings.TrimSpace(version)
-
-	if version == "vectorized" {
+	if getVersion(t, version) == "vectorized" {
 		checkV1ClusterAvailability(ctx, t, clusterName)
 		return
 	}

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -15,33 +15,32 @@ func init() {
 	// General scenario steps
 	framework.RegisterStep(`^(vectorized )?cluster "([^"]*)" is available$`, checkClusterAvailability)
 	framework.RegisterStep(`^I apply Kubernetes manifest:$`, iApplyKubernetesManifest)
-
 	framework.RegisterStep(`^I store "([^"]*)" of Kubernetes object with type "([^"]*)" and name "([^"]*)" as "([^"]*)"$`, recordVariable)
 	framework.RegisterStep(`^the recorded value "([^"]*)" has the same value as "([^"]*)" of the Kubernetes object with type "([^"]*)" and name "([^"]*)"$`, assertVariableValue)
 	framework.RegisterStep(`^the recorded value "([^"]*)" is one less than "([^"]*)" of the Kubernetes object with type "([^"]*)" and name "([^"]*)"$`, assertVariableValueIncremented)
 
 	// Schema scenario steps
-	framework.RegisterStep(`^there is no schema "([^"]*)" in cluster "([^"]*)"$`, thereIsNoSchema)
+	framework.RegisterStep(`^there is no schema "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, thereIsNoSchema)
 	framework.RegisterStep(`^schema "([^"]*)" is successfully synced$`, schemaIsSuccessfullySynced)
-	framework.RegisterStep(`^I should be able to check compatibility against "([^"]*)" in cluster "([^"]*)"$`, iShouldBeAbleToCheckCompatibilityAgainst)
+	framework.RegisterStep(`^I should be able to check compatibility against "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, iShouldBeAbleToCheckCompatibilityAgainst)
 
 	// Topic scenario steps
-	framework.RegisterStep(`^there is no topic "([^"]*)" in cluster "([^"]*)"$`, thereIsNoTopic)
+	framework.RegisterStep(`^there is no topic "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, thereIsNoTopic)
 	framework.RegisterStep(`^topic "([^"]*)" is successfully synced$`, topicIsSuccessfullySynced)
-	framework.RegisterStep(`^I should be able to produce and consume from "([^"]*)" in cluster "([^"]*)"$`, iShouldBeAbleToProduceAndConsumeFrom)
+	framework.RegisterStep(`^I should be able to produce and consume from "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, iShouldBeAbleToProduceAndConsumeFrom)
 	framework.RegisterStep(`I create topic "([^"]*)" in( vectorized)? cluster "([^"]*)"`, iCreateTopicInCluster)
 
 	// User scenario steps
 	framework.RegisterStep(`^user "([^"]*)" is successfully synced$`, userIsSuccessfullySynced)
 	framework.RegisterStep(`^"([^"]*)" should be able to read from topic "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, userShouldBeAbleToReadFromTopicInCluster)
 	framework.RegisterStep(`^there is no user "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, thereIsNoUser)
-	framework.RegisterStep(`^there are already the following ACLs in cluster "([^"]*)":$`, thereAreAlreadyTheFollowingACLsInCluster)
+	framework.RegisterStep(`^there are already the following ACLs in( vectorized)? cluster "([^"]*)":$`, thereAreAlreadyTheFollowingACLsInCluster)
 	framework.RegisterStep(`^there are the following pre-existing users in( vectorized)? cluster "([^"]*)"$`, thereAreTheFollowingPreexistingUsersInCluster)
-	framework.RegisterStep(`^I create CRD-based users for cluster "([^"]*)":$`, iCreateCRDbasedUsers)
+	framework.RegisterStep(`^I create CRD-based users for( vectorized)? cluster "([^"]*)":$`, iCreateCRDbasedUsers)
 	framework.RegisterStep(`^I delete the CRD user "([^"]*)"$`, iDeleteTheCRDUser)
-	framework.RegisterStep(`^there should be ACLs in the cluster "([^"]*)" for user "([^"]*)"$`, thereShouldBeACLsInTheClusterForUser)
-	framework.RegisterStep(`^"([^"]*)" should exist and be able to authenticate to the "([^"]*)" cluster$`, shouldExistAndBeAbleToAuthenticateToTheCluster)
-	framework.RegisterStep(`^"([^"]*)" should be able to authenticate to the "([^"]*)" cluster with password "([^"]*)" and mechanism "([^"]*)"$`, shouldBeAbleToAuthenticateToTheClusterWithPasswordAndMechanism)
+	framework.RegisterStep(`^there should be ACLs in the( vectorized)? cluster "([^"]*)" for user "([^"]*)"$`, thereShouldBeACLsInTheClusterForUser)
+	framework.RegisterStep(`^"([^"]*)" should exist and be able to authenticate to the( vectorized)? "([^"]*)" cluster$`, shouldExistAndBeAbleToAuthenticateToTheCluster)
+	framework.RegisterStep(`^"([^"]*)" should be able to authenticate to the( vectorized)? "([^"]*)" cluster with password "([^"]*)" and mechanism "([^"]*)"$`, shouldBeAbleToAuthenticateToTheClusterWithPasswordAndMechanism)
 
 	// Role scenario steps
 	framework.RegisterStep(`^role "([^"]*)" is successfully synced$`, roleIsSuccessfullySynced)

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -34,11 +34,11 @@ func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schem
 	}, schemaObject.Status.Conditions)
 }
 
-func thereIsNoSchema(ctx context.Context, schema, cluster string) {
-	clientsForCluster(ctx, cluster).ExpectNoSchema(ctx, schema)
+func thereIsNoSchema(ctx context.Context, schema, version, cluster string) {
+	versionedClientsForCluster(ctx, version, cluster).ExpectNoSchema(ctx, schema)
 }
 
-func iShouldBeAbleToCheckCompatibilityAgainst(ctx context.Context, schema, cluster string) {
-	clients := clientsForCluster(ctx, cluster)
+func iShouldBeAbleToCheckCompatibilityAgainst(ctx context.Context, schema, version, cluster string) {
+	clients := versionedClientsForCluster(ctx, version, cluster)
 	clients.ExpectSchema(ctx, schema)
 }

--- a/acceptance/steps/topics.go
+++ b/acceptance/steps/topics.go
@@ -35,18 +35,18 @@ func topicIsSuccessfullySynced(ctx context.Context, t framework.TestingT, topic 
 	}, topicObject.Status.Conditions)
 }
 
-func thereIsNoTopic(ctx context.Context, topic, cluster string) {
-	clientsForCluster(ctx, cluster).ExpectNoTopic(ctx, topic)
+func thereIsNoTopic(ctx context.Context, topic, version, cluster string) {
+	versionedClientsForCluster(ctx, version, cluster).ExpectNoTopic(ctx, topic)
 }
 
 func iCreateTopicInCluster(ctx context.Context, topic, version, cluster string) {
 	versionedClientsForCluster(ctx, version, cluster).CreateTopic(ctx, topic)
 }
 
-func iShouldBeAbleToProduceAndConsumeFrom(ctx context.Context, t framework.TestingT, topic, cluster string) {
+func iShouldBeAbleToProduceAndConsumeFrom(ctx context.Context, t framework.TestingT, topic, version, cluster string) {
 	payload := []byte("test")
 
-	clients := clientsForCluster(ctx, cluster)
+	clients := versionedClientsForCluster(ctx, version, cluster)
 	clients.ExpectTopic(ctx, topic)
 
 	kafkaClient := clients.Kafka(ctx)

--- a/harpoon/features/stub.feature
+++ b/harpoon/features/stub.feature
@@ -1,4 +1,4 @@
-@vcluster @isolated
+@isolated @variant:something
 Feature: stub
   Scenario Outline: templated stub
     Given there is a stub

--- a/harpoon/internal/tracking/features.go
+++ b/harpoon/internal/tracking/features.go
@@ -116,10 +116,12 @@ func (f *FeatureHookTracker) ScenarioFinished(ctx context.Context, scenario *god
 	f.features[scenario.Uri] = features
 
 	f.scenarios.finish(ctx, scenario)
+	features.t.Logf("finished feature scenario, %d scenarios left", features.scenariosToRun)
 	if features.scenariosToRun <= 0 {
 		delete(f.features, scenario.Uri)
 
 		features.t.SetMessagePrefix(fmt.Sprintf("Feature (%s) Cleanup Failure: ", features.name))
+		features.t.Log("running cleanup handlers")
 		internaltesting.WrapWithPanicHandler(false, f.opts.ExitBehavior, features.DoCleanup)(ctx, features.hasStepFailure)
 	}
 }
@@ -171,8 +173,7 @@ func (f *FeatureHookTracker) TestRunStarted() {}
 func (f *FeatureHookTracker) Defined(*messages.Pickle, *messages.PickleStep, *formatters.StepDefinition) {
 }
 
-func (f *FeatureHookTracker) Pickle(pickle *messages.Pickle) {
-}
+func (f *FeatureHookTracker) Pickle(*messages.Pickle) {}
 
 func (f *FeatureHookTracker) Failed(*messages.Pickle, *messages.PickleStep, *formatters.StepDefinition, error) {
 }

--- a/harpoon/tags.go
+++ b/harpoon/tags.go
@@ -11,6 +11,8 @@ package framework
 
 import (
 	"context"
+
+	"github.com/stretchr/testify/require"
 )
 
 func isolatedTag(ctx context.Context, t TestingT, args ...string) context.Context {
@@ -20,5 +22,16 @@ func isolatedTag(ctx context.Context, t TestingT, args ...string) context.Contex
 
 func vclusterTag(ctx context.Context, t TestingT, args ...string) context.Context {
 	t.VCluster(ctx)
+	return ctx
+}
+
+func variantTag(ctx context.Context, t TestingT, args ...string) context.Context {
+	require.Equal(t, len(args), 1, "variant tags take a single argument")
+	return ctx
+}
+
+func injectVariantTag(ctx context.Context, t TestingT, args ...string) context.Context {
+	require.Equal(t, len(args), 1, "variant tags take a single argument")
+	t.MarkVariant(args[0])
 	return ctx
 }

--- a/harpoon/types.go
+++ b/harpoon/types.go
@@ -54,6 +54,8 @@ type TestingT interface {
 
 	IsolateNamespace(ctx context.Context) string
 	VCluster(ctx context.Context) string
+	MarkVariant(variant string)
+	Variant() string
 
 	InstallHelmChart(ctx context.Context, url, repo, chart string, options helm.InstallOptions)
 	UpgradeHelmChart(ctx context.Context, repo, chart, release string, options helm.UpgradeOptions)

--- a/harpoon/variant.go
+++ b/harpoon/variant.go
@@ -1,0 +1,17 @@
+package framework
+
+import (
+	"strings"
+
+	messages "github.com/cucumber/messages/go/v21"
+)
+
+func featureVariant(tags []*messages.Tag) string {
+	for _, tag := range tags {
+		name := strings.TrimPrefix(tag.Name, "@")
+		if strings.HasPrefix(name, "variant:") {
+			return strings.TrimPrefix(name, "variant:")
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
This is the alternative to https://github.com/redpanda-data/redpanda-operator/pull/1127 in which we use expanded, duplicated feature definitions rather than the `variant` tags.