### PR TITLE
StretchCluster: fix NodePool image upgrades not rolling StatefulSets

### DIFF
--- a/operator/internal/lifecycle/constants.go
+++ b/operator/internal/lifecycle/constants.go
@@ -12,12 +12,13 @@ package lifecycle
 import "sigs.k8s.io/controller-runtime/pkg/client"
 
 const (
-	DefaultFieldOwner     = client.FieldOwner("cluster.redpanda.com/operator")
-	DefaultNamespaceLabel = "cluster.redpanda.com/namespace"
-	defaultOperatorLabel  = "cluster.redpanda.com/operator"
-	defaultOwnerLabel     = "cluster.redpanda.com/owner"
-	generationLabel       = "cluster.redpanda.com/generation"
-	configVersionLabel    = "cluster.redpanda.com/configVersion"
+	DefaultFieldOwner       = client.FieldOwner("cluster.redpanda.com/operator")
+	DefaultNamespaceLabel   = "cluster.redpanda.com/namespace"
+	defaultOperatorLabel    = "cluster.redpanda.com/operator"
+	defaultOwnerLabel       = "cluster.redpanda.com/owner"
+	generationLabel         = "cluster.redpanda.com/generation"
+	configVersionLabel      = "cluster.redpanda.com/configVersion"
+	nodePoolGenerationLabel = "cluster.redpanda.com/nodepool-generation"
 	// GCLabel is applied to out-of-band resources (Endpoints, EndpointSlices)
 	// that should retain ownership labels for tracking but should not be
 	// garbage collected by the syncer.

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -300,7 +300,8 @@ func (p *PoolTracker) RequiresUpdate() []*MulticlusterStatefulSet {
 
 		outOfDateGeneration := labels[generationLabel] != generation
 		outOfDateConfigVersion := labels[configVersionLabel] != desired.set.Labels[configVersionLabel]
-		if outOfDateGeneration || outOfDateConfigVersion {
+		outOfDateNodePool := labels[nodePoolGenerationLabel] != desired.set.Labels[nodePoolGenerationLabel]
+		if outOfDateGeneration || outOfDateConfigVersion || outOfDateNodePool {
 			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
 			desiredReplicas := ptr.Deref(desired.set.Spec.Replicas, 0)
 

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -533,6 +533,119 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 				},
 			}},
 		},
+		"nodepool-generation-changed": {
+			// StretchCluster generation unchanged, but NodePool generation bumped
+			// (e.g. user changed spec.image.tag on the NodePool).
+			generation:           1,
+			expectedSetsToUpdate: []string{"pool-1"},
+			existingPools: []*MulticlusterStatefulSet{{
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-1",
+						Labels: map[string]string{
+							generationLabel:         "1",
+							nodePoolGenerationLabel: "1",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}},
+			desiredPools: []*MulticlusterStatefulSet{{
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-1",
+						Labels: map[string]string{
+							nodePoolGenerationLabel: "2",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}},
+		},
+		"nodepool-generation-unchanged": {
+			// Both StretchCluster and NodePool generations match — no update.
+			generation: 1,
+			existingPools: []*MulticlusterStatefulSet{{
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-1",
+						Labels: map[string]string{
+							generationLabel:         "1",
+							nodePoolGenerationLabel: "2",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}},
+			desiredPools: []*MulticlusterStatefulSet{{
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-1",
+						Labels: map[string]string{
+							nodePoolGenerationLabel: "2",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}},
+		},
+		"only-one-pool-nodepool-generation-changed": {
+			// Two pools, only pool-2 has a NodePool generation bump.
+			generation:           1,
+			expectedSetsToUpdate: []string{"pool-2"},
+			existingPools: []*MulticlusterStatefulSet{{
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-1",
+						Labels: map[string]string{
+							generationLabel:         "1",
+							nodePoolGenerationLabel: "3",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}, {
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-2",
+						Labels: map[string]string{
+							generationLabel:         "1",
+							nodePoolGenerationLabel: "3",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}},
+			desiredPools: []*MulticlusterStatefulSet{{
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-1",
+						Labels: map[string]string{
+							nodePoolGenerationLabel: "3",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}, {
+				clusterName: mcmanager.LocalCluster,
+				StatefulSet: &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-2",
+						Labels: map[string]string{
+							nodePoolGenerationLabel: "4",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+				},
+			}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
RequiresUpdate() only compared the StretchCluster's generation label to detect out-of-date StatefulSets. When a NodePool's spec changed (e.g. spec.image.tag for a version upgrade), the StretchCluster generation stayed the same, so RequiresUpdate() returned an empty list and the StatefulSet was never patched with the new image.

Fix by also comparing the nodepool-generation label between existing and desired StatefulSets. The renderer already stamps this label with the NodePool's metadata.generation, so when a NodePool spec changes:
- That NodePool's generation increments
- The desired StatefulSet gets the new generation label
- RequiresUpdate() detects the mismatch and includes it for patching

This correctly handles both upgrade paths:
- StretchCluster spec change → cluster generation bumps → all pools update
- NodePool spec change → only that pool's generation bumps → only that pool's StatefulSet updates