### PR TITLE
acceptance: Change decommission node pruning

### DIFF
--- a/acceptance/features/decommissioning.feature
+++ b/acceptance/features/decommissioning.feature
@@ -8,6 +8,6 @@ Feature: Decommissioning brokers
     When I physically shutdown a kubernetes node for cluster "decommissioning"
     And cluster "decommissioning" is unhealthy
     And cluster "decommissioning" has only 2 remaining nodes
-    And I prune any kubernetes node that is now in a NotReady status
+    And I prune kubernetes node that was removed in previous step
     Then cluster "decommissioning" should recover
     And cluster "decommissioning" should be stable with 3 nodes

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -109,6 +109,7 @@ func init() {
 	framework.RegisterStep(`^I prune any kubernetes node that is now in a NotReady status$`, deleteNotReadyKubernetesNodes)
 	framework.RegisterStep(`I stop the Node running Pod "([^"]+)"`, shutdownNodeOfPod)
 	framework.RegisterStep(`^cluster "([^"]*)" has only (\d+) remaining nodes$`, checkClusterNodeCount)
+	framework.RegisterStep(`^I prune kubernetes node that was removed in previous step$`, deleteKubernetesNodesFromContext)
 
 	// Operator upgrade scenario steps
 	framework.RegisterStep(`^I install local CRDs from "([^"]*)"`, iInstallLocalCRDs)


### PR DESCRIPTION
In the current decommission test, the K3D node is removed, but for some unknown reason more Kubernetes nodes than the removed can become unhealthy. When the step, that removes unhealthy nodes, deletes two Kubernetes nodes, it can result in two Redpanda nodes going offline. The decommission test runs a three-node Redpanda cluster, so the decommission controller often cannot complete the decommission in time.