### PR TITLE
operator: fix Role CRD singular name collision with kubectl

### DIFF
--- a/.changes/unreleased/operator-Fixed-20251015-120822.yaml
+++ b/.changes/unreleased/operator-Fixed-20251015-120822.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Rename Role CRD resource path to avoid kubectl collision
+time: 2025-10-15T12:08:22.921426581+02:00

--- a/operator/api/redpanda/v1alpha2/role_types.go
+++ b/operator/api/redpanda/v1alpha2/role_types.go
@@ -20,7 +20,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=redpandaroles
+// +kubebuilder:resource:path=redpandaroles,singular=redpandarole
 // +kubebuilder:resource:shortName=rpr
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=`.status.conditions[?(@.type=="Synced")].status`
 // +kubebuilder:printcolumn:name="Managing ACLs",type="boolean",JSONPath=`.status.managedAcls`

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandaroles.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandaroles.yaml
@@ -13,7 +13,7 @@ spec:
     plural: redpandaroles
     shortNames:
     - rpr
-    singular: role
+    singular: redpandarole
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
Set explicit singular name 'redpandarole' to avoid collision with kubectl's built-in 'role' resource.