### PR TITLE
feat: allow TLS on external listeners when internal listener TLS is disabled

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20260320-163000.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260320-163000.yaml
@@ -1,4 +1,4 @@
 project: charts/redpanda
-kind: Fixed
-body: Fixed external listener TLS certificates not being mounted when the internal listener has TLS disabled. Previously, disabling TLS on an internal listener would skip certificate collection for all associated external sub-listeners, causing Redpanda to fail to start when an external listener referenced a TLS certificate.
+kind: Added
+body: Added support for enabling TLS on external listeners independently of the internal listener's TLS state. External sub-listener TLS certificates are now correctly mounted even when the internal listener has TLS disabled.
 time: 2026-03-20T16:30:00.000000-07:00

--- a/.changes/unreleased/charts-redpanda-Fixed-20260320-163000.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260320-163000.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Fixed external listener TLS certificates not being mounted when the internal listener has TLS disabled. Previously, disabling TLS on an internal listener would skip certificate collection for all associated external sub-listeners, causing Redpanda to fail to start when an external listener referenced a TLS certificate.
+time: 2026-03-20T16:30:00.000000-07:00

--- a/charts/redpanda/chart/templates/_values.go.tpl
+++ b/charts/redpanda/chart/templates/_values.go.tpl
@@ -508,10 +508,9 @@
 {{- $_ := (set $certs $l.rpc.tls.cert true) -}}
 {{- end -}}
 {{- range $_, $listener := $listeners -}}
-{{- if (not (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $listener.tls $tls)))) "r")) -}}
-{{- continue -}}
-{{- end -}}
+{{- if (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $listener.tls $tls)))) "r") -}}
 {{- $_ := (set $certs $listener.tls.cert true) -}}
+{{- end -}}
 {{- range $_, $external := $listener.external -}}
 {{- if (or (not (get (fromJson (include "redpanda.ExternalListener.IsEnabled" (dict "a" (list $external)))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $external.tls $listener.tls $tls)))) "r"))) -}}
 {{- continue -}}
@@ -627,9 +626,9 @@
 {{- $seen := (dict) -}}
 {{- $deduped := (coalesce nil) -}}
 {{- range $_, $item := $items -}}
-{{- $_1029___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
-{{- $_ := (index $_1029___ok_11 0) -}}
-{{- $ok_11 := (index $_1029___ok_11 1) -}}
+{{- $_1027___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
+{{- $_ := (index $_1027___ok_11 0) -}}
+{{- $ok_11 := (index $_1027___ok_11 1) -}}
 {{- if $ok_11 -}}
 {{- continue -}}
 {{- end -}}
@@ -852,9 +851,9 @@
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1317_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
-{{- $cert := (index $_1317_cert_ok 0) -}}
-{{- $ok := (index $_1317_cert_ok 1) -}}
+{{- $_1315_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
+{{- $cert := (index $_1315_cert_ok 0) -}}
+{{- $ok := (index $_1315_cert_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
@@ -1333,9 +1332,9 @@
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_1847___ok_15 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
-{{- $_ := ((index $_1847___ok_15 0) | float64) -}}
-{{- $ok_15 := (index $_1847___ok_15 1) -}}
+{{- $_1845___ok_15 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
+{{- $_ := ((index $_1845___ok_15 0) | float64) -}}
+{{- $ok_15 := (index $_1845___ok_15 1) -}}
 {{- if $ok_15 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
@@ -1361,9 +1360,9 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
-{{- $_1867_b_16_ok_17 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
-{{- $b_16 := (index $_1867_b_16_ok_17 0) -}}
-{{- $ok_17 := (index $_1867_b_16_ok_17 1) -}}
+{{- $_1865_b_16_ok_17 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
+{{- $b_16 := (index $_1865_b_16_ok_17 0) -}}
+{{- $ok_17 := (index $_1865_b_16_ok_17 1) -}}
 {{- if $ok_17 -}}
 {{- $_ := (set $result $k $b_16) -}}
 {{- continue -}}
@@ -1406,15 +1405,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1912___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1912___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_1912___hasAccessKey 1) -}}
-{{- $_1913___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1913___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_1913___hasSecretKey 1) -}}
-{{- $_1914___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1914___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_1914___hasSharedKey 1) -}}
+{{- $_1910___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1910___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_1910___hasAccessKey 1) -}}
+{{- $_1911___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1911___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_1911___hasSecretKey 1) -}}
+{{- $_1912___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1912___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_1912___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey)))) "r")) -}}
 {{- $envvars = (concat (default (list) $envvars) (list (mustMergeOverwrite (dict "name" "") (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey)))) "r"))))) -}}
@@ -1437,12 +1436,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1950___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1950___containerExists 0) -}}
-{{- $containerExists := (index $_1950___containerExists 1) -}}
-{{- $_1951___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_1951___accountExists 0) -}}
-{{- $accountExists := (index $_1951___accountExists 1) -}}
+{{- $_1948___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1948___containerExists 0) -}}
+{{- $containerExists := (index $_1948___containerExists 1) -}}
+{{- $_1949___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_1949___accountExists 0) -}}
+{{- $accountExists := (index $_1949___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1453,9 +1452,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1956_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
-{{- $value := (index $_1956_value_ok 0) -}}
-{{- $ok := (index $_1956_value_ok 1) -}}
+{{- $_1954_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
+{{- $value := (index $_1954_value_ok 0) -}}
+{{- $ok := (index $_1954_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -904,11 +904,9 @@ func (l *Listeners) InUseServerCerts(tls *TLS) []string {
 	}
 
 	for _, listener := range listeners {
-		if !listener.TLS.IsEnabled(tls) {
-			continue
+		if listener.TLS.IsEnabled(tls) {
+			certs[listener.TLS.Cert] = true
 		}
-
-		certs[listener.TLS.Cert] = true
 
 		for _, external := range helmette.SortedMap(listener.External) {
 			if !external.IsEnabled() || !external.TLS.IsEnabled(&listener.TLS, tls) {

--- a/charts/redpanda/values_test.go
+++ b/charts/redpanda/values_test.go
@@ -627,6 +627,335 @@ func TestTieredStorageConfigCreds(t *testing.T) {
 	}
 }
 
+func TestInUseServerCerts(t *testing.T) {
+	cases := map[string]struct {
+		TLS       TLS
+		Listeners Listeners
+		Expected  []string
+	}{
+		"internal TLS enabled collects internal cert": {
+			TLS: TLS{Enabled: false},
+			Listeners: Listeners{
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9092,
+					TLS: InternalTLS{
+						Enabled: ptr.To(true),
+						Cert:    "default",
+					},
+				},
+				Admin:          ListenerConfig[NoAuth]{Port: 9644, TLS: InternalTLS{Cert: "default"}},
+				HTTP:           ListenerConfig[HTTPAuthenticationMethod]{Port: 8082, TLS: InternalTLS{Cert: "default"}},
+				SchemaRegistry: ListenerConfig[NoAuth]{Port: 8081, TLS: InternalTLS{Cert: "default"}},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Cert: "default"}},
+			},
+			Expected: []string{"default"},
+		},
+		"internal TLS disabled, external TLS enabled with explicit cert": {
+			TLS: TLS{
+				Enabled: true,
+				Certs: TLSCertMap{
+					"default":  TLSCert{},
+					"external": TLSCert{},
+				},
+			},
+			Listeners: Listeners{
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9094,
+					TLS: InternalTLS{
+						Enabled: ptr.To(false),
+						Cert:    "default",
+					},
+					External: map[string]ExternalListener[KafkaAuthenticationMethod]{
+						"default": {
+							Port:    9095,
+							Enabled: ptr.To(true),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(true),
+								Cert:    ptr.To("external"),
+							},
+						},
+					},
+				},
+				Admin:          ListenerConfig[NoAuth]{Port: 9644, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				HTTP:           ListenerConfig[HTTPAuthenticationMethod]{Port: 8082, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				SchemaRegistry: ListenerConfig[NoAuth]{Port: 8081, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+			},
+			Expected: []string{"external"},
+		},
+		"both internal and external TLS enabled with different certs": {
+			TLS: TLS{
+				Enabled: true,
+				Certs: TLSCertMap{
+					"default":  TLSCert{},
+					"external": TLSCert{},
+				},
+			},
+			Listeners: Listeners{
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9094,
+					TLS: InternalTLS{
+						Enabled: ptr.To(true),
+						Cert:    "default",
+					},
+					External: map[string]ExternalListener[KafkaAuthenticationMethod]{
+						"default": {
+							Port:    9095,
+							Enabled: ptr.To(true),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(true),
+								Cert:    ptr.To("external"),
+							},
+						},
+					},
+				},
+				Admin:          ListenerConfig[NoAuth]{Port: 9644, TLS: InternalTLS{Cert: "default"}},
+				HTTP:           ListenerConfig[HTTPAuthenticationMethod]{Port: 8082, TLS: InternalTLS{Cert: "default"}},
+				SchemaRegistry: ListenerConfig[NoAuth]{Port: 8081, TLS: InternalTLS{Cert: "default"}},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Cert: "default"}},
+			},
+			Expected: []string{"default", "external"},
+		},
+		"all TLS disabled returns empty": {
+			TLS: TLS{Enabled: false},
+			Listeners: Listeners{
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9094,
+					TLS: InternalTLS{
+						Enabled: ptr.To(false),
+						Cert:    "default",
+					},
+					External: map[string]ExternalListener[KafkaAuthenticationMethod]{
+						"default": {
+							Port:    9095,
+							Enabled: ptr.To(true),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(false),
+							},
+						},
+					},
+				},
+				Admin:          ListenerConfig[NoAuth]{Port: 9644, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				HTTP:           ListenerConfig[HTTPAuthenticationMethod]{Port: 8082, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				SchemaRegistry: ListenerConfig[NoAuth]{Port: 8081, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+			},
+			Expected: []string{},
+		},
+		"customer scenario: global TLS on, all internal off, kafka external on with secretRef cert": {
+			TLS: TLS{
+				Enabled: true,
+				Certs: TLSCertMap{
+					"default":  TLSCert{},
+					"external": TLSCert{CAEnabled: false},
+				},
+			},
+			Listeners: Listeners{
+				Admin: ListenerConfig[NoAuth]{
+					Port: 9644,
+					TLS:  InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+				},
+				HTTP: ListenerConfig[HTTPAuthenticationMethod]{
+					Port: 8082,
+					TLS:  InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+				},
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9094,
+					TLS: InternalTLS{
+						Enabled: ptr.To(false),
+						Cert:    "default",
+					},
+					External: map[string]ExternalListener[KafkaAuthenticationMethod]{
+						"default": {
+							Port:    9095,
+							Enabled: ptr.To(true),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(true),
+								Cert:    ptr.To("external"),
+							},
+						},
+					},
+				},
+				SchemaRegistry: ListenerConfig[NoAuth]{
+					Port: 8081,
+					TLS:  InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+				},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+			},
+			Expected: []string{"external"},
+		},
+		"multiple listeners with external-only TLS": {
+			TLS: TLS{
+				Enabled: true,
+				Certs: TLSCertMap{
+					"default":   TLSCert{},
+					"kafka-ext": TLSCert{},
+					"admin-ext": TLSCert{},
+				},
+			},
+			Listeners: Listeners{
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9094,
+					TLS:  InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+					External: map[string]ExternalListener[KafkaAuthenticationMethod]{
+						"default": {
+							Port:    9095,
+							Enabled: ptr.To(true),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(true),
+								Cert:    ptr.To("kafka-ext"),
+							},
+						},
+					},
+				},
+				Admin: ListenerConfig[NoAuth]{
+					Port: 9644,
+					TLS:  InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+					External: map[string]ExternalListener[NoAuth]{
+						"default": {
+							Port:    9645,
+							Enabled: ptr.To(true),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(true),
+								Cert:    ptr.To("admin-ext"),
+							},
+						},
+					},
+				},
+				HTTP:           ListenerConfig[HTTPAuthenticationMethod]{Port: 8082, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				SchemaRegistry: ListenerConfig[NoAuth]{Port: 8081, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+			},
+			Expected: []string{"admin-ext", "kafka-ext"},
+		},
+		"disabled external listener should not include its cert": {
+			TLS: TLS{Enabled: true},
+			Listeners: Listeners{
+				Kafka: ListenerConfig[KafkaAuthenticationMethod]{
+					Port: 9094,
+					TLS:  InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+					External: map[string]ExternalListener[KafkaAuthenticationMethod]{
+						"default": {
+							Port:    9095,
+							Enabled: ptr.To(false),
+							TLS: &ExternalTLS{
+								Enabled: ptr.To(true),
+								Cert:    ptr.To("external"),
+							},
+						},
+					},
+				},
+				Admin:          ListenerConfig[NoAuth]{Port: 9644, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				HTTP:           ListenerConfig[HTTPAuthenticationMethod]{Port: 8082, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				SchemaRegistry: ListenerConfig[NoAuth]{Port: 8081, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+				RPC: struct {
+					Port int32       `json:"port" jsonschema:"required"`
+					TLS  InternalTLS `json:"tls" jsonschema:"required"`
+				}{Port: 33145, TLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"}},
+			},
+			Expected: []string{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := tc.Listeners.InUseServerCerts(&tc.TLS)
+			assert.Equal(t, tc.Expected, result)
+		})
+	}
+}
+
+func TestExternalTLSIsEnabled(t *testing.T) {
+	cases := map[string]struct {
+		ExternalTLS *ExternalTLS
+		InternalTLS InternalTLS
+		GlobalTLS   TLS
+		Expected    bool
+	}{
+		"nil external TLS returns false": {
+			ExternalTLS: nil,
+			InternalTLS: InternalTLS{Enabled: ptr.To(true), Cert: "default"},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    false,
+		},
+		"external explicitly enabled, internal disabled": {
+			ExternalTLS: &ExternalTLS{
+				Enabled: ptr.To(true),
+				Cert:    ptr.To("external"),
+			},
+			InternalTLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    true,
+		},
+		"external explicitly disabled, internal enabled": {
+			ExternalTLS: &ExternalTLS{
+				Enabled: ptr.To(false),
+				Cert:    ptr.To("external"),
+			},
+			InternalTLS: InternalTLS{Enabled: ptr.To(true), Cert: "default"},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    false,
+		},
+		"external not specified, falls back to internal enabled": {
+			ExternalTLS: &ExternalTLS{
+				Cert: ptr.To("external"),
+			},
+			InternalTLS: InternalTLS{Enabled: ptr.To(true), Cert: "default"},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    true,
+		},
+		"external not specified, falls back to internal disabled": {
+			ExternalTLS: &ExternalTLS{
+				Cert: ptr.To("external"),
+			},
+			InternalTLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    false,
+		},
+		"external enabled but no cert and internal has empty cert": {
+			ExternalTLS: &ExternalTLS{
+				Enabled: ptr.To(true),
+			},
+			InternalTLS: InternalTLS{Enabled: ptr.To(false), Cert: ""},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    false,
+		},
+		"external enabled, cert falls back to internal cert name": {
+			ExternalTLS: &ExternalTLS{
+				Enabled: ptr.To(true),
+			},
+			InternalTLS: InternalTLS{Enabled: ptr.To(false), Cert: "default"},
+			GlobalTLS:   TLS{Enabled: true},
+			Expected:    true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := tc.ExternalTLS.IsEnabled(&tc.InternalTLS, &tc.GlobalTLS)
+			assert.Equal(t, tc.Expected, result)
+		})
+	}
+}
+
 func TestRedpandaResources_RedpandaFlags(t *testing.T) {
 	cases := []struct {
 		Resources RedpandaResources


### PR DESCRIPTION
## Summary

- `InUseServerCerts()` short-circuited the entire listener when internal TLS was disabled, skipping all external sub-listeners. External TLS cert secrets were never mounted, causing Redpanda to crash: `Could not read certificate file /etc/tls/certs/external/tls.crt`
- Changed the early `continue` to a conditional block so external sub-listeners are always evaluated regardless of internal TLS state
- Added `TestInUseServerCerts` (7 cases including exact customer scenario) and `TestExternalTLSIsEnabled` (7 cases)
- Regenerated helm templates via gotohelm and updated golden files

TLS-on-external-only (internal disabled, external enabled with custom cert) is a valid deployment pattern.

## UX overview

This fix enables a deployment pattern where users configure TLS on external-facing listeners while keeping internal (intra-cluster) listeners unencrypted. This is common when external traffic crosses untrusted networks but internal pod-to-pod traffic stays within a trusted network boundary.

### Before (broken)

Users who disabled internal TLS but enabled TLS on an external sub-listener would see Redpanda pods crash-loop:

```
Could not read certificate file /etc/tls/certs/external/tls.crt: No such file or directory
```

The certificate Secret existed in the cluster, but was never mounted into the pod because the Helm chart skipped the entire listener—including all its external sub-listeners—when internal TLS was disabled.

### After (fixed)

External sub-listener TLS certificates are now correctly collected and mounted regardless of the internal listener's TLS state.

**Example: Kafka listener with internal TLS disabled, external TLS enabled**

```yaml
listeners:
  kafka:
    tls:
      enabled: false          # internal listener — no TLS
    external:
      my-external:
        enabled: true
        tls:
          enabled: true       # external sub-listener — TLS on
          cert: my-ext-cert   # references tls.certs.my-ext-cert
tls:
  certs:
    my-ext-cert:
      secretRef:
        name: my-external-tls-secret
```

With this config, the `my-ext-cert` certificate Secret is now mounted at `/etc/tls/certs/my-ext-cert/` and Redpanda starts successfully.

**Example: Multiple listeners, mixed TLS**

```yaml
listeners:
  kafka:
    tls:
      enabled: false
    external:
      public:
        enabled: true
        tls:
          enabled: true
          cert: kafka-external
  http:
    tls:
      enabled: true           # internal HTTP/Admin TLS on
      cert: default
    external:
      public-http:
        enabled: true
        tls:
          enabled: true
          cert: http-external
```

Both `kafka-external` and `http-external` certs are mounted alongside `default`, even though Kafka's internal TLS is disabled.

### Details

In `values.go:906-909`:
```go
// BEFORE: skips ALL external sub-listeners
if !listener.TLS.IsEnabled(tls) {
    continue
}

// AFTER: only gates the internal cert addition
if listener.TLS.IsEnabled(tls) {
    certs[listener.TLS.Cert] = true
}
// external sub-listeners always evaluated below
```

## Test plan

- [x] `TestInUseServerCerts` — verifies cert collection for: internal-only TLS, external-only TLS, both enabled, all disabled, customer's exact config, multiple listeners with external-only TLS, disabled external listener
- [x] `TestExternalTLSIsEnabled` — verifies enable/disable logic for external TLS with various internal/global TLS combinations
- [x] `TestTemplate` — golden file updated for `07-multiple-listeners` showing `cert2` now correctly mounted
- [x] All existing template tests pass
