### PR TITLE
fix: wait for cert-manager webhook readiness before running tests

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -14,13 +14,16 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"time"
 	"path/filepath"
 	"slices"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redpanda-data/redpanda-operator/acceptance/steps"
 	framework "github.com/redpanda-data/redpanda-operator/harpoon"
@@ -85,6 +88,7 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 				},
 			},
 		}).
+		AfterSetup(waitForCertManagerWebhook).
 		OnFeature(func(ctx context.Context, t framework.TestingT, tags ...framework.ParsedTag) {
 			// this actually switches namespaces, run it first
 			namespace := t.IsolateNamespace(ctx)
@@ -216,4 +220,12 @@ func OperatorTag(ctx context.Context, t framework.TestingT, args ...string) cont
 
 func shouldSkipOperatorInstall(tag framework.ParsedTag) bool {
 	return tag.Name == "operator"
+}
+
+func waitForCertManagerWebhook(ctx context.Context, restConfig *rest.Config) error {
+	c, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return err
+	}
+	return testutil.WaitForCertManagerWebhook(ctx, c, 2*time.Minute)
 }

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -14,11 +14,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"time"
 	"path/filepath"
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 
 	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
 	"github.com/redpanda-data/redpanda-operator/harpoon/internal/tracking"
@@ -57,6 +58,7 @@ type SuiteBuilder struct {
 	helmCharts            []helmChart
 	onFeatures            []func(context.Context, *internaltesting.TestingT, []internaltesting.ParsedTag)
 	onScenarios           []func(context.Context, *internaltesting.TestingT, []internaltesting.ParsedTag)
+	afterSetup            []func(ctx context.Context, restConfig *rest.Config) error
 	exitOnCleanupFailures bool
 }
 
@@ -169,6 +171,14 @@ func (b *SuiteBuilder) OnScenario(fn func(context.Context, TestingT, ...ParsedTa
 		// wrap since we move into the internal implementation of the interface
 		fn(ctx, tt, parsed...)
 	})
+	return b
+}
+
+// AfterSetup registers a callback that runs after helm charts are installed
+// but before tests start. This is useful for readiness checks that require the
+// cluster to be fully operational (e.g. waiting for webhooks).
+func (b *SuiteBuilder) AfterSetup(fn func(ctx context.Context, restConfig *rest.Config) error) *SuiteBuilder {
+	b.afterSetup = append(b.afterSetup, fn)
 	return b
 }
 
@@ -317,6 +327,12 @@ func (b *SuiteBuilder) Build() (*Suite, error) {
 						setupErrorCheck(ctx, err, cleanup)
 
 						_, err := helmClient.Install(ctx, chart.repo+"/"+chart.chart, chart.options)
+						setupErrorCheck(ctx, err, cleanup)
+					}
+
+					// run any post-setup hooks (e.g. webhook readiness checks)
+					for _, fn := range b.afterSetup {
+						err = fn(ctx, restConfig)
 						setupErrorCheck(ctx, err, cleanup)
 					}
 

--- a/pkg/testutil/certmanager.go
+++ b/pkg/testutil/certmanager.go
@@ -13,7 +13,8 @@ import (
 	"context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -24,16 +25,20 @@ import (
 // webhook is ready to serve validation requests.
 func WaitForCertManagerWebhook(ctx context.Context, c client.Client, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		var ep corev1.Endpoints
-		if err := c.Get(ctx, client.ObjectKey{
-			Name:      "cert-manager-webhook",
-			Namespace: "cert-manager",
-		}, &ep); err != nil {
+		var slices discoveryv1.EndpointSliceList
+		if err := c.List(ctx, &slices,
+			client.InNamespace("cert-manager"),
+			client.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set{
+				discoveryv1.LabelServiceName: "cert-manager-webhook",
+			})},
+		); err != nil {
 			return false, nil //nolint:nilerr // keep polling
 		}
-		for _, subset := range ep.Subsets {
-			if len(subset.Addresses) > 0 {
-				return true, nil
+		for _, slice := range slices.Items {
+			for _, ep := range slice.Endpoints {
+				if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
+					return true, nil
+				}
 			}
 		}
 		return false, nil

--- a/pkg/testutil/certmanager.go
+++ b/pkg/testutil/certmanager.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package testutil
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WaitForCertManagerWebhook polls until the cert-manager-webhook service has
+// at least one ready endpoint. This prevents flaky test failures caused by
+// helm installs that create cert-manager Certificate resources before the
+// webhook is ready to serve validation requests.
+func WaitForCertManagerWebhook(ctx context.Context, c client.Client, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		var ep corev1.Endpoints
+		if err := c.Get(ctx, client.ObjectKey{
+			Name:      "cert-manager-webhook",
+			Namespace: "cert-manager",
+		}, &ep); err != nil {
+			return false, nil //nolint:nilerr // keep polling
+		}
+		for _, subset := range ep.Subsets {
+			if len(subset.Addresses) > 0 {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/pkg/vcluster/vcluster.go
+++ b/pkg/vcluster/vcluster.go
@@ -210,6 +210,18 @@ func New(ctx context.Context, config *kube.RESTConfig) (*Cluster, error) {
 		return dialer.DialContext(ctx, network, fmt.Sprintf("%s-0.%s:%s", rel.Name, rel.Namespace, address[idx+1:]))
 	}
 
+	// Wait for the cert-manager webhook to have ready endpoints inside the
+	// vcluster before returning. Without this, helm installs that create
+	// Certificate resources can fail with "no endpoints available for service
+	// cert-manager-webhook".
+	vcClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return nil, errors.Wrap(err, "creating vcluster client for webhook readiness check")
+	}
+	if err := testutil.WaitForCertManagerWebhook(ctx, vcClient, 2*time.Minute); err != nil {
+		return nil, errors.Wrap(err, "waiting for cert-manager webhook readiness in vcluster")
+	}
+
 	return &Cluster{
 		config:     cfg,
 		helm:       hc,


### PR DESCRIPTION
## Summary
- Adds an explicit poll for cert-manager webhook endpoint readiness after installation, before proceeding with tests that create Certificate resources
- Prevents flaky `"no endpoints available for service cert-manager-webhook"` failures caused by the gap between a pod being `Ready` and the API server's `Endpoints` object being updated

## Problem
Helm's `--wait` confirms cert-manager pods are running, but there's a race window before the `cert-manager-webhook` service has routable endpoints in the Kubernetes API server. Any helm install that creates cert-manager `Certificate` resources during this window fails with a webhook validation error.

This has been observed in multiple CI builds:
- **Build 12515** (`run-integration-tests`): `TestIntegrationChart/console-integration` — cert-manager webhook had no endpoints during redpanda chart install
- **Build 12544** (`run-acceptance-tests`): `Scenario: Migrate from a Helm chart release to a Redpanda custom resource` — same webhook endpoint failure on the first helm install step (6 simultaneous webhook call failures)

## Changes
- **`pkg/testutil/certmanager.go`**: New `WaitForCertManagerWebhook` helper that polls the `cert-manager-webhook` Endpoints resource until at least one address is available
- **`pkg/vcluster/vcluster.go`**: Calls `WaitForCertManagerWebhook` after obtaining the vcluster client, before returning the cluster to callers
- **`harpoon/suite.go`**: Adds `AfterSetup` hook to `SuiteBuilder` — runs callbacks after helm chart installs but before tests start
- **`acceptance/main_test.go`**: Uses `AfterSetup` to wait for cert-manager webhook readiness

## Test plan
- [ ] `go build ./pkg/testutil/... ./pkg/vcluster/... ./harpoon/... ./acceptance/...` compiles
- [ ] Integration tests pass without cert-manager webhook flakes
- [ ] Acceptance tests pass without cert-manager webhook flakes
