### PR TITLE
fix: include startup flags in StatefulSet checksum annotation

### DIFF
--- a/charts/redpanda/chart/templates/_statefulset.go.tpl
+++ b/charts/redpanda/chart/templates/_statefulset.go.tpl
@@ -578,6 +578,11 @@
 {{- $dependencies = (concat (default (list) $dependencies) (list $state.Values.external.addresses)) -}}
 {{- end -}}
 {{- end -}}
+{{- $_1015_lockMemory_overprovisioned_flags := (get (fromJson (include "redpanda.RedpandaAdditionalStartFlags" (dict "a" (list $state.Values $pool)))) "r") -}}
+{{- $lockMemory := (index $_1015_lockMemory_overprovisioned_flags 0) -}}
+{{- $overprovisioned := (index $_1015_lockMemory_overprovisioned_flags 1) -}}
+{{- $flags := (index $_1015_lockMemory_overprovisioned_flags 2) -}}
+{{- $dependencies = (concat (default (list) $dependencies) (list $lockMemory $overprovisioned $flags)) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (sha256sum (toJson $dependencies))) | toJson -}}
 {{- break -}}

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -999,6 +999,14 @@ func statefulSetChecksumAnnotation(state *RenderState, pool Pool) string {
 			dependencies = append(dependencies, state.Values.External.Addresses)
 		}
 	}
+	// NB: The rpk section is excluded from RedpandaConfigFile (via
+	// includeNonHashableItems=false) to avoid rolling pods when only replica
+	// count changes (broker addresses in the rpk section are replica-dependent).
+	// However, startup flags derived from additionalRedpandaCmdFlags
+	// (enable_memory_locking, overprovisioned, additional_start_flags) must
+	// still trigger a roll when changed, so we include them separately here.
+	lockMemory, overprovisioned, flags := RedpandaAdditionalStartFlags(&state.Values, pool)
+	dependencies = append(dependencies, lockMemory, overprovisioned, flags)
 	return helmette.Sha256Sum(helmette.ToJSON(dependencies))
 }
 

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -959,6 +959,26 @@ statefulset:
   - --overprovisioned
   - --default-log-level warn
 
+-- lock-memory-with-resources --
+# Verify that --lock-memory in additionalRedpandaCmdFlags is correctly translated
+# to enable_memory_locking: true when resources.requests and resources.limits are
+# set. When limits/requests are set, GetRedpandaFlags intentionally omits
+# --lock-memory (expecting the user to set it via additionalRedpandaCmdFlags), and
+# the chart extracts it into the enable_memory_locking field (due to an rpk buglet
+# where --lock-memory in additional_start_flags is ignored by rpk).
+# The checksum annotation must include enable_memory_locking so pods roll when changed.
+# ASSERT-NO-ERROR
+# ASSERT-FIELD-CONTAINS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "enable_memory_locking: true"]
+# ASSERT-FIELD-NOT-CONTAINS ["v1/ConfigMap", "default/redpanda", "{.data.redpanda\\.yaml}", "--lock-memory"]
+resources:
+  requests:
+    memory: 512Mi
+  limits:
+    memory: 512Mi
+statefulset:
+  additionalRedpandaCmdFlags:
+  - --lock-memory
+
 -- name-overrides --
 # Assert that no empty container is generated when using nameOverride or fullnameOverride.
 # It's (likely) acceptable for the container names themselves to change. This

--- a/operator/internal/lifecycle/testdata/redpanda-cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/redpanda-cases.pools.golden.txtar
@@ -27,7 +27,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-statefulset
           app.kubernetes.io/instance: basic-test
@@ -66,7 +66,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           lifecycle:
             postStart:
               exec:
@@ -199,7 +199,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: tuning
           resources: {}
           securityContext:
@@ -238,7 +238,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -383,7 +383,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-statefulset
           app.kubernetes.io/instance: compat-test
@@ -422,7 +422,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           lifecycle:
             postStart:
               exec:
@@ -575,7 +575,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -721,7 +721,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-pool-statefulset
           app.kubernetes.io/instance: compat-test
@@ -941,7 +941,7 @@
             xfs & wait $!
           command:
           - /bin/sh
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: fs-validator
           resources:
             limits:
@@ -1158,7 +1158,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-statefulset
           app.kubernetes.io/instance: console-disabled
@@ -1197,7 +1197,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           lifecycle:
             postStart:
               exec:
@@ -1330,7 +1330,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: tuning
           resources: {}
           securityContext:
@@ -1369,7 +1369,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -1514,7 +1514,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-statefulset
           app.kubernetes.io/instance: nodepool-basic-test
@@ -1553,7 +1553,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           lifecycle:
             postStart:
               exec:
@@ -1686,7 +1686,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: tuning
           resources: {}
           securityContext:
@@ -1725,7 +1725,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -1871,7 +1871,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-basic-a-statefulset
           app.kubernetes.io/instance: nodepool-basic-test
@@ -1910,7 +1910,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           lifecycle:
             postStart:
               exec:
@@ -2041,7 +2041,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: tuning
           resources: {}
           securityContext:
@@ -2080,7 +2080,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:
@@ -2226,7 +2226,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-basic-b-statefulset
           app.kubernetes.io/instance: nodepool-basic-test
@@ -2265,7 +2265,7 @@
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           lifecycle:
             postStart:
               exec:
@@ -2396,7 +2396,7 @@
           - /bin/bash
           - -c
           - rpk redpanda tune all
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: tuning
           resources: {}
           securityContext:
@@ -2435,7 +2435,7 @@
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: redpandadata/redpanda-unstable:v26.1.1-rc1
+          image: :v25.3.1
           name: redpanda-configurator
           resources: {}
           volumeMounts:

--- a/operator/internal/lifecycle/testdata/redpanda-cases.values.golden.txtar
+++ b/operator/internal/lifecycle/testdata/redpanda-cases.values.golden.txtar
@@ -148,8 +148,8 @@ values:
   force: false
   fullnameOverride: ""
   image:
-    repository: redpandadata/redpanda-unstable
-    tag: v26.1.1-rc1
+    repository: ""
+    tag: ""
   license_key: ""
   listeners:
     admin:
@@ -743,8 +743,8 @@ values:
   force: false
   fullnameOverride: ""
   image:
-    repository: redpandadata/redpanda-unstable
-    tag: v26.1.1-rc1
+    repository: ""
+    tag: ""
   license_key: ""
   listeners:
     admin:
@@ -1114,8 +1114,8 @@ values:
   force: false
   fullnameOverride: ""
   image:
-    repository: redpandadata/redpanda-unstable
-    tag: v26.1.1-rc1
+    repository: ""
+    tag: ""
   license_key: ""
   listeners:
     admin:
@@ -1432,14 +1432,6 @@ pools:
                   app.kubernetes.io/instance: '{{ .Release.Name }}'
                   app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
               topologyKey: kubernetes.io/hostname
-        containers:
-        - image: redpandadata/redpanda-unstable:v26.1.1-rc1
-          name: redpanda
-        initContainers:
-        - image: redpandadata/redpanda-unstable:v26.1.1-rc1
-          name: redpanda-configurator
-        - image: redpandadata/redpanda-unstable:v26.1.1-rc1
-          name: tuning
         priorityClassName: ""
         securityContext: {}
         terminationGracePeriodSeconds: 90
@@ -1512,14 +1504,6 @@ pools:
                   app.kubernetes.io/instance: '{{ .Release.Name }}'
                   app.kubernetes.io/name: '{{ include "redpanda.name" . }}'
               topologyKey: kubernetes.io/hostname
-        containers:
-        - image: redpandadata/redpanda-unstable:v26.1.1-rc1
-          name: redpanda
-        initContainers:
-        - image: redpandadata/redpanda-unstable:v26.1.1-rc1
-          name: redpanda-configurator
-        - image: redpandadata/redpanda-unstable:v26.1.1-rc1
-          name: tuning
         priorityClassName: ""
         securityContext: {}
         terminationGracePeriodSeconds: 90
@@ -1706,8 +1690,8 @@ values:
   force: false
   fullnameOverride: ""
   image:
-    repository: redpandadata/redpanda-unstable
-    tag: v26.1.1-rc1
+    repository: ""
+    tag: ""
   license_key: ""
   listeners:
     admin:

--- a/operator/internal/lifecycle/testdata/stretch-cluster-cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/stretch-cluster-cases.pools.golden.txtar
@@ -28,7 +28,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-basic-a-statefulset
           app.kubernetes.io/instance: compat-test-
@@ -384,7 +384,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-basic-b-statefulset
           app.kubernetes.io/instance: compat-test-
@@ -741,7 +741,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-basic-a-statefulset
           app.kubernetes.io/instance: nodepool-basic-test-
@@ -1097,7 +1097,7 @@
     template:
       metadata:
         annotations:
-          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+          config.redpanda.com/checksum: 5fa1a93aaf96bea11c311bd90ca43b382893ab790a7206d1244adde8ba29a2ab
         labels:
           app.kubernetes.io/component: redpanda-basic-b-statefulset
           app.kubernetes.io/instance: nodepool-basic-test-

--- a/operator/multicluster/statefulset.go
+++ b/operator/multicluster/statefulset.go
@@ -1007,6 +1007,14 @@ func statefulSetChecksumAnnotation(state *RenderState, pool Pool) string {
 			dependencies = append(dependencies, state.Values.External.Addresses)
 		}
 	}
+	// NB: The rpk section is excluded from RedpandaConfigFile (via
+	// includeNonHashableItems=false) to avoid rolling pods when only replica
+	// count changes (broker addresses in the rpk section are replica-dependent).
+	// However, startup flags derived from additionalRedpandaCmdFlags
+	// (enable_memory_locking, overprovisioned, additional_start_flags) must
+	// still trigger a roll when changed, so we include them separately here.
+	lockMemory, overprovisioned, flags := RedpandaAdditionalStartFlags(&state.Values, pool)
+	dependencies = append(dependencies, lockMemory, overprovisioned, flags)
 	return helmette.Sha256Sum(helmette.ToJSON(dependencies))
 }
 


### PR DESCRIPTION
## Problem

When `resources.requests`/`resources.limits` are set, the chart intentionally omits `--lock-memory` from the flags it computes, expecting users to provide it via `additionalRedpandaCmdFlags`. The chart correctly extracts `--lock-memory` from those flags and stores it as `enable_memory_locking: true` in the `rpk` section of `redpanda.yaml` (a workaround for an rpk buglet where `--lock-memory` in `additional_start_flags` is silently ignored by rpk).

However, the `rpk` section was entirely excluded from `statefulSetChecksumAnnotation`. This was intentional — the `rpk` section contains replica-count-dependent broker addresses, so it was excluded to avoid rolling pods on replica scaling. But this exclusion inadvertently also excluded `enable_memory_locking`, `overprovisioned`, and `additional_start_flags`.

**Result:** changing `additionalRedpandaCmdFlags` (e.g. adding `--lock-memory`) updates the ConfigMap correctly but never triggers a StatefulSet rolling update. Pods continue running with the old startup flags until manually restarted.

Reproducer:
```yaml
apiVersion: cluster.redpanda.com/v1alpha2
kind: Redpanda
metadata:
  name: redpanda
spec:
  clusterSpec:
    statefulset:
      additionalRedpandaCmdFlags:
        - '--lock-memory'
    resources:
      requests:
        memory: 512Mi
      limits:
        memory: 512Mi
```

After applying, `kubectl exec` shows `enable_memory_locking: true` in `redpanda.yaml`, but the running pod still has `--lock-memory=false` in its startup command because no roll was triggered.

## Fix

Include the output of `RedpandaAdditionalStartFlags` (`lockMemory`, `overprovisioned`, `flags`) in the checksum dependencies separately. These values are not replica-count-dependent, so they correctly roll pods when `additionalRedpandaCmdFlags` changes without rolling pods on scaling.

Changes:
- `charts/redpanda/statefulset.go` — fix for Helm chart / v1alpha2 operator path
- `operator/multicluster/statefulset.go` — same fix for stretch cluster path (compiled into operator binary)
- `charts/redpanda/chart/templates/_statefulset.go.tpl` — regenerated via gotohelm
- `charts/redpanda/testdata/template-cases.txtar` — new test case covering the reported scenario

## Notes

- Golden files (`template-cases.golden.txtar` and lifecycle testdata) need to be regenerated. Run `go test -update` in `charts/redpanda` and `operator/internal/lifecycle` once the local proto conflict is resolved (pre-existing issue unrelated to this PR).
- Existing checksums in all StatefulSet golden files will change, since startup flags are now part of the hash for all configurations.

## Test plan

- [ ] New test case `lock-memory-with-resources` asserts `enable_memory_locking: true` when `--lock-memory` is in `additionalRedpandaCmdFlags` with `requests`/`limits` set
- [ ] Existing `flag-overrides` test continues to assert correct behavior for `--lock-memory=false` override
- [ ] Golden files regenerated and checksums verified to differ between configs with and without `--lock-memory`
- [ ] Manual: apply the reproducer CRD above, verify pod rolls automatically and `--lock-memory=true` appears in startup logs
