### PR TITLE
docs: update supported versions - add v26.1.x/v26.2.x, remove v25.1.x

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,7 +4,7 @@
   "commitConflicts": true,
   "repoOwner": "redpanda-data",
   "repoName": "redpanda-operator",
-  "targetBranchChoices": ["release/v25.3.x", "release/v25.2.x", "release/v25.1.x"],
+  "targetBranchChoices": ["release/v26.1.x", "release/v25.3.x", "release/v25.2.x"],
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v(\\d+).(\\d+).x$": "release/v$1.$2.x"

--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -1,1 +1,1 @@
-active: ["main", "release/v25.3.x", "release/v25.2.x", "release/v25.1.x"]
+active: ["main", "release/v26.1.x", "release/v25.3.x", "release/v25.2.x"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 | Branch                                                                                       | Release Series | [End of Support](https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions) |
 | :------------------------------------------------------------------------------------------: | :------------: | :---------------------------------------------------------------------------------------------------------: |
-| [`main`](https://github.com/redpanda-data/redpanda-operator/tree/main)                       | v26.1.x        | TBD                                                                                                         |
+| [`main`](https://github.com/redpanda-data/redpanda-operator/tree/main)                       | v26.2.x        | TBD                                                                                                         |
+| [`release/v26.1.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v26.1.x) | v26.1.x        | Mar 31, 2027 (est)                                                                                          |
 | [`release/v25.3.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.3.x) | v25.3.x        | Nov 19, 2026 (est)                                                                                           |
 | [`release/v25.2.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.2.x) | v25.2.x        | Jul 31, 2026 (est)                                                                                           |
-| [`release/v25.1.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.1.x) | v25.1.x        | Mar 25, 2026 (est)                                                                                           |


### PR DESCRIPTION
## Summary
- Add v26.2.x as the new `main` branch release series (end of support TBD)
- Add v26.1.x as a release branch with end of support Mar 31, 2027 (est)
- Remove v25.1.x which has reached end of support
- Update `.github/branches.yml` and `.backportrc.json` to match

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] `TestBranches` passes with updated branch configs
