### PR TITLE
fix: resolve acceptance test flakiness for CRD sync, role membership, and rpk exec

### DIFF
--- a/acceptance/steps/groups.go
+++ b/acceptance/steps/groups.go
@@ -28,15 +28,9 @@ func groupIsSuccessfullySynced(ctx context.Context, t framework.TestingT, group 
 	var groupObject redpandav1alpha2.Group
 	require.NoError(t, t.Get(ctx, t.ResourceKey(group), &groupObject))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &groupObject)
-
-	// make sure it's synchronized
-	t.RequireCondition(metav1.Condition{
-		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
-		Status: metav1.ConditionTrue,
-		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
-	}, groupObject.Status.Conditions)
+	waitForSyncedCondition(ctx, t, &groupObject, func() []metav1.Condition {
+		return groupObject.Status.Conditions
+	})
 
 	t.Cleanup(func(ctx context.Context) {
 		t.Logf("Deleting group %q", group)

--- a/acceptance/steps/groups.go
+++ b/acceptance/steps/groups.go
@@ -30,6 +30,8 @@ func groupIsSuccessfullySynced(ctx context.Context, t framework.TestingT, group 
 
 	waitForSyncedCondition(ctx, t, &groupObject, func() []metav1.Condition {
 		return groupObject.Status.Conditions
+	}, func() int64 {
+		return groupObject.Status.ObservedGeneration
 	})
 
 	t.Cleanup(func(ctx context.Context) {

--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -600,6 +600,35 @@ func checkStableResource(ctx context.Context, t framework.TestingT, o runtimecli
 	t.Logf("Resource %q has been stable for 5 seconds", key.String())
 }
 
+// waitForCondition polls the resource until the expected condition is found.
+// getConditions extracts the conditions slice from the resource after each fetch.
+// This replaces the previous pattern of checkStableResource + RequireCondition,
+// which had a race condition: the resource could be "stable" (resourceVersion
+// unchanged) but the controller hadn't set the condition yet.
+func waitForCondition(ctx context.Context, t framework.TestingT, o runtimeclient.Object, expected metav1.Condition, getConditions func() []metav1.Condition) {
+	key := runtimeclient.ObjectKeyFromObject(o)
+
+	t.Logf("Waiting for resource %q condition %s=%s", key.String(), expected.Type, expected.Status)
+	require.Eventually(t, func() bool {
+		if err := t.Get(ctx, key, o); err != nil {
+			t.Logf("Failed to get resource %q: %v", key.String(), err)
+			return false
+		}
+		return t.HasCondition(expected, getConditions())
+	}, 2*time.Minute, 2*time.Second, "Resource %q never reached condition %s=%s", key.String(), expected.Type, expected.Status)
+	t.Logf("Resource %q has condition %s=%s", key.String(), expected.Type, expected.Status)
+}
+
+// waitForSyncedCondition is a convenience wrapper for waitForCondition that
+// waits for the standard Synced=True condition used by most CRD resources.
+func waitForSyncedCondition(ctx context.Context, t framework.TestingT, o runtimeclient.Object, getConditions func() []metav1.Condition) {
+	waitForCondition(ctx, t, o, metav1.Condition{
+		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
+		Status: metav1.ConditionTrue,
+		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
+	}, getConditions)
+}
+
 type operatorClients struct {
 	client             http.Client
 	operatorPodName    string

--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -619,9 +619,32 @@ func waitForCondition(ctx context.Context, t framework.TestingT, o runtimeclient
 	t.Logf("Resource %q has condition %s=%s", key.String(), expected.Type, expected.Status)
 }
 
-// waitForSyncedCondition is a convenience wrapper for waitForCondition that
-// waits for the standard Synced=True condition used by most CRD resources.
-func waitForSyncedCondition(ctx context.Context, t framework.TestingT, o runtimeclient.Object, getConditions func() []metav1.Condition) {
+// waitForSyncedCondition waits for the controller to reconcile the current
+// generation of the resource and set the standard Synced=True condition.
+//
+// It first waits for status.observedGeneration to catch up to metadata.generation,
+// ensuring the controller has processed the latest spec change. Then it waits for
+// the Synced=True condition. This prevents a race where a stale Synced=True from a
+// previous reconciliation causes the wait to return before the current spec change
+// has been applied.
+func waitForSyncedCondition(ctx context.Context, t framework.TestingT, o runtimeclient.Object, getConditions func() []metav1.Condition, getObservedGeneration ...func() int64) {
+	key := runtimeclient.ObjectKeyFromObject(o)
+
+	// If an observedGeneration accessor is provided, first wait for the
+	// controller to observe the current generation.
+	if len(getObservedGeneration) > 0 {
+		getObsGen := getObservedGeneration[0]
+		t.Logf("Waiting for resource %q observedGeneration to catch up to generation", key.String())
+		require.Eventually(t, func() bool {
+			if err := t.Get(ctx, key, o); err != nil {
+				t.Logf("Failed to get resource %q: %v", key.String(), err)
+				return false
+			}
+			return getObsGen() >= o.GetGeneration()
+		}, 2*time.Minute, 2*time.Second, "Resource %q observedGeneration never caught up to generation %d", key.String(), o.GetGeneration())
+		t.Logf("Resource %q observedGeneration (%d) caught up to generation (%d)", key.String(), getObsGen(), o.GetGeneration())
+	}
+
 	waitForCondition(ctx, t, o, metav1.Condition{
 		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
 		Status: metav1.ConditionTrue,

--- a/acceptance/steps/roles.go
+++ b/acceptance/steps/roles.go
@@ -54,6 +54,8 @@ func roleIsSuccessfullySynced(ctx context.Context, t framework.TestingT, role st
 
 	waitForSyncedCondition(ctx, t, &roleObject, func() []metav1.Condition {
 		return roleObject.Status.Conditions
+	}, func() int64 {
+		return roleObject.Status.ObservedGeneration
 	})
 
 	t.Cleanup(func(ctx context.Context) {
@@ -135,25 +137,35 @@ func roleShouldHaveMembersAndInCluster(ctx context.Context, t framework.TestingT
 
 	expectedMembers := parseMembersList(members)
 
-	// Get role members from Redpanda using the effective role name
-	membersResp, err := adminClient.RoleMembers(ctx, effectiveRoleName)
-	if err != nil {
-		t.Fatalf("Failed to get members for role %q (effective name %q): %v", role, effectiveRoleName, err)
-	}
+	// Poll for role members — after the controller sets Synced=True, Redpanda's
+	// internal state may take a moment to propagate the membership changes.
+	var actualMembers map[string]bool
+	require.Eventually(t, func() bool {
+		membersResp, err := adminClient.RoleMembers(ctx, effectiveRoleName)
+		if err != nil {
+			t.Logf("Failed to get members for role %q (will retry): %v", role, err)
+			return false
+		}
 
-	// Check that expected members are present
-	actualMembers := make(map[string]bool)
-	for _, member := range membersResp.Members {
-		actualMembers[member.Name] = true
-	}
+		actualMembers = make(map[string]bool)
+		for _, member := range membersResp.Members {
+			actualMembers[member.Name] = true
+		}
 
-	// Verify all expected members are present
+		for _, expectedMember := range expectedMembers {
+			if !actualMembers[expectedMember] {
+				return false
+			}
+		}
+		return len(actualMembers) == len(expectedMembers)
+	}, 1*time.Minute, 2*time.Second, "Role %q members never converged to expected: %v", role, expectedMembers)
+
+	// Final assertions for clear error messages
 	for _, expectedMember := range expectedMembers {
 		require.True(t, actualMembers[expectedMember],
 			"Expected member %q not found in role %q (effective name %q)", expectedMember, role, effectiveRoleName)
 	}
 
-	// Verify we have exactly the expected number of members
 	require.Equal(t, len(expectedMembers), len(actualMembers),
 		"Role %q (effective name %q) should have exactly %d members, got %d", role, effectiveRoleName, len(expectedMembers), len(actualMembers))
 }
@@ -165,17 +177,21 @@ func roleShouldNotHaveMemberInCluster(ctx context.Context, t framework.TestingT,
 	adminClient := clients.RedpandaAdmin(ctx)
 	defer adminClient.Close()
 
-	// Get role members from Redpanda using the effective role name
-	membersResp, err := adminClient.RoleMembers(ctx, effectiveRoleName)
-	if err != nil {
-		t.Fatalf("Failed to get members for role %q (effective name %q): %v", role, effectiveRoleName, err)
-	}
-
-	// Check that the member is not present
-	for _, m := range membersResp.Members {
-		require.NotEqual(t, member, m.Name,
-			"Member %q should not be in role %q (effective name %q)", member, role, effectiveRoleName)
-	}
+	// Poll until the member is removed — Redpanda's state may lag behind
+	// the controller's Synced condition.
+	require.Eventually(t, func() bool {
+		membersResp, err := adminClient.RoleMembers(ctx, effectiveRoleName)
+		if err != nil {
+			t.Logf("Failed to get members for role %q (will retry): %v", role, err)
+			return false
+		}
+		for _, m := range membersResp.Members {
+			if m.Name == member {
+				return false
+			}
+		}
+		return true
+	}, 1*time.Minute, 2*time.Second, "Member %q still present in role %q", member, role)
 }
 
 func roleShouldHaveACLsForTopicPatternInCluster(ctx context.Context, t framework.TestingT, role, pattern, version, cluster string) {
@@ -321,14 +337,16 @@ func roleShouldHaveNoMembersInCluster(ctx context.Context, t framework.TestingT,
 	adminClient := clients.RedpandaAdmin(ctx)
 	defer adminClient.Close()
 
-	// Get role members from Redpanda using the effective role name
-	membersResp, err := adminClient.RoleMembers(ctx, effectiveRoleName)
-	if err != nil {
-		t.Fatalf("Failed to get members for role %q (effective name %q): %v", role, effectiveRoleName, err)
-	}
-
-	// Check that there are no members
-	require.Empty(t, membersResp.Members, "Role %q (effective name %q) should have no members", role, effectiveRoleName)
+	// Poll until members list is empty — Redpanda's state may lag behind
+	// the controller's Synced condition after principal removal.
+	require.Eventually(t, func() bool {
+		membersResp, err := adminClient.RoleMembers(ctx, effectiveRoleName)
+		if err != nil {
+			t.Logf("Failed to get members for role %q (will retry): %v", role, err)
+			return false
+		}
+		return len(membersResp.Members) == 0
+	}, 1*time.Minute, 2*time.Second, "Role %q (effective name %q) still has members", role, effectiveRoleName)
 }
 
 func redpandaRoleShouldHaveStatusFieldSetTo(ctx context.Context, t framework.TestingT, roleName, field, value string) {

--- a/acceptance/steps/roles.go
+++ b/acceptance/steps/roles.go
@@ -52,15 +52,9 @@ func roleIsSuccessfullySynced(ctx context.Context, t framework.TestingT, role st
 	var roleObject redpandav1alpha2.RedpandaRole
 	require.NoError(t, t.Get(ctx, t.ResourceKey(role), &roleObject))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &roleObject)
-
-	// make sure it's synchronized
-	t.RequireCondition(metav1.Condition{
-		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
-		Status: metav1.ConditionTrue,
-		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
-	}, roleObject.Status.Conditions)
+	waitForSyncedCondition(ctx, t, &roleObject, func() []metav1.Condition {
+		return roleObject.Status.Conditions
+	})
 
 	t.Cleanup(func(ctx context.Context) {
 		t.Logf("Deleting role %q", role)

--- a/acceptance/steps/rpk.go
+++ b/acceptance/steps/rpk.go
@@ -110,26 +110,27 @@ func checkRPKCommands(ctx context.Context, t framework.TestingT, clusterName str
 		t.Logf("Checking rpk commands on pod %q", p.Name)
 		var stdout bytes.Buffer
 		var stderr bytes.Buffer
-		// rpk.yaml is not available in operator v2. The v1 (Cluster custom resource) needs to
-		// create rpk profile file to overcome the problem with flux dependency (kubernetes version
-		// mismatch between rpk and flux fork).
-		//require.NoErrorf(t, ctl.Exec(ctx, &p, kube.ExecOptions{
-		//	Container: "redpanda",
-		//	Command:   []string{"rpk", "profile", "print"},
-		//	Stdin:     nil,
-		//	Stdout:    &stdout,
-		//	Stderr:    &stderr,
-		//}), "\nStdout: %s\nStderr: %s\n", stdout.String(), stderr.String())
-		//require.Len(t, stderr.Bytes(), 0)
 
-		require.NoErrorf(t, ctl.Exec(ctx, &p, kube.ExecOptions{
-			Container: "redpanda",
-			Command:   []string{"rpk", "redpanda", "admin", "brokers", "list"},
-			Stdin:     nil,
-			Stdout:    &stdout,
-			Stderr:    &stderr,
-		}), "\nStdout: %s\nStderr: %s\n", stdout.String(), stderr.String())
-		require.Len(t, stderr.Bytes(), 0)
+		// Wait for the redpanda container to be ready before exec'ing.
+		// After config changes (e.g., admin port update), the pod restarts
+		// and the container may not be available immediately even though
+		// the cluster reports as "stable".
+		require.Eventually(t, func() bool {
+			stdout.Reset()
+			stderr.Reset()
+			err := ctl.Exec(ctx, &p, kube.ExecOptions{
+				Container: "redpanda",
+				Command:   []string{"rpk", "redpanda", "admin", "brokers", "list"},
+				Stdin:     nil,
+				Stdout:    &stdout,
+				Stderr:    &stderr,
+			})
+			if err != nil {
+				t.Logf("rpk brokers list on pod %q failed (will retry): %v", p.Name, err)
+				return false
+			}
+			return len(stderr.Bytes()) == 0
+		}, 2*time.Minute, 2*time.Second, "rpk brokers list never succeeded on pod %q\nStdout: %s\nStderr: %s", p.Name, stdout.String(), stderr.String())
 		stdout.Reset()
 
 		require.Eventually(t, func() bool {

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -23,15 +23,9 @@ func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schem
 	var schemaObject redpandav1alpha2.Schema
 	require.NoError(t, t.Get(ctx, t.ResourceKey(schema), &schemaObject))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &schemaObject)
-
-	// make sure it's synchronized
-	t.RequireCondition(metav1.Condition{
-		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
-		Status: metav1.ConditionTrue,
-		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
-	}, schemaObject.Status.Conditions)
+	waitForSyncedCondition(ctx, t, &schemaObject, func() []metav1.Condition {
+		return schemaObject.Status.Conditions
+	})
 }
 
 func thereIsNoSchema(ctx context.Context, schema, version, cluster string) {

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -25,6 +25,8 @@ func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schem
 
 	waitForSyncedCondition(ctx, t, &schemaObject, func() []metav1.Condition {
 		return schemaObject.Status.Conditions
+	}, func() int64 {
+		return schemaObject.Status.ObservedGeneration
 	})
 }
 

--- a/acceptance/steps/shadow_link.go
+++ b/acceptance/steps/shadow_link.go
@@ -23,13 +23,7 @@ func shadowLinkIsSuccessfullySynced(ctx context.Context, t framework.TestingT, l
 	var shadowLinkObject redpandav1alpha2.ShadowLink
 	require.NoError(t, t.Get(ctx, t.ResourceKey(link), &shadowLinkObject))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &shadowLinkObject)
-
-	// make sure it's synchronized
-	t.RequireCondition(metav1.Condition{
-		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
-		Status: metav1.ConditionTrue,
-		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
-	}, shadowLinkObject.Status.Conditions)
+	waitForSyncedCondition(ctx, t, &shadowLinkObject, func() []metav1.Condition {
+		return shadowLinkObject.Status.Conditions
+	})
 }

--- a/acceptance/steps/topics.go
+++ b/acceptance/steps/topics.go
@@ -24,15 +24,13 @@ func topicIsSuccessfullySynced(ctx context.Context, t framework.TestingT, topic 
 	var topicObject redpandav1alpha2.Topic
 	require.NoError(t, t.Get(ctx, t.ResourceKey(topic), &topicObject))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &topicObject)
-
-	// make sure it's synchronized
-	t.RequireCondition(metav1.Condition{
+	waitForCondition(ctx, t, &topicObject, metav1.Condition{
 		Type:   redpandav1alpha2.ReadyCondition,
 		Status: metav1.ConditionTrue,
 		Reason: redpandav1alpha2.SucceededReason,
-	}, topicObject.Status.Conditions)
+	}, func() []metav1.Condition {
+		return topicObject.Status.Conditions
+	})
 }
 
 func thereIsNoTopic(ctx context.Context, topic, version, cluster string) {

--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -28,15 +28,9 @@ func userIsSuccessfullySynced(ctx context.Context, t framework.TestingT, user st
 	var userObject redpandav1alpha2.User
 	require.NoError(t, t.Get(ctx, t.ResourceKey(user), &userObject))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &userObject)
-
-	// make sure it's synchronized
-	t.RequireCondition(metav1.Condition{
-		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
-		Status: metav1.ConditionTrue,
-		Reason: redpandav1alpha2.ResourceConditionReasonSynced,
-	}, userObject.Status.Conditions)
+	waitForSyncedCondition(ctx, t, &userObject, func() []metav1.Condition {
+		return userObject.Status.Conditions
+	})
 }
 
 func iCreateCRDbasedUsers(ctx context.Context, t framework.TestingT, version, cluster string, users *godog.Table) {
@@ -46,15 +40,9 @@ func iCreateCRDbasedUsers(ctx context.Context, t framework.TestingT, version, cl
 		t.Logf("Creating user %q", user.Name)
 		require.NoError(t, t.Create(ctx, user))
 
-		// make sure the resource is stable
-		checkStableResource(ctx, t, user)
-
-		// make sure it's synchronized
-		t.RequireCondition(metav1.Condition{
-			Type:   redpandav1alpha2.ResourceConditionTypeSynced,
-			Status: metav1.ConditionTrue,
-			Reason: redpandav1alpha2.ResourceConditionReasonSynced,
-		}, user.Status.Conditions)
+		waitForSyncedCondition(ctx, t, user, func() []metav1.Condition {
+			return user.Status.Conditions
+		})
 
 		t.Cleanup(func(ctx context.Context) {
 			t.Logf("Deleting user %q", user.Name)

--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -30,6 +30,8 @@ func userIsSuccessfullySynced(ctx context.Context, t framework.TestingT, user st
 
 	waitForSyncedCondition(ctx, t, &userObject, func() []metav1.Condition {
 		return userObject.Status.Conditions
+	}, func() int64 {
+		return userObject.Status.ObservedGeneration
 	})
 }
 
@@ -42,6 +44,8 @@ func iCreateCRDbasedUsers(ctx context.Context, t framework.TestingT, version, cl
 
 		waitForSyncedCondition(ctx, t, user, func() []metav1.Condition {
 			return user.Status.Conditions
+		}, func() int64 {
+			return user.Status.ObservedGeneration
 		})
 
 		t.Cleanup(func(ctx context.Context) {


### PR DESCRIPTION
## Summary

Fixes intermittent acceptance test failures across both v1 (vectorized) and v2 controller test suites. Four categories of race conditions were identified and fixed:

### 1. CRD Synced condition race (v1 + v2 controllers)

After applying a CRD manifest, the tests used `checkStableResource()` (waits for resourceVersion to stabilize for 5 seconds) then immediately asserted `Synced=True`. But the controller may not have set the condition yet — the resource can be "stable" metadata-wise while still being reconciled.

**Observed failures on [#1334](https://github.com/redpanda-data/redpanda-operator/pull/1334):**
- Build 12329 (run 2): `vectorized - Manage authentication-only users` — `condition: {Type:Synced Status:True} not found in conditions: [{Status:Unknown Reason:Pending}]`
- Build 12277: `Manage authorization-only users` — same Synced condition race
- Build 12345: `vectorized - Manage group ACLs` — same on Group CRD
- Build 12265: `vectorized - Remove managed principals from the role`, `vectorized - Manage ShadowLink`

**Fix:** Replace `checkStableResource` + `RequireCondition` with `waitForCondition` / `waitForSyncedCondition` helpers that poll (2 min timeout, 2 sec interval) until the expected condition appears. Applied to all 6 resource types (users, roles, groups, schemas, shadow_links, topics).

### 2. Role membership propagation race (v2 controllers)

After the controller sets `Synced=True` on a RedpandaRole, the test immediately queries the Redpanda Admin API for role members. But Redpanda's internal state may lag — the controller has written the change, but the Admin API returns stale data.

**Observed failures on [#1349](https://github.com/redpanda-data/redpanda-operator/pull/1349) (this PR) and [#1334](https://github.com/redpanda-data/redpanda-operator/pull/1334):**
- Build 12351: `Replace all managed principals` — `Expected member "newuser1" not found in role "swap-role"` (Synced=True was set, but Admin API returned old members)
- Build 12351: `Stop managing principals`, `Remove managed principals from the role` — same pattern with member removal
- Build 12329 (run 1): `vectorized - Replace all managed principals` — same

**Fix:** Wrap role member checks (`roleShouldHaveMembersAndInCluster`, `roleShouldNotHaveMemberInCluster`, `roleShouldHaveNoMembersInCluster`) in `require.Eventually` polling loops (1 min timeout, 2 sec interval).

### 3. Stale Synced condition after spec updates (observedGeneration race)

After a spec update (e.g., changing `principals: [User:temp1, User:temp2]` to `principals: []`), the `Synced=True` condition from the previous reconciliation is still present. `waitForSyncedCondition` returns immediately without waiting for the controller to process the new generation, so the test asserts against stale state.

**Observed failure on [#1334](https://github.com/redpanda-data/redpanda-operator/pull/1334):**
- Build 12345: `vectorized - Stop managing principals` — `Should be empty, but was [{temp2 User} {temp1 User}]` (Synced=True was stale from the first sync; controller hadn't processed the `principals: []` update yet)

**Fix:** `waitForSyncedCondition` now accepts an optional `getObservedGeneration` callback. When provided, it first polls until `status.observedGeneration >= metadata.generation`, ensuring the controller has processed the latest spec change before checking `Synced=True`. Applied to all CRD sync checks that have `ObservedGeneration` in their status: RedpandaRole, Group, Schema, User. ShadowLink does not have `ObservedGeneration` and is unchanged.

### 4. rpk exec on restarting container

After a config change (e.g., admin port update), the pod restarts. The cluster reports as "stable" but the `redpanda` container may not be available yet. The `rpk` exec fails with `container not found ("redpanda")`.

**Observed failure on Build 12356 (run 1) of this PR:**
- `Updating admin ports` — `unable to upgrade connection: container not found ("redpanda")`

**Fix:** Wrap the `rpk redpanda admin brokers list` exec in `require.Eventually` (2 min timeout, 2 sec interval) so it retries when the container isn't available. The subsequent `rpk registry schema list` exec already used this pattern.

### Changes

| File | Change |
|---|---|
| `acceptance/steps/helpers.go` | Add `waitForCondition` and `waitForSyncedCondition` helpers; `waitForSyncedCondition` accepts optional `getObservedGeneration` callback to wait for generation before condition |
| `acceptance/steps/users.go` | Replace `checkStableResource` + `RequireCondition` with `waitForSyncedCondition` + `ObservedGeneration` callback (2 call sites) |
| `acceptance/steps/roles.go` | Replace sync check + add `ObservedGeneration` callback (1 site); wrap member checks in `require.Eventually` (3 sites: has-members, not-has-member, no-members) |
| `acceptance/steps/groups.go` | Replace sync check + add `ObservedGeneration` callback (1 site) |
| `acceptance/steps/schemas.go` | Replace sync check + add `ObservedGeneration` callback (1 site) |
| `acceptance/steps/shadow_link.go` | Replace sync check (1 site); no `ObservedGeneration` — ShadowLink status does not have this field |
| `acceptance/steps/topics.go` | Replace with `waitForCondition` using `Ready/Succeeded` condition (1 site) |
| `acceptance/steps/rpk.go` | Wrap `rpk brokers list` exec in `require.Eventually` retry loop (1 site) |

### Before vs After

**Synced condition checks:**
- Before: `checkStableResource` (30s) → immediate `RequireCondition` → FAIL if controller is slow
- After: `waitForSyncedCondition` polls for up to 2 minutes → handles slow controllers

**Synced condition after spec updates:**
- Before: `waitForSyncedCondition` returns immediately on stale `Synced=True` → FAIL when asserting against unprocessed state
- After: waits for `observedGeneration >= generation` first → ensures controller has processed the update

**Role member checks:**
- Before: single Admin API call immediately after sync → FAIL if Redpanda state lags
- After: `require.Eventually` polls for up to 1 minute → handles propagation delay

**rpk exec after config changes:**
- Before: single `ctl.Exec` call → immediate failure if container is restarting
- After: `require.Eventually` polls for up to 2 minutes → handles pod restart gracefully

## CI results

**Build 12356 (2 runs on this PR):**
- **Run 1:** All CRD sync and role membership tests passed. One failure in `Updating admin ports` — `container not found ("redpanda")` caused by pod restarting after admin port change. Now fixed by the rpk exec retry (fix number 4).
- **Run 2:** All tests passed.

Previously, the same tests were failing non-deterministically on every CI run of #1334, with different CRD controller tests failing each time.

## Test plan
- [x] `go build -tags acceptance ./acceptance/...` compiles
- [x] `go vet -tags acceptance ./acceptance/...` passes
- [x] CRD Synced condition tests pass consistently (both runs)
- [x] Role membership tests pass consistently (both runs)
- [x] `Stop managing principals` test passes consistently (both runs)
- [ ] `Updating admin ports` test passes consistently (fix number 4 not yet validated in CI)
