### PR TITLE
topic: allow finalizer removal when broker is unreachable

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260122-100940.yaml
+++ b/.changes/unreleased/operator-Fixed-20260122-100940.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Allow Topic finalizer removal when broker is unreachable or credentials are missing during deletion, preventing stuck namespaces.
+time: 2026-01-22T10:00:00.000000+01:00

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -21,6 +21,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// ErrSecretNotFound is returned when a cloud secret cannot be found.
+var ErrSecretNotFound = errors.New("cloud secret not found")
+
 type CloudExpander struct {
 	client secrets.SecretAPI
 	logger *slog.Logger
@@ -97,7 +100,7 @@ func NewCloudExpanderFromAPI(api secrets.SecretAPI) *CloudExpander {
 func (t *CloudExpander) Expand(ctx context.Context, name string) (string, error) {
 	value, found := t.client.GetSecretValue(ctx, name)
 	if !found {
-		return "", errors.Newf("secret %s not found", name)
+		return "", errors.Wrapf(ErrSecretNotFound, "secret %s", name)
 	}
 	return value, nil
 }


### PR DESCRIPTION
## What

Allow Topic CR finalizer removal when the Kafka broker is unreachable or credentials are missing during deletion.

## Why

Topics were getting stuck in Terminating state indefinitely when:
- Broker is unreachable (connection refused, DNS failure)
- Credentials Secret was deleted before the Topic
- Cloud secret doesn't exist

This blocks namespace deletion and requires manual intervention to remove finalizers.

## Implementation details

Extend `ignoreAllConnectionErrors()` to detect network dial errors via `net.OpError` in the error chain. When deletion fails due to non-recoverable connection errors, allow the finalizer to be removed instead of retrying forever.

Error types now handled during deletion:
- `net.OpError` - connection refused, DNS failures, timeouts
- `secrets.ErrSecretNotFound` - cloud secret missing
- K8s NotFound - credentials Secret missing
- Terminal client errors - SASL auth failures
- Invalid cluster reference errors

Also adds `operator.redpanda.com/allow-deletion` annotation as an escape hatch to force deletion when other connectivity issues exist.

Unit tests added for `isNetworkDialError()` covering various error wrapping scenarios.

## References

Tested on GKE clusters - topics with unreachable brokers now delete successfully.