### PR TITLE
charts/redpanda: Add new cloud_storage_credentials_source type

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20260120-101449.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260120-101449.yaml
@@ -1,0 +1,6 @@
+project: charts/redpanda
+kind: Fixed
+body: |-
+    In the 24.1.1 version Redpanda introduces new value `cloud_storage_credentials_source` for `cloud_storage_azure_managed_identity_id`
+    property. Redpanda helm chart schema validation rejected new value. Schema is extended to include new value.
+time: 2026-01-20T10:14:49.185925+01:00

--- a/charts/redpanda/chart/values.schema.json
+++ b/charts/redpanda/chart/values.schema.json
@@ -21801,7 +21801,7 @@
                   ]
                 },
                 "cloud_storage_credentials_source": {
-                  "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata)$",
+                  "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata|azure_aks_oidc_federation)$",
                   "type": "string"
                 },
                 "cloud_storage_disable_tls": {
@@ -22002,7 +22002,7 @@
               ]
             },
             "cloud_storage_credentials_source": {
-              "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata)$",
+              "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata|azure_aks_oidc_federation)$",
               "type": "string"
             },
             "cloud_storage_disable_tls": {

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -2002,7 +2002,7 @@ func (TieredStorageConfig) JSONSchema() *jsonschema.Schema {
 		// `config.node`.
 		CloudStorageCacheDirectory              string            `json:"cloud_storage_cache_directory" jsonschema:"deprecated"`
 		CloudStorageCacheSize                   *ResourceQuantity `json:"cloud_storage_cache_size"`
-		CloudStorageCredentialsSource           string            `json:"cloud_storage_credentials_source" jsonschema:"pattern=^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata)$"`
+		CloudStorageCredentialsSource           string            `json:"cloud_storage_credentials_source" jsonschema:"pattern=^(config_file|aws_instance_metadata|sts|gcp_instance_metadata|azure_vm_instance_metadata|azure_aks_oidc_federation)$"`
 		CloudStorageDisableTLS                  bool              `json:"cloud_storage_disable_tls"`
 		CloudStorageEnableRemoteRead            bool              `json:"cloud_storage_enable_remote_read"`
 		CloudStorageEnableRemoteWrite           bool              `json:"cloud_storage_enable_remote_write"`


### PR DESCRIPTION
In the 24.1.1 version Redpanda introduces new value `azure_aks_oidc_federation ` for `cloud_storage_credentials_source` property. Redpanda helm chart schema validation rejected new value. Schema is extended to include new value.

Reference

https://github.com/redpanda-data/redpanda/releases/tag/v24.1.1