### PR TITLE
feat(console): add Gateway API HTTPRoute support

### DIFF
--- a/charts/console/chart/values.yaml
+++ b/charts/console/chart/values.yaml
@@ -107,6 +107,24 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- Gateway API HTTPRoute configuration (alternative to ingress)
+# For details, see https://gateway-api.sigs.k8s.io/
+httproute:
+  # -- Enable HTTPRoute resource for Redpanda Console
+  enabled: false
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs for the HTTPRoute. Must reference an existing Gateway.
+  parentRefs: []
+  #  - name: example-gateway
+  #    namespace: example-gateway-namespace
+  #    sectionName: https
+  # -- List of hostnames for the HTTPRoute
+  hostnames: []
+  #  - console.example.com
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/client-go v0.34.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/charts/console/go.sum
+++ b/charts/console/go.sum
@@ -394,8 +394,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
-github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
+github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
+github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
@@ -812,8 +812,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
-sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
-sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
+sigs.k8s.io/gateway-api v1.2.1 h1:fZZ/+RyRb+Y5tGkwxFKuYuSRQHu9dZtbjenblleOLHM=
+sigs.k8s.io/gateway-api v1.2.1/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.19.0 h1:F+2HB2mU1MSiR9Hp1NEgoU2q9ItNOaBJl0I4Dlus5SQ=

--- a/charts/console/httproute.go
+++ b/charts/console/httproute.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package console
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func HTTPRoute(state *RenderState) *gatewayv1.HTTPRoute {
+	if !state.Values.HTTPRoute.Enabled {
+		return nil
+	}
+
+	var parentRefs []gatewayv1.ParentReference
+	for _, ref := range state.Values.HTTPRoute.ParentRefs {
+		parentRef := gatewayv1.ParentReference{
+			Name: gatewayv1.ObjectName(ref.Name),
+		}
+		if ref.Namespace != nil {
+			ns := gatewayv1.Namespace(*ref.Namespace)
+			parentRef.Namespace = &ns
+		}
+		if ref.SectionName != nil {
+			sn := gatewayv1.SectionName(*ref.SectionName)
+			parentRef.SectionName = &sn
+		}
+		parentRefs = append(parentRefs, parentRef)
+	}
+
+	var hostnames []gatewayv1.Hostname
+	for _, host := range state.Values.HTTPRoute.Hostnames {
+		hostnames = append(hostnames, gatewayv1.Hostname(state.Template(host)))
+	}
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	port := gatewayv1.PortNumber(state.Values.Service.Port)
+
+	rules := []gatewayv1.HTTPRouteRule{
+		{
+			Matches: []gatewayv1.HTTPRouteMatch{
+				{
+					Path: &gatewayv1.HTTPPathMatch{
+						Type:  &pathType,
+						Value: ptrTo("/"),
+					},
+				},
+			},
+			BackendRefs: []gatewayv1.HTTPBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName(state.FullName()),
+							Port: &port,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return &gatewayv1.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HTTPRoute",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        state.FullName(),
+			Labels:      state.Labels(state.Values.HTTPRoute.Labels),
+			Namespace:   state.Namespace,
+			Annotations: state.Values.HTTPRoute.Annotations,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: parentRefs,
+			},
+			Hostnames: hostnames,
+			Rules:     rules,
+		},
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/charts/console/render.go
+++ b/charts/console/render.go
@@ -24,6 +24,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
@@ -45,6 +46,7 @@ const (
 // +gotohelm:ignore=true
 func init() {
 	must(scheme.AddToScheme(Scheme))
+	must(gatewayv1.Install(Scheme))
 }
 
 // +gotohelm:ignore=true
@@ -165,6 +167,7 @@ func Render(state *RenderState) []kube.Object {
 		ConfigMap(state),
 		Service(state),
 		Ingress(state),
+		HTTPRoute(state),
 		Deployment(state),
 		HorizontalPodAutoscaler(state),
 	}
@@ -182,6 +185,7 @@ func Types() []kube.Object {
 		&corev1.ConfigMap{},
 		&corev1.Service{},
 		&networkingv1.Ingress{},
+		&gatewayv1.HTTPRoute{},
 		&appsv1.Deployment{},
 		&autoscalingv2.HorizontalPodAutoscaler{},
 	}

--- a/charts/console/rendervalues.go
+++ b/charts/console/rendervalues.go
@@ -32,6 +32,7 @@ type RenderValues struct {
 	SecurityContext              corev1.SecurityContext            `json:"securityContext" partial:"builtin"`
 	Service                      ServiceConfig                     `json:"service"`
 	Ingress                      IngressConfig                     `json:"ingress"`
+	HTTPRoute                    HTTPRouteConfig                   `json:"httproute"`
 	Resources                    corev1.ResourceRequirements       `json:"resources"`
 	Autoscaling                  AutoScaling                       `json:"autoscaling"`
 	NodeSelector                 map[string]string                 `json:"nodeSelector"`
@@ -186,4 +187,19 @@ type Image struct {
 	Repository string            `json:"repository"`
 	PullPolicy corev1.PullPolicy `json:"pullPolicy"`
 	Tag        string            `json:"tag"`
+}
+
+// HTTPRouteConfig configures Gateway API HTTPRoute as an alternative to Ingress
+type HTTPRouteConfig struct {
+	Enabled     bool                 `json:"enabled"`
+	Labels      map[string]string    `json:"labels"`
+	Annotations map[string]string    `json:"annotations"`
+	ParentRefs  []HTTPRouteParentRef `json:"parentRefs"`
+	Hostnames   []string             `json:"hostnames"`
+}
+
+type HTTPRouteParentRef struct {
+	Name        string  `json:"name"`
+	Namespace   *string `json:"namespace,omitempty"`
+	SectionName *string `json:"sectionName,omitempty"`
 }


### PR DESCRIPTION
## Summary
Add HTTPRoute configuration to Console Helm chart as an alternative to traditional Ingress resources. This enables users to leverage Gateway API for traffic management.

## Changes
- Added `httproute.go` - generates HTTPRoute resource when enabled
- Updated `rendervalues.go` - added HTTPRouteConfig types
- Updated `render.go` - included HTTPRoute in manifest rendering
- Updated `chart/values.yaml` - added default httproute configuration

## Configuration Options
```yaml
httproute:
  enabled: false
  labels: {}
  annotations: {}
  parentRefs: []
  #  - name: example-gateway
  #    namespace: example-gateway-namespace
  #    sectionName: https
  hostnames: []
  #  - console.example.com
```

## Motivation
Gateway API went GA in late 2023 and is becoming the standard for Kubernetes ingress. Many users are migrating from traditional Ingress to Gateway API and need native support in helm charts.

Closes: https://github.com/redpanda-data/helm-charts/issues/1722

## Test Plan
- [x] Code compiles successfully (`go build ./...`)
- [ ] Unit tests pass
- [ ] Integration testing with Istio Gateway

🤖 Generated with [Claude Code](https://claude.ai/code)