### PR TITLE
fix: update generate task paths after API code relocation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -125,7 +125,7 @@ tasks:
     deps:
     - build:gen
     cmds:
-    - gen applyconfig-copy --header "licenses/boilerplate.go.txt" --package "v1alpha2" --out "./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy.go"  --test "./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy_test.go" --struct "PodSpecApplyConfiguration" k8s.io/client-go/applyconfigurations/core/v1
+    - gen applyconfig-copy --header "licenses/boilerplate.go.txt" --package "v1alpha2" --out "./api/redpanda/v1alpha2/zz_generated.applyconfigcopy.go"  --test "./api/redpanda/v1alpha2/zz_generated.applyconfigcopy_test.go" --struct "PodSpecApplyConfiguration" k8s.io/client-go/applyconfigurations/core/v1
 
   generate:third-party-licenses-list:
     dir: operator

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -9,7 +9,7 @@ tasks:
     - generate-manifests
     cmds:
       # Generates SchemaBuilders and automatically registers CRs with it.
-      - register-gen --go-header-file "../licenses/boilerplate.go.txt" --output-file 'zz_generated.register.go' ./api/redpanda/... ./api/vectorized/...
+      - register-gen --go-header-file "../licenses/boilerplate.go.txt" --output-file 'zz_generated.register.go' ../api/redpanda/... ../api/vectorized/...
 
       # Generate the full RBAC bundle for kustomize and the operator chart, CRD
       # manifests, and deep copy methods.
@@ -122,15 +122,15 @@ tasks:
       - |
         applyconfiguration-gen \
         --go-header-file "../licenses/boilerplate.go.txt" \
-        --output-dir "api/applyconfiguration" \
-        --output-pkg "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration" \
-        ./api/redpanda/v1alpha2
-      - find ./api/applyconfiguration/redpanda/v1alpha2 -type f -exec sed -i'' 's/"redpanda\/v1/"cluster.redpanda.com\/v1/g' {} \;
-      - rm -rf api/applyconfiguration/utils.go api/applyconfiguration/internal
+        --output-dir "../api/applyconfiguration" \
+        --output-pkg "github.com/redpanda-data/redpanda-operator/api/applyconfiguration" \
+        ../api/redpanda/v1alpha2
+      - find ../api/applyconfiguration/redpanda/v1alpha2 -type f -exec sed -i'' 's/"redpanda\/v1/"cluster.redpanda.com\/v1/g' {} \;
+      - rm -rf ../api/applyconfiguration/utils.go ../api/applyconfiguration/internal
 
       # Generate rote conversion functions.
       # Must run after deepcopy is generated.
-      - goverter gen ./api/redpanda/v1alpha2/
+      - goverter gen ./internal/conversion/v1alpha2/
 
   generate:crd-docs:
     desc: Generates an example ascii doc from our crd-ref-docs configuration.
@@ -139,15 +139,15 @@ tasks:
     - |
       crd-ref-docs \
       --config crd-ref-docs-config.yaml \
-      --source-path ./api/redpanda/v1alpha2/ \
-      --output-path ./api/redpanda/v1alpha2/testdata/crd-docs.adoc \
+      --source-path ../api/redpanda/v1alpha2/ \
+      --output-path ../api/redpanda/v1alpha2/testdata/crd-docs.adoc \
       --templates-dir=./crd-docs-templates/
 
   generate:deprecations:
     label: "generate:deprecations"
     desc: "Generate the deprecation tests for our deprecation warnings."
     cmds:
-    - rp-controller-gen deprecations --directory ./operator/api/redpanda/v1alpha2
+    - rp-controller-gen deprecations --directory ./api/redpanda/v1alpha2
 
   generate:statuses:
     run: when_changed


### PR DESCRIPTION
## Summary
Fixed generate task paths after the API code was moved from `operator/api/` to `api/`. The generate tasks were failing because they still referenced the old paths.

## Changes
- **Taskfile.yml**: Updated `generate:applyconfig-copy` output paths from `./operator/api/` to `./api/`
- **taskfiles/k8s.yml**: Updated all API path references to use `../api/` (since these tasks run from the `operator` directory):
  - `register-gen` paths for redpanda and vectorized APIs
  - `applyconfiguration-gen` output directory and source paths
  - `crd-ref-docs` source and output paths
  - `rp-controller-gen` deprecations directory path
  - Fixed `goverter` path to use `./internal/conversion/v1alpha2/`

## Problem
After the API code relocation, running `task generate` would fail with errors like:
```
Error writing test file: open ./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy_test.go: no such file or directory
```

and

```
pattern ./api/redpanda/...: lstat ./api/redpanda/: no such file or directory
```

## Testing
- `task generate:applyconfig-copy` - Completes successfully
- `task k8s:generate` - Completes successfully  
- `task generate` - Full generate suite completes successfully

All generated files are now created in the correct locations under `api/`.