### PR TITLE
StretchCluster: fix CA secret lookup for issuerRef TLS certs

### DIFF
--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -228,15 +228,21 @@ func (c *Factory) stretchClusterListenerTLSConfig(ctx context.Context, sc *redpa
 		certName = "default"
 	}
 
-	caSecretName := rendermulticluster.CASecretName(sc.Name, certName)
+	// CertificatesFor resolves the CA secret name and key based on the cert
+	// type: operator-managed CA, user-provided SecretRef, or external IssuerRef.
+	caSecretName, caKey, _ := spec.TLS.CertificatesFor(sc.Name, certName)
 	var caSecret corev1.Secret
 	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sc.Namespace, Name: caSecretName}, &caSecret); err != nil {
 		return nil, errors.Wrapf(err, "reading CA secret %q", caSecretName)
 	}
 
-	caCert := caSecret.Data["ca.crt"]
+	caCert := caSecret.Data[caKey]
 	if len(caCert) == 0 {
-		caCert = caSecret.Data[corev1.TLSCertKey]
+		// Fallback: try ca.crt then tls.crt.
+		caCert = caSecret.Data["ca.crt"]
+		if len(caCert) == 0 {
+			caCert = caSecret.Data[corev1.TLSCertKey]
+		}
 	}
 
 	tlsConfig := &tls.Config{


### PR DESCRIPTION
When a TLS certificate uses an external issuerRef, there is no separate root-certificate secret. The CA is available in the leaf cert secret's ca.crt key, populated by cert-manager.

The admin client factory was unconditionally using CASecretName() which constructs "<cluster>-<cert>-root-certificate", but this secret only exists for operator-bootstrapped CAs. For issuerRef certs, the secret name and key differ.

Fix by using TLS.CertificatesFor() which already handles all three cert types (bootstrapped, SecretRef, IssuerRef) and returns the correct secret name and key for each.