### PR TITLE
StretchCluster / Nodepool related resources (cleanup tests)

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260413-120000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260413-120000.yaml
@@ -1,0 +1,10 @@
+project: operator
+kind: Fixed
+body: |
+  Fixed StretchCluster partial deletion causing cross-cluster resource destruction. When a
+  StretchCluster was deleted from a subset of clusters, the reconciler would destroy resources
+  on surviving clusters and leave the cluster in an unrecoverable state. Added a partial
+  deletion guard that blocks cleanup when the StretchCluster is still active on other clusters,
+  and scoped cross-cluster sync operations (SyncAll, syncBootstrapUser, syncCA) to skip clusters
+  where the StretchCluster is being deleted.
+time: 2026-04-13T12:00:00.000000+02:00

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -260,18 +261,29 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 // findAliveCluster checks whether the StretchCluster exists and is NOT being
 // deleted on any cluster other than localClusterName. Returns the name of the
 // first alive cluster found, or "" if all clusters are deleting.
+//
+// On transient errors (anything other than NotFound) the function assumes the
+// remote cluster is alive and returns its name. This is the safe default —
+// allowing cleanup to proceed when a cluster is unreachable could destroy
+// resources that the surviving cluster still needs.
 func (r *MulticlusterReconciler) findAliveCluster(ctx context.Context, sc *redpandav1alpha2.StretchCluster, localClusterName string) string {
+	l := log.FromContext(ctx).WithName("findAliveCluster")
 	for _, clusterName := range r.Manager.GetClusterNames() {
 		if clusterName == localClusterName || clusterName == "" {
 			continue
 		}
 		remote, err := r.Manager.GetCluster(ctx, clusterName)
 		if err != nil {
-			continue
+			l.Info("cannot reach cluster, assuming alive to block cleanup", "cluster", clusterName, "error", err)
+			return clusterName
 		}
 		remoteSC := &redpandav1alpha2.StretchCluster{}
 		if err := remote.GetClient().Get(ctx, client.ObjectKeyFromObject(sc), remoteSC); err != nil {
-			continue
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			l.Info("cannot fetch StretchCluster from cluster, assuming alive to block cleanup", "cluster", clusterName, "error", err)
+			return clusterName
 		}
 		if remoteSC.DeletionTimestamp.IsZero() {
 			return clusterName

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -154,7 +154,25 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 	// Examine if the object is under deletion
 	if !stretchCluster.ObjectMeta.DeletionTimestamp.IsZero() {
 		l.V(log.TraceLevel).Info("deletion timestamp is not zero. Resources cleanup and remove finalizer")
-		// clean up all dependant resources
+		// Guard: block partial deletion. If the SC is still alive on any other
+		// cluster, refuse to clean up resources — running cleanup here would
+		// destroy resources that the surviving clusters still need, and the
+		// cross-cluster syncers would fight with deletion.
+		// Recovery: remove the finalizer (kubectl patch) then re-apply the SC.
+		if aliveCluster := r.findAliveCluster(ctx, stretchCluster, req.ClusterName); aliveCluster != "" {
+			msg := fmt.Sprintf(
+				"StretchCluster still active on cluster %q — deletion blocked to prevent data loss. "+
+					"Either delete from all clusters, or recover by removing the finalizer and re-applying the StretchCluster.",
+				aliveCluster,
+			)
+			l.Info("blocking partial deletion", "aliveCluster", aliveCluster)
+			state.status.StretchClusterStatus.SetResourcesSynced(
+				statuses.StretchClusterResourcesSyncedReasonError, msg,
+			)
+			return r.syncStatus(ctx, cluster, state, ctrl.Result{RequeueAfter: requeueTimeout}, nil)
+		}
+
+		// All clusters are deleting — safe to proceed with cleanup.
 		if deleted, err := r.LifecycleClient.DeleteAll(ctx, state.cluster); deleted || err != nil {
 			return r.syncStatus(ctx, cluster, state, ctrl.Result{}, err)
 		}
@@ -237,6 +255,29 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 	// we're at the end of reconciliation, so sync back our status
 	l.V(log.TraceLevel).Info("finished normal reconciliation loop")
 	return r.syncStatus(ctx, cluster, state, ctrl.Result{}, nil)
+}
+
+// findAliveCluster checks whether the StretchCluster exists and is NOT being
+// deleted on any cluster other than localClusterName. Returns the name of the
+// first alive cluster found, or "" if all clusters are deleting.
+func (r *MulticlusterReconciler) findAliveCluster(ctx context.Context, sc *redpandav1alpha2.StretchCluster, localClusterName string) string {
+	for _, clusterName := range r.Manager.GetClusterNames() {
+		if clusterName == localClusterName || clusterName == "" {
+			continue
+		}
+		remote, err := r.Manager.GetCluster(ctx, clusterName)
+		if err != nil {
+			continue
+		}
+		remoteSC := &redpandav1alpha2.StretchCluster{}
+		if err := remote.GetClient().Get(ctx, client.ObjectKeyFromObject(sc), remoteSC); err != nil {
+			continue
+		}
+		if remoteSC.DeletionTimestamp.IsZero() {
+			return clusterName
+		}
+	}
+	return ""
 }
 
 // checkSpecConsistency fetches the StretchCluster from every reachable cluster
@@ -464,9 +505,18 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 
 		// Fetch the StretchCluster from this specific cluster to get the correct
 		// UID for the owner reference (UIDs differ across clusters).
+		// Skip clusters where the SC doesn't exist or is being deleted.
 		localSC := &redpandav1alpha2.StretchCluster{}
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sc), localSC); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				logger.V(log.TraceLevel).Info("StretchCluster not found on cluster, skipping bootstrap user sync", "cluster", clusterName)
+				continue
+			}
 			return ctrl.Result{}, errors.Wrapf(err, "fetching StretchCluster from cluster %s for owner reference", clusterName)
+		}
+		if !localSC.DeletionTimestamp.IsZero() {
+			logger.V(log.TraceLevel).Info("StretchCluster is being deleted on cluster, skipping bootstrap user sync", "cluster", clusterName)
+			continue
 		}
 
 		labels := r.LifecycleClient.AddOwnerLabels(state.cluster)
@@ -594,9 +644,18 @@ func (r *MulticlusterReconciler) syncCA(ctx context.Context, state *stretchClust
 			}
 
 			// Fetch the StretchCluster from this cluster for owner reference.
+			// Skip clusters where the SC doesn't exist or is being deleted.
 			localSC := &redpandav1alpha2.StretchCluster{}
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sc), localSC); err != nil {
+				if client.IgnoreNotFound(err) == nil {
+					logger.V(log.TraceLevel).Info("StretchCluster not found on cluster, skipping CA sync", "cluster", clusterName)
+					continue
+				}
 				return ctrl.Result{}, errors.Wrapf(err, "fetching StretchCluster from cluster %s for CA owner reference", clusterName)
+			}
+			if !localSC.DeletionTimestamp.IsZero() {
+				logger.V(log.TraceLevel).Info("StretchCluster is being deleted on cluster, skipping CA sync", "cluster", clusterName)
+				continue
 			}
 
 			caLabels := r.LifecycleClient.AddOwnerLabels(state.cluster)
@@ -1056,9 +1115,12 @@ func (r *MulticlusterReconciler) syncStatus(ctx context.Context, _ cluster.Clust
 			}
 
 			// Fetch the latest version from this cluster to get the correct resource version.
+			// Skip clusters where the SC doesn't exist (e.g. partial deletion).
 			remoteSC := &redpandav1alpha2.StretchCluster{}
 			if clErr := cl.GetClient().Get(ctx, client.ObjectKeyFromObject(state.cluster.StretchCluster), remoteSC); clErr != nil {
-				err = errors.Join(err, errors.Wrapf(clErr, "fetching StretchCluster from cluster %s for status update", clusterName))
+				if client.IgnoreNotFound(clErr) != nil {
+					err = errors.Join(err, errors.Wrapf(clErr, "fetching StretchCluster from cluster %s for status update", clusterName))
+				}
 				continue
 			}
 

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -282,7 +282,7 @@ func (r *MulticlusterReconciler) findAliveCluster(ctx context.Context, sc *redpa
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			l.Info("cannot fetch StretchCluster from cluster, assuming alive to block cleanup", "cluster", clusterName, "error", err)
+			l.Error(err, "cannot fetch StretchCluster from cluster, assuming alive to block cleanup", "cluster", clusterName)
 			return clusterName
 		}
 		if remoteSC.DeletionTimestamp.IsZero() {

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -520,16 +520,17 @@ func (r *ResourceClient[T, U]) DeleteAll(ctx context.Context, owner U) (bool, er
 		}
 
 		// Check whether the owner exists and is being deleted on this cluster.
-		// Skip clusters where the owner is alive and healthy.
+		// Skip clusters where the owner is alive and healthy. If the owner is
+		// NotFound (e.g. force-deleted with finalizer stripped), proceed with
+		// cleanup to avoid leaking orphaned resources.
 		resolvedOwner, err := r.ownershipResolver.ResolveOwnerReference(ctx, owner, clusterName, ctl)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
+				deleteErr = errors.Join(deleteErr, err)
 				continue
 			}
-			deleteErr = errors.Join(deleteErr, err)
-			continue
-		}
-		if resolvedOwner.GetDeletionTimestamp().IsZero() {
+			// Owner gone — fall through to clean up orphaned resources.
+		} else if resolvedOwner.GetDeletionTimestamp().IsZero() {
 			continue
 		}
 

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -274,7 +274,8 @@ func (r *ResourceClient[T, U]) syncer(ctx context.Context, owner U, clusterName 
 }
 
 // SyncAll synchronizes the simple resources associated with the given cluster,
-// cleaning up any resources that should no longer exist.
+// cleaning up any resources that should no longer exist. It skips clusters
+// where the owner is being deleted or does not exist.
 func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 	var syncErr error
 	logger := log.FromContext(ctx).WithName("SyncAll")
@@ -289,6 +290,16 @@ func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 			"ownerName", owner.GetName(),
 			"ownerUID", owner.GetUID(),
 			"ownerGroupVersionKind", owner.GetObjectKind().GroupVersionKind().String())
+
+		// Skip clusters where the owner is being deleted — the deletion
+		// reconciler handles cleanup there independently.
+		if deleting, err := r.isOwnerDeleting(ctx, owner, clusterName); err != nil {
+			return err
+		} else if deleting {
+			logger.V(log.TraceLevel).Info("owner is being deleted on cluster, skipping sync", "clusterName", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName))
+			continue
+		}
+
 		syncer, err := r.syncer(ctx, owner, clusterName)
 		if err != nil {
 			return err
@@ -300,6 +311,23 @@ func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 		syncErr = errors.Join(syncErr, err)
 	}
 	return syncErr
+}
+
+// isOwnerDeleting checks if the owner resource is being deleted on a given cluster.
+// Returns true if the owner is being deleted or does not exist.
+func (r *ResourceClient[T, U]) isOwnerDeleting(ctx context.Context, owner U, clusterName string) (bool, error) {
+	ctl, err := r.ctl(ctx, clusterName)
+	if err != nil {
+		return false, err
+	}
+	resolved, err := r.ownershipResolver.ResolveOwnerReference(ctx, owner, clusterName, ctl)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return !resolved.GetDeletionTimestamp().IsZero(), nil
 }
 
 // FetchExistingAndDesiredPools fetches the existing and desired node pools for a given cluster, returning
@@ -479,11 +507,32 @@ func (r *ResourceClient[T, U]) WatchResources(builder Builder, cluster client.Ob
 }
 
 // DeleteAll deletes all resources owned by the given cluster, including node pools.
+// It only cleans up resources on clusters where the owner is being deleted or no
+// longer exists, leaving resources on healthy clusters untouched.
 func (r *ResourceClient[T, U]) DeleteAll(ctx context.Context, owner U) (bool, error) {
 	allDeleted := true
 
 	var deleteErr error
 	for _, clusterName := range r.clusterList(owner) {
+		ctl, err := r.ctl(ctx, clusterName)
+		if err != nil {
+			return false, err
+		}
+
+		// Check whether the owner exists and is being deleted on this cluster.
+		// Skip clusters where the owner is alive and healthy.
+		resolvedOwner, err := r.ownershipResolver.ResolveOwnerReference(ctx, owner, clusterName, ctl)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			deleteErr = errors.Join(deleteErr, err)
+			continue
+		}
+		if resolvedOwner.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+
 		var clusterResourcesDeleted bool
 		syncer, err := r.syncer(ctx, owner, clusterName)
 		if err != nil {
@@ -493,11 +542,6 @@ func (r *ResourceClient[T, U]) DeleteAll(ctx context.Context, owner U) (bool, er
 			if err != nil {
 				deleteErr = errors.Join(deleteErr, err)
 			}
-		}
-
-		ctl, err := r.ctl(ctx, clusterName)
-		if err != nil {
-			return false, err
 		}
 
 		pools, err := r.fetchExistingPools(ctx, owner, clusterName)

--- a/operator/internal/lifecycle/client_test.go
+++ b/operator/internal/lifecycle/client_test.go
@@ -331,6 +331,11 @@ func TestClientDeleteAll(t *testing.T) {
 				require.NoError(t, instances.k8sClient.Create(ctx, resource))
 			}
 
+			// Mark the cluster as deleting — DeleteAll only cleans up clusters
+			// where the owner has a DeletionTimestamp set.
+			now := metav1.Now()
+			cluster.DeletionTimestamp = &now
+
 			deleted, err := instances.resourceClient.DeleteAll(ctx, cluster)
 			require.NoError(t, err)
 			require.Equal(t, tt.HasDeleteableResources(), deleted)

--- a/operator/pkg/client/stretch_cluster_test.go
+++ b/operator/pkg/client/stretch_cluster_test.go
@@ -510,81 +510,57 @@ func (s *StretchClusterFactorySuite) TestResourceCleanup() {
 	})
 
 	t.Run("PartialStretchClusterDeletion", func(t *testing.T) {
-		// Delete the StretchCluster from clusters 1 and 2 only (keep on cluster 0).
-		// This simulates an accidental partial deletion and exposes reconciler bugs.
-		for i := 1; i <= 2; i++ {
-			scToDelete := &redpandav1alpha2.StretchCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nn.Name,
-					Namespace: nn.Namespace,
-				},
-			}
-			require.NoError(t, s.mc.Envs[i].Client().Delete(ctx, scToDelete))
-		}
-
-		// The StretchCluster on cluster 0 still exists. The reconciler's
-		// checkSpecConsistency will fail because it can't fetch the SC from
-		// clusters 1 and 2 (NotFound). Verify the cluster is no longer Stable.
-		require.Eventually(t, func() bool {
-			var cluster redpandav1alpha2.StretchCluster
-			if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
-				return false
-			}
-			cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterStable)
-			if cond != nil && cond.Status == metav1.ConditionTrue {
-				return false
-			}
-			return true
-		}, 2*time.Minute, 5*time.Second, "reconciler did not detect partial StretchCluster deletion")
-
-		// Verify the SCs on clusters 1 and 2 are fully deleted (finalizers removed).
-		// Known bug: the deletion cleanup path iterates ALL clusters (including
-		// cluster 0 where the SC still exists), destroying resources that should
-		// be kept. The SC finalizer may also get stuck due to raft peer issues.
-		for i := 1; i <= 2; i++ {
-			env := s.mc.Envs[i]
-			require.Eventually(t, func() bool {
-				var list redpandav1alpha2.StretchClusterList
-				if err := env.Client().List(ctx, &list, client.InNamespace(ns)); err != nil {
-					return false
-				}
-				for _, item := range list.Items {
-					if item.Name == nn.Name {
-						return false
-					}
-				}
-				return true
-			}, 2*time.Minute, 1*time.Second, "StretchCluster on cluster %d was not fully deleted", i)
-		}
-
-		// Restore: re-apply the StretchCluster to all clusters so the
-		// FullDeletion subtest can clean up properly.
-		s.mc.ApplyAll(t, ctx, &redpandav1alpha2.StretchCluster{
+		// Delete the StretchCluster from cluster 1 only (keep on clusters 0 and 2).
+		// The partial deletion guard should block cleanup and preserve resources.
+		scToDelete := &redpandav1alpha2.StretchCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nn.Name,
 				Namespace: nn.Namespace,
 			},
-			Spec: redpandav1alpha2.StretchClusterSpec{
-				Networking: &redpandav1alpha2.Networking{
-					CrossClusterMode: ptr.To(redpandav1alpha2.CrossClusterModeFlat),
-				},
-				External: &redpandav1alpha2.External{
-					Enabled: ptr.To(false),
-				},
-			},
-		})
+		}
+		require.NoError(t, s.mc.Envs[1].Client().Delete(ctx, scToDelete))
 
-		// Wait for the reconciler to recover (Stable=True).
-		// Known bug: recovery after partial deletion + re-creation fails because
-		// the reconciler gets stuck on stale state / empty cluster name "".
+		// The guard should block deletion — the SC stays in Terminating state
+		// with its finalizer intact. Verify via ResourcesSynced condition.
+		require.Eventually(t, func() bool {
+			var sc redpandav1alpha2.StretchCluster
+			if err := s.mc.Envs[1].Client().Get(ctx, nn, &sc); err != nil {
+				return false
+			}
+			if sc.DeletionTimestamp.IsZero() {
+				return false
+			}
+			cond := apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterResourcesSynced)
+			if cond == nil {
+				return false
+			}
+			t.Logf("ResourcesSynced on cluster 1: status=%s reason=%s msg=%s", cond.Status, cond.Reason, cond.Message)
+			return cond.Status == metav1.ConditionFalse
+		}, 2*time.Minute, 5*time.Second, "partial deletion guard did not activate on cluster 1")
+
+		// The SC on cluster 1 should still have its finalizer (deletion blocked).
+		var guardedSC redpandav1alpha2.StretchCluster
+		require.NoError(t, s.mc.Envs[1].Client().Get(ctx, nn, &guardedSC))
+		require.True(t, slices.Contains(guardedSC.Finalizers, redpandacontrollers.FinalizerKey),
+			"finalizer should be preserved by the partial deletion guard")
+
+		// Resources on cluster 1 should still exist (no cleanup ran).
+		stsCount := s.countOwnedResourcesAcrossClusters(t, ctx, &appsv1.StatefulSetList{}, ownerLabels)
+		require.GreaterOrEqual(t, stsCount, 2, "StatefulSets should be preserved during guarded partial deletion")
+
+		// The surviving cluster should remain healthy while the guard holds.
 		require.Eventually(t, func() bool {
 			var cluster redpandav1alpha2.StretchCluster
 			if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
 				return false
 			}
-			cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterStable)
-			return cond != nil && cond.Status == metav1.ConditionTrue
-		}, 3*time.Minute, 5*time.Second, "reconciler did not recover after restoring StretchCluster")
+			for _, pool := range cluster.Status.NodePools {
+				if pool.ReadyReplicas > 0 {
+					return true
+				}
+			}
+			return false
+		}, 1*time.Minute, 5*time.Second, "surviving cluster lost all healthy brokers during guarded partial deletion")
 	})
 
 	t.Run("FullDeletion", func(t *testing.T) {
@@ -593,14 +569,21 @@ func (s *StretchClusterFactorySuite) TestResourceCleanup() {
 		// Delete the StretchCluster from all clusters.
 		s.mc.DeleteAll(t, ctx, ns, &redpandav1alpha2.StretchCluster{})
 
-		// Wait for the StretchCluster to be fully deleted (finalizer removed).
-		require.Eventually(t, func() bool {
-			var list redpandav1alpha2.StretchClusterList
-			if err := s.mc.Envs[0].Client().List(ctx, &list, client.InNamespace(ns)); err != nil {
-				return false
-			}
-			return len(list.Items) == 0
-		}, 3*time.Minute, 1*time.Second, "StretchCluster was not fully deleted")
+		// Wait for the StretchCluster to be fully deleted on all clusters.
+		// The SC on cluster 1 was already Terminating (from partial deletion);
+		// once clusters 0 and 2 also start deleting, the guard passes and
+		// cleanup proceeds on all clusters.
+		for i, env := range s.mc.Envs {
+			env := env
+			i := i
+			require.Eventually(t, func() bool {
+				var list redpandav1alpha2.StretchClusterList
+				if err := env.Client().List(ctx, &list, client.InNamespace(ns)); err != nil {
+					return false
+				}
+				return len(list.Items) == 0
+			}, 3*time.Minute, 1*time.Second, "StretchCluster was not fully deleted on cluster %d", i)
+		}
 
 		// Verify ALL owned StatefulSets are deleted across all clusters.
 		require.Eventually(t, func() bool {

--- a/operator/pkg/client/stretch_cluster_test.go
+++ b/operator/pkg/client/stretch_cluster_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/franz-go/pkg/kadm"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,29 +54,17 @@ func TestMulticlusterStretchClusterFactory(t *testing.T) {
 type StretchClusterFactorySuite struct {
 	suite.Suite
 
-	ctx           context.Context
 	mc            *testenv.MulticlusterEnv
 	factory       *internalclient.Factory
 	redpandaImage lifecycle.Image
 	sidecarImage  lifecycle.Image
 }
 
-var (
-	_ suite.SetupAllSuite  = (*StretchClusterFactorySuite)(nil)
-	_ suite.SetupTestSuite = (*StretchClusterFactorySuite)(nil)
-)
-
-func (s *StretchClusterFactorySuite) SetupTest() {
-	prev := s.ctx
-	s.ctx = trace.Test(s.T())
-	s.T().Cleanup(func() {
-		s.ctx = prev
-	})
-}
+var _ suite.SetupAllSuite = (*StretchClusterFactorySuite)(nil)
 
 func (s *StretchClusterFactorySuite) SetupSuite() {
 	t := s.T()
-	s.ctx = trace.Test(t)
+	ctx := trace.Test(t)
 
 	cloudSecrets := lifecycle.CloudSecretsFlags{CloudSecretsEnabled: false}
 	s.redpandaImage = lifecycle.Image{
@@ -91,13 +82,14 @@ func (s *StretchClusterFactorySuite) SetupSuite() {
 	// SetupFn) and the test's factory. Since NewMulticluster hasn't returned
 	// yet when SetupFn runs, we capture the pointer and set it after.
 	var mc *testenv.MulticlusterEnv
-	s.mc = testenv.NewMulticluster(t, s.ctx, testenv.MulticlusterOptions{
+	s.mc = testenv.NewMulticluster(t, ctx, testenv.MulticlusterOptions{
 		Name:               "sc-factory",
 		ClusterSize:        3,
 		Scheme:             controller.MulticlusterScheme,
 		CRDs:               crds.All(),
 		Namespace:          "sc-factory",
-		Logger:             log.FromContext(s.ctx),
+		Logger:             log.FromContext(ctx),
+		WatchAllNamespaces: true,
 		InstallCertManager: true,
 		ImportImages: []string{
 			redpandaImage.Repository + ":" + redpandaImage.Tag,
@@ -115,7 +107,7 @@ func (s *StretchClusterFactorySuite) SetupSuite() {
 					return mc.DialContext(ctx, network, address)
 				},
 			)
-			return redpandacontrollers.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory)
+			return redpandacontrollers.SetupMulticlusterController(ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory)
 		},
 	})
 	mc = s.mc
@@ -124,9 +116,70 @@ func (s *StretchClusterFactorySuite) SetupSuite() {
 	s.factory = internalclient.NewFactory(mgr, nil).WithDialer(s.mc.DialContext)
 }
 
+// applyNodePools creates one NodePool per cluster referencing the given StretchCluster.
+func (s *StretchClusterFactorySuite) applyNodePools(t *testing.T, ctx context.Context, scName, ns, poolPrefix string) {
+	t.Helper()
+	for i, env := range s.mc.Envs {
+		pool := &redpandav1alpha2.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", poolPrefix, i),
+				Namespace: ns,
+			},
+			Spec: redpandav1alpha2.NodePoolSpec{
+				EmbeddedNodePoolSpec: redpandav1alpha2.EmbeddedNodePoolSpec{
+					Replicas: ptr.To(int32(1)),
+				},
+				ClusterRef: redpandav1alpha2.ClusterRef{
+					Name:  scName,
+					Group: ptr.To("cluster.redpanda.com"),
+					Kind:  ptr.To("StretchCluster"),
+				},
+			},
+		}
+
+		gvk, err := env.Client().GroupVersionKindFor(pool)
+		require.NoError(t, err)
+		pool.GetObjectKind().SetGroupVersionKind(gvk)
+		pool.SetManagedFields(nil)
+		require.NoError(t, env.Client().Patch(ctx, pool, client.Apply, client.ForceOwnership, client.FieldOwner("tests"))) //nolint:staticcheck // TODO
+	}
+}
+
+// waitForFinalizer waits until the StretchCluster has the operator finalizer.
+func (s *StretchClusterFactorySuite) waitForFinalizer(t *testing.T, ctx context.Context, nn types.NamespacedName) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var cluster redpandav1alpha2.StretchCluster
+		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
+			return false
+		}
+		return slices.Contains(cluster.Finalizers, redpandacontrollers.FinalizerKey)
+	}, 2*time.Minute, 1*time.Second, "StretchCluster never received finalizer")
+}
+
+// waitForBrokerReady waits until at least one broker has ReadyReplicas > 0.
+func (s *StretchClusterFactorySuite) waitForBrokerReady(t *testing.T, ctx context.Context, nn types.NamespacedName) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var cluster redpandav1alpha2.StretchCluster
+		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
+			return false
+		}
+		for _, pool := range cluster.Status.NodePools {
+			if pool.ReadyReplicas > 0 {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Minute, 5*time.Second, "no brokers became ready")
+}
+
 func (s *StretchClusterFactorySuite) TestFactoryClients() {
 	t := s.T()
-	ns := "sc-factory"
+	t.Parallel()
+	ctx := trace.Test(t)
+	tn := s.mc.CreateTestNamespace(t)
+	ns := tn.Name
 	nn := types.NamespacedName{Name: "factory-test", Namespace: ns}
 
 	// Deploy a StretchCluster with flat networking across all clusters.
@@ -141,65 +194,18 @@ func (s *StretchClusterFactorySuite) TestFactoryClients() {
 			},
 		},
 	}
-	s.mc.ApplyAll(t, s.ctx, sc)
+	s.mc.ApplyAll(t, ctx, sc)
 
-	// Deploy NodePools on each cluster.
-	for i, env := range s.mc.Envs {
-		pool := &redpandav1alpha2.NodePool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("pool-%d", i),
-				Namespace: ns,
-			},
-			Spec: redpandav1alpha2.NodePoolSpec{
-				EmbeddedNodePoolSpec: redpandav1alpha2.EmbeddedNodePoolSpec{
-					Replicas: ptr.To(int32(1)),
-				},
-				ClusterRef: redpandav1alpha2.ClusterRef{
-					Name:  nn.Name,
-					Group: ptr.To("cluster.redpanda.com"),
-					Kind:  ptr.To("StretchCluster"),
-				},
-			},
-		}
-
-		gvk, err := env.Client().GroupVersionKindFor(pool)
-		require.NoError(t, err)
-		pool.GetObjectKind().SetGroupVersionKind(gvk)
-		pool.SetManagedFields(nil)
-		require.NoError(t, env.Client().Patch(s.ctx, pool, client.Apply, client.ForceOwnership, client.FieldOwner("tests"))) //nolint:staticcheck // TODO
-	}
-
-	// Wait for the reconciler to process the cluster (finalizer present).
-	require.Eventually(t, func() bool {
-		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
-			return false
-		}
-		return slices.Contains(cluster.Finalizers, redpandacontrollers.FinalizerKey)
-	}, 2*time.Minute, 1*time.Second, "StretchCluster never received finalizer")
-
-	// Wait for at least one broker to become ready.
-	// In flat network mode, the controller manages EndpointSlices for remote
-	// per-pod Services, so brokers can discover each other without manual fixup.
-	require.Eventually(t, func() bool {
-		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
-			return false
-		}
-		for _, pool := range cluster.Status.NodePools {
-			if pool.ReadyReplicas > 0 {
-				return true
-			}
-		}
-		return false
-	}, 5*time.Minute, 5*time.Second, "no brokers became ready")
+	s.applyNodePools(t, ctx, nn.Name, ns, "pool")
+	s.waitForFinalizer(t, ctx, nn)
+	s.waitForBrokerReady(t, ctx, nn)
 
 	// Re-fetch the StretchCluster for the factory.
-	require.NoError(t, s.mc.Envs[0].Client().Get(s.ctx, nn, sc))
+	require.NoError(t, s.mc.Envs[0].Client().Get(ctx, nn, sc))
 
 	t.Run("AdminClient", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			adminClient, err := s.factory.RedpandaAdminClient(s.ctx, sc)
+			adminClient, err := s.factory.RedpandaAdminClient(ctx, sc)
 			if err != nil {
 				t.Logf("AdminClient error (will retry): %v", err)
 				return false
@@ -225,7 +231,7 @@ func (s *StretchClusterFactorySuite) TestFactoryClients() {
 
 	t.Run("KafkaClient", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			kafkaClient, err := s.factory.KafkaClient(s.ctx, sc)
+			kafkaClient, err := s.factory.KafkaClient(ctx, sc)
 			if err != nil {
 				t.Logf("KafkaClient error (will retry): %v", err)
 				return false
@@ -243,7 +249,7 @@ func (s *StretchClusterFactorySuite) TestFactoryClients() {
 
 	t.Run("SchemaRegistryClient", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			srClient, err := s.factory.SchemaRegistryClient(s.ctx, sc)
+			srClient, err := s.factory.SchemaRegistryClient(ctx, sc)
 			if err != nil {
 				t.Logf("SchemaRegistryClient error (will retry): %v", err)
 				return false
@@ -260,11 +266,15 @@ func (s *StretchClusterFactorySuite) TestFactoryClients() {
 
 func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 	t := s.T()
-	ns := "sc-factory"
+	t.Parallel()
+	ctx := trace.Test(t)
+	tn := s.mc.CreateTestNamespace(t)
+	ns := tn.Name
 	nn := types.NamespacedName{Name: "config-sync", Namespace: ns}
 
 	// Deploy a StretchCluster with SASL auth, initial cluster config, and
-	// the restart-on-config-change annotation.
+	// the restart-on-config-change annotation. External disabled to avoid
+	// NodePort collisions with parallel tests.
 	sc := &redpandav1alpha2.StretchCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nn.Name,
@@ -276,6 +286,9 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 		Spec: redpandav1alpha2.StretchClusterSpec{
 			Networking: &redpandav1alpha2.Networking{
 				CrossClusterMode: ptr.To(redpandav1alpha2.CrossClusterModeFlat),
+			},
+			External: &redpandav1alpha2.External{
+				Enabled: ptr.To(false),
 			},
 			RBAC: &redpandav1alpha2.RBAC{
 				Enabled: ptr.To(true),
@@ -296,61 +309,16 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 			},
 		},
 	}
-	s.mc.ApplyAll(t, s.ctx, sc)
+	s.mc.ApplyAll(t, ctx, sc)
 
-	// Deploy NodePools on each cluster.
-	for i, env := range s.mc.Envs {
-		pool := &redpandav1alpha2.NodePool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("cfg-pool-%d", i),
-				Namespace: ns,
-			},
-			Spec: redpandav1alpha2.NodePoolSpec{
-				EmbeddedNodePoolSpec: redpandav1alpha2.EmbeddedNodePoolSpec{
-					Replicas: ptr.To(int32(1)),
-				},
-				ClusterRef: redpandav1alpha2.ClusterRef{
-					Name:  nn.Name,
-					Group: ptr.To("cluster.redpanda.com"),
-					Kind:  ptr.To("StretchCluster"),
-				},
-			},
-		}
-
-		gvk, err := env.Client().GroupVersionKindFor(pool)
-		require.NoError(t, err)
-		pool.GetObjectKind().SetGroupVersionKind(gvk)
-		pool.SetManagedFields(nil)
-		require.NoError(t, env.Client().Patch(s.ctx, pool, client.Apply, client.ForceOwnership, client.FieldOwner("tests"))) //nolint:staticcheck // TODO
-	}
-
-	// Wait for the reconciler to process (finalizer present).
-	require.Eventually(t, func() bool {
-		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
-			return false
-		}
-		return slices.Contains(cluster.Finalizers, redpandacontrollers.FinalizerKey)
-	}, 2*time.Minute, 1*time.Second, "StretchCluster never received finalizer")
-
-	// Wait for at least one broker to become ready.
-	require.Eventually(t, func() bool {
-		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
-			return false
-		}
-		for _, pool := range cluster.Status.NodePools {
-			if pool.ReadyReplicas > 0 {
-				return true
-			}
-		}
-		return false
-	}, 5*time.Minute, 5*time.Second, "no brokers became ready")
+	s.applyNodePools(t, ctx, nn.Name, ns, "cfg-pool")
+	s.waitForFinalizer(t, ctx, nn)
+	s.waitForBrokerReady(t, ctx, nn)
 
 	// Wait for ConfigurationApplied=True.
 	require.Eventually(t, func() bool {
 		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
+		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
 			return false
 		}
 		cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterConfigurationApplied)
@@ -360,7 +328,7 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 	// Wait for Stable=True.
 	require.Eventually(t, func() bool {
 		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
+		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
 			return false
 		}
 		cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterStable)
@@ -371,7 +339,7 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 	var initialConfigVersion string
 	{
 		var cluster redpandav1alpha2.StretchCluster
-		require.NoError(t, s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster))
+		require.NoError(t, s.mc.Envs[0].Client().Get(ctx, nn, &cluster))
 		initialConfigVersion = cluster.Status.ConfigVersion
 	}
 	require.NotEmpty(t, initialConfigVersion, "expected non-empty initial config version")
@@ -389,6 +357,9 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 		Spec: redpandav1alpha2.StretchClusterSpec{
 			Networking: &redpandav1alpha2.Networking{
 				CrossClusterMode: ptr.To(redpandav1alpha2.CrossClusterModeFlat),
+			},
+			External: &redpandav1alpha2.External{
+				Enabled: ptr.To(false),
 			},
 			RBAC: &redpandav1alpha2.RBAC{
 				Enabled: ptr.To(true),
@@ -409,12 +380,12 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 			},
 		},
 	}
-	s.mc.ApplyAll(t, s.ctx, mutatedSC)
+	s.mc.ApplyAll(t, ctx, mutatedSC)
 
 	// Verify ConfigurationApplied returns to True and the config version changed.
 	require.Eventually(t, func() bool {
 		var cluster redpandav1alpha2.StretchCluster
-		if err := s.mc.Envs[0].Client().Get(s.ctx, nn, &cluster); err != nil {
+		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
 			return false
 		}
 		cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterConfigurationApplied)
@@ -423,17 +394,282 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 		}
 		return cluster.Status.ConfigVersion != "" && cluster.Status.ConfigVersion != initialConfigVersion
 	}, 3*time.Minute, 5*time.Second, "ConfigurationApplied=True with new config version never appeared after config change")
+}
 
-	// Clean up to avoid resource conflicts with other tests in the suite.
-	s.mc.DeleteAll(t, s.ctx, ns, &redpandav1alpha2.NodePool{})
-	s.mc.DeleteAll(t, s.ctx, ns, &redpandav1alpha2.StretchCluster{})
+// TestResourceCleanup verifies that owned resources are properly cleaned up
+// after NodePool and StretchCluster deletion. It creates a StretchCluster with
+// 3 NodePools, waits for the cluster to become healthy, then runs sequential
+// subtests that exercise different deletion scenarios.
+func (s *StretchClusterFactorySuite) TestResourceCleanup() {
+	t := s.T()
+	t.Parallel()
+	ctx := trace.Test(t)
+	tn := s.mc.CreateTestNamespace(t)
+	ns := tn.Name
+	nn := types.NamespacedName{Name: "cleanup-test", Namespace: ns}
 
-	// Wait for the StretchCluster to be fully deleted (finalizer removed).
+	ownerLabels := client.MatchingLabels{
+		"cluster.redpanda.com/namespace": ns,
+		"cluster.redpanda.com/owner":     nn.Name,
+	}
+
+	// Deploy a StretchCluster with flat networking across all clusters.
+	// External access is explicitly disabled to avoid NodePort collisions
+	// with parallel tests.
+	sc := &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		Spec: redpandav1alpha2.StretchClusterSpec{
+			Networking: &redpandav1alpha2.Networking{
+				CrossClusterMode: ptr.To(redpandav1alpha2.CrossClusterModeFlat),
+			},
+			External: &redpandav1alpha2.External{
+				Enabled: ptr.To(false),
+			},
+		},
+	}
+	s.mc.ApplyAll(t, ctx, sc)
+
+	s.applyNodePools(t, ctx, nn.Name, ns, "cleanup-pool")
+	s.waitForFinalizer(t, ctx, nn)
+
+	// Wait for all 3 brokers to become ready.
 	require.Eventually(t, func() bool {
-		var list redpandav1alpha2.StretchClusterList
-		if err := s.mc.Envs[0].Client().List(s.ctx, &list, client.InNamespace(ns)); err != nil {
+		var cluster redpandav1alpha2.StretchCluster
+		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
 			return false
 		}
-		return len(list.Items) == 0
-	}, 2*time.Minute, 1*time.Second, "StretchCluster was not fully deleted")
+		readyCount := int32(0)
+		for _, pool := range cluster.Status.NodePools {
+			readyCount += pool.ReadyReplicas
+		}
+		return readyCount >= 3
+	}, 5*time.Minute, 5*time.Second, "not all brokers became ready")
+
+	// Verify that owned resources exist before we start deleting.
+	stsCounts := s.countOwnedResourcesAcrossClusters(t, ctx, &appsv1.StatefulSetList{}, ownerLabels)
+	require.Equal(t, 3, stsCounts, "expected 3 StatefulSets (one per NodePool) before cleanup")
+
+	svcCounts := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.ServiceList{}, ownerLabels, client.InNamespace(ns))
+	require.Greater(t, svcCounts, 0, "expected Services to exist before cleanup")
+
+	cmCounts := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.ConfigMapList{}, ownerLabels, client.InNamespace(ns))
+	require.Greater(t, cmCounts, 0, "expected ConfigMaps to exist before cleanup")
+
+	t.Run("SingleNodePoolDeletion", func(t *testing.T) {
+		// Delete the NodePool from cluster 2 only.
+		poolToDelete := "cleanup-pool-2"
+		pool := &redpandav1alpha2.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      poolToDelete,
+				Namespace: ns,
+			},
+		}
+		require.NoError(t, s.mc.Envs[2].Client().Delete(ctx, pool))
+
+		// The StretchCluster reconciler should decommission the broker and
+		// delete the StatefulSet for the removed pool.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &appsv1.StatefulSetList{}, ownerLabels)
+			t.Logf("StatefulSet count: %d (want 2)", count)
+			return count == 2
+		}, 5*time.Minute, 5*time.Second, "StatefulSet for deleted NodePool was not cleaned up")
+
+		// The other two pools should remain healthy.
+		require.Eventually(t, func() bool {
+			var cluster redpandav1alpha2.StretchCluster
+			if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
+				return false
+			}
+			readyCount := int32(0)
+			for _, pool := range cluster.Status.NodePools {
+				readyCount += pool.ReadyReplicas
+			}
+			t.Logf("ready brokers: %d (want >= 2)", readyCount)
+			return readyCount >= 2
+		}, 3*time.Minute, 5*time.Second, "remaining pools did not stay healthy after single NodePool deletion")
+
+		// Per-pod Services for the deleted pool's broker should be cleaned up.
+		// The syncer GC removes Services that are no longer rendered.
+		require.Eventually(t, func() bool {
+			var svcs corev1.ServiceList
+			if err := s.mc.Envs[2].Client().List(ctx, &svcs, ownerLabels, client.InNamespace(ns)); err != nil {
+				return false
+			}
+			for _, svc := range svcs.Items {
+				// Per-pod services are named after the pod (e.g. cleanup-pool-2-0).
+				if svc.Name == poolToDelete+"-0" {
+					t.Logf("per-pod Service %s still exists on cluster 2", svc.Name)
+					return false
+				}
+			}
+			return true
+		}, 3*time.Minute, 5*time.Second, "per-pod Service for deleted NodePool was not cleaned up")
+	})
+
+	t.Run("PartialStretchClusterDeletion", func(t *testing.T) {
+		// Delete the StretchCluster from clusters 1 and 2 only (keep on cluster 0).
+		// This simulates an accidental partial deletion and exposes reconciler bugs.
+		for i := 1; i <= 2; i++ {
+			scToDelete := &redpandav1alpha2.StretchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nn.Name,
+					Namespace: nn.Namespace,
+				},
+			}
+			require.NoError(t, s.mc.Envs[i].Client().Delete(ctx, scToDelete))
+		}
+
+		// The StretchCluster on cluster 0 still exists. The reconciler's
+		// checkSpecConsistency will fail because it can't fetch the SC from
+		// clusters 1 and 2 (NotFound). Verify the cluster is no longer Stable.
+		require.Eventually(t, func() bool {
+			var cluster redpandav1alpha2.StretchCluster
+			if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
+				return false
+			}
+			cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterStable)
+			if cond != nil && cond.Status == metav1.ConditionTrue {
+				return false
+			}
+			return true
+		}, 2*time.Minute, 5*time.Second, "reconciler did not detect partial StretchCluster deletion")
+
+		// Verify the SCs on clusters 1 and 2 are fully deleted (finalizers removed).
+		// Known bug: the deletion cleanup path iterates ALL clusters (including
+		// cluster 0 where the SC still exists), destroying resources that should
+		// be kept. The SC finalizer may also get stuck due to raft peer issues.
+		for i := 1; i <= 2; i++ {
+			env := s.mc.Envs[i]
+			require.Eventually(t, func() bool {
+				var list redpandav1alpha2.StretchClusterList
+				if err := env.Client().List(ctx, &list, client.InNamespace(ns)); err != nil {
+					return false
+				}
+				for _, item := range list.Items {
+					if item.Name == nn.Name {
+						return false
+					}
+				}
+				return true
+			}, 2*time.Minute, 1*time.Second, "StretchCluster on cluster %d was not fully deleted", i)
+		}
+
+		// Restore: re-apply the StretchCluster to all clusters so the
+		// FullDeletion subtest can clean up properly.
+		s.mc.ApplyAll(t, ctx, &redpandav1alpha2.StretchCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nn.Name,
+				Namespace: nn.Namespace,
+			},
+			Spec: redpandav1alpha2.StretchClusterSpec{
+				Networking: &redpandav1alpha2.Networking{
+					CrossClusterMode: ptr.To(redpandav1alpha2.CrossClusterModeFlat),
+				},
+				External: &redpandav1alpha2.External{
+					Enabled: ptr.To(false),
+				},
+			},
+		})
+
+		// Wait for the reconciler to recover (Stable=True).
+		// Known bug: recovery after partial deletion + re-creation fails because
+		// the reconciler gets stuck on stale state / empty cluster name "".
+		require.Eventually(t, func() bool {
+			var cluster redpandav1alpha2.StretchCluster
+			if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
+				return false
+			}
+			cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterStable)
+			return cond != nil && cond.Status == metav1.ConditionTrue
+		}, 3*time.Minute, 5*time.Second, "reconciler did not recover after restoring StretchCluster")
+	})
+
+	t.Run("FullDeletion", func(t *testing.T) {
+		// Delete all remaining NodePools across all clusters.
+		s.mc.DeleteAll(t, ctx, ns, &redpandav1alpha2.NodePool{})
+		// Delete the StretchCluster from all clusters.
+		s.mc.DeleteAll(t, ctx, ns, &redpandav1alpha2.StretchCluster{})
+
+		// Wait for the StretchCluster to be fully deleted (finalizer removed).
+		require.Eventually(t, func() bool {
+			var list redpandav1alpha2.StretchClusterList
+			if err := s.mc.Envs[0].Client().List(ctx, &list, client.InNamespace(ns)); err != nil {
+				return false
+			}
+			return len(list.Items) == 0
+		}, 3*time.Minute, 1*time.Second, "StretchCluster was not fully deleted")
+
+		// Verify ALL owned StatefulSets are deleted across all clusters.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &appsv1.StatefulSetList{}, ownerLabels)
+			t.Logf("StatefulSets remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "StatefulSets were not cleaned up after full deletion")
+
+		// Verify owned Services are deleted.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.ServiceList{}, ownerLabels, client.InNamespace(ns))
+			t.Logf("Services remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "Services were not cleaned up after full deletion")
+
+		// Verify owned ConfigMaps are deleted.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.ConfigMapList{}, ownerLabels, client.InNamespace(ns))
+			t.Logf("ConfigMaps remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "ConfigMaps were not cleaned up after full deletion")
+
+		// Verify owned Secrets are deleted.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.SecretList{}, ownerLabels, client.InNamespace(ns))
+			t.Logf("Secrets remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "Secrets were not cleaned up after full deletion")
+
+		// Verify owned PodDisruptionBudgets are deleted.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &policyv1.PodDisruptionBudgetList{}, ownerLabels, client.InNamespace(ns))
+			t.Logf("PDBs remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "PodDisruptionBudgets were not cleaned up after full deletion")
+
+		// Verify owned ServiceAccounts are deleted.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.ServiceAccountList{}, ownerLabels, client.InNamespace(ns))
+			t.Logf("ServiceAccounts remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "ServiceAccounts were not cleaned up after full deletion")
+
+		// Verify no Pods remain for the deleted cluster.
+		require.Eventually(t, func() bool {
+			count := s.countOwnedResourcesAcrossClusters(t, ctx, &corev1.PodList{}, ownerLabels, client.InNamespace(ns))
+			t.Logf("Pods remaining: %d", count)
+			return count == 0
+		}, 2*time.Minute, 5*time.Second, "Pods were not cleaned up after full deletion")
+	})
+}
+
+// countOwnedResourcesAcrossClusters counts resources matching the given options
+// across all multicluster envs.
+func (s *StretchClusterFactorySuite) countOwnedResourcesAcrossClusters(t *testing.T, ctx context.Context, list client.ObjectList, opts ...client.ListOption) int {
+	t.Helper()
+	total := 0
+	for _, env := range s.mc.Envs {
+		freshList := list.DeepCopyObject().(client.ObjectList)
+		if err := env.Client().List(ctx, freshList, opts...); err != nil {
+			t.Logf("error listing %T on %s: %v", list, env.Name, err)
+			continue
+		}
+		items, err := apimeta.ExtractList(freshList)
+		if err != nil {
+			t.Logf("error extracting list items: %v", err)
+			continue
+		}
+		total += len(items)
+	}
+	return total
 }


### PR DESCRIPTION
---
  Cleanup behavior by resource level

  StatefulSet deletion (single NodePool removed)

  - What happens: The StretchCluster reconciler detects the missing NodePool, decommissions the broker via admin API, scales down the StatefulSet to 0 replicas, then deletes
   it. The syncer GC removes per-pod Services that are no longer rendered.
  - PVCs: Retained by default (K8s StatefulSet retention policy).
  - Recovery: Not needed — this is the designed scale-down path. Re-create the NodePool to scale back up.
  - Test: SingleNodePoolDeletion — PASS

  StretchCluster deletion (all clusters)

  - What happens: Each cluster's SC finalizer triggers DeleteAll which removes all owned resources (StatefulSets, Services, ConfigMaps, Secrets, PDBs, ServiceAccounts,
  Certificates, etc.) via the kube.Syncer. The finalizer is removed once all resources are gone.
  - PVCs: Retained (not directly owned by the syncer). User must delete manually if desired.
  - Recovery: Re-create SC + NodePools. If PVCs exist, brokers resume with existing data.
  - Test: FullDeletion — PASS

  StretchCluster deletion (partial — subset of clusters)

  - What happens: The partial deletion guard detects that the SC is still alive on other clusters and blocks the finalizer. No cleanup runs. The SC stays in Terminating
  state. A ResourcesSynced=False condition explains the situation.
  - Cross-cluster syncers (syncBootstrapUser, syncCA, SyncAll): Skip clusters where the SC is being deleted, preventing resource creation that would fight with the guarded
  deletion.
  - Resources: Preserved on all clusters while the guard holds.
  - Recovery: Delete the SC from ALL remaining clusters. The guard on each cluster re-evaluates — once all clusters are deleting, cleanup proceeds normally (sequential
  delete is supported).
  - Current limitation: No way to "undo" a partial deletion without deleting from all clusters. Future work could add an orphaning mechanism (strip OwnerReferences, remove
  finalizer, re-apply SC) to recover without full teardown.
  - Test: PartialStretchClusterDeletion — verifies guard activation, finalizer preservation, resource preservation, surviving cluster health

  Scenarios considered but not implemented

  1. Orphan-on-delete: Strip OwnerReferences from resources before removing finalizer, allowing re-apply without data loss. Deferred because it's hard to distinguish "user
  deleting sequentially from all clusters" (needs cleanup) from "accidental single-cluster delete" (needs orphaning).
  2. Time-based heuristic: Wait N minutes before deciding partial vs sequential. Rejected as fragile.
  3. Annotation-driven orphaning: User sets orphan-on-delete annotation to opt into orphaning. Viable future enhancement.