### PR TITLE
fix: topic and console controller tight reconciliation loops ignoring interval

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260322-topic-reconcile-loop.yaml
+++ b/.changes/unreleased/operator-Fixed-20260322-topic-reconcile-loop.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed topic controller tight reconciliation loop that ignored the configured spec.interval value, causing reconciliation every ~1 second instead of honoring the specified interval (e.g. 60s, 120s). Also bumped the default interval from 3s to 10s.
+time: 2026-03-22T00:00:00.000000+00:00

--- a/.changes/unreleased/operator-Fixed-20260325-console-reconcile-loop.yaml
+++ b/.changes/unreleased/operator-Fixed-20260325-console-reconcile-loop.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed Console controller tight reconciliation loop by adding GenerationChangedPredicate to filter out status-only updates that bypassed RequeueAfter.
+time: 2026-03-25T12:00:00.000000-04:00

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -4489,7 +4489,7 @@ name of the metric. This should be easier to identify if +
 multiple operator instances runs inside the same Kubernetes cluster. +
 By default, it is set to `redpanda-operator`. + |  | 
 | *`interval`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta[$$Duration$$]__ | Defines when the topic controller will schedule the next reconciliation. +
-Default is 3 seconds. + | 3s | Format: duration +
+Default is 10 seconds. + | 10s | Format: duration +
 Type: string +
 
 |===

--- a/operator/api/redpanda/v1alpha2/topic_types.go
+++ b/operator/api/redpanda/v1alpha2/topic_types.go
@@ -63,10 +63,10 @@ type TopicSpec struct {
 	MetricsNamespace *string `json:"metricsNamespace,omitempty"`
 
 	// Defines when the topic controller will schedule the next reconciliation.
-	// Default is 3 seconds.
+	// Default is 10 seconds.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
-	// +kubebuilder:default="3s"
+	// +kubebuilder:default="10s"
 	SynchronizationInterval *metav1.Duration `json:"interval,omitempty"`
 }
 

--- a/operator/config/crd/bases/cluster.redpanda.com_topics.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_topics.yaml
@@ -2339,10 +2339,10 @@ spec:
                 - message: either clusterRef or staticConfiguration must be set
                   rule: has(self.clusterRef) || has(self.staticConfiguration)
               interval:
-                default: 3s
+                default: 10s
                 description: |-
                   Defines when the topic controller will schedule the next reconciliation.
-                  Default is 3 seconds.
+                  Default is 10 seconds.
                 format: duration
                 type: string
               kafkaApiSpec:
@@ -5853,10 +5853,10 @@ spec:
                 - message: either clusterRef or staticConfiguration must be set
                   rule: has(self.clusterRef) || has(self.staticConfiguration)
               interval:
-                default: 3s
+                default: 10s
                 description: |-
                   Defines when the topic controller will schedule the next reconciliation.
-                  Default is 3 seconds.
+                  Default is 10 seconds.
                 format: duration
                 type: string
               kafkaApiSpec:

--- a/operator/internal/controller/console/controller.go
+++ b/operator/internal/controller/console/controller.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
@@ -85,7 +86,7 @@ func (c *Controller) SetupWithManager(ctx context.Context, mgr multicluster.Mana
 	}
 
 	builder := mcbuilder.ControllerManagedBy(mgr).
-		For(&redpandav1alpha2.Console{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+		For(&redpandav1alpha2.Console{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true), mcbuilder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
 	// NB: As of writing, all console types are namespace scoped.
 	for _, t := range console.Types() {

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	v2 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
@@ -146,7 +147,7 @@ func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expande
 	}
 
 	builder := mcbuilder.ControllerManagedBy(mgr).
-		For(&redpandav1alpha2.Topic{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+		For(&redpandav1alpha2.Topic{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true), mcbuilder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
 	for _, clusterName := range mgr.GetClusterNames() {
 		if includeV1 {
@@ -172,7 +173,7 @@ func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expande
 func (r *TopicReconciler) reconcile(ctx context.Context, recorder record.EventRecorder, topic *redpandav1alpha2.Topic, l logr.Logger) (*redpandav1alpha2.Topic, ctrl.Result, error) {
 	l = l.WithName("reconcile")
 
-	interval := metav1.Duration{Duration: time.Second * 3}
+	interval := metav1.Duration{Duration: time.Second * 10}
 	if topic.Spec.SynchronizationInterval != nil {
 		interval = *topic.Spec.SynchronizationInterval
 	}

--- a/operator/internal/controller/redpanda/topic_controller_test.go
+++ b/operator/internal/controller/redpanda/topic_controller_test.go
@@ -243,7 +243,7 @@ func TestReconcile(t *testing.T) { // nolint:funlen // These tests have clear su
 		result, err := tr.Reconcile(ctx, req)
 		assert.NoError(t, err)
 
-		assert.Equal(t, time.Second*3, result.RequeueAfter)
+		assert.Equal(t, time.Second*10, result.RequeueAfter)
 
 		var mrt kmsg.MetadataResponseTopic
 		{
@@ -662,7 +662,7 @@ func TestReconcile(t *testing.T) { // nolint:funlen // These tests have clear su
 		result, err := tr.Reconcile(ctx, req)
 		assert.NoError(t, err)
 
-		assert.Equal(t, time.Second*3, result.RequeueAfter)
+		assert.Equal(t, time.Second*10, result.RequeueAfter)
 
 		err = c.Get(ctx, types.NamespacedName{
 			Name:      topicName,


### PR DESCRIPTION
## Summary

- Add `GenerationChangedPredicate` to the **Topic** and **Console** controllers' `For()` watches, filtering out status-only updates that were triggering immediate re-reconciliation and bypassing the configured `spec.interval`
- Bump the Topic controller's default synchronization interval from 3s to 10s to reduce baseline load

## Root cause

Both the Topic and Console controllers watch their respective resources via `For()` with no predicates. Every reconciliation updates status fields (topic configuration, deployment replicas/conditions), which changes `resourceVersion`. The informer sees this as a new event and immediately enqueues another reconcile — bypassing `RequeueAfter: interval.Duration`. This creates a tight loop (~1 reconcile/second) regardless of the configured interval.

The same bug was identified and fixed for the other resource controllers (User, Group, Schema, Role, ShadowLink) in a prior change, but the Topic and Console controllers were missed.

### Topic controller

The Topic controller's `reportStatusTopicConfiguration` fetches topic config from Kafka and writes it to `status.topicConfiguration`. `patchTopicStatus` applies the status patch, `resourceVersion` changes, the informer fires, and a new reconcile is immediately enqueued — ignoring `RequeueAfter`.

### Console controller

The Console controller calls `syncer.Sync()` then patches status with deployment replica counts via `ApplyStatus()` on every reconcile. The same `resourceVersion` feedback loop applies. Additionally, the Console controller's tight loop was causing cascading reconciliation on the **User controller**, as reported in #1291.

## Customer-reported examples

### Topic (reported via support)

Topic CRDs were reconciling every ~1 second despite having explicit `interval` values of 60s and 120s:

```yaml
apiVersion: cluster.redpanda.com/v1alpha2
kind: Topic
metadata:
  name: test-1
spec:
  additionalConfig:
    retention.ms: "604800000"
  cluster:
    clusterRef:
      name: rp-test-cluster-1
  interval: 120s
  overwriteTopicName: test-1
  partitions: 6
  replicationFactor: 1
```

### Console (#1291)

After deploying a standalone `Console` CR, both the Console and User controllers entered a continuous reconcile loop (~1/sec). Deleting the Console CR stopped the loop. The Redpanda CRD `resourceVersion` was incrementing every ~1 second despite no spec changes.

## After this fix

- **Topics with explicit interval**: Reconcile once, then wait the full interval (e.g. 60s, 120s) before the next run
- **Topics with no explicit interval**: Use the new default of 10s (previously 3s)
- **Console**: Status-only updates no longer trigger re-reconciliation. Only spec changes (which increment `metadata.generation`) trigger watch-based reconciliation
- **Spec changes**: Still trigger immediate reconciliation because they increment `metadata.generation`, which passes the `GenerationChangedPredicate` filter

## Changes

| File | Description |
|------|-------------|
| `operator/internal/controller/redpanda/topic_controller.go` | Added `GenerationChangedPredicate` to `For()` watch |
| `operator/internal/controller/redpanda/topic_controller_test.go` | Updated default interval from 3s to 10s |
| `operator/internal/controller/console/controller.go` | Added `GenerationChangedPredicate` to `For()` watch |
| `operator/api/redpanda/v1alpha2/topic_types.go` | Bumped default sync interval from 3s to 10s |
| `operator/config/crd/bases/cluster.redpanda.com_topics.yaml` | Updated CRD default |
| `operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc` | Updated docs |

## Test plan

- [ ] Verify topic reconciliation respects the configured `spec.interval` (e.g. 60s, 120s)
- [ ] Verify Console controller reconciliation settles after initial sync
- [ ] Verify spec changes still trigger immediate reconciliation
- [ ] Verify existing unit tests pass with updated 10s default
- [ ] Confirm no regression in topic create/update/delete flows
- [ ] Confirm Console + User controllers no longer loop continuously (#1291)
