### PR TITLE
Unhide shadow link-related CRDs from docs

### DIFF
--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -1089,28 +1089,6 @@ CredentialSecretRef can be used to set cloud_storage_secret_key from referenced 
 |===
 
 
-[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-deprecatedenablable"]
-==== DeprecatedEnablable
-
-
-
-This structure is deprecated and should be removed
-
-
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
-- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaconsole[$$RedpandaConsole$$]
-****
-
-[cols="20a,50a,15a,15a", options="header"]
-|===
-| Field | Description | Default | Validation
-| *`enabled`* __boolean__ |  |  | 
-|===
-
-
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-enterprise"]
 ==== Enterprise
 
@@ -2559,7 +2537,6 @@ StatefulSets and Jobs. For details, see the [Kubernetes +
 documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). + |  | 
 | *`license_key`* __string__ | Deprecated: Use `enterprise.license` instead. + |  | 
 | *`license_secret_ref`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-licensesecretref[$$LicenseSecretRef$$]__ | Deprecated: Use `enterprise.licenseSecretRef` instead. + |  | 
-| *`tests`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-deprecatedenablable[$$DeprecatedEnablable$$]__ | Deprecated + |  | 
 |===
 
 
@@ -2667,7 +2644,6 @@ Please consider use Enterprise in RedpandaClusterSpec type. +
 `console` is available in Console chart version earlier or equal to v0.7.31 + |  | 
 | *`enterprise`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Deprecated: Use `licenseSecretRef` instead. +
 `enterprise` is available in Console chart version earlier or equal to v0.7.31 + |  | 
-| *`tests`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-deprecatedenablable[$$DeprecatedEnablable$$]__ | Deprecated + |  | 
 |===
 
 

--- a/operator/crd-ref-docs-config.yaml
+++ b/operator/crd-ref-docs-config.yaml
@@ -4,6 +4,7 @@ processor:
   - 'Migration$'
   - 'NodePool.*$'
   - 'EmbeddedNodePoolSpec$'
+  - 'Deprecated.*$'
   ignoreFields:
   - 'migration$'
   customMarkers:


### PR DESCRIPTION
This makes sure CRD docs related to ShadowLinks show up.