### PR TITLE
Add disabled upgrade acceptance test

### DIFF
--- a/acceptance/features/upgrade.feature
+++ b/acceptance/features/upgrade.feature
@@ -1,0 +1,47 @@
+Feature: Upgrading redpanda
+  @skip:gke @skip:aks @skip:eks @skip:k3d
+  Scenario: Redpanda upgrade from 25.2.11
+    Given I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Redpanda
+    metadata:
+      name: cluster-upgrade
+    spec:
+      clusterSpec:
+        image:
+          repository: redpandadata/redpanda
+          tag: v25.2.11
+        console:
+          enabled: false
+        statefulset:
+          replicas: 3
+          sideCars:
+            image:
+              tag: dev
+              repository: localhost/redpanda-operator
+    """
+    And cluster "cluster-upgrade" should be stable with 3 nodes
+    Then I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Redpanda
+    metadata:
+      name: cluster-upgrade
+    spec:
+      clusterSpec:
+        image:
+          repository: redpandadata/redpanda-unstable
+          tag: v25.3.1-rc4
+        console:
+          enabled: false
+        statefulset:
+          replicas: 3
+          sideCars:
+            image:
+              tag: dev
+              repository: localhost/redpanda-operator
+    """
+    And cluster "cluster-upgrade" should be stable with 3 nodes


### PR DESCRIPTION
This adds an acceptance test to do some basic smoke verification on Redpanda cluster broker compatability. In this case, from our latest 25.2 release to the current 25.3 RC. It's disabled by default as we really only need to run/verify it manually leading up to releases, in which case someone can just update the versions here and run it locally.