### PR TITLE
Change leader election to run in kube-system namespace when cluster-scoped and namespace is unspecified

### DIFF
--- a/.changes/unreleased/operator-Changed-20251210-125034.yaml
+++ b/.changes/unreleased/operator-Changed-20251210-125034.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Changed
+body: Use the kube-system namespace by default for leader election when the operator is running in cluster-scoped mode.
+time: 2025-12-10T12:50:34.401218-05:00

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -353,7 +353,11 @@ func Run(
 	opts.managerOptions.Scheme = controller.UnifiedScheme
 
 	if opts.managerOptions.LeaderElectionNamespace == "" {
-		opts.managerOptions.LeaderElectionNamespace = opts.namespace
+		if opts.namespace == "" {
+			opts.managerOptions.LeaderElectionNamespace = "kube-system"
+		} else {
+			opts.managerOptions.LeaderElectionNamespace = opts.namespace
+		}
 	}
 
 	if opts.namespace != "" {


### PR DESCRIPTION
Fixes K8S-734

Prior to this commit when namespace is unspecified, then we wind up with: 

```go
opts.managerOptions.LeaderElectionNamespace = ""
```

as our default value in our leader election options handed to the controller-runtime manager due to `opts.namespace` not being set (as we're cluster-scoped).

When that's set to an empty string, the controller-runtime attempts to automatically detect the running namespace of the container via calling:

```go
const inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"

func getInClusterNamespace() (string, error) {
	// Check whether the namespace file exists.
	// If not, we are not running in cluster so can't guess the namespace.
	if _, err := os.Stat(inClusterNamespacePath); os.IsNotExist(err) {
		return "", fmt.Errorf("not running in-cluster, please specify LeaderElectionNamespace")
	} else if err != nil {
		return "", fmt.Errorf("error checking namespace file: %w", err)
	}

	// Load the namespace file and return its content
	namespace, err := os.ReadFile(inClusterNamespacePath)
	if err != nil {
		return "", fmt.Errorf("error reading namespace file: %w", err)
	}
	return string(namespace), nil
}
```

and using that. What this means is that we have no enforcement mechanism for making the operator unable to run multiple cluster-scoped controllers simultaneously. Moving the lease namespace to `kube-system` enables all cluster-scoped operators by default to attempt the same lease lock, causing only a single operator to grab the leader election lock and run its controllers at any given time.