### PR TITLE
StretchCluster: fix IssuerRef CA lookup and add TLS integration tests

### DIFF
--- a/acceptance/features/multicluster.feature
+++ b/acceptance/features/multicluster.feature
@@ -17,6 +17,36 @@ Feature: Multicluster Operator
         enabled: false
       rbac:
         enabled: true
+      tls:
+        enabled: true
+        certs:
+          issuer-managed:
+            caEnabled: true
+            applyInternalDNSNames: true
+            issuerRef:
+              name: custom-issuer-managed-issuer
+              kind: Issuer
+              group: cert-manager.io
+          user-provided:
+            caEnabled: true
+            secretRef:
+              name: cluster-user-provided-cert
+      listeners:
+        admin:
+          tls:
+            cert: issuer-managed
+        kafka:
+          tls:
+            cert: user-provided
+        http:
+          tls:
+            cert: issuer-managed
+        schemaRegistry:
+          tls:
+            cert: issuer-managed
+        rpc:
+          tls:
+            cert: issuer-managed
     """
     Then in "multicluster" the Kubernetes object "cluster" in namespace "default" of type "StretchCluster.v1alpha2.cluster.redpanda.com" should have finalizer "operator.redpanda.com/finalizer"
     And I apply a NodePool Kubernetes manifest to "multicluster":
@@ -42,3 +72,6 @@ Feature: Multicluster Operator
     And I expect all 3 NodePools in "multicluster" to be eventually bound and deployed
     When I execute "rpk redpanda admin brokers list" command in the statefulset container in each cluster
     And I expect them to return the same Redpanda broker list
+    # rpk topic list exercises the Kafka listener which uses the "user-provided"
+    # cert (SecretRef), validating that the pre-signed TLS secret works.
+    And I execute "rpk topic list" command in the statefulset container in each cluster

--- a/acceptance/steps/multicluster.go
+++ b/acceptance/steps/multicluster.go
@@ -486,10 +486,44 @@ func bootstrapTLS(ctx context.Context, t framework.TestingT, vclusters []*vclust
 }
 
 func deployOperators(ctx context.Context, t framework.TestingT, vclusters []*vclusterNode, namespace, redpandaLicense string, peers []any) {
-	defaultSecret, err := generateCASecret("cluster", "default", namespace)
+	// "issuer-managed" cert: user provides CA secret + Issuer, StretchCluster
+	// uses IssuerRef. Used by admin, http, schemaRegistry, and rpc listeners.
+	issuerManagedSecret, err := generateCASecret("cluster", "issuer-managed", namespace)
 	require.NoError(t, err)
-	externalSecret, err := generateCASecret("cluster", "external", namespace)
+
+	// "user-provided" cert: user provides a pre-signed server cert secret
+	// directly, StretchCluster uses SecretRef (no cert-manager involvement).
+	// Used by the kafka listener.
+	userProvidedCASecret, err := generateCASecret("cluster", "user-provided", namespace)
 	require.NoError(t, err)
+	userProvidedCA, err := bootstrap.LoadCA(
+		userProvidedCASecret.Data[corev1.TLSCertKey],
+		userProvidedCASecret.Data[corev1.TLSPrivateKeyKey],
+		&bootstrap.CAConfiguration{CALifetime: caLifetime, CertificateLifetime: 24 * time.Hour},
+	)
+	require.NoError(t, err)
+	// Sign a wildcard leaf cert. Include localhost (rpk connects locally)
+	// and wildcard SANs for cross-pod service resolution.
+	userProvidedLeafCert, err := userProvidedCA.Sign(
+		"localhost",
+		"*.default.svc.cluster.local",
+		"*.cluster.default.svc.cluster.local",
+		"*.default.svc",
+		"*.default",
+	)
+	require.NoError(t, err)
+	userProvidedServerSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-user-provided-cert",
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       userProvidedLeafCert.Bytes(),
+			corev1.TLSPrivateKeyKey: userProvidedLeafCert.PrivateKeyBytes(),
+			"ca.crt":                userProvidedCA.Bytes(),
+		},
+	}
 
 	for _, cluster := range vclusters {
 		t.Logf("creating license secret in %q", cluster.Name())
@@ -502,12 +536,12 @@ func deployOperators(ctx context.Context, t framework.TestingT, vclusters []*vcl
 				"redpanda.license": []byte(redpandaLicense),
 			},
 		}))
-		t.Logf("creating TLS secrets and issuers in %q", cluster.Name())
-		require.NoError(t, cluster.Create(ctx, defaultSecret.DeepCopy()))
-		require.NoError(t, cluster.Create(ctx, externalSecret.DeepCopy()))
 
-		defaultIssuer := newCAIssuer("cluster", "default", namespace)
-		externalIssuer := newCAIssuer("cluster", "external", namespace)
+		// Create the CA secret + Issuer for "issuer-managed" cert (IssuerRef flow).
+		t.Logf("creating TLS secrets and issuers in %q", cluster.Name())
+		require.NoError(t, cluster.Create(ctx, issuerManagedSecret.DeepCopy()))
+
+		issuerManagedIssuer := newCAIssuer("cluster", "issuer-managed", namespace)
 		webhookRetry := wait.Backoff{
 			Steps:    100,
 			Duration: 1 * time.Second,
@@ -518,11 +552,12 @@ func deployOperators(ctx context.Context, t framework.TestingT, vclusters []*vcl
 			return err != nil && strings.Contains(err.Error(), "webhook")
 		}
 		require.NoError(t, retry.OnError(webhookRetry, isWebhookErr, func() error {
-			return cluster.Create(ctx, defaultIssuer)
+			return cluster.Create(ctx, issuerManagedIssuer)
 		}))
-		require.NoError(t, retry.OnError(webhookRetry, isWebhookErr, func() error {
-			return cluster.Create(ctx, externalIssuer)
-		}))
+
+		// Create the pre-signed server cert secret for "user-provided" cert (SecretRef flow).
+		// No Issuer needed — the operator uses this secret directly.
+		require.NoError(t, cluster.Create(ctx, userProvidedServerSecret.DeepCopy()))
 
 		t.Logf("deploying operator in %q", cluster.Name())
 		rel, err := cluster.HelmInstall(ctx, "../operator/chart", helm.InstallOptions{
@@ -571,7 +606,7 @@ func cleanupWrapper(t framework.TestingT, f func(ctx context.Context)) {
 // and returns it as a kubernetes.io/tls Secret matching the naming convention used
 // by the Redpanda helm chart: {clusterName}-{listener}-root-certificate.
 func generateCASecret(clusterName, listener, namespace string) (*corev1.Secret, error) {
-	secretName := fmt.Sprintf("%s-%s-root-certificate", clusterName, listener)
+	secretName := fmt.Sprintf("%s-%s-ca-provided-by-user", clusterName, listener)
 
 	ca, err := bootstrap.GenerateCA("redpanda", secretName, &bootstrap.CAConfiguration{
 		CALifetime: caLifetime,
@@ -580,22 +615,10 @@ func generateCASecret(clusterName, listener, namespace string) (*corev1.Secret, 
 		return nil, err
 	}
 
-	issuerName := fmt.Sprintf("%s-%s-selfsigned-issuer", clusterName, listener)
-
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: namespace,
-			Annotations: map[string]string{
-				"cert-manager.io/alt-names":        "",
-				"cert-manager.io/certificate-name": secretName,
-				"cert-manager.io/common-name":      secretName,
-				"cert-manager.io/ip-sans":          "",
-				"cert-manager.io/issuer-group":     "cert-manager.io",
-				"cert-manager.io/issuer-kind":      "Issuer",
-				"cert-manager.io/issuer-name":      issuerName,
-				"cert-manager.io/uri-sans":         "",
-			},
 		},
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{
@@ -608,9 +631,9 @@ func generateCASecret(clusterName, listener, namespace string) (*corev1.Secret, 
 
 // newCAIssuer creates a cert-manager Issuer that references the CA secret
 // matching the naming convention: {clusterName}-{listener}-root-{certificate,issuer}.
-func newCAIssuer(clusterName, listener, namespace string) *certmanagerv1.Issuer {
-	secretName := fmt.Sprintf("%s-%s-root-certificate", clusterName, listener)
-	issuerName := fmt.Sprintf("%s-%s-root-issuer", clusterName, listener)
+func newCAIssuer(clusterName, certName, namespace string) *certmanagerv1.Issuer {
+	secretName := fmt.Sprintf("%s-%s-ca-provided-by-user", clusterName, certName)
+	issuerName := fmt.Sprintf("custom-%s-issuer", certName)
 
 	return &certmanagerv1.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -750,7 +773,7 @@ func executeCommandInStatefulsetContainers(ctx context.Context, t framework.Test
 				Command:   []string{"/bin/bash", "-c", command},
 				Stdout:    &healthOut,
 			}); err != nil {
-				t.Logf("error executing %q in %s: %v", command, cfg.node.Name(), err)
+				t.Logf("error executing %q in %s: %v \n output: %s", command, cfg.node.Name(), err, healthOut.String())
 				return false
 			}
 

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_helpers.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_helpers.go
@@ -744,12 +744,27 @@ func (t *TLS) CertServerCAPath(certName string) string {
 
 // CertificatesFor returns the server cert secret name, cert key, and client cert secret name
 // for the given TLS certificate. Safe to call on nil receiver.
+//
+// The returned certSecret and certKey identify where the root CA public key can
+// be read from. The behaviour depends on how the certificate is configured:
+//   - Default (operator-managed CA): the root-certificate secret, key "tls.crt".
+//   - SecretRef set: the user-provided secret, key "tls.crt".
+//   - IssuerRef set (no SecretRef): the leaf cert secret created by cert-manager,
+//     key "ca.crt" (cert-manager populates the CA chain there).
 func (t *TLS) CertificatesFor(fullname, name string) (certSecret, certKey, clientSecret string) {
 	if t != nil {
 		if cert, ok := t.Certs[name]; ok && cert.IsEnabled() {
 			certSecret = fmt.Sprintf("%s-%s-root-certificate", fullname, name)
+			certKey = corev1.TLSCertKey
 			if cert.SecretRef != nil && cert.SecretRef.Name != nil {
 				certSecret = *cert.SecretRef.Name
+			} else if cert.IssuerRef != nil {
+				// When using an external issuer, there is no separate
+				// root-certificate secret. cert-manager populates the
+				// leaf cert's secret with a ca.crt key containing the
+				// CA chain.
+				certSecret = t.CertServerSecretName(fullname, name)
+				certKey = "ca.crt"
 			}
 
 			clientSecret = fmt.Sprintf("%s-%s-client-cert", fullname, name)
@@ -757,7 +772,7 @@ func (t *TLS) CertificatesFor(fullname, name string) (certSecret, certKey, clien
 				clientSecret = *cert.ClientSecretRef.Name
 			}
 
-			return certSecret, corev1.TLSCertKey, clientSecret
+			return certSecret, certKey, clientSecret
 		}
 	}
 

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_helpers_test.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_helpers_test.go
@@ -258,6 +258,63 @@ func TestTLS(t *testing.T) {
 			assert.Equal(t, "release-unknown-root-certificate", certSecret)
 			assert.Equal(t, "release-default-client-cert", clientSecret)
 		})
+
+		t.Run("with issuerRef returns leaf cert secret and ca.crt key", func(t *testing.T) {
+			tls := &redpandav1alpha2.TLS{
+				Certs: map[string]*redpandav1alpha2.Certificate{
+					"my-cert": {
+						Enabled: ptr.To(true),
+						IssuerRef: &redpandav1alpha2.IssuerRef{
+							Name: ptr.To("my-issuer"),
+							Kind: ptr.To("ClusterIssuer"),
+						},
+					},
+				},
+			}
+			certSecret, certKey, clientSecret := tls.CertificatesFor("release", "my-cert")
+			// When IssuerRef is set, the CA is in the leaf cert's secret under ca.crt.
+			assert.Equal(t, "release-my-cert-cert", certSecret)
+			assert.Equal(t, "ca.crt", certKey)
+			assert.Equal(t, "release-my-cert-client-cert", clientSecret)
+		})
+
+		t.Run("with issuerRef and clientSecretRef", func(t *testing.T) {
+			tls := &redpandav1alpha2.TLS{
+				Certs: map[string]*redpandav1alpha2.Certificate{
+					"my-cert": {
+						Enabled: ptr.To(true),
+						IssuerRef: &redpandav1alpha2.IssuerRef{
+							Name: ptr.To("my-issuer"),
+							Kind: ptr.To("Issuer"),
+						},
+						ClientSecretRef: &redpandav1alpha2.SecretRef{Name: ptr.To("custom-client")},
+					},
+				},
+			}
+			certSecret, certKey, clientSecret := tls.CertificatesFor("release", "my-cert")
+			assert.Equal(t, "release-my-cert-cert", certSecret)
+			assert.Equal(t, "ca.crt", certKey)
+			assert.Equal(t, "custom-client", clientSecret)
+		})
+
+		t.Run("secretRef takes precedence over issuerRef", func(t *testing.T) {
+			tls := &redpandav1alpha2.TLS{
+				Certs: map[string]*redpandav1alpha2.Certificate{
+					"my-cert": {
+						Enabled:   ptr.To(true),
+						SecretRef: &redpandav1alpha2.SecretRef{Name: ptr.To("custom-server")},
+						IssuerRef: &redpandav1alpha2.IssuerRef{
+							Name: ptr.To("my-issuer"),
+						},
+					},
+				},
+			}
+			certSecret, certKey, clientSecret := tls.CertificatesFor("release", "my-cert")
+			// SecretRef takes precedence — user provides everything.
+			assert.Equal(t, "custom-server", certSecret)
+			assert.Equal(t, corev1.TLSCertKey, certKey)
+			assert.Equal(t, "release-my-cert-client-cert", clientSecret)
+		})
 	})
 }
 

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -10,6 +10,7 @@
 package redpanda_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -17,14 +18,18 @@ import (
 	"testing"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/redpanda-data/common-go/otelutil/trace"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
@@ -33,7 +38,9 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
+	rendermulticluster "github.com/redpanda-data/redpanda-operator/operator/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster/bootstrap"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )
 
@@ -91,6 +98,7 @@ func (s *MulticlusterControllerSuite) SetupSuite() {
 		CRDs:               crds.All(),
 		Logger:             log.FromContext(s.ctx),
 		WatchAllNamespaces: true,
+		InstallCertManager: true,
 		SetupFn: func(mgr multicluster.Manager) error {
 			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, nil)
 		},
@@ -230,4 +238,320 @@ func (s *MulticlusterControllerSuite) TestSpecConsistencyConditionSetOnDrift() {
 		}
 		return true
 	}, 1*time.Minute, 1*time.Second, "SpecSynced condition never went back to True after fixing drift")
+}
+
+// TestIssuerRef verifies that when a user provides their own CA and Issuers
+// (Option 1), the operator:
+//   - Does NOT generate or distribute root-certificate secrets for certs with IssuerRef
+//   - Creates cert-manager Certificate resources that reference the user's Issuer
+//   - cert-manager issues leaf certs with ca.crt containing the user's CA
+//   - All clusters end up with leaf certs signed by the same user-provided CA
+func (s *MulticlusterControllerSuite) TestIssuerRef() {
+	t, ctx, cancel, ns := s.setup()
+	defer cancel()
+
+	const (
+		caSecretName = "user-ca"
+		issuerName   = "user-ca-issuer"
+		scName       = "tls-issuer"
+	)
+	nn := types.NamespacedName{Name: scName, Namespace: ns.Name}
+
+	// Step 1: Generate a CA that the "user" would create.
+	ca, err := bootstrap.GenerateCA("test-org", "user-ca", nil)
+	require.NoError(t, err)
+
+	// Step 2: Create the CA Secret and a cert-manager CA Issuer in each cluster.
+	// This simulates the user distributing their CA and creating Issuers.
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+
+		caSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caSecretName,
+				Namespace: ns.Name,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				corev1.TLSCertKey:       ca.Bytes(),
+				corev1.TLSPrivateKeyKey: ca.PrivateKeyBytes(),
+				"ca.crt":                ca.Bytes(),
+			},
+		}
+		require.NoError(t, cl.Create(ctx, caSecret), "creating CA secret in cluster %d", i)
+
+		issuer := &certmanagerv1.Issuer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      issuerName,
+				Namespace: ns.Name,
+			},
+			Spec: certmanagerv1.IssuerSpec{
+				IssuerConfig: certmanagerv1.IssuerConfig{
+					CA: &certmanagerv1.CAIssuer{
+						SecretName: caSecretName,
+					},
+				},
+			},
+		}
+		require.NoError(t, cl.Create(ctx, issuer), "creating Issuer in cluster %d", i)
+	}
+
+	// Step 3: Create a StretchCluster with IssuerRef pointing to the user's Issuer.
+	// ApplyInternalDNSNames must be true so that cert-manager generates certs
+	// with DNS SANs (cert-manager requires at least one subject identifier).
+	s.mc.ApplyAllInNamespace(t, ctx, ns.Name, &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		Spec: redpandav1alpha2.StretchClusterSpec{
+			TLS: &redpandav1alpha2.TLS{
+				Enabled: ptr.To(true),
+				Certs: map[string]*redpandav1alpha2.Certificate{
+					"default": {
+						CAEnabled:             ptr.To(true),
+						ApplyInternalDNSNames: ptr.To(true),
+						IssuerRef: &redpandav1alpha2.IssuerRef{
+							Name:  ptr.To(issuerName),
+							Kind:  ptr.To("Issuer"),
+							Group: ptr.To("cert-manager.io"),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Step 4: Wait for the reconciler to pick it up (finalizer added).
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var sc redpandav1alpha2.StretchCluster
+			if err := cl.Get(ctx, nn, &sc); err != nil {
+				return false
+			}
+			return slices.Contains(sc.Finalizers, redpanda.FinalizerKey)
+		}, 1*time.Minute, 1*time.Second, "cluster in env %d never got finalizer", i)
+	}
+
+	// Step 5: Verify that NO operator-managed root-certificate secret was created
+	// for the "default" cert. syncCA should have skipped it.
+	rootCertSecretName := rendermulticluster.CASecretName(scName, "default")
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		var secret corev1.Secret
+		err := cl.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      rootCertSecretName,
+		}, &secret)
+		require.True(t, k8sapierrors.IsNotFound(err),
+			"root-certificate secret %q should NOT exist in cluster %d (IssuerRef is set), but got: %v",
+			rootCertSecretName, i, err)
+	}
+
+	// Step 6: Wait for cert-manager to create the leaf cert secret in each cluster.
+	// The reconciler creates Certificate resources; cert-manager then issues them.
+	// We look for the server cert secret name that the renderer produces.
+	defaultedSpec := redpandav1alpha2.StretchClusterSpec{
+		TLS: &redpandav1alpha2.TLS{
+			Enabled: ptr.To(true),
+			Certs: map[string]*redpandav1alpha2.Certificate{
+				"default": {
+					CAEnabled:             ptr.To(true),
+					ApplyInternalDNSNames: ptr.To(true),
+					IssuerRef: &redpandav1alpha2.IssuerRef{
+						Name:  ptr.To(issuerName),
+						Kind:  ptr.To("Issuer"),
+						Group: ptr.To("cert-manager.io"),
+					},
+				},
+			},
+		},
+	}
+	defaultedSpec.MergeDefaults()
+	leafCertSecretName := defaultedSpec.TLS.CertServerSecretName(scName, "default")
+
+	leafCACerts := make([][]byte, len(s.mc.Envs))
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var secret corev1.Secret
+			if err := cl.Get(ctx, client.ObjectKey{
+				Namespace: ns.Name,
+				Name:      leafCertSecretName,
+			}, &secret); err != nil {
+				t.Logf("[TestIssuerRef] waiting for leaf cert secret %q in cluster %d: %v", leafCertSecretName, i, err)
+				return false
+			}
+			// cert-manager must have populated tls.crt, tls.key, and ca.crt.
+			if _, ok := secret.Data[corev1.TLSCertKey]; !ok {
+				return false
+			}
+			if _, ok := secret.Data[corev1.TLSPrivateKeyKey]; !ok {
+				return false
+			}
+			caCrt, ok := secret.Data["ca.crt"]
+			if !ok || len(caCrt) == 0 {
+				return false
+			}
+			leafCACerts[i] = caCrt
+			return true
+		}, 2*time.Minute, 2*time.Second, "leaf cert secret %q never appeared in cluster %d", leafCertSecretName, i)
+	}
+
+	// Step 7: Verify all clusters have the same CA in their leaf cert's ca.crt.
+	// This confirms that the user's CA is consistently used across clusters.
+	for i := 1; i < len(leafCACerts); i++ {
+		require.True(t, bytes.Equal(leafCACerts[0], leafCACerts[i]),
+			"ca.crt in leaf cert differs between cluster 0 and cluster %d", i)
+	}
+
+	// Verify the CA in the leaf cert matches the user-provided CA.
+	require.True(t, bytes.Equal(ca.Bytes(), leafCACerts[0]),
+		"ca.crt in leaf cert does not match the user-provided CA")
+}
+
+// TestUserProvidedCA verifies Option 3: the user pre-creates a CA secret with
+// the well-known naming convention in a single cluster. The operator's syncCA
+// should find it, distribute it to all other clusters, and create Issuers
+// backed by it. cert-manager then issues leaf certs signed by the user's CA.
+func (s *MulticlusterControllerSuite) TestUserProvidedCA() {
+	t, ctx, cancel, ns := s.setup()
+	defer cancel()
+
+	const scName = "tls-userca"
+	nn := types.NamespacedName{Name: scName, Namespace: ns.Name}
+
+	// Step 1: Generate a CA that the "user" would create.
+	ca, err := bootstrap.GenerateCA("user-org", "user-provided-ca", nil)
+	require.NoError(t, err)
+
+	// Step 2: Pre-create the CA Secret in just ONE cluster using the well-known
+	// name that syncCA scans for: "{stretchClusterName}-{certName}-root-certificate".
+	// The operator should find it and distribute it to the other clusters.
+	caSecretName := rendermulticluster.CASecretName(scName, "default")
+	t.Logf("pre-creating CA secret %q in cluster 0 only", caSecretName)
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caSecretName,
+			Namespace: ns.Name,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       ca.Bytes(),
+			corev1.TLSPrivateKeyKey: ca.PrivateKeyBytes(),
+			"ca.crt":                ca.Bytes(),
+		},
+	}
+	require.NoError(t, s.mc.Envs[0].Client().Create(ctx, caSecret))
+
+	// Step 3: Create a StretchCluster with default TLS (no IssuerRef).
+	// The operator should use the pre-existing CA secret rather than
+	// generating a new one.
+	s.mc.ApplyAllInNamespace(t, ctx, ns.Name, &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		Spec: redpandav1alpha2.StretchClusterSpec{
+			TLS: &redpandav1alpha2.TLS{
+				Enabled: ptr.To(true),
+				Certs: map[string]*redpandav1alpha2.Certificate{
+					"default": {
+						CAEnabled: ptr.To(true),
+					},
+				},
+			},
+		},
+	})
+
+	// Step 4: Wait for the reconciler to pick it up.
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var sc redpandav1alpha2.StretchCluster
+			if err := cl.Get(ctx, nn, &sc); err != nil {
+				return false
+			}
+			return slices.Contains(sc.Finalizers, redpanda.FinalizerKey)
+		}, 1*time.Minute, 1*time.Second, "cluster in env %d never got finalizer", i)
+	}
+
+	// Step 5: Verify the CA secret was distributed to ALL clusters by syncCA.
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var secret corev1.Secret
+			if err := cl.Get(ctx, client.ObjectKey{
+				Namespace: ns.Name,
+				Name:      caSecretName,
+			}, &secret); err != nil {
+				t.Logf("[TestUserProvidedCA] waiting for CA secret %q in cluster %d: %v", caSecretName, i, err)
+				return false
+			}
+			return len(secret.Data[corev1.TLSCertKey]) > 0
+		}, 1*time.Minute, 1*time.Second, "CA secret %q never appeared in cluster %d", caSecretName, i)
+	}
+
+	// Step 6: Verify the distributed CA matches the user's original CA.
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		var secret corev1.Secret
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      caSecretName,
+		}, &secret))
+		require.True(t, bytes.Equal(ca.Bytes(), secret.Data[corev1.TLSCertKey]),
+			"CA secret tls.crt in cluster %d does not match the user-provided CA", i)
+	}
+
+	// Step 7: Verify cert-manager Issuers were created backed by the user's CA.
+	// The renderer creates "{fullname}-default-root-issuer" per cluster.
+	issuerName := fmt.Sprintf("%s-default-root-issuer", scName)
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var issuer certmanagerv1.Issuer
+			if err := cl.Get(ctx, client.ObjectKey{
+				Namespace: ns.Name,
+				Name:      issuerName,
+			}, &issuer); err != nil {
+				t.Logf("[TestUserProvidedCA] waiting for Issuer %q in cluster %d: %v", issuerName, i, err)
+				return false
+			}
+			// Verify the Issuer references our CA secret.
+			return issuer.Spec.CA != nil && issuer.Spec.CA.SecretName == caSecretName
+		}, 2*time.Minute, 2*time.Second, "Issuer %q never appeared in cluster %d", issuerName, i)
+	}
+
+	// Step 8: Wait for cert-manager to issue leaf certs and verify they use the user's CA.
+	defaultedSpec := redpandav1alpha2.StretchClusterSpec{
+		TLS: &redpandav1alpha2.TLS{
+			Enabled: ptr.To(true),
+			Certs: map[string]*redpandav1alpha2.Certificate{
+				"default": {CAEnabled: ptr.To(true)},
+			},
+		},
+	}
+	defaultedSpec.MergeDefaults()
+	leafCertSecretName := defaultedSpec.TLS.CertServerSecretName(scName, "default")
+
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var secret corev1.Secret
+			if err := cl.Get(ctx, client.ObjectKey{
+				Namespace: ns.Name,
+				Name:      leafCertSecretName,
+			}, &secret); err != nil {
+				t.Logf("[TestUserProvidedCA] waiting for leaf cert secret %q in cluster %d: %v", leafCertSecretName, i, err)
+				return false
+			}
+			caCrt, ok := secret.Data["ca.crt"]
+			if !ok || len(caCrt) == 0 {
+				return false
+			}
+			// The leaf cert's ca.crt should match the user's CA.
+			return bytes.Equal(ca.Bytes(), caCrt)
+		}, 2*time.Minute, 2*time.Second, "leaf cert secret %q never appeared with correct CA in cluster %d", leafCertSecretName, i)
+	}
 }

--- a/operator/multicluster/testdata/render-cases.pools.golden.txtar
+++ b/operator/multicluster/testdata/render-cases.pools.golden.txtar
@@ -12265,6 +12265,767 @@
   status:
     availableReplicas: 0
     replicas: 0
+-- tls-issuer-ref --
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/nodepool-generation: "0"
+      cluster.redpanda.com/nodepool-name: pool-a
+    name: tls-issuer-ref-pool-a
+    namespace: tls-issuer-ref
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/cluster-name: test
+        app.kubernetes.io/component: redpanda-pool-a-statefulset
+        app.kubernetes.io/instance: tls-issuer-ref
+        app.kubernetes.io/name: redpanda
+    serviceName: tls-issuer-ref
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: a90b21628d89546d234075143f437a7118e87dca2eb009f7ffb653e7b8f09eca
+        labels:
+          app.kubernetes.io/cluster-name: test
+          app.kubernetes.io/component: redpanda-pool-a-statefulset
+          app.kubernetes.io/instance: tls-issuer-ref
+          app.kubernetes.io/managed-by: redpanda-operator
+          app.kubernetes.io/name: redpanda
+          cluster.redpanda.com/broker: "true"
+          redpanda.com/poddisruptionbudget: tls-issuer-ref
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/cluster-name: test
+                  app.kubernetes.io/component: redpanda-pool-a-statefulset
+                  app.kubernetes.io/instance: tls-issuer-ref
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=pool-a-$(ORDINAL_NUMBER).tls-issuer-ref:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ORDINAL_NUMBER
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          - name: REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE
+            value: operator
+          - name: REDPANDA_METRICS_K8S_CHART_VERSION
+            value: v99.9.9
+          - name: REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION
+            value: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+                "https://${SERVICE_NAME}.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - tls-issuer-ref
+          - --redpanda-cluster-name
+          - tls-issuer-ref
+          - --selector=app.kubernetes.io/name=redpanda,app.kubernetes.io/instance=tls-issuer-ref
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ORDINAL_NUMBER
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          name: redpanda-configurator
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: tls-issuer-ref-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsUser: 101
+        serviceAccountName: tls-issuer-ref
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/cluster-name: test
+              app.kubernetes.io/component: redpanda-pool-a-statefulset
+              app.kubernetes.io/instance: tls-issuer-ref
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: tls-issuer-ref-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: tls-issuer-ref-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: tls-issuer-ref-sts-lifecycle
+        - configMap:
+            name: tls-issuer-ref-pool-a
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: tls-issuer-ref-configurator
+          secret:
+            defaultMode: 509
+            secretName: tls-issuer-ref-pool-a-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: OnDelete
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: tls-issuer-ref
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0
+-- tls-issuer-ref-mtls --
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/nodepool-generation: "0"
+      cluster.redpanda.com/nodepool-name: pool-a
+    name: tls-issuer-ref-mtls-pool-a
+    namespace: tls-issuer-ref-mtls
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/cluster-name: test
+        app.kubernetes.io/component: redpanda-pool-a-statefulset
+        app.kubernetes.io/instance: tls-issuer-ref-mtls
+        app.kubernetes.io/name: redpanda
+    serviceName: tls-issuer-ref-mtls
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: d2caedc46eb3f595b07b2ff350b3b7afb4bc3fa426b4228f25009abb60c34837
+        labels:
+          app.kubernetes.io/cluster-name: test
+          app.kubernetes.io/component: redpanda-pool-a-statefulset
+          app.kubernetes.io/instance: tls-issuer-ref-mtls
+          app.kubernetes.io/managed-by: redpanda-operator
+          app.kubernetes.io/name: redpanda
+          cluster.redpanda.com/broker: "true"
+          redpanda.com/poddisruptionbudget: tls-issuer-ref-mtls
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/cluster-name: test
+                  app.kubernetes.io/component: redpanda-pool-a-statefulset
+                  app.kubernetes.io/instance: tls-issuer-ref-mtls
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=pool-a-$(ORDINAL_NUMBER).tls-issuer-ref-mtls:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ORDINAL_NUMBER
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          - name: REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE
+            value: operator
+          - name: REDPANDA_METRICS_K8S_CHART_VERSION
+            value: v99.9.9
+          - name: REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION
+            value: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default-client/ca.crt
+                --cert /etc/tls/certs/default-client/tls.crt --key /etc/tls/certs/default-client/tls.key
+                "https://${SERVICE_NAME}.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default-client/ca.crt --cert /etc/tls/certs/default-client/tls.crt --key /etc/tls/certs/default-client/tls.key "https://${SERVICE_NAME}.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/tls/certs/default-client
+            name: redpanda-default-client-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - tls-issuer-ref-mtls
+          - --redpanda-cluster-name
+          - tls-issuer-ref-mtls
+          - --selector=app.kubernetes.io/name=redpanda,app.kubernetes.io/instance=tls-issuer-ref-mtls
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ORDINAL_NUMBER
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/tls/certs/default-client
+            name: redpanda-default-client-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/tls/certs/default-client
+            name: redpanda-default-client-cert
+          - mountPath: /etc/redpanda
+            name: base-config
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          name: redpanda-configurator
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/tls/certs/default-client
+            name: redpanda-default-client-cert
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: tls-issuer-ref-mtls-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsUser: 101
+        serviceAccountName: tls-issuer-ref-mtls
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/cluster-name: test
+              app.kubernetes.io/component: redpanda-pool-a-statefulset
+              app.kubernetes.io/instance: tls-issuer-ref-mtls
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: redpanda-default-cert
+          secret:
+            defaultMode: 288
+            secretName: tls-issuer-ref-mtls-default-cert
+        - name: redpanda-external-cert
+          secret:
+            defaultMode: 288
+            secretName: tls-issuer-ref-mtls-external-cert
+        - name: redpanda-default-client-cert
+          secret:
+            defaultMode: 288
+            secretName: tls-issuer-ref-mtls-default-client-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: tls-issuer-ref-mtls-sts-lifecycle
+        - configMap:
+            name: tls-issuer-ref-mtls-pool-a
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: tls-issuer-ref-mtls-configurator
+          secret:
+            defaultMode: 509
+            secretName: tls-issuer-ref-mtls-pool-a-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: OnDelete
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: tls-issuer-ref-mtls
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0
 -- tls-mtls --
 - apiVersion: apps/v1
   kind: StatefulSet

--- a/operator/multicluster/testdata/render-cases.resources.golden.txtar
+++ b/operator/multicluster/testdata/render-cases.resources.golden.txtar
@@ -23386,6 +23386,1473 @@
     type: ClusterIP
   status:
     loadBalancer: {}
+-- tls-issuer-ref --
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-external
+    namespace: tls-issuer-ref
+  spec:
+    externalTrafficPolicy: Local
+    ports:
+    - name: admin-default
+      nodePort: 31644
+      port: 9645
+      protocol: TCP
+      targetPort: 0
+    - name: kafka-default
+      nodePort: 31092
+      port: 9094
+      protocol: TCP
+      targetPort: 0
+    - name: http-default
+      nodePort: 30082
+      port: 8083
+      protocol: TCP
+      targetPort: 0
+    - name: schema-default
+      nodePort: 30081
+      port: 8084
+      protocol: TCP
+      targetPort: 0
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/name: redpanda
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref
+    namespace: tls-issuer-ref
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/cluster-name: test
+        app.kubernetes.io/instance: tls-issuer-ref
+        app.kubernetes.io/name: redpanda
+        redpanda.com/poddisruptionbudget: tls-issuer-ref
+  status:
+    currentHealthy: 0
+    desiredHealthy: 0
+    disruptionsAllowed: 0
+    expectedPods: 0
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref
+    namespace: tls-issuer-ref
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: tls-issuer-ref
+    namespace: tls-issuer-ref
+  spec:
+    clusterIP: None
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/name: redpanda
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","default_topic_replications":"3","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: tls-issuer-ref-pool-a-0.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-pool-a-1.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-pool-a-2.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.
+          port: 9093
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: pool-a-0.default
+            port: 33145
+        - host:
+            address: pool-a-1.default
+            port: 33145
+        - host:
+            address: pool-a-2.default
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - tls-issuer-ref-pool-a-0.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9644
+          - tls-issuer-ref-pool-a-1.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9644
+          - tls-issuer-ref-pool-a-2.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - tls-issuer-ref-pool-a-0.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9093
+          - tls-issuer-ref-pool-a-1.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9093
+          - tls-issuer-ref-pool-a-2.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - tls-issuer-ref-pool-a-0.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:8081
+          - tls-issuer-ref-pool-a-1.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:8081
+          - tls-issuer-ref-pool-a-2.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          enabled: true
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: tls-issuer-ref-pool-a-0.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-pool-a-1.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-pool-a-2.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.
+          port: 9093
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-pool-a
+    namespace: tls-issuer-ref
+- apiVersion: v1
+  data:
+    profile: |-
+      admin_api:
+        addresses: []
+        tls:
+          ca_file: ca.crt
+      kafka_api:
+        brokers: []
+        tls:
+          ca_file: ca.crt
+      name: default
+      schema_registry:
+        addresses: []
+        tls:
+          ca_file: ca.crt
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-rpk
+    namespace: tls-issuer-ref
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-external-root-issuer
+    namespace: tls-issuer-ref
+  spec:
+    ca:
+      secretName: tls-issuer-ref-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-default-cert
+    namespace: tls-issuer-ref
+  spec:
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: my-ca-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: tls-issuer-ref-default-cert
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-external-cert
+    namespace: tls-issuer-ref
+  spec:
+    dnsNames:
+    - tls-issuer-ref-cluster.tls-issuer-ref.tls-issuer-ref.svc.cluster.local
+    - tls-issuer-ref-cluster.tls-issuer-ref.tls-issuer-ref.svc
+    - tls-issuer-ref-cluster.tls-issuer-ref.tls-issuer-ref
+    - '*.tls-issuer-ref-cluster.tls-issuer-ref.tls-issuer-ref.svc.cluster.local'
+    - '*.tls-issuer-ref-cluster.tls-issuer-ref.tls-issuer-ref.svc'
+    - '*.tls-issuer-ref-cluster.tls-issuer-ref.tls-issuer-ref'
+    - tls-issuer-ref.tls-issuer-ref.svc.cluster.local
+    - tls-issuer-ref.tls-issuer-ref.svc
+    - tls-issuer-ref.tls-issuer-ref
+    - '*.tls-issuer-ref.tls-issuer-ref.svc.cluster.local'
+    - '*.tls-issuer-ref.tls-issuer-ref.svc'
+    - '*.tls-issuer-ref.tls-issuer-ref'
+    - '*.tls-issuer-ref.svc.cluster.local'
+    - '*.tls-issuer-ref.svc'
+    - '*.tls-issuer-ref'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: tls-issuer-ref-external-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: tls-issuer-ref-external-cert
+  status: {}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-sidecar
+    namespace: tls-issuer-ref
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-sidecar
+    namespace: tls-issuer-ref
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: tls-issuer-ref-sidecar
+  subjects:
+  - kind: ServiceAccount
+    name: tls-issuer-ref
+    namespace: tls-issuer-ref
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-sts-lifecycle
+    namespace: tls-issuer-ref
+  stringData:
+    common.sh: |-
+      #!/usr/bin/env bash
+
+      # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+      CURL_URL="https://${SERVICE_NAME}.tls-issuer-ref.tls-issuer-ref.svc.cluster.local:9644"
+
+      # commands used throughout
+      CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+      CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+    postStart.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      postStartHook () {
+        set -x
+
+        touch /tmp/postStartHookStarted
+
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Clearing maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        # a 400 here would mean not in maintenance mode
+        until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+            status=$(${CURL_MAINTENANCE_DELETE_CMD})
+            sleep 0.5
+        done
+
+        touch /tmp/postStartHookFinished
+      }
+
+      postStartHook
+      true
+    preStop.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      touch /tmp/preStopHookStarted
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      set -x
+
+      preStopHook () {
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Setting maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        until [ "${status:-}" = '"200"' ]; do
+            status=$(${CURL_MAINTENANCE_PUT_CMD})
+            sleep 0.5
+        done
+
+        until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+            res=$(${CURL_MAINTENANCE_GET_CMD})
+            finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+            draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+            sleep 0.5
+        done
+
+        touch /tmp/preStopHookFinished
+      }
+      preStopHook
+      true
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-pool-a-configurator
+    namespace: tls-issuer-ref
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.tls-issuer-ref.tls-issuer-ref.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "$LISTENER"
+  type: Opaque
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: pool-a-0
+    namespace: tls-issuer-ref
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "0"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: pool-a-1
+    namespace: tls-issuer-ref
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "1"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: pool-a-2
+    namespace: tls-issuer-ref
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-issuer-ref
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "2"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+-- tls-issuer-ref-mtls --
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-external
+    namespace: tls-issuer-ref-mtls
+  spec:
+    externalTrafficPolicy: Local
+    ports:
+    - name: admin-default
+      nodePort: 31644
+      port: 9645
+      protocol: TCP
+      targetPort: 0
+    - name: kafka-default
+      nodePort: 31092
+      port: 9094
+      protocol: TCP
+      targetPort: 0
+    - name: http-default
+      nodePort: 30082
+      port: 8083
+      protocol: TCP
+      targetPort: 0
+    - name: schema-default
+      nodePort: 30081
+      port: 8084
+      protocol: TCP
+      targetPort: 0
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/name: redpanda
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls
+    namespace: tls-issuer-ref-mtls
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/cluster-name: test
+        app.kubernetes.io/instance: tls-issuer-ref-mtls
+        app.kubernetes.io/name: redpanda
+        redpanda.com/poddisruptionbudget: tls-issuer-ref-mtls
+  status:
+    currentHealthy: 0
+    desiredHealthy: 0
+    disruptionsAllowed: 0
+    expectedPods: 0
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls
+    namespace: tls-issuer-ref-mtls
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: tls-issuer-ref-mtls
+    namespace: tls-issuer-ref-mtls
+  spec:
+    clusterIP: None
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/name: redpanda
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","default_topic_replications":"3","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+        pandaproxy_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: true
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      pandaproxy_client:
+        broker_tls:
+          cert_file: /etc/tls/certs/default-client/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default-client/tls.key
+          require_client_auth: true
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: tls-issuer-ref-mtls-pool-a-0.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-mtls-pool-a-1.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-mtls-pool-a-2.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.
+          port: 9093
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        admin_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: true
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        kafka_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: true
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        rpc_server_tls:
+          cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        seed_servers:
+        - host:
+            address: pool-a-0.default
+            port: 33145
+        - host:
+            address: pool-a-1.default
+            port: 33145
+        - host:
+            address: pool-a-2.default
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - tls-issuer-ref-mtls-pool-a-0.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9644
+          - tls-issuer-ref-mtls-pool-a-1.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9644
+          - tls-issuer-ref-mtls-pool-a-2.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9644
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+            cert_file: /etc/tls/certs/default-client/tls.crt
+            key_file: /etc/tls/certs/default-client/tls.key
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - tls-issuer-ref-mtls-pool-a-0.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9093
+          - tls-issuer-ref-mtls-pool-a-1.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9093
+          - tls-issuer-ref-mtls-pool-a-2.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:9093
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+            cert_file: /etc/tls/certs/default-client/tls.crt
+            key_file: /etc/tls/certs/default-client/tls.key
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - tls-issuer-ref-mtls-pool-a-0.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:8081
+          - tls-issuer-ref-mtls-pool-a-1.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:8081
+          - tls-issuer-ref-mtls-pool-a-2.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.:8081
+          tls:
+            ca_file: /etc/tls/certs/default/ca.crt
+            cert_file: /etc/tls/certs/default-client/tls.crt
+            key_file: /etc/tls/certs/default-client/tls.key
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+        schema_registry_api_tls:
+        - cert_file: /etc/tls/certs/default/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default/tls.key
+          name: internal
+          require_client_auth: true
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - cert_file: /etc/tls/certs/external/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/external/tls.key
+          name: default
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      schema_registry_client:
+        broker_tls:
+          cert_file: /etc/tls/certs/default-client/tls.crt
+          enabled: true
+          key_file: /etc/tls/certs/default-client/tls.key
+          require_client_auth: true
+          truststore_file: /etc/tls/certs/default/ca.crt
+        brokers:
+        - address: tls-issuer-ref-mtls-pool-a-0.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-mtls-pool-a-1.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.
+          port: 9093
+        - address: tls-issuer-ref-mtls-pool-a-2.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.
+          port: 9093
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-pool-a
+    namespace: tls-issuer-ref-mtls
+- apiVersion: v1
+  data:
+    profile: |-
+      admin_api:
+        addresses: []
+        tls:
+          ca_file: ca.crt
+      kafka_api:
+        brokers: []
+        tls:
+          ca_file: ca.crt
+      name: default
+      schema_registry:
+        addresses: []
+        tls:
+          ca_file: ca.crt
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-rpk
+    namespace: tls-issuer-ref-mtls
+- apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-external-root-issuer
+    namespace: tls-issuer-ref-mtls
+  spec:
+    ca:
+      secretName: tls-issuer-ref-mtls-external-root-certificate
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-default-cert
+    namespace: tls-issuer-ref-mtls
+  spec:
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: my-ca-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: tls-issuer-ref-mtls-default-cert
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-external-cert
+    namespace: tls-issuer-ref-mtls
+  spec:
+    dnsNames:
+    - tls-issuer-ref-mtls-cluster.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local
+    - tls-issuer-ref-mtls-cluster.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc
+    - tls-issuer-ref-mtls-cluster.tls-issuer-ref-mtls.tls-issuer-ref-mtls
+    - '*.tls-issuer-ref-mtls-cluster.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local'
+    - '*.tls-issuer-ref-mtls-cluster.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc'
+    - '*.tls-issuer-ref-mtls-cluster.tls-issuer-ref-mtls.tls-issuer-ref-mtls'
+    - tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local
+    - tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc
+    - tls-issuer-ref-mtls.tls-issuer-ref-mtls
+    - '*.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local'
+    - '*.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc'
+    - '*.tls-issuer-ref-mtls.tls-issuer-ref-mtls'
+    - '*.tls-issuer-ref-mtls.svc.cluster.local'
+    - '*.tls-issuer-ref-mtls.svc'
+    - '*.tls-issuer-ref-mtls'
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: tls-issuer-ref-mtls-external-root-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: tls-issuer-ref-mtls-external-cert
+  status: {}
+- apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-default-client
+    namespace: tls-issuer-ref-mtls
+  spec:
+    commonName: tls-issuer-ref-mtls--default-client
+    duration: 43800h0m0s
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: my-ca-issuer
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    secretName: tls-issuer-ref-mtls-default-client-cert
+  status: {}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-sidecar
+    namespace: tls-issuer-ref-mtls
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-sidecar
+    namespace: tls-issuer-ref-mtls
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: tls-issuer-ref-mtls-sidecar
+  subjects:
+  - kind: ServiceAccount
+    name: tls-issuer-ref-mtls
+    namespace: tls-issuer-ref-mtls
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-sts-lifecycle
+    namespace: tls-issuer-ref-mtls
+  stringData:
+    common.sh: |-
+      #!/usr/bin/env bash
+
+      # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+      CURL_URL="https://${SERVICE_NAME}.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local:9644"
+
+      # commands used throughout
+      CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default-client/ca.crt --cert /etc/tls/certs/default-client/tls.crt --key /etc/tls/certs/default-client/tls.key ${CURL_URL}/v1/node_config"
+
+      CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default-client/ca.crt --cert /etc/tls/certs/default-client/tls.crt --key /etc/tls/certs/default-client/tls.key ${CURL_URL}/v1/maintenance"
+    postStart.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      postStartHook () {
+        set -x
+
+        touch /tmp/postStartHookStarted
+
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Clearing maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default-client/ca.crt --cert /etc/tls/certs/default-client/tls.crt --key /etc/tls/certs/default-client/tls.key ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        # a 400 here would mean not in maintenance mode
+        until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+            status=$(${CURL_MAINTENANCE_DELETE_CMD})
+            sleep 0.5
+        done
+
+        touch /tmp/postStartHookFinished
+      }
+
+      postStartHook
+      true
+    preStop.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      touch /tmp/preStopHookStarted
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      set -x
+
+      preStopHook () {
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Setting maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default-client/ca.crt --cert /etc/tls/certs/default-client/tls.crt --key /etc/tls/certs/default-client/tls.key ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        until [ "${status:-}" = '"200"' ]; do
+            status=$(${CURL_MAINTENANCE_PUT_CMD})
+            sleep 0.5
+        done
+
+        until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+            res=$(${CURL_MAINTENANCE_GET_CMD})
+            finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+            draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+            sleep 0.5
+        done
+
+        touch /tmp/preStopHookFinished
+      }
+      preStopHook
+      true
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-issuer-ref-mtls-pool-a-configurator
+    namespace: tls-issuer-ref-mtls
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}.tls-issuer-ref-mtls.tls-issuer-ref-mtls.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "$LISTENER"
+  type: Opaque
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: pool-a-0
+    namespace: tls-issuer-ref-mtls
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "0"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: pool-a-1
+    namespace: tls-issuer-ref-mtls
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "1"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: pool-a-2
+    namespace: tls-issuer-ref-mtls
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-issuer-ref-mtls
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "2"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
 -- tls-mtls --
 - apiVersion: v1
   kind: Service

--- a/operator/multicluster/testdata/render-cases.txtar
+++ b/operator/multicluster/testdata/render-cases.txtar
@@ -426,6 +426,107 @@ spec:
     kind: StretchCluster
     name: cluster
   replicas: 3
+-- tls-issuer-ref --
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: StretchCluster
+metadata:
+  name: cluster
+  namespace: default
+spec:
+  tls:
+    enabled: true
+    certs:
+      default:
+        caEnabled: true
+        issuerRef:
+          name: my-ca-issuer
+          kind: ClusterIssuer
+          group: cert-manager.io
+  listeners:
+    kafka:
+      port: 9093
+      tls:
+        cert: default
+        requireClientAuth: false
+    admin:
+      port: 9644
+      tls:
+        cert: default
+    http:
+      port: 8082
+      tls:
+        cert: default
+    schemaRegistry:
+      port: 8081
+      tls:
+        cert: default
+    rpc:
+      port: 33145
+      tls:
+        cert: default
+---
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: NodePool
+metadata:
+  name: pool-a
+  namespace: default
+spec:
+  clusterRef:
+    group: cluster.redpanda.com/v1alpha2
+    kind: StretchCluster
+    name: cluster
+  replicas: 3
+-- tls-issuer-ref-mtls --
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: StretchCluster
+metadata:
+  name: cluster
+  namespace: default
+spec:
+  tls:
+    enabled: true
+    certs:
+      default:
+        caEnabled: true
+        issuerRef:
+          name: my-ca-issuer
+          kind: ClusterIssuer
+          group: cert-manager.io
+  listeners:
+    kafka:
+      port: 9093
+      tls:
+        cert: default
+        requireClientAuth: true
+    admin:
+      port: 9644
+      tls:
+        cert: default
+        requireClientAuth: true
+    http:
+      port: 8082
+      tls:
+        cert: default
+    schemaRegistry:
+      port: 8081
+      tls:
+        cert: default
+    rpc:
+      port: 33145
+      tls:
+        cert: default
+---
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: NodePool
+metadata:
+  name: pool-a
+  namespace: default
+spec:
+  clusterRef:
+    group: cluster.redpanda.com/v1alpha2
+    kind: StretchCluster
+    name: cluster
+  replicas: 3
 -- rack-awareness --
 apiVersion: cluster.redpanda.com/v1alpha2
 kind: StretchCluster


### PR DESCRIPTION
###  Problem
                                                                                                                                                                             
  When a user provides their own cert-manager Issuer via IssuerRef on a StretchCluster TLS cert (Option 1), the operator's CertificatesFor method returns the name of a      
  root-certificate secret that doesn't exist — syncCA correctly skips CA generation for certs with IssuerRef, but the operator's TLS client config still looks for that      
  non-existent secret, breaking admin API connections.                                                                                                                       
                  
###   Solution

  Fix CertificatesFor in stretch_cluster_helpers.go to handle the IssuerRef case: when IssuerRef is set (and SecretRef is not), return the leaf cert's secret name with key  
  ca.crt instead of the missing root-certificate secret. cert-manager populates the CA chain in the leaf cert's secret under ca.crt.
                                                                                                                                                                             
###   Tests           

  Unit tests (stretch_cluster_helpers_test.go):
  - CertificatesFor with IssuerRef returns leaf cert secret + ca.crt key
  - CertificatesFor with IssuerRef + ClientSecretRef                                                                                                                         
  - CertificatesFor with SecretRef taking precedence over IssuerRef
                                                                                                                                                                             
  Render golden tests (render-cases.txtar):
  - tls-issuer-ref: verifies no Issuer is created for IssuerRef certs, leaf Certificates reference the user's issuer                                                         
  - tls-issuer-ref-mtls: same with mTLS — client certs also use the user's issuer                                                                                            
                                                                                                                                                                             
  Integration tests (multicluster_controller_test.go, 3 k3d clusters with cert-manager):                                                                                     
  - TestIssuerRef (Option 1): user creates CA + Issuers in each cluster, sets IssuerRef. Verifies no operator-managed root-certificate secret exists, cert-manager issues    
  leaf certs, and ca.crt matches the user's CA across all clusters.                                                                                                          
  - TestUserProvidedCA (Option 3): user pre-creates CA secret in one cluster. Verifies syncCA distributes it to all clusters, operator creates Issuers backed by it, and     
  cert-manager issues leaf certs signed by the user's CA.                                                                                                                    
                                                                                                                                                                             
  Acceptance test (multicluster.feature):
  - StretchCluster now exercises both TLS flows on a single cluster: issuer-managed cert (IssuerRef) on admin/http/schemaRegistry/rpc listeners, user-provided cert          
  (SecretRef with pre-signed leaf) on kafka listener. Both paths validated by rpk redpanda admin brokers list and rpk topic list respectively.