### PR TITLE
Enable using localhost for SR/PP internal clients in v1

### DIFF
--- a/operator/pkg/resources/configuration.go
+++ b/operator/pkg/resources/configuration.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 
 	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cockroachdb/errors"
@@ -429,9 +430,18 @@ func preparePandaproxyClient(
 	// Alternatively, localhost could be used to the same end but using DNS
 	// might save us in some cases where the local broker is having some
 	// trouble and it makes the config more generally reusable.
+	// Can be overridden to localhost via additionalConfiguration:
+	//   pandaproxy_client.use_localhost: "true"
+	brokerAddress := serviceFQDN
+	if useLocalhost, exists := pandaCluster.Spec.AdditionalConfiguration["pandaproxy_client.use_localhost"]; exists {
+		if parsedBool, err := strconv.ParseBool(useLocalhost); err == nil && parsedBool {
+			brokerAddress = "localhost"
+		}
+	}
+
 	cfg.Node.PandaproxyClient = &config.KafkaClient{
 		Brokers: []config.SocketAddress{
-			{Address: serviceFQDN, Port: pandaCluster.InternalListener().Port},
+			{Address: brokerAddress, Port: pandaCluster.InternalListener().Port},
 		},
 	}
 
@@ -497,9 +507,18 @@ func prepareSchemaRegistryClient(
 	// Alternatively, localhost could be used to the same end but using DNS
 	// might save us in some cases where the local broker is having some
 	// trouble and it makes the config more generally reusable.
+	// Can be overridden to localhost via additionalConfiguration:
+	//   schema_registry_client.use_localhost: "true"
+	brokerAddress := serviceFQDN
+	if useLocalhost, exists := pandaCluster.Spec.AdditionalConfiguration["schema_registry_client.use_localhost"]; exists {
+		if parsedBool, err := strconv.ParseBool(useLocalhost); err == nil && parsedBool {
+			brokerAddress = "localhost"
+		}
+	}
+
 	cfg.Node.SchemaRegistryClient = &config.KafkaClient{
 		Brokers: []config.SocketAddress{
-			{Address: serviceFQDN, Port: pandaCluster.InternalListener().Port},
+			{Address: brokerAddress, Port: pandaCluster.InternalListener().Port},
 		},
 	}
 


### PR DESCRIPTION
Add opt-in configuration to Cluster CR (v1) to use localhost instead of headless service FQDN for Schema Registry and Pandaproxy internal client broker addresses via `pandaproxy_client.use_localhost` and `schema_registry_client.use_localhost` in Cluster CR `spec.additionalConfiguration`. Default behavior unchanged (continues using headless service FQDN for backward compatibility).

Refs:
- https://redpandadata.atlassian.net/browse/K8S-762
