### PR TITLE
operator: Replace zap logger with global ContextFree logger

### DIFF
--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -18,13 +18,12 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/redpanda-data/common-go/license"
+	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -60,7 +59,6 @@ type MulticlusterOptions struct {
 	KubernetesAPIServer    string
 	KubeconfigNamespace    string
 	KubeconfigName         string
-	LogLevel               string
 	BaseImage              string
 	BaseTag                string
 	HealthProbeBindAddress string
@@ -141,23 +139,6 @@ func peerFromFlag(value string) (RaftCluster, error) {
 	}, nil
 }
 
-func parseLogLevel(level string) (zapcore.Level, error) {
-	switch level {
-	case "debug":
-		return zapcore.DebugLevel, nil
-	case "info":
-		return zapcore.InfoLevel, nil
-	case "warn", "warning":
-		return zapcore.WarnLevel, nil
-	case "error":
-		return zapcore.ErrorLevel, nil
-	case "fatal":
-		return zapcore.FatalLevel, nil
-	default:
-		return zapcore.InfoLevel, fmt.Errorf("unknown log level: %s, defaulting to info", level)
-	}
-}
-
 func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Name, "name", "", "raft node name")
 	cmd.Flags().StringVar(&o.Address, "raft-address", "", "raft node address")
@@ -170,7 +151,6 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.KubernetesAPIServer, "kubernetes-api-address", "", "raft kubernetes api server address")
 	cmd.Flags().StringVar(&o.KubeconfigNamespace, "kubeconfig-namespace", "default", "raft kubeconfig namespace")
 	cmd.Flags().StringVar(&o.KubeconfigName, "kubeconfig-name", "multicluster-kubeconfig", "raft kubeconfig name")
-	cmd.Flags().StringVar(&o.LogLevel, "log-level", "info", "log level")
 	cmd.Flags().StringVar(&o.WebhookCertPath, "webhook-cert-path", "", "path on disk to the webhook certificate, implies enabling webhooks")
 	cmd.Flags().StringVar(&o.WebhookKeyPath, "webhook-key-path", "", "path on disk to the webhook certificate key, implies enabling webhooks")
 	cmd.Flags().StringVar(&o.MetricsBindAddress, "metrics-bind-address", "", "address for binding metrics server")
@@ -207,7 +187,7 @@ func Run(
 	ctx context.Context,
 	opts *MulticlusterOptions,
 ) error {
-	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
+	setupLog := log.FromContext(ctx).WithName("setup")
 
 	if err := opts.validate(); err != nil {
 		return err
@@ -233,21 +213,12 @@ func Run(
 		return err
 	}
 
-	// Parse and configure log level
-	logLevel, err := parseLogLevel(opts.LogLevel)
-	if err != nil {
-		setupLog.Error(err, "failed to parse log level, using default")
-	}
-
-	// Create a logger with the specified log level
-	raftLogger := ctrlzap.New(ctrlzap.Level(logLevel)).WithName("raft")
-
 	config := multicluster.RaftConfiguration{
 		Name:                opts.Name,
 		Address:             opts.Address,
 		ElectionTimeout:     opts.ElectionTimeout,
 		HeartbeatInterval:   opts.HeartbeatInterval,
-		Logger:              raftLogger,
+		Logger:              log.FromContext(ctx).WithName(opts.Name),
 		RestConfig:          k8sConfig,
 		Meta:                []byte("node-name=" + opts.Name),
 		Scheme:              controller.MulticlusterScheme,

--- a/pkg/multicluster/raft.go
+++ b/pkg/multicluster/raft.go
@@ -256,7 +256,7 @@ func NewRaftRuntimeManager(config RaftConfiguration) (Manager, error) {
 			}
 			c, err := cluster.New(kubeConfig, func(o *cluster.Options) {
 				o.Scheme = config.Scheme
-				o.Logger = config.Logger
+				o.Logger = config.Logger.WithName("clusterProvider")
 			})
 			if err != nil {
 				return nil, err
@@ -268,7 +268,7 @@ func NewRaftRuntimeManager(config RaftConfiguration) (Manager, error) {
 		if peer.Kubeconfig != nil {
 			c, err := cluster.New(peer.Kubeconfig, func(o *cluster.Options) {
 				o.Scheme = config.Scheme
-				o.Logger = config.Logger
+				o.Logger = config.Logger.WithName("clusterProvider")
 			})
 			if err != nil {
 				return nil, err
@@ -288,7 +288,7 @@ func NewRaftRuntimeManager(config RaftConfiguration) (Manager, error) {
 		ElectionTimeout:   config.ElectionTimeout,
 		HeartbeatInterval: config.HeartbeatInterval,
 		GRPCMaxBackoff:    config.GRPCMaxBackoff,
-		Logger:            &raftLogr{logger: config.Logger},
+		Logger:            &raftLogr{logger: config.Logger.WithName("raft")},
 	}
 
 	if config.Bootstrap {
@@ -403,7 +403,7 @@ func NewRaftRuntimeManager(config RaftConfiguration) (Manager, error) {
 					config.Logger.Info("initializing cluster for peer", "peer", peer.Name)
 					c, err := cluster.New(kubeConfig, func(o *cluster.Options) {
 						o.Scheme = config.Scheme
-						o.Logger = config.Logger
+						o.Logger = config.Logger.WithName("clusterProvider")
 					})
 					if err != nil {
 						config.Logger.Error(err, "initializing cluster for peer", "peer", peer.Name)
@@ -424,7 +424,7 @@ func NewRaftRuntimeManager(config RaftConfiguration) (Manager, error) {
 		}
 	}
 
-	manager, err := newManager(config.Name, config.LocalLeaderElection != nil, config.Logger, restConfig, clusterProvider, broadcaster, func() string {
+	manager, err := newManager(config.Name, config.LocalLeaderElection != nil, config.Logger.WithName("manager"), restConfig, clusterProvider, broadcaster, func() string {
 		return idsToNames[currentLeader.Load()]
 	}, func() map[string]cluster.Cluster {
 		clusters := map[string]cluster.Cluster{}
@@ -492,7 +492,9 @@ func (m *raftManager) Health(req *http.Request) error {
 }
 
 func newManager(localClusterName string, localLeaderElection bool, logger logr.Logger, config *rest.Config, provider multicluster.Provider, broadcaster *restartBroadcaster, getLeader func() string, getClusters func() map[string]cluster.Cluster, addOrReplaceCluster func(ctx context.Context, clusterName string, cl cluster.Cluster) error, manager *leaderelection.LeaderManager, opts manager.Options) (Manager, error) {
-	mgr, err := mcmanager.New(config, provider, opts)
+	optsCopy := opts
+	optsCopy.Logger = opts.Logger.WithName("manager")
+	mgr, err := mcmanager.New(config, provider, optsCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -504,11 +506,11 @@ func newManager(localClusterName string, localLeaderElection bool, logger logr.L
 		return nil
 	})
 
-	runnable := &leaderRunnable{manager: manager, logger: logger, broadcaster: broadcaster, getClusters: getClusters, needsLocalLeaderElection: localLeaderElection}
+	runnable := &leaderRunnable{manager: manager, logger: logger.WithName("leader-runnable"), broadcaster: broadcaster, getClusters: getClusters, needsLocalLeaderElection: localLeaderElection}
 	if err := mgr.Add(runnable); err != nil {
 		return nil, err
 	}
-	return &raftManager{Manager: mgr, manager: manager, runnable: runnable, logger: logger, localClusterName: localClusterName, getLeader: getLeader, getClusters: getClusters, addOrReplaceCluster: addOrReplaceCluster}, nil
+	return &raftManager{Manager: mgr, manager: manager, runnable: runnable, logger: logger.WithName("raft-manager"), localClusterName: localClusterName, getLeader: getLeader, getClusters: getClusters, addOrReplaceCluster: addOrReplaceCluster}, nil
 }
 
 func (m *raftManager) Add(r mcmanager.Runnable) error {


### PR DESCRIPTION
The multicluster command constructed its own ctrlzap.New() logger and passed it to RaftConfiguration.Logger, which forwarded it to the controller-runtime manager via ctrl.Options.Logger.

Because this logger had a non-nil sink, controller-runtime skipped the global logger fallback:

    if options.Logger.GetSink() == nil {
        options.Logger = log.Log  // <-- never reached
    }

The manager then used this raw zap sink to build per-reconciliation loggers in reconcileHandler:

    log := c.LogConstructor(&req)
    ctx = logf.IntoContext(ctx, log)

When reconciler code called otelutil/log.FromContext(ctx), which appends "ctx", ctx to keysAndValues, the zap sink serialized context.Context as the full wrapper chain:

    "ctx":"context.Background.WithCancel.WithCancel.WithValue(logr...)"

The global logger set by main.go via log.SetGlobals(logger.NewLogger()) wraps non-OTEL sinks with ContextFree, which strips context.Context values from keysAndValues before they reach the underlying sink. But the per-command zap logger bypassed SetGlobals entirely, so it never got the ContextFree wrapper.

Fix by replacing the standalone ctrlzap.New() with log.FromContext(ctx), which retrieves the global logger already wrapped with ContextFree. Remove the now-unused --log-level flag and parseLogLevel helper, as log level is already configured globally via the root command's logOptions.