### PR TITLE
charts/redpanda: Enable using localhost for SR/PP internal clients

### DIFF
--- a/charts/redpanda/chart/values.yaml
+++ b/charts/redpanda/chart/values.yaml
@@ -958,6 +958,10 @@ config:
 
   # Reference schema registry client https://docs.redpanda.com/current/reference/node-configuration-sample/
   schema_registry_client: {}
+    #  # Override to use localhost instead of headless service FQDN.
+    #  # Useful when DNS issues occur. Default: false (uses headless service)
+    # use_localhost: false
+    #
     #  # Number of times to retry a request to a broker
     #  # Default: 5
     # retries: 5
@@ -1000,6 +1004,10 @@ config:
 
   # Reference panda proxy client https://docs.redpanda.com/current/reference/node-configuration-sample/
   pandaproxy_client: {}
+    #  # Override to use localhost instead of headless service FQDN.
+    #  # Useful when DNS issues occur. Default: false (uses headless service)
+    # use_localhost: false
+    #
     #  # Number of times to retry a request to a broker
     #  # Default: 5
     # retries: 5


### PR DESCRIPTION
Add opt-in configuration to use localhost instead of headless service FQDN for Schema Registry and Pandaproxy internal client broker addresses via `pandaproxy_client.use_localhost` and `schema_registry_client.use_localhost`. Default behavior unchanged (continues using headless service FQDN for backward compatibility).

Refs:
- https://redpandadata.atlassian.net/browse/K8S-762
- https://github.com/redpanda-data/redpanda-operator/pull/1233 (v1 implementation)
