### PR TITLE
ci: migrate pipeline-uploader queue to devprod-t4gmicro

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -3,8 +3,8 @@
 # ignore errors
 set +e
 
-if [[ $BUILDKITE_AGENT_META_DATA_QUEUE == "pipeline-uploader" ]]; then
-  echo "Skipping on 'pipeline-uploader' agents"
+if [[ $BUILDKITE_AGENT_META_DATA_QUEUE == "devprod-t4gmicro" ]]; then
+  echo "Skipping on 'devprod-t4gmicro' agents"
   exit 0
 fi
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
   - key: ci-entry-point
     label: Operator CI Entrypoint
     agents:
-      queue: pipeline-uploader
+      queue: devprod-t4gmicro
     # Run for:
     # - all pull requests that aren't from forks
     # - nightly test schedule or nightly triggered from buildkite ui

--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -57,7 +57,7 @@ steps:
   - continue_on_failure: true
     wait: null
   - agents:
-      queue: pipeline-uploader
+      queue: devprod-t4gmicro
     allow_dependency_failure: true
     command: ""
     key: unit-parse
@@ -105,7 +105,7 @@ steps:
   - continue_on_failure: true
     wait: null
   - agents:
-      queue: pipeline-uploader
+      queue: devprod-t4gmicro
     allow_dependency_failure: true
     command: ""
     key: integration-parse
@@ -153,7 +153,7 @@ steps:
   - continue_on_failure: true
     wait: null
   - agents:
-      queue: pipeline-uploader
+      queue: devprod-t4gmicro
     allow_dependency_failure: true
     command: ""
     key: acceptance-parse
@@ -202,7 +202,7 @@ steps:
   - continue_on_failure: true
     wait: null
   - agents:
-      queue: pipeline-uploader
+      queue: devprod-t4gmicro
     allow_dependency_failure: true
     command: ""
     key: kuttl-v1-parse
@@ -247,7 +247,7 @@ steps:
   - continue_on_failure: true
     wait: null
   - agents:
-      queue: pipeline-uploader
+      queue: devprod-t4gmicro
     allow_dependency_failure: true
     command: ""
     key: kuttl-v1-nodepools-parse

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -32,7 +32,7 @@ var (
 
 	// Known/Permitted Agent Pools
 
-	AgentsPipeLineUploader = map[string]any{"queue": "pipeline-uploader"}
+	AgentsPipeLineUploader = map[string]any{"queue": "devprod-t4gmicro"}
 	AgentsLarge            = map[string]any{"queue": "k8s-m6id12xlarge"}
 )
 


### PR DESCRIPTION
## Summary
- Replaces all `pipeline-uploader` queue references with `devprod-t4gmicro` in pipeline.yml, testsuite.yml, and hooks/post-checkout
- Part of DEVPROD-3155: migrating from the manually-managed pipeline-uploader pool (x86 `t3a.micro`, CloudFormation) to the Terraform-managed `devprod-t4gmicro` queue (ARM64 `t4g.micro`)
