### PR TITLE
fix: wait for observedGeneration before checking Synced condition in acceptance tests

### DIFF
--- a/acceptance/steps/groups.go
+++ b/acceptance/steps/groups.go
@@ -30,6 +30,8 @@ func groupIsSuccessfullySynced(ctx context.Context, t framework.TestingT, group 
 
 	waitForSyncedCondition(ctx, t, &groupObject, func() []metav1.Condition {
 		return groupObject.Status.Conditions
+	}, func() int64 {
+		return groupObject.Status.ObservedGeneration
 	})
 
 	t.Cleanup(func(ctx context.Context) {

--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -619,9 +619,32 @@ func waitForCondition(ctx context.Context, t framework.TestingT, o runtimeclient
 	t.Logf("Resource %q has condition %s=%s", key.String(), expected.Type, expected.Status)
 }
 
-// waitForSyncedCondition is a convenience wrapper for waitForCondition that
-// waits for the standard Synced=True condition used by most CRD resources.
-func waitForSyncedCondition(ctx context.Context, t framework.TestingT, o runtimeclient.Object, getConditions func() []metav1.Condition) {
+// waitForSyncedCondition waits for the controller to reconcile the current
+// generation of the resource and set the standard Synced=True condition.
+//
+// It first waits for status.observedGeneration to catch up to metadata.generation,
+// ensuring the controller has processed the latest spec change. Then it waits for
+// the Synced=True condition. This prevents a race where a stale Synced=True from a
+// previous reconciliation causes the wait to return before the current spec change
+// has been applied.
+func waitForSyncedCondition(ctx context.Context, t framework.TestingT, o runtimeclient.Object, getConditions func() []metav1.Condition, getObservedGeneration ...func() int64) {
+	key := runtimeclient.ObjectKeyFromObject(o)
+
+	// If an observedGeneration accessor is provided, first wait for the
+	// controller to observe the current generation.
+	if len(getObservedGeneration) > 0 {
+		getObsGen := getObservedGeneration[0]
+		t.Logf("Waiting for resource %q observedGeneration to catch up to generation", key.String())
+		require.Eventually(t, func() bool {
+			if err := t.Get(ctx, key, o); err != nil {
+				t.Logf("Failed to get resource %q: %v", key.String(), err)
+				return false
+			}
+			return getObsGen() >= o.GetGeneration()
+		}, 2*time.Minute, 2*time.Second, "Resource %q observedGeneration never caught up to generation %d", key.String(), o.GetGeneration())
+		t.Logf("Resource %q observedGeneration (%d) caught up to generation (%d)", key.String(), getObsGen(), o.GetGeneration())
+	}
+
 	waitForCondition(ctx, t, o, metav1.Condition{
 		Type:   redpandav1alpha2.ResourceConditionTypeSynced,
 		Status: metav1.ConditionTrue,

--- a/acceptance/steps/roles.go
+++ b/acceptance/steps/roles.go
@@ -54,6 +54,8 @@ func roleIsSuccessfullySynced(ctx context.Context, t framework.TestingT, role st
 
 	waitForSyncedCondition(ctx, t, &roleObject, func() []metav1.Condition {
 		return roleObject.Status.Conditions
+	}, func() int64 {
+		return roleObject.Status.ObservedGeneration
 	})
 
 	t.Cleanup(func(ctx context.Context) {

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -25,6 +25,8 @@ func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schem
 
 	waitForSyncedCondition(ctx, t, &schemaObject, func() []metav1.Condition {
 		return schemaObject.Status.Conditions
+	}, func() int64 {
+		return schemaObject.Status.ObservedGeneration
 	})
 }
 

--- a/acceptance/steps/users.go
+++ b/acceptance/steps/users.go
@@ -30,6 +30,8 @@ func userIsSuccessfullySynced(ctx context.Context, t framework.TestingT, user st
 
 	waitForSyncedCondition(ctx, t, &userObject, func() []metav1.Condition {
 		return userObject.Status.Conditions
+	}, func() int64 {
+		return userObject.Status.ObservedGeneration
 	})
 }
 
@@ -42,6 +44,8 @@ func iCreateCRDbasedUsers(ctx context.Context, t framework.TestingT, version, cl
 
 		waitForSyncedCondition(ctx, t, user, func() []metav1.Condition {
 			return user.Status.Conditions
+		}, func() int64 {
+			return user.Status.ObservedGeneration
 		})
 
 		t.Cleanup(func(ctx context.Context) {


### PR DESCRIPTION
## Summary

Fixes the `Stop managing principals` acceptance test flake by waiting for `status.observedGeneration >= metadata.generation` before checking the `Synced=True` condition.

**Depends on:** #1349

## Problem

After a spec update (e.g., changing `principals: [User:temp1, User:temp2]` to `principals: []`), the `waitForSyncedCondition` helper would return immediately because `Synced=True` was still set from the **previous** reconciliation. The controller hadn't processed the new generation yet, so the members hadn't been removed when the test asserted they should be empty.

```
Error: Should be empty, but was [{temp2 User} {temp1 User}]
Test: TestAcceptanceSuite/vectorized_-_Stop_managing_principals
```

## Fix

Updated `waitForSyncedCondition` to accept an optional `getObservedGeneration` callback. When provided, it first polls until `observedGeneration >= generation`, ensuring the controller has processed the latest spec change before checking the Synced condition.

Applied to all CRD sync checks that have `ObservedGeneration` in their status:
- RedpandaRole
- Group
- Schema
- User

`ShadowLink` does not have `ObservedGeneration` and is left unchanged (variadic parameter — no callback = no generation check).

## Changes

| File | Change |
|---|---|
| `acceptance/steps/helpers.go` | `waitForSyncedCondition` now accepts optional `getObservedGeneration` callback; waits for generation before condition |
| `acceptance/steps/roles.go` | Pass `ObservedGeneration` callback |
| `acceptance/steps/groups.go` | Pass `ObservedGeneration` callback |
| `acceptance/steps/schemas.go` | Pass `ObservedGeneration` callback |
| `acceptance/steps/users.go` | Pass `ObservedGeneration` callback (2 call sites) |

## Test plan

- [x] `go build -tags acceptance ./acceptance/...` compiles
- [x] `go vet -tags acceptance ./acceptance/...` passes
- [ ] `Stop managing principals` acceptance test passes consistently
