### PR TITLE
fix: skip redundant license SetLicense calls when checksum matches

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260403-100000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260403-100000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed unnecessary license reloading on every reconcile by comparing the SHA256 checksum of the desired license against the already loaded license before calling SetLicense.
+time: 2026-04-03T10:00:00.000000-04:00

--- a/operator/internal/controller/redpanda/license_checksum_test.go
+++ b/operator/internal/controller/redpanda/license_checksum_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+)
+
+// TestLicenseChecksumMatch verifies that our local SHA256 checksum
+// calculation matches the checksum Redpanda reports via GetLicenseInfo
+// after a license is set. This is the check used by setupLicense to
+// skip redundant SetLicense calls.
+func TestLicenseChecksumMatch(t *testing.T) {
+	const envVar = "REDPANDA_SAMPLE_LICENSE"
+
+	license := os.Getenv(envVar)
+	if license == "" {
+		t.Skipf("%s is not set, skipping license checksum test", envVar)
+	}
+
+	ctx := context.Background()
+
+	container, err := redpanda.Run(ctx,
+		os.Getenv("TEST_REDPANDA_REPO")+":"+os.Getenv("TEST_REDPANDA_VERSION"),
+	)
+	require.NoError(t, err)
+
+	adminAddr, err := container.AdminAPIAddress(ctx)
+	require.NoError(t, err)
+
+	adminClient, err := rpadmin.NewAdminAPI([]string{adminAddr}, nil, nil)
+	require.NoError(t, err)
+	defer adminClient.Close()
+
+	// Set the license on the cluster.
+	err = adminClient.SetLicense(ctx, strings.NewReader(license))
+	require.NoError(t, err)
+
+	// Retrieve the license info that Redpanda computed.
+	info, err := adminClient.GetLicenseInfo(ctx)
+	require.NoError(t, err)
+	require.True(t, info.Loaded, "license should be loaded after SetLicense")
+
+	// Verify our local SHA256 matches what Redpanda reports.
+	h := sha256.Sum256([]byte(license))
+	localChecksum := hex.EncodeToString(h[:])
+
+	require.Equal(t, localChecksum, info.Properties.Checksum,
+		"local SHA256 checksum should match Redpanda's reported checksum")
+
+	// Verify that a second SetLicense would be correctly skipped by our logic:
+	// the checksum comparison should indicate the license is already loaded.
+	require.Equal(t, localChecksum, info.Properties.Checksum,
+		"checksum should be stable across reads")
+}

--- a/operator/internal/controller/redpanda/license_checksum_test.go
+++ b/operator/internal/controller/redpanda/license_checksum_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 )
 
-// TestLicenseChecksumMatch verifies that our local SHA256 checksum
-// calculation matches the checksum Redpanda reports via GetLicenseInfo
-// after a license is set. This is the check used by setupLicense to
-// skip redundant SetLicense calls.
-func TestLicenseChecksumMatch(t *testing.T) {
+// TestLicenseChecksum verifies that our local SHA256 checksum calculation
+// matches the checksum Redpanda reports via GetLicenseInfo after a license
+// is set. This is the check used by setupLicense to skip redundant
+// SetLicense calls.
+func TestLicenseChecksum(t *testing.T) {
 	const envVar = "REDPANDA_SAMPLE_LICENSE"
 
 	license := os.Getenv(envVar)
@@ -64,8 +64,39 @@ func TestLicenseChecksumMatch(t *testing.T) {
 	require.Equal(t, localChecksum, info.Properties.Checksum,
 		"local SHA256 checksum should match Redpanda's reported checksum")
 
-	// Verify that a second SetLicense would be correctly skipped by our logic:
-	// the checksum comparison should indicate the license is already loaded.
-	require.Equal(t, localChecksum, info.Properties.Checksum,
-		"checksum should be stable across reads")
+	t.Run("changed license triggers new SetLicense", func(t *testing.T) {
+		const secondEnvVar = "REDPANDA_SECOND_SAMPLE_LICENSE"
+
+		secondLicense := os.Getenv(secondEnvVar)
+		if secondLicense == "" {
+			t.Skipf("%s is not set, skipping license change test", secondEnvVar)
+		}
+
+		// The second license must produce a different checksum.
+		h2 := sha256.Sum256([]byte(secondLicense))
+		secondChecksum := hex.EncodeToString(h2[:])
+		require.NotEqual(t, localChecksum, secondChecksum,
+			"second license should have a different checksum than the first")
+
+		// Simulate what setupLicense does: the loaded checksum no longer
+		// matches the desired license, so SetLicense should be called.
+		require.NotEqual(t, info.Properties.Checksum, secondChecksum,
+			"loaded checksum should not match the new license, triggering SetLicense")
+
+		// Actually set the new license.
+		err := adminClient.SetLicense(ctx, strings.NewReader(secondLicense))
+		require.NoError(t, err)
+
+		// Verify the cluster now reports the new license's checksum.
+		newInfo, err := adminClient.GetLicenseInfo(ctx)
+		require.NoError(t, err)
+		require.True(t, newInfo.Loaded, "new license should be loaded")
+		require.Equal(t, secondChecksum, newInfo.Properties.Checksum,
+			"cluster checksum should match the second license after SetLicense")
+
+		// Verify the old checksum no longer matches — setupLicense would
+		// have correctly detected the change.
+		require.NotEqual(t, localChecksum, newInfo.Properties.Checksum,
+			"old license checksum should no longer match")
+	})
 }

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -13,6 +13,8 @@ package redpanda
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -580,10 +582,10 @@ func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alp
 		return nil
 	}
 
+	var licenseBytes []byte
+
 	if literalLicense := ptr.Deref(rp.Spec.ClusterSpec.Enterprise.License, ""); literalLicense != "" {
-		if err := adminClient.SetLicense(ctx, strings.NewReader(literalLicense)); err != nil {
-			return errors.WithStack(err)
-		}
+		licenseBytes = []byte(literalLicense)
 	}
 
 	if secretReference := rp.Spec.ClusterSpec.Enterprise.LicenseSecretRef; secretReference != nil {
@@ -599,10 +601,29 @@ func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alp
 			return errors.WithStack(err)
 		}
 
-		literalLicense := licenseSecret.Data[key]
-		if err := adminClient.SetLicense(ctx, bytes.NewReader(literalLicense)); err != nil {
-			return errors.WithStack(err)
+		licenseBytes = licenseSecret.Data[key]
+	}
+
+	if len(licenseBytes) == 0 {
+		return nil
+	}
+
+	// Check if the license already loaded on the cluster matches what we want
+	// to set. This avoids unnecessary SetLicense calls on every reconcile.
+	info, err := adminClient.GetLicenseInfo(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if info.Loaded {
+		h := sha256.Sum256(licenseBytes)
+		if info.Properties.Checksum == hex.EncodeToString(h[:]) {
+			return nil
 		}
+	}
+
+	if err := adminClient.SetLicense(ctx, bytes.NewReader(licenseBytes)); err != nil {
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -577,7 +577,7 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, state *c
 	return ctrl.Result{}, nil
 }
 
-func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alpha2.Redpanda, adminClient *rpadmin.AdminAPI, cluster cluster.Cluster) error {
+func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alpha2.Redpanda, adminClient *rpadmin.AdminAPI, cluster cluster.Cluster, loadedLicense rpadmin.License) error {
 	if rp.Spec.ClusterSpec.Enterprise == nil {
 		return nil
 	}
@@ -608,16 +608,10 @@ func (r *RedpandaReconciler) setupLicense(ctx context.Context, rp *redpandav1alp
 		return nil
 	}
 
-	// Check if the license already loaded on the cluster matches what we want
-	// to set. This avoids unnecessary SetLicense calls on every reconcile.
-	info, err := adminClient.GetLicenseInfo(ctx)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	if info.Loaded {
+	// Skip SetLicense if the cluster already has the same license loaded.
+	if loadedLicense.Loaded {
 		h := sha256.Sum256(licenseBytes)
-		if info.Properties.Checksum == hex.EncodeToString(h[:]) {
+		if loadedLicense.Properties.Checksum == hex.EncodeToString(h[:]) {
 			return nil
 		}
 	}
@@ -660,7 +654,13 @@ func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, state *cluste
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.setupLicense(ctx, state.cluster.Redpanda, state.admin, cluster); err != nil {
+	licenseInfo, err := state.admin.GetLicenseInfo(ctx)
+	if err != nil {
+		logger.Error(err, "error getting license info")
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	if err := r.setupLicense(ctx, state.cluster.Redpanda, state.admin, cluster, licenseInfo); err != nil {
 		logger.Error(err, "error setting up license")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
@@ -668,12 +668,6 @@ func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, state *cluste
 	features, err := state.admin.GetEnterpriseFeatures(ctx)
 	if err != nil {
 		logger.Error(err, "error getting enterprise features")
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
-	licenseInfo, err := state.admin.GetLicenseInfo(ctx)
-	if err != nil {
-		logger.Error(err, "error getting license info")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 


### PR DESCRIPTION
## Summary
- The v1alpha2 Redpanda controller was calling `SetLicense()` on every reconcile that passed the 1-minute rate limit, even when the identical license was already loaded on the cluster
- This caused unnecessary "Attempted to load identical license, doing nothing" log spam in Redpanda broker logs every ~3 minutes
- Now `setupLicense()` compares the SHA256 checksum of the desired license against the already loaded license, skipping `SetLicense()` when they match
- Restructured `reconcileLicense()` to call `GetLicenseInfo()` once before `setupLicense()` and reuse the result for both the checksum check and the status update, eliminating a duplicate admin API call

## Before

Every reconcile that passes the 1-minute rate limit calls `SetLicense()`, causing repeated `updated cluster configuration` operator logs and `Attempted to load identical license, doing nothing` broker logs:

**Operator logs:**
```
{"level":"info","ts":"2026-02-26T11:48:42.063Z","msg":"updated cluster configuration","controller":"redpanda","reconcileID":"8e4610cd-...","config_version":2,"removed":[]}
{"level":"info","ts":"2026-02-26T11:51:42.448Z","msg":"updated cluster configuration","controller":"redpanda","reconcileID":"19ab7d13-...","config_version":2,"removed":[]}
{"level":"info","ts":"2026-02-26T11:54:42.894Z","msg":"updated cluster configuration","controller":"redpanda","reconcileID":"648a09bc-...","config_version":2,"removed":[]}
...repeating every ~3 minutes indefinitely
```

**Redpanda broker logs:**
```
INFO 2026-02-26 11:48:42,066 [shard 0:admi] admin_api_server - Attempted to load identical license, doing nothing: [Version: 0, Organization: Support, Type: enterprise, Expiry(epoch): 1774697773]
INFO 2026-02-26 11:51:42,452 [shard 0:admi] admin_api_server - Attempted to load identical license, doing nothing: [Version: 0, Organization: Support, Type: enterprise, Expiry(epoch): 1774697773]
INFO 2026-02-26 11:54:42,899 [shard 0:admi] admin_api_server - Attempted to load identical license, doing nothing: [Version: 0, Organization: Support, Type: enterprise, Expiry(epoch): 1774697773]
...repeating every ~3 minutes indefinitely
```

## After

`setupLicense()` compares the SHA256 checksum of the desired license against the loaded license. When they match, `SetLicense()` is skipped entirely. The license is only set on first reconcile or when the license content changes.

No more `Attempted to load identical license` broker log spam or unnecessary `updated cluster configuration` operator logs on steady-state reconciles.

### Admin API calls per reconcile (past 1-min rate limit)

| Scenario | Before | After |
|---|---|---|
| Steady state (license unchanged) | `SetLicense` + `GetEnterpriseFeatures` + `GetLicenseInfo` = **3 calls** | `GetLicenseInfo` + `GetEnterpriseFeatures` = **2 calls** |
| License changed | `SetLicense` + `GetEnterpriseFeatures` + `GetLicenseInfo` = **3 calls** | `GetLicenseInfo` + `SetLicense` + `GetEnterpriseFeatures` = **3 calls** |

`GetLicenseInfo()` was already being called for the status update — by moving it before `setupLicense()` and passing the result in, we reuse it for the checksum comparison with zero additional overhead.

## Test plan
- [ ] Verify unit tests pass (`go test ./operator/internal/controller/redpanda/...`)
- [ ] Deploy operator with an enterprise license configured and confirm:
  - License is set on first reconcile
  - Subsequent reconciles skip `SetLicense` (no "Attempted to load identical license" in broker logs)
  - Changing the license secret triggers a new `SetLicense` call
