### PR TITLE
Add console to kustomization file

### DIFF
--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -7,6 +7,7 @@ kind: Kustomization
 resources:
 - bases/redpanda.vectorized.io_clusters.yaml
 - bases/redpanda.vectorized.io_consoles.yaml
+- bases/cluster.redpanda.com_consoles.yaml
 - bases/cluster.redpanda.com_redpandas.yaml
 - bases/cluster.redpanda.com_redpandaroles.yaml
 - bases/cluster.redpanda.com_schemas.yaml


### PR DESCRIPTION
Since some folks internally are still leveraging the `kustomization.yaml` process for installing CRDs, updating it for now with the required `Console` CRD which is enabled by default and not-overridable in our nightly operator build, though we should try and get everyone off of it ASAP as we don't particularly want to support it.

Tested:

```
➜  redpanda-operator git:(as/add-console-crd-to-kustomize) k apply -k ./operator/config/crd --server-side > /dev/null && k get crds | grep consoles.cluster.redpanda.com
consoles.cluster.redpanda.com        2025-10-17T18:50:46Z
```