### PR TITLE
fix: retry rpk exec when redpanda container is restarting

### DIFF
--- a/acceptance/steps/rpk.go
+++ b/acceptance/steps/rpk.go
@@ -110,26 +110,27 @@ func checkRPKCommands(ctx context.Context, t framework.TestingT, clusterName str
 		t.Logf("Checking rpk commands on pod %q", p.Name)
 		var stdout bytes.Buffer
 		var stderr bytes.Buffer
-		// rpk.yaml is not available in operator v2. The v1 (Cluster custom resource) needs to
-		// create rpk profile file to overcome the problem with flux dependency (kubernetes version
-		// mismatch between rpk and flux fork).
-		//require.NoErrorf(t, ctl.Exec(ctx, &p, kube.ExecOptions{
-		//	Container: "redpanda",
-		//	Command:   []string{"rpk", "profile", "print"},
-		//	Stdin:     nil,
-		//	Stdout:    &stdout,
-		//	Stderr:    &stderr,
-		//}), "\nStdout: %s\nStderr: %s\n", stdout.String(), stderr.String())
-		//require.Len(t, stderr.Bytes(), 0)
 
-		require.NoErrorf(t, ctl.Exec(ctx, &p, kube.ExecOptions{
-			Container: "redpanda",
-			Command:   []string{"rpk", "redpanda", "admin", "brokers", "list"},
-			Stdin:     nil,
-			Stdout:    &stdout,
-			Stderr:    &stderr,
-		}), "\nStdout: %s\nStderr: %s\n", stdout.String(), stderr.String())
-		require.Len(t, stderr.Bytes(), 0)
+		// Wait for the redpanda container to be ready before exec'ing.
+		// After config changes (e.g., admin port update), the pod restarts
+		// and the container may not be available immediately even though
+		// the cluster reports as "stable".
+		require.Eventually(t, func() bool {
+			stdout.Reset()
+			stderr.Reset()
+			err := ctl.Exec(ctx, &p, kube.ExecOptions{
+				Container: "redpanda",
+				Command:   []string{"rpk", "redpanda", "admin", "brokers", "list"},
+				Stdin:     nil,
+				Stdout:    &stdout,
+				Stderr:    &stderr,
+			})
+			if err != nil {
+				t.Logf("rpk brokers list on pod %q failed (will retry): %v", p.Name, err)
+				return false
+			}
+			return len(stderr.Bytes()) == 0
+		}, 2*time.Minute, 2*time.Second, "rpk brokers list never succeeded on pod %q\nStdout: %s\nStderr: %s", p.Name, stdout.String(), stderr.String())
 		stdout.Reset()
 
 		require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary

Fixes the `Updating admin ports` acceptance test flake where `rpk redpanda admin brokers list` fails with `container not found ("redpanda")` after a config change triggers a pod restart.

**Depends on:** #1349

## Problem

The `Updating admin ports` scenario:
1. Deploys a cluster with admin port 9645 → stable ✓
2. Updates admin port to 9640 → cluster reports "stable" ✓ → service port updated ✓
3. Runs `rpk redpanda admin brokers list` via exec → **FAILS**: `unable to upgrade connection: container not found ("redpanda")`

The cluster can report "stable" (all conditions met, replicas match) while the pod is still restarting after the config change. The `checkRPKCommands` function immediately exec'd into the container without waiting for it to be ready.

**Observed on Build 12356 (run 1) of #1349.**

## Fix

Wrap the `rpk redpanda admin brokers list` exec in `require.Eventually` (2 min timeout, 2 sec interval) so it retries when the container isn't available. The subsequent `rpk registry schema list` exec already used `require.Eventually`.

### Changes

| File | Change |
|---|---|
| `acceptance/steps/rpk.go` | Wrap `rpk brokers list` exec in `require.Eventually` retry loop (1 site) |

### Before vs After

- **Before:** Single `ctl.Exec` call → immediate failure if container is restarting
- **After:** `require.Eventually` polls for up to 2 minutes → handles pod restart gracefully

## Test plan

- [x] `go build -tags acceptance ./acceptance/...` compiles
- [x] `go vet -tags acceptance ./acceptance/...` passes
- [ ] `Updating admin ports` test passes consistently
