### PR TITLE
Enable shadow links by default

### DIFF
--- a/.changes/unreleased/operator-Added-20251210-121913.yaml
+++ b/.changes/unreleased/operator-Added-20251210-121913.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: ShadowLink CRD for controlling 25.3 shadow link settings. See documentation for details.
+time: 2025-12-10T12:19:13.689549-05:00

--- a/operator/cmd/crd/crd.go
+++ b/operator/cmd/crd/crd.go
@@ -35,6 +35,7 @@ var (
 		crds.Redpanda(),
 		crds.Role(),
 		crds.Schema(),
+		crds.ShadowLink(),
 		crds.Topic(),
 		crds.User(),
 	}
@@ -44,7 +45,6 @@ var (
 	}
 	experimentalCRDs = []*apiextensionsv1.CustomResourceDefinition{
 		crds.NodePool(),
-		crds.ShadowLink(),
 	}
 	schemes = []func(s *runtime.Scheme) error{
 		clientgoscheme.AddToScheme,


### PR DESCRIPTION
This PR enables the ShadowLink controller by default and installs the CRDs for it outside of the `--experimental` flag in the crd installation job. This is to make it in the 25.3 release.