### PR TITLE
Add new schema and topic CRD examples for docs

### DIFF
--- a/acceptance/features/schema-crds.feature
+++ b/acceptance/features/schema-crds.feature
@@ -104,3 +104,131 @@ Feature: Schema CRDs
     """
     And schema "order-event" is successfully synced
     Then I should be able to check compatibility against "order-event" in cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage fully compatible schema (Avro)
+    Given there is no schema "fully-compatible-schema" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+# tag::full-compatibility-schema-manifest[]
+    # This manifest creates an Avro schema named "fully-compatible-schema" in the "basic" cluster.
+    # The schema uses Full compatibility, ensuring backward and forward compatibility across versions.
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: fully-compatible-schema
+      namespace: ${NAMESPACE}
+    spec:
+      cluster:
+        clusterRef:
+          name: basic
+      schemaType: avro
+      compatibilityLevel: Full
+      text: |
+        {
+          "type": "record",
+          "name": "ExampleRecord",
+          "fields": [
+            { "type": "string", "name": "field1" },
+            { "type": "int", "name": "field2" }
+          ]
+        }
+# end::full-compatibility-schema-manifest[]
+    """
+    And schema "fully-compatible-schema" is successfully synced
+    Then I should be able to check compatibility against "fully-compatible-schema" in cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage product schema (Avro)
+    Given there is no schema "product-schema" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    # This manifest creates an Avro schema named "product-schema" in the "basic" cluster.
+    # This schema will be referenced by other schemas to demonstrate schema references.
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: product-schema
+      namespace: ${NAMESPACE}
+    spec:
+      cluster:
+        clusterRef:
+          name: basic
+      schemaType: avro
+      compatibilityLevel: Backward
+      text: |
+        {
+          "type": "record",
+          "name": "Product",
+          "fields": [
+            { "type": "string", "name": "product_id" },
+            { "type": "string", "name": "name" }
+          ]
+        }
+    """
+    And schema "product-schema" is successfully synced
+    Then I should be able to check compatibility against "product-schema" in cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage order schema with references (Avro)
+    Given there is no schema "product-schema" in cluster "basic"
+    And there is no schema "order-schema" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: product-schema
+      namespace: ${NAMESPACE}
+    spec:
+      cluster:
+        clusterRef:
+          name: basic
+      schemaType: avro
+      compatibilityLevel: Backward
+      text: |
+        {
+          "type": "record",
+          "name": "Product",
+          "fields": [
+            { "type": "string", "name": "product_id" },
+            { "type": "string", "name": "name" }
+          ]
+        }
+    """
+    And schema "product-schema" is successfully synced
+    And there is a schema "product-schema" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+# tag::schema-references-manifest[]
+    # This manifest creates an Avro schema named "order-schema" that references another schema.
+    # Schema references enable modular and reusable schema components for complex data structures.
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: order-schema
+      namespace: ${NAMESPACE}
+    spec:
+      cluster:
+        clusterRef:
+          name: basic
+      references:
+        - name: Product
+          subject: product-schema
+          version: 1
+      text: |
+        {
+          "type": "record",
+          "name": "Order",
+          "fields": [
+            { "name": "product", "type": "Product" }
+          ]
+        }
+# end::schema-references-manifest[]
+    """
+    And schema "order-schema" is successfully synced
+    Then I should be able to check compatibility against "order-schema" in cluster "basic"

--- a/acceptance/features/topic-crds.feature
+++ b/acceptance/features/topic-crds.feature
@@ -25,3 +25,55 @@ Feature: Topic CRDs
     """
     And topic "topic1" is successfully synced
     Then I should be able to produce and consume from "topic1" in cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage topic with write caching
+    Given there is no topic "chat-room" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+# tag::write-caching-topic-example[]
+    # This manifest creates a topic called "chat-room" with write caching enabled.
+    # Write caching provides better performance at the expense of durability.
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Topic
+    metadata:
+      name: chat-room
+    spec:
+      cluster:
+        clusterRef:
+          name: basic
+      partitions: 3
+      replicationFactor: 1
+      additionalConfig:
+        write.caching: "true"
+# end::write-caching-topic-example[]
+    """
+    And topic "chat-room" is successfully synced
+    Then I should be able to produce and consume from "chat-room" in cluster "basic"
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Manage topic with cleanup policy
+    Given there is no topic "delete-policy-topic" in cluster "basic"
+    When I apply Kubernetes manifest:
+    """
+# tag::cleanup-policy-topic-example[]
+    # This manifest creates a topic with the cleanup policy set to "delete".
+    # The cleanup policy determines how partition log files are managed when they reach a certain size.
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Topic
+    metadata:
+      name: delete-policy-topic
+    spec:
+      cluster:
+        clusterRef:
+          name: basic
+      partitions: 3
+      replicationFactor: 1
+      additionalConfig:
+        cleanup.policy: "delete"
+# end::cleanup-policy-topic-example[]
+    """
+    And topic "delete-policy-topic" is successfully synced
+    Then I should be able to produce and consume from "delete-policy-topic" in cluster "basic"

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -26,6 +26,7 @@ func init() {
 	framework.RegisterStep(`^I enable "([^"]*)" logging for the "([^"]*)" logger on( vectorized)? cluster "([^"]*)"`, setLogLevelOn)
 
 	// Schema scenario steps
+	framework.RegisterStep(`^there is a schema "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, thereIsASchema)
 	framework.RegisterStep(`^there is no schema "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, thereIsNoSchema)
 	framework.RegisterStep(`^schema "([^"]*)" is successfully synced$`, schemaIsSuccessfullySynced)
 	framework.RegisterStep(`^I should be able to check compatibility against "([^"]*)" in( vectorized)? cluster "([^"]*)"$`, iShouldBeAbleToCheckCompatibilityAgainst)

--- a/acceptance/steps/schemas.go
+++ b/acceptance/steps/schemas.go
@@ -30,6 +30,10 @@ func schemaIsSuccessfullySynced(ctx context.Context, t framework.TestingT, schem
 	})
 }
 
+func thereIsASchema(ctx context.Context, schema, version, cluster string) {
+	versionedClientsForCluster(ctx, version, cluster).ExpectSchema(ctx, schema)
+}
+
 func thereIsNoSchema(ctx context.Context, schema, version, cluster string) {
 	versionedClientsForCluster(ctx, version, cluster).ExpectNoSchema(ctx, schema)
 }


### PR DESCRIPTION
## Summary
Add new test scenarios to feature files that will be referenced by documentation.

### Schema CRD scenarios added:
- Manage fully compatible schema (Avro) - demonstrates Full compatibility level
- Manage product schema (Avro) - prerequisite for schema references example  
- Manage order schema with references (Avro) - demonstrates schema references

### Topic CRD scenarios added:
- Manage topic with write caching - demonstrates `write.caching` configuration
- Manage topic with cleanup policy - demonstrates `cleanup.policy` configuration

## Related PRs
- Docs PR: https://github.com/redpanda-data/docs/pull/1650

## Fixes from CodeRabbit review
- Added prerequisite product-schema before order-schema to ensure referenced schema exists
- Named delete-policy-topic appropriately to match `cleanup.policy: "delete"`

## Test plan
- [ ] Run acceptance tests to ensure new scenarios pass
- [x] Verify feature file tags are properly extracted in docs build