### PR TITLE
fix: seed initial raft snapshot to prevent panic on fresh leader

### DIFF
--- a/pkg/multicluster/leaderelection/lock.go
+++ b/pkg/multicluster/leaderelection/lock.go
@@ -347,6 +347,14 @@ func runRaft(ctx context.Context, transport *grpcTransport, config LockConfigura
 	}
 	confState := raftpb.ConfState{Voters: voters}
 
+	// Seed an initial snapshot at index 0 so that maybeSendSnapshot never
+	// panics with "need non-empty snapshot". Without this, a fresh node that
+	// wins leadership before its first compaction cycle (10 s) will panic
+	// when it tries to send a snapshot to a peer whose log is behind.
+	if _, err := storage.CreateSnapshot(0, &confState, nil); err != nil {
+		config.Logger.Warningf("failed to seed initial snapshot: %v", err)
+	}
+
 	go func() {
 		compactions := 1000 // every 10 seconds
 		for {

--- a/pkg/multicluster/leaderelection/lock_test.go
+++ b/pkg/multicluster/leaderelection/lock_test.go
@@ -484,6 +484,72 @@ func (s *stubNode) ReportUnreachable(uint64)                                    
 func (s *stubNode) ReportSnapshot(uint64, raft.SnapshotStatus)                  {}
 func (s *stubNode) Stop()                                                       {}
 
+// TestFreshLeaderSnapshotSend validates the initial snapshot seed added to
+// runRaft. Without it, a fresh node that wins leadership before its first
+// compaction cycle (10 s) panics with "need non-empty snapshot" when it tries
+// to send a snapshot to a peer whose log is behind.
+//
+// Scenario:
+//  1. Start a 3-node cluster and wait for leader election.
+//  2. Stop the leader and one follower — only one node remains.
+//  3. Wait for a compaction cycle so the surviving node's log is compacted.
+//  4. Restart both stopped nodes. They start with fresh MemoryStorage.
+//  5. The surviving node loses quorum, so one of the fresh nodes wins the
+//     new election. As leader it must send a snapshot to a peer — without
+//     the initial snapshot seed this panics.
+func TestFreshLeaderSnapshotSend(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+
+	leaders := setupLockTest(t, ctx, 3)
+
+	defer func() {
+		cancel()
+		for _, l := range leaders {
+			l.WaitForStopped(t, 10*time.Second)
+		}
+	}()
+
+	// Wait for initial leader election.
+	leader, followers := waitForAnyLeader(t, 30*time.Second, leaders...)
+	t.Logf("initial leader: %d", leader.config.ID)
+
+	// Stop the leader and one follower, leaving a single node running.
+	leader.Stop()
+	leader.WaitForStopped(t, 5*time.Second)
+	followers[0].Stop()
+	followers[0].WaitForStopped(t, 5*time.Second)
+	t.Logf("stopped leader %d and follower %d", leader.config.ID, followers[0].config.ID)
+
+	// Wait for a compaction cycle so the surviving node has compacted its log.
+	t.Log("waiting for compaction on surviving node (~12 s)...")
+	select {
+	case <-time.After(12 * time.Second):
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for compaction")
+	}
+
+	// Drain stale follower signals.
+	for _, l := range []*testLeader{leader, followers[0]} {
+		select {
+		case <-l.follower:
+		default:
+		}
+	}
+
+	// Restart both nodes. They have fresh MemoryStorage (no snapshot).
+	// One of them will likely win the next election before its compaction
+	// timer fires. Without the initial snapshot seed, the new leader panics
+	// when it tries to send a snapshot to bring a peer up to date.
+	t.Log("restarting both nodes...")
+	leader.Start(t, ctx)
+	followers[0].Start(t, ctx)
+
+	// Wait for a new leader to emerge — if we get here without a panic the
+	// initial snapshot seed is working.
+	newLeader, _ := waitForAnyLeader(t, 30*time.Second, leaders...)
+	t.Logf("new leader %d elected without panic", newLeader.config.ID)
+}
+
 func TestLocker(t *testing.T) {
 	for name, tt := range map[string]struct {
 		nodes int


### PR DESCRIPTION
## Summary
- Fixes a race condition where a fresh raft node that wins leadership before its first compaction cycle (10s) panics with `panic: need non-empty snapshot`
- Seeds an initial snapshot at index 0 in `MemoryStorage` immediately after `StartNode`, so `maybeSendSnapshot` always has a valid snapshot to send to lagging peers
- Adds `TestFreshLeaderSnapshotSend` that reproduces the exact scenario: stop leader + follower, wait for compaction on survivor, restart both fresh nodes — one wins election and must send snapshot without panic

## Root cause
The compaction goroutine in `runRaft` creates snapshots on a 10-second timer. A node that starts fresh (empty `MemoryStorage`) and wins an election within those first 10 seconds has log entries but no snapshot. When it tries to bring a lagging peer up to date via `maybeSendSnapshot`, etcd/raft panics because the storage has no snapshot to send.

This was observed as a flaky failure in `TestIntegrationDoubleLeaderElection` ([build 12505](https://buildkite.com/redpanda/redpanda-operator/builds/12505)).

## Test plan
- [x] `go build ./pkg/multicluster/...` compiles
- [ ] `TestFreshLeaderSnapshotSend` — new unit test covering the exact scenario
- [ ] `TestLaggingPeerCatchesUpViaSnapshot` — existing test still passes
- [ ] `TestCompactionRaceWithCatchUp` — existing test still passes
- [ ] `TestFreshNodeJoinsRunningCluster` — existing test still passes
