### PR TITLE
Bump raft lock test timeout

### DIFF
--- a/pkg/multicluster/leaderelection/lock_test.go
+++ b/pkg/multicluster/leaderelection/lock_test.go
@@ -46,7 +46,7 @@ func TestLocker(t *testing.T) {
 			currentLeaders := leaders
 			// scale down til we get to the min followers
 			for len(currentLeaders) != (minQuorum - 1) {
-				currentLeader, currentLeaders = waitForAnyLeader(t, 15*time.Second, currentLeaders...)
+				currentLeader, currentLeaders = waitForAnyLeader(t, 30*time.Second, currentLeaders...)
 				currentLeader.Stop()
 				stopped = append(stopped, currentLeader)
 				t.Log("killing leader", currentLeader.config.ID)
@@ -57,7 +57,7 @@ func TestLocker(t *testing.T) {
 				leader.Start(t, ctx)
 			}
 
-			_, _ = waitForAnyLeader(t, 15*time.Second, leaders...)
+			_, _ = waitForAnyLeader(t, 30*time.Second, leaders...)
 		})
 	}
 }


### PR DESCRIPTION
This increases the timeout we allow for leader re-election in our raft multicluster test. For context, the test spins up 13 nodes and then keeps killing the leader until it's at the edge of quorum loss. We are occassionally running into test flakes with errors that roughly look like:

>   TestLocker/13_node_quorum INFO: 6 has received 6 MsgVoteResp votes and 1 vote rejections
>   lock_test.go:215: timed out waiting for leader to be elected

In this particular flake this mostly happens in the final configuration where we have 7 remaining nodes in the cluster and they all need to agree on leadership within the given time frame. My guess is that we get a couple of election deadlocks which would resolve within a couple more election cycles, but we hit the artificial test timeout before that happens, so it's a flake. Another potentialy thing we can try if this doesn't work to decrease the flakiness... as the election cycles happen with some jitter we could increase the timeout between election cycles so that each node is less likely to start simultaneous election terms (and hence less likely to wind up rejecting each other's leadership candidacy). The only thing there is that each step of the test is less likely to quickly pass since we'll have to wait a bit more time between a node dying and an election term kicking off.