### PR TITLE
Fix acceptance test flakes on release/v25.1.x

### DIFF
--- a/acceptance/steps/cluster.go
+++ b/acceptance/steps/cluster.go
@@ -33,7 +33,10 @@ func checkClusterAvailability(ctx context.Context, t framework.TestingT, cluster
 
 	t.Logf("Checking cluster %q is ready", clusterName)
 	require.Eventually(t, func() bool {
-		require.NoError(t, t.Get(ctx, key, &cluster))
+		if err := t.Get(ctx, key, &cluster); err != nil {
+			t.Logf("Failed to get cluster %q: %v", key, err)
+			return false
+		}
 		hasConditionReady := t.HasCondition(metav1.Condition{
 			Type:   "Ready",
 			Status: metav1.ConditionTrue,
@@ -50,7 +53,7 @@ func checkClusterAvailability(ctx context.Context, t framework.TestingT, cluster
 
 		t.Logf(`Checking cluster resource conditions contains "Ready"? %v`, hasCondition)
 		return hasCondition
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, 10*time.Minute, 5*time.Second, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason "Ready", final Conditions: %+v`, key.String(), cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q is ready!", clusterName)
@@ -65,11 +68,14 @@ func redpandaClusterIsHealthy(ctx context.Context, t framework.TestingT, cluster
 
 	require.Eventually(t, func() bool {
 		health, err = c.GetHealthOverview(ctx)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("Failed to get health overview: %v", err)
+			return false
+		}
 
 		t.Logf("Cluster health: %v", health.IsHealthy)
 		return health.IsHealthy
-	}, 5*time.Minute, 5*time.Second, `Cluster %q never become healthy: %+v`, cluster, health)
+	}, 10*time.Minute, 5*time.Second, `Cluster %q never become healthy: %+v`, cluster, health)
 }
 
 func checkClusterUnhealthy(ctx context.Context, t framework.TestingT, clusterName string) {
@@ -87,7 +93,10 @@ func checkClusterHealthCondition(ctx context.Context, t framework.TestingT, clus
 
 	t.Logf("Checking cluster %q Healthy reason %q", clusterName, reason)
 	require.Eventually(t, func() bool {
-		require.NoError(t, t.Get(ctx, key, &cluster))
+		if err := t.Get(ctx, key, &cluster); err != nil {
+			t.Logf("Failed to get cluster %q: %v", key, err)
+			return false
+		}
 		hasCondition := t.HasCondition(metav1.Condition{
 			Type:   "Healthy",
 			Status: status,
@@ -96,7 +105,7 @@ func checkClusterHealthCondition(ctx context.Context, t framework.TestingT, clus
 
 		t.Logf(`Checking cluster conditions contains Healthy reason %q? %v`, reason, hasCondition)
 		return hasCondition
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, 10*time.Minute, 5*time.Second, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason %q, final Conditions: %+v`, key.String(), reason, cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q contains Healthy reason %q!", clusterName, reason)
@@ -174,7 +183,10 @@ func checkClusterNodeCount(ctx context.Context, t framework.TestingT, clusterNam
 	t.Logf("Checking cluster %q node count is %d", clusterName, nodeCount)
 	require.Eventually(t, func() bool {
 		actualNodeCount = 0
-		require.NoError(t, t.Get(ctx, key, &cluster))
+		if err := t.Get(ctx, key, &cluster); err != nil {
+			t.Logf("Failed to get cluster %q: %v", key, err)
+			return false
+		}
 
 		for _, pool := range cluster.Status.NodePools {
 			actualNodeCount += pool.UpToDateReplicas
@@ -184,7 +196,7 @@ func checkClusterNodeCount(ctx context.Context, t framework.TestingT, clusterNam
 		t.Logf("Checking cluster %q has %d total nodes? %v (%d)", clusterName, nodeCount, matchesCount, actualNodeCount)
 
 		return matchesCount
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, 10*time.Minute, 5*time.Second, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never had a matching node count, node Count: %d`, key.String(), actualNodeCount)
 	}))
 	t.Logf("Cluster %q has %d nodes!", clusterName, nodeCount)
@@ -199,7 +211,10 @@ func checkClusterStableWithCount(ctx context.Context, t framework.TestingT, clus
 	t.Logf("Checking cluster %q is stable", clusterName)
 	require.Eventually(t, func() bool {
 		actualNodeCount = 0
-		require.NoError(t, t.Get(ctx, key, &cluster))
+		if err := t.Get(ctx, key, &cluster); err != nil {
+			t.Logf("Failed to get cluster %q: %v", key, err)
+			return false
+		}
 		hasCondition := t.HasCondition(metav1.Condition{
 			Type:   "Stable",
 			Status: metav1.ConditionTrue,
@@ -226,7 +241,7 @@ func checkClusterStableWithCount(ctx context.Context, t framework.TestingT, clus
 		t.Logf("Checking cluster %q has %d total nodes? %v (%d)", clusterName, nodeCount, matchesCount, actualNodeCount)
 
 		return hasCondition && matchesCount
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, 10*time.Minute, 5*time.Second, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason "Ready" with a matching node count, node Count: %d, final Conditions: %+v`, key.String(), actualNodeCount, cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q is stable with %d nodes!", clusterName, nodeCount)


### PR DESCRIPTION
## Summary
- Backport of 53871fba from `main` to `release/v25.1.x`
- Increase cluster availability/health check timeouts from 5min to 10min to handle slow CI environments
- Replace `require.NoError` inside `require.Eventually` callbacks with error checks that return false — `require.NoError` calls `FailNow` which panics the `Eventually` goroutine instead of letting it retry

The acceptance tests, operator test suite, k8s-operator-v2, and k8s-operator-v2-helm checks have been consistently failing on `release/v25.1.x` since commit 68d36a3f (snyk/govulncheck dep bump). This fix was already applied to `main` but not yet backported.

## Test plan
- [ ] Acceptance tests pass on CI
- [ ] Operator Test Suite passes
- [ ] k8s-operator-v2 and k8s-operator-v2-helm checks pass
