### PR TITLE
Cache kubeconfigs on all raft members and fix race condition with re-engagement

### DIFF
--- a/pkg/multicluster/broadcaster.go
+++ b/pkg/multicluster/broadcaster.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package multicluster
+
+import (
+	"context"
+	"sync"
+)
+
+// restartBroadcaster delivers notifications to multiple concurrent consumers
+// with two guarantees:
+//
+//  1. Fanout: every notify() wakes all goroutines currently waiting, not just
+//     one (close-and-replace gives channel-close broadcast semantics).
+//
+//  2. No missed notifications: if notify() fires while a consumer's fn is
+//     executing, fn will be called again after it returns.
+type restartBroadcaster struct {
+	mu sync.Mutex
+	ch chan struct{}
+}
+
+func newRestartBroadcaster() *restartBroadcaster {
+	return &restartBroadcaster{ch: make(chan struct{})}
+}
+
+// notify wakes all goroutines currently blocked in drainNotifications and
+// replaces the channel so consumers can detect notifications that fired while
+// their fn was executing.
+func (b *restartBroadcaster) notify() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	close(b.ch)
+	b.ch = make(chan struct{})
+}
+
+// channel returns the current channel under the lock so callers get a
+// consistent snapshot.
+func (b *restartBroadcaster) channel() <-chan struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.ch
+}
+
+// drainNotifications runs fn each time b fires. It handles two concerns:
+//
+//   - Fanout: because notify() closes the channel, all goroutines running
+//     drainNotifications for the same broadcaster wake simultaneously.
+//
+//   - No missed notifications: the channel reference is snapshotted before fn
+//     runs. After fn returns, if the reference changed then at least one
+//     notify() fired during fn, so fn is called again immediately. Multiple
+//     concurrent notifies during a single fn execution collapse into one extra
+//     fn call.
+func drainNotifications(ctx context.Context, b *restartBroadcaster, fn func(context.Context)) {
+	ch := b.channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			// Snapshot the channel before fn runs. Any notify() during fn
+			// replaces the channel, making the reference stale.
+			ch = b.channel()
+			fn(ctx)
+			// Drain: if the channel changed while fn was running, a
+			// notification was missed — call fn again and repeat.
+			for next := b.channel(); next != ch; next = b.channel() {
+				ch = next
+				fn(ctx)
+			}
+		}
+	}
+}

--- a/pkg/multicluster/broadcaster_test.go
+++ b/pkg/multicluster/broadcaster_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package multicluster
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+)
+
+// TestDrainNotificationsNoConcurrentMiss verifies that drainNotifications
+// never drops a notification that fires while fn is already executing.
+//
+// The scenario that previously caused a missed engage:
+//
+//  1. Goroutine is waiting on channel ch_A.
+//  2. notify() fires → ch_A closes, ch_B created.
+//  3. Goroutine wakes, snapshots ch = ch_B, calls fn (slow).
+//  4. A second notify() fires while fn is running → ch_B closes, ch_C created.
+//  5. fn returns.
+//  6. Old code: goroutine calls channel() → gets ch_C (open), waits forever.
+//     New code: ch_C != ch_B → goroutine detects the missed notification and
+//     calls fn again before waiting on ch_C.
+//
+// synctest.Wait() is used to advance all goroutines to their next durable
+// blocking point, making the steps above fully deterministic without sleeps.
+func TestDrainNotificationsNoConcurrentMiss(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b := newRestartBroadcaster()
+
+		var count atomic.Int32
+
+		// gate controls when fn returns, simulating a slow doEngage.
+		gate := make(chan struct{})
+		fn := func(_ context.Context) {
+			count.Add(1)
+			<-gate
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		go drainNotifications(ctx, b, fn)
+
+		// Ensure the goroutine has started and is blocked in the select before
+		// we fire any notification. Without this, the goroutine might start
+		// AFTER notify() replaces the channel and miss the first notification.
+		synctest.Wait()
+
+		// ── Step 1: first notify ─────────────────────────────────────────────
+		// The goroutine wakes, snapshots the new channel reference (ch_B), and
+		// calls fn. fn increments count then blocks on <-gate.
+		b.notify()
+		synctest.Wait() // goroutine is now blocked inside fn on <-gate
+
+		if count.Load() != 1 {
+			t.Fatalf("after first notify: expected count=1, got %d", count.Load())
+		}
+
+		// ── Step 2: second notify while fn is still running ──────────────────
+		// The broadcaster closes ch_B and creates ch_C. Because fn has not
+		// returned yet, the goroutine cannot observe this change.
+		b.notify()
+
+		// ── Step 3: release fn ───────────────────────────────────────────────
+		// fn returns. The drain check sees ch_C != ch_B and calls fn again.
+		// fn increments count then blocks on <-gate again.
+		gate <- struct{}{}
+		synctest.Wait() // goroutine is blocked inside the second fn call
+
+		if count.Load() != 2 {
+			t.Fatalf("after second notify: expected count=2, got %d (notification was dropped)", count.Load())
+		}
+
+		// ── Step 4: release the second fn and shut down ──────────────────────
+		gate <- struct{}{}
+		cancel()
+		synctest.Wait() // goroutine exits via ctx.Done()
+	})
+}
+
+// TestDrainNotificationsSingleNotify is a basic sanity check: a single notify
+// calls fn exactly once and the goroutine then waits for the next notification.
+func TestDrainNotificationsSingleNotify(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b := newRestartBroadcaster()
+
+		var count atomic.Int32
+		fn := func(_ context.Context) { count.Add(1) }
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		go drainNotifications(ctx, b, fn)
+		synctest.Wait() // goroutine subscribed and blocking in select
+
+		b.notify()
+		synctest.Wait() // fn ran and goroutine is back waiting for next notify
+
+		if count.Load() != 1 {
+			t.Fatalf("expected count=1, got %d", count.Load())
+		}
+
+		cancel()
+		synctest.Wait()
+	})
+}
+
+// TestDrainNotificationsThreeRapidNotifies verifies that three back-to-back
+// notify() calls issued while fn is blocked result in fn being called at
+// least twice: once for the first notification and at least once more for the
+// concurrent ones (which collapse into a single drain pass since each
+// subsequent notify() replaces the previous replacement channel).
+func TestDrainNotificationsThreeRapidNotifies(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b := newRestartBroadcaster()
+
+		var count atomic.Int32
+		gate := make(chan struct{})
+		fn := func(_ context.Context) {
+			count.Add(1)
+			<-gate
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		go drainNotifications(ctx, b, fn)
+		synctest.Wait() // goroutine subscribed
+
+		// First notify starts fn.
+		b.notify()
+		synctest.Wait() // goroutine blocked on <-gate in fn
+
+		if count.Load() != 1 {
+			t.Fatalf("after first notify: expected count=1, got %d", count.Load())
+		}
+
+		// Two more notifies while fn is blocked. They replace the channel
+		// twice; the third notify's channel is what the drain check will see.
+		// A single drain pass is sufficient to call fn once more.
+		b.notify()
+		b.notify()
+
+		// Release first fn; drain detects missed notifications and re-runs fn.
+		gate <- struct{}{}
+		synctest.Wait() // goroutine blocked on <-gate in drain-pass fn call
+
+		if count.Load() < 2 {
+			t.Fatalf("after two concurrent notifies: expected count>=2, got %d", count.Load())
+		}
+
+		// Release remaining fn calls until the goroutine is back in the select.
+		for {
+			select {
+			case gate <- struct{}{}:
+				synctest.Wait()
+			default:
+				// goroutine is not blocked on gate — drain complete
+				cancel()
+				synctest.Wait()
+				return
+			}
+		}
+	})
+}

--- a/pkg/multicluster/raft.go
+++ b/pkg/multicluster/raft.go
@@ -17,17 +17,22 @@ import (
 	"net/http"
 	"os"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -49,33 +54,105 @@ func stringToHash(s string) uint64 {
 	return h.Sum64()
 }
 
-// restartBroadcaster provides a broadcast notification mechanism.
-// Calling notify() wakes ALL goroutines waiting on channel(), unlike a
-// regular channel send which wakes only one receiver.
-type restartBroadcaster struct {
-	mu sync.Mutex
-	ch chan struct{}
+// kubeconfigCacheSecretName returns the name of the Secret used to cache a
+// peer's kubeconfig in the local cluster.
+func kubeconfigCacheSecretName(kubeconfigName, peerName string) string {
+	return kubeconfigName + "-" + peerName
 }
 
-func newRestartBroadcaster() *restartBroadcaster {
-	return &restartBroadcaster{ch: make(chan struct{})}
+// writeCachedKubeconfig writes kubeconfig bytes as a Secret in the local cluster.
+func writeCachedKubeconfig(ctx context.Context, cl client.Client, name, namespace string, data []byte) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, cl, secret, func() error {
+		secret.Data = map[string][]byte{"kubeconfig.yaml": data}
+		return nil
+	})
+	return err
 }
 
-// notify wakes all goroutines currently blocked on channel().
-func (b *restartBroadcaster) notify() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	close(b.ch)
-	b.ch = make(chan struct{})
+// readCachedKubeconfig reads a previously cached kubeconfig from a local Secret.
+// Returns nil, nil if the Secret does not exist.
+func readCachedKubeconfig(ctx context.Context, cl client.Client, name, namespace string) ([]byte, error) {
+	var secret corev1.Secret
+	if err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret.Data["kubeconfig.yaml"], nil
 }
 
-// channel returns the current broadcast channel. Callers should select on
-// it; when it closes (via notify), they must call channel() again to get
-// the fresh replacement.
-func (b *restartBroadcaster) channel() <-chan struct{} {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.ch
+// startupKubeconfigFetcher is a Runnable that unconditionally fetches kubeconfigs
+// for all bootstrap peers at startup and caches them as Secrets in the local
+// cluster. This ensures the raft leader can recover cached configs on failover
+// without requiring a live gRPC connection to each peer.
+type startupKubeconfigFetcher struct {
+	config     RaftConfiguration
+	raftConfig leaderelection.LockConfiguration
+	client     client.Client
+	logger     logr.Logger
+}
+
+func (s *startupKubeconfigFetcher) Start(ctx context.Context) error {
+	// Collect indices of peers that need bootstrap kubeconfigs cached.
+	pending := []int{}
+	for i, peer := range s.config.Peers {
+		if peer.Name != s.config.Name && peer.KubeconfigFile == "" && peer.Kubeconfig == nil {
+			pending = append(pending, i)
+		}
+	}
+
+	// Retry failed peers until all succeed or the context is cancelled.
+	// This handles the case where a peer's gRPC server isn't ready yet at
+	// startup (e.g., concurrent pod restarts).
+	for len(pending) > 0 {
+		var failed []int
+		for _, i := range pending {
+			peer := s.config.Peers[i]
+			secretName := kubeconfigCacheSecretName(s.config.KubeconfigName, peer.Name)
+			s.logger.Info("startup: fetching kubeconfig for peer", "peer", peer.Name)
+			grpcClient, err := leaderelection.ClientFor(s.raftConfig, s.raftConfig.Peers[i])
+			if err != nil {
+				s.logger.Error(err, "startup: failed to connect to peer", "peer", peer.Name)
+				failed = append(failed, i)
+				continue
+			}
+			response, err := grpcClient.Kubeconfig(ctx, &transportv1.KubeconfigRequest{})
+			if err != nil {
+				s.logger.Error(err, "startup: failed to fetch kubeconfig from peer", "peer", peer.Name)
+				failed = append(failed, i)
+				continue
+			}
+			if err := writeCachedKubeconfig(ctx, s.client, secretName, s.config.KubeconfigNamespace, response.Payload); err != nil {
+				s.logger.Error(err, "startup: failed to cache kubeconfig", "peer", peer.Name)
+				failed = append(failed, i)
+				continue
+			}
+		}
+		pending = failed
+		if len(pending) == 0 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(5 * time.Second):
+		}
+	}
+
+	<-ctx.Done()
+	return nil
+}
+
+// Engage is a no-op; the startup fetcher does not respond to cluster events.
+func (s *startupKubeconfigFetcher) Engage(_ context.Context, _ string, _ cluster.Cluster) error {
+	return nil
 }
 
 // RaftCluster describes a single cluster participating in raft-based
@@ -154,6 +231,11 @@ type RaftConfiguration struct {
 	KubeconfigNamespace string
 	// KubeconfigName is the name of the bootstrap kubeconfig secret.
 	KubeconfigName string
+
+	// Fetcher overrides the kubeconfig fetcher used in bootstrap mode. When
+	// nil, a default fetcher that creates a ServiceAccount and token in the
+	// local cluster is used. Primarily useful for testing.
+	Fetcher leaderelection.KubeconfigFetcher
 
 	// SkipNameValidation allows multiple controllers with the same name,
 	// needed for multicluster run in the same testing process.
@@ -292,20 +374,26 @@ func NewRaftRuntimeManager(config *RaftConfiguration) (Manager, error) {
 		IDsToNames:        idsToNames,
 	}
 
+	var localClient client.Client
 	if config.Bootstrap {
-		raftConfig.Fetcher = leaderelection.KubeconfigFetcherFn(func(ctx context.Context) ([]byte, error) {
-			data, err := bootstrap.CreateRemoteKubeconfig(ctx, &bootstrap.RemoteKubernetesConfiguration{
-				RESTConfig: restConfig,
-				APIServer:  config.KubernetesAPIServer,
-				Namespace:  config.KubeconfigNamespace,
-				Name:       config.KubeconfigName,
-			})
-			if err != nil {
-				return nil, err
-			}
+		var err error
+		localClient, err = client.New(restConfig, client.Options{Scheme: config.Scheme})
+		if err != nil {
+			return nil, err
+		}
 
-			return data, nil
-		})
+		if config.Fetcher != nil {
+			raftConfig.Fetcher = config.Fetcher
+		} else {
+			raftConfig.Fetcher = leaderelection.KubeconfigFetcherFn(func(ctx context.Context) ([]byte, error) {
+				return bootstrap.CreateRemoteKubeconfig(ctx, &bootstrap.RemoteKubernetesConfiguration{
+					RESTConfig: restConfig,
+					APIServer:  config.KubernetesAPIServer,
+					Namespace:  config.KubeconfigNamespace,
+					Name:       config.KubeconfigName,
+				})
+			})
+		}
 	}
 
 	if !config.Insecure && (len(config.ClientTLSOptions) == 0 || len(config.ServerTLSOptions) == 0) {
@@ -379,24 +467,38 @@ func NewRaftRuntimeManager(config *RaftConfiguration) (Manager, error) {
 
 	if config.Bootstrap {
 		for i, peer := range config.Peers {
-			if peer.Name != config.Name && peer.KubeconfigFile == "" {
+			if peer.Name != config.Name && peer.KubeconfigFile == "" && peer.Kubeconfig == nil {
 				config.Logger.Info("registering leader routine", "peer", peer.Name)
 				lockManager.RegisterRoutine(func(ctx context.Context) error {
-					config.Logger.Info("fetching client for peer", "peer", peer.Name)
-					client, err := leaderelection.ClientFor(raftConfig, raftConfig.Peers[i])
+					secretName := kubeconfigCacheSecretName(config.KubeconfigName, peer.Name)
+
+					// Try the local secret cache first so that a new raft leader
+					// can reconnect to peers without requiring a live gRPC call.
+					kubeconfigBytes, err := readCachedKubeconfig(ctx, localClient, secretName, config.KubeconfigNamespace)
 					if err != nil {
-						config.Logger.Error(err, "fetching client for peer", "peer", peer.Name)
-						return err
+						config.Logger.Error(err, "reading cached kubeconfig, falling back to gRPC", "peer", peer.Name)
 					}
-					config.Logger.Info("fetching kubeconfig for peer", "peer", peer.Name)
-					response, err := client.Kubeconfig(ctx, &transportv1.KubeconfigRequest{})
-					if err != nil {
-						config.Logger.Error(err, "fetching kubeconfig for peer", "peer", peer.Name)
-						return err
+
+					if len(kubeconfigBytes) == 0 {
+						config.Logger.Info("no cached kubeconfig, fetching from peer", "peer", peer.Name)
+						grpcClient, err := leaderelection.ClientFor(raftConfig, raftConfig.Peers[i])
+						if err != nil {
+							config.Logger.Error(err, "fetching client for peer", "peer", peer.Name)
+							return err
+						}
+						response, err := grpcClient.Kubeconfig(ctx, &transportv1.KubeconfigRequest{})
+						if err != nil {
+							config.Logger.Error(err, "fetching kubeconfig for peer", "peer", peer.Name)
+							return err
+						}
+						kubeconfigBytes = response.Payload
+						if cacheErr := writeCachedKubeconfig(ctx, localClient, secretName, config.KubeconfigNamespace, kubeconfigBytes); cacheErr != nil {
+							config.Logger.Error(cacheErr, "caching kubeconfig for peer", "peer", peer.Name)
+						}
 					}
 
 					config.Logger.Info("loading kubeconfig for peer", "peer", peer.Name)
-					kubeConfig, err := loadKubeconfigFromBytes(response.Payload)
+					kubeConfig, err := loadKubeconfigFromBytes(kubeconfigBytes)
 					if err != nil {
 						config.Logger.Error(err, "loading kubeconfig for peer", "peer", peer.Name)
 						return err
@@ -444,6 +546,17 @@ func NewRaftRuntimeManager(config *RaftConfiguration) (Manager, error) {
 	}, lockManager, opts)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.Bootstrap {
+		if err := manager.Add(&startupKubeconfigFetcher{
+			config:     config,
+			raftConfig: raftConfig,
+			client:     localClient,
+			logger:     config.Logger,
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	return manager, nil
@@ -593,17 +706,7 @@ func (l *leaderRunnable) wrapStart(doEngage func(context.Context), fn func(conte
 
 		doEngage(cancelCtx)
 
-		go func() {
-			for {
-				ch := l.broadcaster.channel()
-				select {
-				case <-cancelCtx.Done():
-					return
-				case <-ch:
-					doEngage(cancelCtx)
-				}
-			}
-		}()
+		go drainNotifications(cancelCtx, l.broadcaster, doEngage)
 
 		return fn(cancelCtx)
 	}

--- a/pkg/multicluster/raft.go
+++ b/pkg/multicluster/raft.go
@@ -550,7 +550,7 @@ func NewRaftRuntimeManager(config *RaftConfiguration) (Manager, error) {
 
 	if config.Bootstrap {
 		if err := manager.Add(&startupKubeconfigFetcher{
-			config:     config,
+			config:     *config,
 			raftConfig: raftConfig,
 			client:     localClient,
 			logger:     config.Logger,

--- a/pkg/multicluster/raft_bootstrap_test.go
+++ b/pkg/multicluster/raft_bootstrap_test.go
@@ -127,7 +127,7 @@ func setupBootstrapNodes(t *testing.T, ctx context.Context, numNodes int) []*boo
 		require.NoError(t, err)
 
 		rctx, rcancel := context.WithCancel(ctx)
-		mgr, err := multicluster.NewRaftRuntimeManager(multicluster.RaftConfiguration{
+		mgr, err := multicluster.NewRaftRuntimeManager(&multicluster.RaftConfiguration{
 			Name:                clusterName,
 			Address:             peers[i].Address,
 			Peers:               peers,

--- a/pkg/multicluster/raft_bootstrap_test.go
+++ b/pkg/multicluster/raft_bootstrap_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package multicluster_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/redpanda-data/common-go/kube/kubetest"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster/leaderelection"
+	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
+)
+
+// bootstrapNode is a single-replica raft node running in bootstrap mode with a
+// custom kubeconfig fetcher backed by envtest.
+type bootstrapNode struct {
+	name    string
+	mgr     multicluster.Manager
+	tracker *engageTracker
+	cancel  context.CancelFunc
+	done    chan error
+	stopped bool
+	// client is a k8s client for the local envtest cluster, used to read
+	// secrets written by the startup fetcher.
+	client sigs_client.Client
+}
+
+// stop cancels the node's context and waits for it to shut down.
+func (n *bootstrapNode) stop(t *testing.T) {
+	t.Helper()
+	n.cancel()
+	select {
+	case <-n.done:
+	case <-time.After(stopTimeout):
+		t.Fatalf("bootstrap node %s did not stop in time", n.name)
+	}
+	n.stopped = true
+}
+
+// restConfigToKubeconfigBytes serialises a REST config into kubeconfig YAML
+// bytes that loadKubeconfigFromBytes can later parse back into a *rest.Config.
+// Envtest uses client-cert auth, so we embed the cert/key/CA directly.
+func restConfigToKubeconfigBytes(name string, cfg *rest.Config) ([]byte, error) {
+	kc := clientcmdapi.NewConfig()
+	kc.Clusters[name] = &clientcmdapi.Cluster{
+		Server:                   cfg.Host,
+		CertificateAuthorityData: cfg.CAData,
+	}
+	kc.AuthInfos[name] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: cfg.CertData,
+		ClientKeyData:         cfg.KeyData,
+	}
+	kc.Contexts[name] = &clientcmdapi.Context{
+		Cluster:  name,
+		AuthInfo: name,
+	}
+	kc.CurrentContext = name
+	return clientcmd.Write(*kc)
+}
+
+// kubeconfigSecretName mirrors the package-internal naming used for cache
+// secrets: <kubeconfigName>-<peerName>.
+func kubeconfigSecretName(kubeconfigName, peerName string) string {
+	return kubeconfigName + "-" + peerName
+}
+
+// setupBootstrapNodes creates numNodes single-replica envtest instances all
+// wired together via raft in bootstrap mode. Each node uses a custom
+// KubeconfigFetcher that returns its envtest REST config directly (no
+// ServiceAccount/token dance needed in tests). An engageTracker runnable is
+// registered on every node so that we can observe cluster engagement after
+// leader election.
+func setupBootstrapNodes(t *testing.T, ctx context.Context, numNodes int) []*bootstrapNode {
+	t.Helper()
+
+	logger := testr.New(t)
+	ctrllog.SetLogger(logger)
+
+	const (
+		kubeconfigName      = "test-kubeconfig"
+		kubeconfigNamespace = "default"
+	)
+
+	ports := testutil.FreePorts(t, numNodes)
+	peers := make([]multicluster.RaftCluster, numNodes)
+	for i := range numNodes {
+		peers[i] = multicluster.RaftCluster{
+			Name:    fmt.Sprintf("cluster-%d", i),
+			Address: fmt.Sprintf("127.0.0.1:%d", ports[i]),
+		}
+	}
+
+	nodes := make([]*bootstrapNode, numNodes)
+	for i := range numNodes {
+		env := kubetest.NewEnv(t)
+		clusterName := peers[i].Name
+		restCfg := env.RestConfig()
+
+		// The fetcher for this node just serialises its own envtest REST
+		// config. This avoids the SA/token setup that CreateRemoteKubeconfig
+		// normally performs, keeping the test self-contained.
+		fetcher := leaderelection.KubeconfigFetcherFn(func(ctx context.Context) ([]byte, error) {
+			return restConfigToKubeconfigBytes(clusterName, restCfg)
+		})
+
+		cl, err := sigs_client.New(restCfg, sigs_client.Options{Scheme: env.Scheme()})
+		require.NoError(t, err)
+
+		rctx, rcancel := context.WithCancel(ctx)
+		mgr, err := multicluster.NewRaftRuntimeManager(multicluster.RaftConfiguration{
+			Name:                clusterName,
+			Address:             peers[i].Address,
+			Peers:               peers,
+			RestConfig:          restCfg,
+			Scheme:              env.Scheme(),
+			Logger:              logger.WithName(clusterName),
+			Insecure:            true,
+			SkipNameValidation:  true,
+			Bootstrap:           true,
+			Fetcher:             fetcher,
+			KubeconfigName:      kubeconfigName,
+			KubeconfigNamespace: kubeconfigNamespace,
+			ElectionTimeout:     raftElectionTimeout,
+			HeartbeatInterval:   raftHeartbeatInterval,
+			GRPCMaxBackoff:      raftGRPCMaxBackoff,
+		})
+		require.NoError(t, err)
+
+		tracker := newEngageTracker()
+		require.NoError(t, mgr.Add(tracker))
+
+		done := make(chan error, 1)
+		go func() {
+			done <- mgr.Start(rctx)
+			close(done)
+		}()
+
+		nodes[i] = &bootstrapNode{
+			name:    clusterName,
+			mgr:     mgr,
+			tracker: tracker,
+			cancel:  rcancel,
+			done:    done,
+			client:  cl,
+		}
+	}
+
+	t.Cleanup(func() {
+		for _, n := range nodes {
+			n.cancel()
+		}
+		for _, n := range nodes {
+			<-n.done
+		}
+	})
+
+	return nodes
+}
+
+// findBootstrapLeader returns the node whose name equals the current raft
+// leader, or nil if no leader has been elected yet. Stopped nodes are skipped
+// both as reporters and as candidates — a stopped node's manager retains a
+// stale currentLeader atomic and must not be returned as the new leader.
+func findBootstrapLeader(nodes []*bootstrapNode) *bootstrapNode {
+	for _, n := range nodes {
+		if n.stopped {
+			continue
+		}
+		leader := n.mgr.GetLeader()
+		if leader == "" {
+			continue
+		}
+		for _, m := range nodes {
+			if m.stopped {
+				continue
+			}
+			if m.name == leader {
+				return m
+			}
+		}
+	}
+	return nil
+}
+
+// TestIntegrationKubeconfigCaching verifies two properties of the kubeconfig
+// cache introduced to make raft-leader failover resilient:
+//
+//  1. Startup caching: every node's startupKubeconfigFetcher fetches each
+//     peer's kubeconfig via gRPC and stores it as a Secret in the local
+//     cluster, so that a future raft leader on that node can read from the
+//     cache without a live gRPC call.
+//
+//  2. Cache-first failover: when the raft leader crashes (its gRPC transport
+//     is shut down), a newly elected leader can still engage the crashed
+//     cluster by reading from its local cache — without any gRPC connectivity
+//     to the former leader.
+//
+// Setup: 3 envtest instances, 1 replica each, bootstrap mode with a custom
+// fetcher that returns the envtest REST config directly.
+func TestIntegrationKubeconfigCaching(t *testing.T) {
+	testutil.SkipIfNotIntegration(t)
+
+	ctx := testutil.Context(t)
+	nodes := setupBootstrapNodes(t, ctx, 3)
+
+	const (
+		kubeconfigName      = "test-kubeconfig"
+		kubeconfigNamespace = "default"
+	)
+
+	// ── Phase 1: wait for initial raft leader election ───────────────────────
+
+	t.Log("waiting for initial raft leader election...")
+	var leaderNode *bootstrapNode
+	require.Eventually(t, func() bool {
+		leaderNode = findBootstrapLeader(nodes)
+		return leaderNode != nil
+	}, waitTimeout, waitInterval, "raft leader should be elected")
+	t.Logf("initial raft leader: %s", leaderNode.name)
+
+	// ── Phase 2: verify startup caching ──────────────────────────────────────
+	//
+	// Every node's startupKubeconfigFetcher should have written a Secret for
+	// each of its peers. We check all 3 × 2 = 6 expected secrets.
+
+	t.Log("waiting for startup kubeconfig cache to be populated...")
+	for _, node := range nodes {
+		for _, peer := range nodes {
+			if peer.name == node.name {
+				continue
+			}
+			secretName := kubeconfigSecretName(kubeconfigName, peer.name)
+			require.Eventually(t, func() bool {
+				var secret corev1.Secret
+				err := node.client.Get(ctx, types.NamespacedName{
+					Name:      secretName,
+					Namespace: kubeconfigNamespace,
+				}, &secret)
+				if err != nil {
+					return false
+				}
+				return len(secret.Data["kubeconfig.yaml"]) > 0
+			}, waitTimeout, waitInterval,
+				"node %s should have cached kubeconfig secret %s for peer %s",
+				node.name, secretName, peer.name)
+			t.Logf("node %s: kubeconfig secret %s/%s is present", node.name, kubeconfigNamespace, secretName)
+		}
+	}
+
+	// ── Phase 3: kill the raft leader ────────────────────────────────────────
+	//
+	// Stopping the leader node shuts down its gRPC transport. Any subsequent
+	// gRPC Kubeconfig call to that node will fail. A new raft leader must
+	// therefore rely on the locally cached Secret to engage the former
+	// leader's cluster.
+
+	t.Logf("stopping raft leader %s...", leaderNode.name)
+	leaderNode.stop(t)
+	t.Log("leader stopped")
+
+	// ── Phase 4: wait for new raft leader ────────────────────────────────────
+
+	t.Log("waiting for new raft leader election...")
+	var newLeaderNode *bootstrapNode
+	require.Eventually(t, func() bool {
+		newLeaderNode = findBootstrapLeader(nodes)
+		// Must be a different node than the one we stopped.
+		return newLeaderNode != nil && newLeaderNode.name != leaderNode.name
+	}, waitTimeout, waitInterval, "a new raft leader should be elected after the old leader stops")
+	t.Logf("new raft leader: %s", newLeaderNode.name)
+
+	// ── Phase 5: verify the new leader engaged the former leader's cluster ───
+	//
+	// The new leader's bootstrap routine reads the former leader's kubeconfig
+	// from its local Secret cache (written in phase 2). It creates a
+	// cluster.Cluster and calls AddOrReplace, which triggers doEngage on the
+	// registered engageTracker. If the cache was NOT used, the gRPC call
+	// would fail permanently (former leader's gRPC is down) and Engage would
+	// never be called.
+
+	t.Logf("verifying new leader %s engaged former leader's cluster %s via cache...", newLeaderNode.name, leaderNode.name)
+	require.Eventually(t, func() bool {
+		return newLeaderNode.tracker.engageCount(leaderNode.name) > 0
+	}, waitTimeout, waitInterval,
+		"new leader %s should have engaged former leader's cluster %s using the cached kubeconfig",
+		newLeaderNode.name, leaderNode.name)
+
+	t.Logf("new leader %s successfully engaged %s via cached kubeconfig", newLeaderNode.name, leaderNode.name)
+}

--- a/pkg/multicluster/raft_engage_test.go
+++ b/pkg/multicluster/raft_engage_test.go
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-//go:build integration
-
 package multicluster_test
 
 import (
@@ -21,12 +19,12 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
+	"github.com/redpanda-data/common-go/kube"
+	"github.com/redpanda-data/common-go/kube/kubetest"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/redpanda-data/common-go/kube"
-	"github.com/redpanda-data/common-go/kube/kubetest"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )

--- a/pkg/multicluster/raft_test.go
+++ b/pkg/multicluster/raft_test.go
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-//go:build integration
-
 package multicluster_test
 
 import (
@@ -20,11 +18,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
+	"github.com/redpanda-data/common-go/kube/kubetest"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/redpanda-data/common-go/kube/kubetest"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )


### PR DESCRIPTION
~*Note: this a stacked PR which will get rebased against main once its base branch is merged*~

## Problem

**Kubeconfigs only exist in-memory on the raft leader.** When a raft leader is elected it fetches kubeconfigs from all peers via gRPC and holds them in memory. If that leader crashes, the new leader must reach every peer over gRPC before it can manage those clusters. If any peer's operator is also down (common during a rolling incident), the new leader cannot engage that cluster until the downed pod recovers -- a recovery dependency cycle.

## Solution

Every raft member now runs a `startupKubeconfigFetcher` at startup that unconditionally fetches each peer's kubeconfig via gRPC and stores it as a `Secret` in its own local cluster (`<kubeconfigName>-<peerName>`). Failed peers are retried every 5 seconds. When a node becomes raft leader, it reads from the local Secret cache first and only falls back to a live gRPC call if the Secret is absent, writing the result back to the cache on success.

## Additional fixes

### Problem

**Concurrent broadcaster notifications could be silently dropped.** `wrapStart` spawned a goroutine that listened on the broadcaster channel and re-ran `doEngage` on each notification. If two `notify()` calls fired in rapid succession (e.g. two clusters added during the same bootstrap sweep), the second notification could be lost: the goroutine woke on the first close, replaced `ch` with the fresh open channel, ran `doEngage`, then re-read the channel — getting the already-replaced channel from the second `notify()`, which it would wait on indefinitely. One cluster would never be engaged after failover.

### Solution

Extracted `restartBroadcaster` and the notification loop into `broadcaster.go`. The drain loop now snapshots the channel reference *before* calling `fn`. After `fn` returns, if the reference changed (a `notify()` fired during `fn`) it calls `fn` again, repeating until the reference stabilises. This guarantees no notification is dropped regardless of how many concurrent `notify()` calls overlap with an in-flight `fn`.

## Tests

- `broadcaster_test.go` — unit tests using `testing/synctest` to step goroutines deterministically through the concurrent-notification race.
- `TestIntegrationKubeconfigCaching` — three envtest instances in bootstrap mode. Verifies every node writes a kubeconfig Secret for each peer, then kills the raft leader and verifies the new leader engages the former leader's cluster from the local Secret cache alone, with the former leader's gRPC transport offline.