### PR TITLE
operator: Replace otelutil/log with controller-runtime/pkg/log

### DIFF
--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -141,7 +141,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1 // indirect
-	github.com/redpanda-data/common-go/otelutil v0.0.0-20260109170727-1dd9f5d22ee1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/rubenv/sql-migrate v1.8.0 // indirect
@@ -166,10 +165,8 @@ require (
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
-	go.opentelemetry.io/otel/sdk/log v0.16.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/harpoon/go.sum
+++ b/harpoon/go.sum
@@ -411,8 +411,6 @@ github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1
 github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1/go.mod h1:V3OBV2kcF/BDDytUZuKvIygbaXoGPT5VO3KmMAz+mBM=
 github.com/redpanda-data/common-go/kube v0.0.0-20260225221458-fec06b917c9a h1:Ce2o1IIQcR1UD8FX8sXwevI7JlEVnWoMtMLkawC5mbU=
 github.com/redpanda-data/common-go/kube v0.0.0-20260225221458-fec06b917c9a/go.mod h1:FMuuUG3IVwwSad+3da0WIPYHsUuvi3LHnjgSv8ovXug=
-github.com/redpanda-data/common-go/otelutil v0.0.0-20260109170727-1dd9f5d22ee1 h1:fLBU7IJZq8PR88AkEdI5G+yyBsftionGapvAOMPW9hg=
-github.com/redpanda-data/common-go/otelutil v0.0.0-20260109170727-1dd9f5d22ee1/go.mod h1:LzztzYWpD+e+A6hV6+eQhYY60zHQR7ePxhLgyMmRn/Q=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/redpanda-data/common-go/kube"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -560,7 +560,8 @@ func Run(
 // runnables for the custom resources in the vectorized group, AKA the V1
 // operator.
 func setupVectorizedControllers(ctx context.Context, mgr ctrl.Manager, factory internalclient.ClientFactory, cloudExpander *pkgsecrets.CloudExpander, opts *RunOptions) error {
-	log.Info(ctx, "Starting Vectorized (V1) Controllers")
+	log := controllerlog.FromContext(ctx)
+	log.Info("Starting Vectorized (V1) Controllers")
 
 	configurator := resources.ConfiguratorSettings{
 		ConfiguratorBaseImage:        opts.configuratorBaseImage,
@@ -589,20 +590,20 @@ func setupVectorizedControllers(ctx context.Context, mgr ctrl.Manager, factory i
 		CloudSecretsExpander:      cloudExpander,
 		Timeout:                   opts.rpClientTimeout,
 	}).WithClusterDomain(opts.clusterDomain).WithConfiguratorSettings(configurator).SetupWithManager(mgr); err != nil {
-		log.Error(ctx, err, "Unable to create controller", "controller", "Cluster")
+		log.Error(err, "Unable to create controller", "controller", "Cluster")
 		return err
 	}
 
 	if err := vectorizedcontrollers.NewClusterMetricsController(mgr.GetClient()).SetupWithManager(mgr); err != nil {
-		log.Error(ctx, err, "Unable to create controller", "controller", "ClustersMetrics")
+		log.Error(err, "Unable to create controller", "controller", "ClustersMetrics")
 		return err
 	}
 
 	// Setup webhooks
 	if opts.webhookEnabled {
-		log.Info(ctx, "Setup webhook")
+		log.Info("Setup webhook")
 		if err := (&vectorizedv1alpha1.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
-			log.Error(ctx, err, "Unable to create webhook", "webhook", "RedpandaCluster")
+			log.Error(err, "Unable to create webhook", "webhook", "RedpandaCluster")
 			return err
 		}
 	}
@@ -626,7 +627,7 @@ func setupVectorizedControllers(ctx context.Context, mgr ctrl.Manager, factory i
 		)
 
 		if err := d.SetupWithManager(mgr); err != nil {
-			log.Error(ctx, err, "unable to create controller", "controller", "StatefulSetDecommissioner")
+			log.Error(err, "unable to create controller", "controller", "StatefulSetDecommissioner")
 			return err
 		}
 	}

--- a/operator/cmd/supervisor/supervisor.go
+++ b/operator/cmd/supervisor/supervisor.go
@@ -19,9 +19,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/time/rate"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Command() *cobra.Command {
@@ -51,6 +52,7 @@ The default retry parameters are tuned for a a long running process, such as the
 
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer cancel()
+			log := log.FromContext(ctx)
 
 			limiter := rate.NewLimiter(rate.Every(retryRate), retryBurst)
 			runner := Runner{
@@ -80,13 +82,13 @@ The default retry parameters are tuned for a a long running process, such as the
 				delay := reservation.Delay()
 
 				if delay > 0 {
-					log.Info(ctx, "backing off retries", "delay", delay.String())
+					log.Info("backing off retries", "delay", delay.String())
 				}
 
 				// Otherwise wait until we have a retry "credit" available.
 				select {
 				case <-ctx.Done():
-					log.Info(ctx, "shutting down")
+					log.Info("shutting down")
 					return
 
 				case <-time.After(reservation.Delay()):
@@ -117,7 +119,8 @@ type Runner struct {
 func (r *Runner) Run(
 	ctx context.Context,
 ) (cont bool) {
-	log.Info(ctx, "starting process", "command", r.Command)
+	log := log.FromContext(ctx)
+	log.Info("starting process", "command", r.Command)
 
 	//nolint:gosec // This is running with a users permissions, nothing to exploit here.
 	subprocess := exec.Command(r.Command[0], r.Command[1:]...)
@@ -127,7 +130,7 @@ func (r *Runner) Run(
 	subprocess.Stdout = r.Stdout
 
 	if err := subprocess.Start(); err != nil {
-		log.Error(ctx, err, "failed to start process", "command", r.Command)
+		log.Error(err, "failed to start process", "command", r.Command)
 		// If we fail to startup the provided process, don't continue to retry
 		// as it's exceptionally unlikely this type of issue will resolve
 		// itself.
@@ -142,19 +145,19 @@ func (r *Runner) Run(
 	for {
 		select {
 		case err := <-doneCh:
-			log.Error(ctx, err, "process exited")
+			log.Error(err, "process exited")
 			return true // Continue to re-run on any process crashes.
 
 		case sig := <-r.Signals:
 			// Forward signals onto our child process.
-			log.Info(ctx, "forwarding signal", "signal", sig)
+			log.Info("forwarding signal", "signal", sig)
 			if err := subprocess.Process.Signal(sig); err != nil {
-				log.Error(ctx, err, "failed to forward signal to subprocess", "signal", sig)
+				log.Error(err, "failed to forward signal to subprocess", "signal", sig)
 			}
 			continue
 
 		case <-ctx.Done():
-			log.Info(ctx, "terminating process")
+			log.Info("terminating process")
 
 			// Initiate the shutdown process by sending SIGTERM to match
 			// Kubernetes' behavior[1] (in most cases).
@@ -167,10 +170,10 @@ func (r *Runner) Run(
 			// before KILL'ing it.
 			select {
 			case <-doneCh:
-				log.Info(ctx, "process gracefully terminated")
+				log.Info("process gracefully terminated")
 			case <-time.After(r.GracePeriod):
 				_ = subprocess.Process.Kill()
-				log.Info(ctx, "process killed")
+				log.Info("process killed")
 			}
 
 			// If the context has been cancelled, don't continue the loop.

--- a/operator/cmd/syncclusterconfig/superusers.go
+++ b/operator/cmd/syncclusterconfig/superusers.go
@@ -17,7 +17,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/redpanda-data/common-go/otelutil/log"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NormalizeSuperusers de-duplicates and sorts the superusers

--- a/operator/internal/controller/console/controller.go
+++ b/operator/internal/controller/console/controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/imdario/mergo"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redpanda-data/common-go/kube"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +31,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
@@ -134,7 +135,7 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	// so we don't NEED to use a finalizer. It's here to prevent accidents if
 	// we need cluster scoped resources one day.
 	if !cr.DeletionTimestamp.IsZero() {
-		log.Info(ctx, "GC'ing Console", "key", kube.AsKey(cr))
+		log.FromContext(ctx).Info("GC'ing Console", "key", kube.AsKey(cr))
 
 		if controllerutil.RemoveFinalizer(cr, finalizerKey) {
 			if _, err := syncer.DeleteAll(ctx); err != nil {
@@ -160,7 +161,7 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	log.Info(ctx, "reconciling Console", "key", kube.AsKey(cr))
+	log.FromContext(ctx).Info("reconciling Console", "key", kube.AsKey(cr))
 
 	// Add the finalizer, if not present.
 	if controllerutil.AddFinalizer(cr, finalizerKey) {
@@ -342,7 +343,7 @@ func (c *Controller) skipServiceMonitorWatchIfNotInstalled(ctx context.Context) 
 	if errors.Is(err, &meta.NoKindMatchError{}) {
 		return true
 	} else if err != nil {
-		log.Error(ctx, err, "could not list ServiceMonitors")
+		log.FromContext(ctx).Error(err, "could not list ServiceMonitors")
 		return true
 	}
 	return false

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
@@ -82,7 +83,7 @@ type stretchClusterReconciliationFn func(ctx context.Context, state *stretchClus
 
 func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (result ctrl.Result, err error) {
 	start := time.Now()
-	l := log.FromContext(ctx).WithName("MulticlusterReconciler.Reconcile")
+	l := controllerlog.FromContext(ctx).WithName("MulticlusterReconciler.Reconcile")
 
 	l.V(1).Info("Starting reconcile loop")
 	defer func() {
@@ -228,7 +229,7 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 // persists the status, and returns drifted=true so the caller can abort reconciliation.
 // When specs are aligned it sets SpecSynced=True.
 func (r *MulticlusterReconciler) checkSpecConsistency(ctx context.Context, state *stretchClusterReconciliationState, sc *redpandav1alpha2.StretchCluster) (drifted bool, _ ctrl.Result, _ error) {
-	l := log.FromContext(ctx).WithName("checkSpecConsistency")
+	l := controllerlog.FromContext(ctx).WithName("checkSpecConsistency")
 
 	localSpec := sc.Spec
 	var driftDetails []string
@@ -285,7 +286,7 @@ func specDiffFields(a, b redpandav1alpha2.StretchClusterSpec) []string {
 }
 
 func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redpandav1alpha2.StretchCluster) (*stretchClusterReconciliationState, error) {
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 	logger.V(log.DebugLevel).Info("fetchInitialState")
 
 	sccluster := lifecycle.NewStretchClusterWithPools(sc, r.Manager.GetClusterNames())
@@ -343,7 +344,7 @@ func bootstrapSecretName(sc *redpandav1alpha2.StretchCluster) string {
 
 func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *stretchClusterReconciliationState, _ cluster.Cluster) (_ ctrl.Result, err error) {
 	ctx, span := trace.Start(ctx, "syncBootstrapUser")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -454,7 +455,7 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 
 func (r *MulticlusterReconciler) reconcileResources(ctx context.Context, state *stretchClusterReconciliationState, cluster cluster.Cluster) (_ ctrl.Result, err error) {
 	ctx, span := trace.Start(ctx, "reconcileResources")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -477,7 +478,7 @@ func (r *MulticlusterReconciler) reconcileResources(ctx context.Context, state *
 
 func (r *MulticlusterReconciler) reconcilePools(ctx context.Context, state *stretchClusterReconciliationState, cluster cluster.Cluster) (_ ctrl.Result, err error) {
 	ctx, span := trace.Start(ctx, "reconcilePools")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -542,7 +543,7 @@ func (r *MulticlusterReconciler) initAdminClient(ctx context.Context, state *str
 		return ctrl.Result{}, nil
 	}
 
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 	adminAPIEndpoints := r.LifecycleClient.GetAdminAPIEndpoints(state.cluster)
 	if len(adminAPIEndpoints) == 0 {
 		return ctrl.Result{}, fmt.Errorf("no admin API endpoints found for cluster %s", state.cluster.Name)
@@ -561,7 +562,7 @@ func (r *MulticlusterReconciler) reconcileDecommission(ctx context.Context, stat
 	var health rpadmin.ClusterHealthOverview
 
 	ctx, span := trace.Start(ctx, "reconcileDecommission")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -683,7 +684,7 @@ func (r *MulticlusterReconciler) reconcileLicense(ctx context.Context, state *st
 	var license *redpandav1alpha2.RedpandaLicenseStatus
 
 	ctx, span := trace.Start(ctx, "reconcileLicense")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -775,7 +776,7 @@ func (r *MulticlusterReconciler) reconcileLicense(ctx context.Context, state *st
 
 func (r *MulticlusterReconciler) reconcileClusterConfig(ctx context.Context, state *stretchClusterReconciliationState, cluster cluster.Cluster) (_ reconcile.Result, err error) {
 	ctx, span := trace.Start(ctx, "reconcileClusterConfig")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -816,7 +817,7 @@ func (r *MulticlusterReconciler) reconcileClusterConfig(ctx context.Context, sta
 func (r *MulticlusterReconciler) syncStatus(ctx context.Context, cluster cluster.Cluster, state *stretchClusterReconciliationState, result ctrl.Result, err error) (ctrl.Result, error) {
 	original := state.cluster.StretchCluster.Status.DeepCopy()
 	if r.LifecycleClient.SetClusterStatus(state.cluster, state.status) {
-		log.FromContext(ctx).V(log.TraceLevel).Info("setting cluster status from diff", "original", original, "new", state.cluster.StretchCluster.Status)
+		controllerlog.FromContext(ctx).V(log.TraceLevel).Info("setting cluster status from diff", "original", original, "new", state.cluster.StretchCluster.Status)
 		syncErr := cluster.GetClient().Status().Update(ctx, state.cluster.StretchCluster)
 		err = errors.Join(syncErr, err)
 	}
@@ -846,7 +847,7 @@ func (r *MulticlusterReconciler) fetchClusterHealth(ctx context.Context, admin *
 // decommissioning the broker with the last pod ordinal and then patching the statefulset with
 // a single less replica.
 func (r *MulticlusterReconciler) scaleDown(ctx context.Context, admin *rpadmin.AdminAPI, cluster *lifecycle.StretchClusterWithPools, set *lifecycle.ScaleDownSet, brokerMap map[string]int) (bool, error) {
-	logger := log.FromContext(ctx).WithName(fmt.Sprintf("MulticlusterReconciler[%T].scaleDown", *cluster))
+	logger := controllerlog.FromContext(ctx).WithName(fmt.Sprintf("MulticlusterReconciler[%T].scaleDown", *cluster))
 	logger.V(log.TraceLevel).Info("starting StatefulSet scale down", "StatefulSet", client.ObjectKeyFromObject(set.StatefulSet).String())
 
 	brokerID, ok := brokerMap[set.LastPod.GetName()]
@@ -879,7 +880,7 @@ func (r *MulticlusterReconciler) scaleDown(ctx context.Context, admin *rpadmin.A
 
 // decommissionBroker handles decommissioning a broker and waiting until it has finished decommissioning
 func (r *MulticlusterReconciler) decommissionBroker(ctx context.Context, admin *rpadmin.AdminAPI, cluster *lifecycle.StretchClusterWithPools, set *lifecycle.ScaleDownSet, brokerID int) (bool, error) {
-	logger := log.FromContext(ctx).WithName(fmt.Sprintf("MulticlusterReconciler[%T].decommissionBroker", *cluster))
+	logger := controllerlog.FromContext(ctx).WithName(fmt.Sprintf("MulticlusterReconciler[%T].decommissionBroker", *cluster))
 	logger.V(log.TraceLevel).Info("checking decommissioning status for pod", "Pod", client.ObjectKeyFromObject(set.LastPod).String())
 
 	decommissionStatus, err := admin.DecommissionBrokerStatus(ctx, brokerID)

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/redpanda-data/common-go/kube"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/redpanda-data/common-go/otelutil/trace"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"

--- a/operator/internal/controller/redpanda/nodepool_controller.go
+++ b/operator/internal/controller/redpanda/nodepool_controller.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/redpanda-data/common-go/otelutil/log"
+	// Remove controller-runtime logger after https://github.com/redpanda-data/common-go/pull/160
 	"github.com/redpanda-data/common-go/otelutil/otelkube"
 	"github.com/redpanda-data/common-go/otelutil/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -27,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
@@ -63,7 +65,7 @@ func SetupWithMultiClusterManager(mgr multicluster.Manager) error {
 		).
 		Watches(&redpandav1alpha2.StretchCluster{}, func(_ string, _ cluster.Cluster) mchandler.EventHandler {
 			return mchandler.TypedEnqueueRequestsFromMapFuncWithClusterPreservation(func(ctx context.Context, object client.Object) []mcreconcile.Request {
-				l := log.FromContext(ctx).WithName("NodePoolReconciler.StretchClusterWatch").V(log.TraceLevel)
+				l := controllerlog.FromContext(ctx).WithName("NodePoolReconciler.StretchClusterWatch").V(log.TraceLevel)
 				l.Info("StretchCluster event received", "stretchCluster", client.ObjectKeyFromObject(object).String(), "knownClusters", mgr.GetClusterNames())
 				var reqs []mcreconcile.Request
 				for _, clusterName := range mgr.GetClusterNames() {
@@ -148,7 +150,7 @@ func (r *NodePoolReconciler) SetupWithManager(ctx context.Context, mgr multiclus
 
 // Reconcile reconciles NodePool objects
 func (r *NodePoolReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (result ctrl.Result, err error) {
-	l := log.FromContext(ctx).WithName("NodePoolReconciler.Reconcile").WithValues("object", req.NamespacedName.String(), "cluster", req.ClusterName)
+	l := controllerlog.FromContext(ctx).WithName("NodePoolReconciler.Reconcile").WithValues("object", req.NamespacedName.String(), "cluster", req.ClusterName)
 	l.V(log.DebugLevel).Info("Starting reconcile loop")
 	start := time.Now()
 	defer func() {
@@ -189,7 +191,7 @@ func (r *NodePoolReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 	))
 	defer func() { trace.EndSpan(span, err) }()
 
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	if !feature.V2Managed.Get(ctx, pool) {
 		if controllerutil.RemoveFinalizer(pool, FinalizerKey) {

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	// Remove controller-runtime logger after https://github.com/redpanda-data/common-go/pull/160
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
@@ -161,7 +163,7 @@ type clusterReconciliationFn func(ctx context.Context, state *clusterReconciliat
 
 func (r *RedpandaReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (result ctrl.Result, err error) {
 	start := time.Now()
-	l := log.FromContext(ctx).WithName("RedpandaReconciler.Reconcile")
+	l := controllerlog.FromContext(ctx).WithName("RedpandaReconciler.Reconcile")
 
 	l.V(1).Info("Starting reconcile loop")
 	defer func() {
@@ -203,7 +205,7 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 	))
 	defer func() { trace.EndSpan(span, err) }()
 
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	if !feature.V2Managed.Get(ctx, rp) {
 		if controllerutil.RemoveFinalizer(rp, FinalizerKey) {
@@ -275,18 +277,18 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 		// if we have an error or an explicit requeue from one of our
 		// sub reconcilers, then just early return
 		if err != nil || result.RequeueAfter > 0 {
-			log.FromContext(ctx).V(log.TraceLevel).Info("aborting reconciliation early", "error", err, "requeueAfter", result.RequeueAfter)
+			controllerlog.FromContext(ctx).V(log.TraceLevel).Info("aborting reconciliation early", "error", err, "requeueAfter", result.RequeueAfter)
 			return r.syncStatus(ctx, cluster, state, result, err)
 		}
 	}
 
 	// we're at the end of reconciliation, so sync back our status
-	log.FromContext(ctx).V(log.TraceLevel).Info("finished normal reconciliation loop")
+	controllerlog.FromContext(ctx).V(log.TraceLevel).Info("finished normal reconciliation loop")
 	return r.syncStatus(ctx, cluster, state, ctrl.Result{}, nil)
 }
 
 func (r *RedpandaReconciler) fetchInitialState(ctx context.Context, rp *redpandav1alpha2.Redpanda, cluster cluster.Cluster) (*clusterReconciliationState, error) {
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	// fetch any related node pools
 	var err error
@@ -336,7 +338,7 @@ func (r *RedpandaReconciler) fetchInitialState(ctx context.Context, rp *redpanda
 }
 
 func (r *RedpandaReconciler) reconcileParameterValidation(ctx context.Context, state *clusterReconciliationState, cluster cluster.Cluster) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	if err := validateClusterParameters(state.cluster.Redpanda); err != nil {
 		state.status.Status.SetResourcesSynced(statuses.ClusterResourcesSyncedReasonTerminalError, err.Error())
@@ -350,7 +352,7 @@ func (r *RedpandaReconciler) reconcileParameterValidation(ctx context.Context, s
 
 func (r *RedpandaReconciler) reconcileResources(ctx context.Context, state *clusterReconciliationState, cluster cluster.Cluster) (_ ctrl.Result, err error) {
 	ctx, span := trace.Start(ctx, "reconcileResources")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -377,7 +379,7 @@ func (r *RedpandaReconciler) reconcileResources(ctx context.Context, state *clus
 // the cluster if a decommissioning operation/scale down is currently in progress.
 func (r *RedpandaReconciler) reconcilePools(ctx context.Context, state *clusterReconciliationState, cluster cluster.Cluster) (_ ctrl.Result, err error) {
 	ctx, span := trace.Start(ctx, "reconcilePools")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -441,7 +443,7 @@ func (r *RedpandaReconciler) initAdminClient(ctx context.Context, state *cluster
 		return ctrl.Result{}, nil
 	}
 
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	admin, err := r.ClientFactory.RedpandaAdminClient(ctx, state.cluster.Redpanda)
 	if err != nil {
@@ -456,7 +458,7 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, state *c
 	var health rpadmin.ClusterHealthOverview
 
 	ctx, span := trace.Start(ctx, "reconcileDecommission")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -612,7 +614,7 @@ func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, state *cluste
 	var license *redpandav1alpha2.RedpandaLicenseStatus
 
 	ctx, span := trace.Start(ctx, "reconcileLicense")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -704,7 +706,7 @@ func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, state *cluste
 
 func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, state *clusterReconciliationState, cluster cluster.Cluster) (_ reconcile.Result, err error) {
 	ctx, span := trace.Start(ctx, "reconcileClusterConfig")
-	logger := log.FromContext(ctx)
+	logger := controllerlog.FromContext(ctx)
 
 	defer func() {
 		if err != nil {
@@ -864,7 +866,7 @@ func (r *RedpandaReconciler) clusterConfigFor(ctx context.Context, rp *redpandav
 func (r *RedpandaReconciler) syncStatus(ctx context.Context, cluster cluster.Cluster, state *clusterReconciliationState, result ctrl.Result, err error) (ctrl.Result, error) {
 	original := state.cluster.Redpanda.Status.DeepCopy()
 	if r.LifecycleClient.SetClusterStatus(state.cluster, state.status) {
-		log.FromContext(ctx).V(log.TraceLevel).Info("setting cluster status from diff", "original", original, "new", state.cluster.Redpanda.Status)
+		controllerlog.FromContext(ctx).V(log.TraceLevel).Info("setting cluster status from diff", "original", original, "new", state.cluster.Redpanda.Status)
 		syncErr := cluster.GetClient().Status().Update(ctx, state.cluster.Redpanda)
 		err = errors.Join(syncErr, err)
 	}
@@ -894,7 +896,7 @@ func (r *RedpandaReconciler) fetchClusterHealth(ctx context.Context, admin *rpad
 // decommissioning the broker with the last pod ordinal and then patching the statefulset with
 // a single less replica.
 func (r *RedpandaReconciler) scaleDown(ctx context.Context, admin *rpadmin.AdminAPI, cluster *lifecycle.ClusterWithPools, set *lifecycle.ScaleDownSet, brokerMap map[string]int) (bool, error) {
-	logger := log.FromContext(ctx).WithName(fmt.Sprintf("ClusterReconciler[%T].scaleDown", *cluster))
+	logger := controllerlog.FromContext(ctx).WithName(fmt.Sprintf("ClusterReconciler[%T].scaleDown", *cluster))
 	logger.V(log.TraceLevel).Info("starting StatefulSet scale down", "StatefulSet", client.ObjectKeyFromObject(set.StatefulSet).String())
 
 	brokerID, ok := brokerMap[set.LastPod.GetName()]
@@ -927,7 +929,7 @@ func (r *RedpandaReconciler) scaleDown(ctx context.Context, admin *rpadmin.Admin
 
 // decommissionBroker handles decommissioning a broker and waiting until it has finished decommissioning
 func (r *RedpandaReconciler) decommissionBroker(ctx context.Context, admin *rpadmin.AdminAPI, cluster *lifecycle.ClusterWithPools, set *lifecycle.ScaleDownSet, brokerID int) (bool, error) {
-	logger := log.FromContext(ctx).WithName(fmt.Sprintf("ClusterReconciler[%T].decommissionBroker", *cluster))
+	logger := controllerlog.FromContext(ctx).WithName(fmt.Sprintf("ClusterReconciler[%T].decommissionBroker", *cluster))
 	logger.V(log.TraceLevel).Info("checking decommissioning status for pod", "Pod", client.ObjectKeyFromObject(set.LastPod).String())
 
 	decommissionStatus, err := admin.DecommissionBrokerStatus(ctx, brokerID)

--- a/operator/internal/controller/redpanda/redpanda_controller_test.go
+++ b/operator/internal/controller/redpanda/redpanda_controller_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/redpanda-data/common-go/kube"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/redpanda-data/common-go/otelutil/trace"
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +40,8 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	redpandachart "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"

--- a/operator/internal/controller/redpanda/resource_controller.go
+++ b/operator/internal/controller/redpanda/resource_controller.go
@@ -17,12 +17,13 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/go-logr/logr"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	// Remove controller-runtime logger after https://github.com/redpanda-data/common-go/pull/160
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	v2 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
@@ -72,7 +74,7 @@ type TopicReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *TopicReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
 	start := time.Now()
-	l := log.FromContext(ctx).WithName("TopicReconciler.Reconcile")
+	l := controllerlog.FromContext(ctx).WithName("TopicReconciler.Reconcile")
 
 	l.V(1).Info("Starting reconcile loop")
 	defer func() {

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	// Remove controller-runtime logger after https://github.com/redpanda-data/common-go/pull/160
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
@@ -221,7 +223,7 @@ func (r *ResourceClient[T, U]) syncer(ctx context.Context, owner U, clusterName 
 // cleaning up any resources that should no longer exist.
 func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 	var syncErr error
-	logger := log.FromContext(ctx).WithName("SyncAll")
+	logger := controllerlog.FromContext(ctx).WithName("SyncAll")
 	clusterList := r.clusterList(owner)
 	logger.V(log.InfoLevel).Info("syncing all clusters", "clusterList", clusterList)
 	for _, clusterName := range r.clusterList(owner) {
@@ -241,6 +243,7 @@ func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 // a tracker that can be used for determining necessary operations on the pools.
 func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context, cluster U, configVersion string) (*PoolTracker, error) {
 	pools := NewPoolTracker(cluster.GetGeneration())
+	logger := controllerlog.FromContext(ctx)
 	for _, clusterName := range r.clusterList(cluster) {
 		existingPools, err := r.fetchExistingPools(ctx, cluster, clusterName)
 		if err != nil {
@@ -269,14 +272,14 @@ func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context,
 				set.Spec.Template.Labels = setConfigVersionLabels(set.Spec.Template.Labels, configVersion)
 			}
 		}
-		log.FromContext(ctx).V(log.DebugLevel).Info(fmt.Sprintf("found [%d] existing pools in cluster %s", len(existingPools), clusterName))
-		log.FromContext(ctx).V(log.DebugLevel).Info(fmt.Sprintf("found [%d] desired pools in cluster %s", len(wrapped), clusterName))
+		logger.V(log.DebugLevel).Info(fmt.Sprintf("found [%d] existing pools in cluster %s", len(existingPools), clusterName))
+		logger.V(log.DebugLevel).Info(fmt.Sprintf("found [%d] desired pools in cluster %s", len(wrapped), clusterName))
 
 		pools.addExisting(existingPools...)
 		pools.addDesired(wrapped...)
 	}
-	log.FromContext(ctx).V(log.DebugLevel).Info(fmt.Sprintf("found [%d] existing pools in all clusters", len(pools.existingPools)))
-	log.FromContext(ctx).V(log.DebugLevel).Info(fmt.Sprintf("found [%d] desired pools in all clusters", len(pools.desiredPools)))
+	logger.V(log.DebugLevel).Info(fmt.Sprintf("found [%d] existing pools in all clusters", len(pools.existingPools)))
+	logger.V(log.DebugLevel).Info(fmt.Sprintf("found [%d] desired pools in all clusters", len(pools.desiredPools)))
 
 	return pools, nil
 }
@@ -323,7 +326,7 @@ func wrapQueue(ctx context.Context, obj client.Object, wq workqueue.TypedRateLim
 }
 
 func (w *wrappedAdder) Add(item mcreconcile.Request) {
-	log.FromContext(w.ctx).V(log.TraceLevel).Info("[enqueue] adding reconciliation request", "request", item, "due-to", reflect.TypeOf(w.obj).String(), "name", client.ObjectKeyFromObject(w.obj))
+	controllerlog.FromContext(w.ctx).V(log.TraceLevel).Info("[enqueue] adding reconciliation request", "request", item, "due-to", reflect.TypeOf(w.obj).String(), "name", client.ObjectKeyFromObject(w.obj))
 	w.TypedRateLimitingInterface.Add(item)
 }
 

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -14,10 +14,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/redpanda-data/common-go/otelutil/log"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type MulticlusterStatefulSet struct {

--- a/operator/pkg/client/spec.go
+++ b/operator/pkg/client/spec.go
@@ -16,11 +16,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/redpanda-data/common-go/otelutil/log"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/client/shadow"

--- a/operator/pkg/client/v1.go
+++ b/operator/pkg/client/v1.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/redpanda-data/common-go/otelutil/log"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"

--- a/operator/pkg/feature/flag.go
+++ b/operator/pkg/feature/flag.go
@@ -13,7 +13,8 @@ import (
 	"context"
 
 	"github.com/cockroachdb/errors"
-	"github.com/redpanda-data/common-go/otelutil/log"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type FlagBundle int
@@ -107,7 +108,7 @@ func (f *AnnotationFeatureFlag[T]) Get(ctx context.Context, obj AnnotationGetter
 			if err == nil {
 				return parsed
 			}
-			log.Error(ctx, err, "failed to parsed annotation; interpreting as default", "default", f.Default, "value", value)
+			log.FromContext(ctx).Error(err, "failed to parsed annotation; interpreting as default", "default", f.Default, "value", value)
 		}
 	}
 

--- a/pkg/vcluster/vcluster.go
+++ b/pkg/vcluster/vcluster.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/redpanda-data/common-go/kube"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -37,6 +36,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	//"github.com/redpanda-data/common-go/otelutil/log" bring back after https://github.com/redpanda-data/common-go/pull/160
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/helm"
 	"github.com/redpanda-data/redpanda-operator/pkg/k3d"


### PR DESCRIPTION
Work around the noisy "ctx" key-value pair that common-go's otelutil/log appends to every log line, serializing the full context.Context wrapper chain (e.g. "context.Background.WithCancel.WithCancel.WithValue(...)").

Switch all call sites from log.Info(ctx, ...) / log.Error(ctx, err, ...) to the standard controller-runtime pattern: log := log.FromContext(ctx) followed by log.Info(...) / log.Error(err, ...).

This is a temporary workaround until redpanda-data/common-go#160 lands, after which we can revert back to otelutil/log.