### PR TITLE
Fix BootstrapServers configuration for shadow links

### DIFF
--- a/operator/pkg/client/spec.go
+++ b/operator/pkg/client/spec.go
@@ -196,6 +196,8 @@ func (c *Factory) remoteClusterSettingsForSpec(ctx context.Context, namespace st
 		return settings, ErrEmptyBrokerList
 	}
 
+	settings.BootstrapServers = spec.Brokers
+
 	if spec.SASL != nil {
 		auth, err := c.remoteClusterAuthSettingsForSpec(ctx, namespace, spec)
 		if err != nil {

--- a/operator/pkg/client/spec_test.go
+++ b/operator/pkg/client/spec_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package client
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
+)
+
+func TestShadowLinkClusterSettings_BootstrapRegression(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	server := &envtest.APIServer{}
+	etcd := &envtest.Etcd{}
+
+	testEnv := testutils.RedpandaTestEnv{
+		Environment: envtest.Environment{
+			ControlPlane: envtest.ControlPlane{
+				APIServer: server,
+				Etcd:      etcd,
+			},
+		},
+	}
+	cfg, err := testEnv.StartRedpandaTestEnv(false)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	t.Cleanup(func() {
+		_ = testEnv.Stop()
+	})
+
+	container, err := redpanda.Run(ctx, "docker.redpanda.com/redpandadata/redpanda:"+os.Getenv("TEST_REDPANDA_VERSION"),
+		redpanda.WithEnableSchemaRegistryHTTPBasicAuth(),
+		redpanda.WithEnableKafkaAuthorization(),
+		redpanda.WithEnableSASL(),
+		redpanda.WithSuperusers("superuser"),
+		redpanda.WithNewServiceAccount("superuser", "password"),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = container.Terminate(context.Background())
+	})
+
+	kafkaAddress, err := container.KafkaSeedBroker(ctx)
+	require.NoError(t, err)
+
+	c, err := client.New(cfg, client.Options{Scheme: controller.UnifiedScheme})
+	require.NoError(t, err)
+
+	factory := NewFactory(cfg, c)
+
+	settings, err := factory.RemoteClusterSettings(ctx, &redpandav1alpha2.ShadowLink{
+		Spec: redpandav1alpha2.ShadowLinkSpec{
+			SourceCluster: redpandav1alpha2.ClusterSource{
+				StaticConfiguration: &redpandav1alpha2.StaticConfigurationSource{
+					Kafka: &redpandav1alpha2.KafkaAPISpec{
+						Brokers: []string{kafkaAddress},
+					},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, settings.BootstrapServers, 1)
+	require.Equal(t, kafkaAddress, settings.BootstrapServers[0])
+}


### PR DESCRIPTION
Looks like we weren't translating the `Brokers` field from the static configuration in a ClusterSource to `BootstrapServers`. This fixes that and, since we don't have a code path that actually leverages the static configuration, adds a regression test to ensure we're setting it properly.