### PR TITLE
Raft snapshots for followers

### DIFF
--- a/pkg/multicluster/leaderelection/lock.go
+++ b/pkg/multicluster/leaderelection/lock.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
 
 	transportv1 "github.com/redpanda-data/redpanda-operator/pkg/multicluster/leaderelection/proto/gen/transport/v1"
 )
@@ -91,6 +92,37 @@ type LockConfiguration struct {
 	// IDsToNames maps raft node IDs to human-readable cluster names.
 	// Used by the Status RPC to return cluster names instead of IDs.
 	IDsToNames map[uint64]string
+
+	// TestHooks is nil in production. Tests can set it to observe and
+	// influence raft behavior for deterministic assertions.
+	TestHooks *TestHooks
+}
+
+// TestHooks provides optional callbacks for testing raft internals.
+type TestHooks struct {
+	// OnSnapshotSent is called on the leader when a snapshot is sent to a
+	// follower after a MsgApp rejection. The argument is the target peer ID.
+	OnSnapshotSent func(to uint64)
+
+	// transport is set by run() so tests can inspect storage state.
+	transport *grpcTransport
+}
+
+// CommittedIndex returns the raft HardState's committed index from this
+// node's storage. Returns 0 if the storage is not yet initialized.
+func (h *TestHooks) CommittedIndex() uint64 {
+	if h == nil || h.transport == nil {
+		return 0
+	}
+	s := h.transport.getStorage()
+	if s == nil {
+		return 0
+	}
+	hs, _, err := s.InitialState()
+	if err != nil {
+		return 0
+	}
+	return hs.Commit
 }
 
 func (c *LockConfiguration) validate() error {
@@ -131,6 +163,14 @@ func peersForNodes(nodes []LockerNode) map[uint64]string {
 		peers[node.ID] = node.Address
 	}
 	return peers
+}
+
+func confStateFromPeers(nodes []LockerNode) raftpb.ConfState {
+	cs := raftpb.ConfState{}
+	for _, node := range nodes {
+		cs.Voters = append(cs.Voters, node.ID)
+	}
+	return cs
 }
 
 func asPeers(nodes []LockerNode) []raft.Peer {
@@ -267,6 +307,9 @@ func run(ctx context.Context, config LockConfiguration, transportCallback func(t
 	transport.logger = config.Logger
 	transport.idsToNames = config.IDsToNames
 	transport.localID = config.ID
+	if config.TestHooks != nil {
+		config.TestHooks.transport = transport
+	}
 
 	for node, address := range nodes {
 		if config.Logger != nil {
@@ -414,7 +457,33 @@ func runRaft(ctx context.Context, transport *grpcTransport, config LockConfigura
 				}
 			}
 
-			_ = storage.Append(rd.Entries)
+			if !raft.IsEmptySnap(rd.Snapshot) {
+				if err := storage.ApplySnapshot(rd.Snapshot); err != nil {
+					config.Logger.Errorf("failed to apply snapshot: %v", err)
+				}
+			}
+			if !raft.IsEmptyHardState(rd.HardState) {
+				if err := storage.SetHardState(rd.HardState); err != nil {
+					config.Logger.Errorf("failed to set hard state: %v", err)
+				}
+			}
+			if err := storage.Append(rd.Entries); err != nil {
+				config.Logger.Errorf("failed to append entries: %v", err)
+			}
+
+			// Only the leader maintains a snapshot — it's used to catch up
+			// followers whose log is behind after a restart. ConfState is
+			// built from this node's peer list; restricting to the leader
+			// ensures only the authoritative config is ever sent.
+			if isLeader {
+				if hs, _, err := storage.InitialState(); err == nil && hs.Commit > 0 {
+					cs := confStateFromPeers(config.Peers)
+					if _, err := storage.CreateSnapshot(hs.Commit, &cs, nil); err != nil && err != raft.ErrSnapOutOfDate {
+						config.Logger.Errorf("failed to create snapshot at commit=%d: %v", hs.Commit, err)
+					}
+				}
+			}
+
 			for _, msg := range rd.Messages {
 				if msg.To == config.ID {
 					if err := node.Step(ctx, msg); err != nil {
@@ -426,6 +495,34 @@ func runRaft(ctx context.Context, transport *grpcTransport, config LockConfigura
 				if err != nil || !applied {
 					if err != nil {
 						config.Logger.Infof("unreachable %d: %v", msg.To, err)
+					}
+					// If a MsgApp was rejected by the follower (Applied=false,
+					// no network error), the follower's log might be behind our
+					// progress tracker's match. Send a snapshot to reset the
+					// follower's state — the snapshot carries our ConfState and
+					// committed index, letting the follower catch up in one step.
+					if (msg.Type == raftpb.MsgApp || msg.Type == raftpb.MsgHeartbeat) && !applied && err == nil {
+						snap, snapErr := storage.Snapshot()
+						if snapErr != nil {
+							config.Logger.Errorf("failed to get snapshot for peer %d: %v", msg.To, snapErr)
+						} else if !raft.IsEmptySnap(snap) {
+							if _, sendErr := transport.DoSend(ctx, raftpb.Message{
+								Type:     raftpb.MsgSnap,
+								To:       msg.To,
+								From:     config.ID,
+								Snapshot: &snap,
+							}); sendErr != nil {
+								config.Logger.Infof("failed to send snapshot to %d: %v", msg.To, sendErr)
+							} else {
+								// Snapshot was accepted — the follower will send
+								// a MsgAppResp that fixes the progress tracker.
+								// Don't report unreachable.
+								if config.TestHooks != nil && config.TestHooks.OnSnapshotSent != nil {
+									config.TestHooks.OnSnapshotSent(msg.To)
+								}
+								continue
+							}
+						}
 					}
 					node.ReportUnreachable(msg.To)
 				}

--- a/pkg/multicluster/leaderelection/lock_test.go
+++ b/pkg/multicluster/leaderelection/lock_test.go
@@ -150,21 +150,20 @@ func TestHeartbeatCommitClamping(t *testing.T) {
 
 	ctx := context.Background()
 
-	// MsgHeartbeat with Commit > lastIndex is clamped (not rejected) so the
-	// raft node can generate a proper MsgHeartbeatResp, keeping the peer
-	// active in the leader's progress tracker.
+	// MsgHeartbeat with Commit > lastIndex returns Applied=false so the
+	// leader can send a snapshot to catch up the follower.
 	msgHB := raftpb.Message{
 		Type:   raftpb.MsgHeartbeat,
 		From:   2,
 		To:     1,
-		Commit: 5, // beyond our lastIndex(3), will be clamped to 3
+		Commit: 5, // beyond our lastIndex(3)
 	}
 	data, err := msgHB.Marshal()
 	require.NoError(t, err)
 
 	resp, err := transport.Send(ctx, &transportv1.SendRequest{Payload: data})
 	require.NoError(t, err)
-	require.True(t, resp.Applied, "MsgHeartbeat with Commit > lastIndex should be clamped and accepted")
+	require.False(t, resp.Applied, "MsgHeartbeat with Commit > lastIndex should be rejected")
 
 	// MsgHeartbeat with Commit <= lastIndex should be accepted unchanged.
 	msgHBOK := raftpb.Message{
@@ -179,6 +178,141 @@ func TestHeartbeatCommitClamping(t *testing.T) {
 	resp, err = transport.Send(ctx, &transportv1.SendRequest{Payload: data})
 	require.NoError(t, err)
 	require.True(t, resp.Applied, "MsgHeartbeat with Commit <= lastIndex should be accepted")
+}
+
+// TestMsgAppRejectedWhenBeyondLog verifies that the follower's Send handler
+// returns Applied=false when it receives a MsgApp whose prev log index is
+// beyond the follower's log. This prevents the infinite rejection loop
+// caused by the leader's stale progress tracker (match+1 floor in
+// MaybeDecrTo) and signals the leader to send a snapshot instead.
+func TestMsgAppRejectedWhenBeyondLog(t *testing.T) {
+	storage := raft.NewMemoryStorage()
+
+	// Simulate a fresh follower: 3 ConfChange entries from StartNode.
+	require.NoError(t, storage.Append([]raftpb.Entry{
+		{Index: 1, Term: 1},
+		{Index: 2, Term: 1},
+		{Index: 3, Term: 1},
+	}))
+
+	transport := &grpcTransport{}
+	transport.setStorage(storage)
+	transport.setNode(&stubNode{})
+
+	ctx := context.Background()
+
+	// MsgApp with Index > lastIndex(3): follower can't match, returns Applied=false.
+	msgApp := raftpb.Message{
+		Type:    raftpb.MsgApp,
+		From:    2,
+		To:      1,
+		Index:   5, // beyond our log
+		LogTerm: 2,
+	}
+	data, err := msgApp.Marshal()
+	require.NoError(t, err)
+
+	resp, err := transport.Send(ctx, &transportv1.SendRequest{Payload: data})
+	require.NoError(t, err)
+	require.False(t, resp.Applied, "MsgApp with Index > lastIndex should be rejected")
+
+	// MsgApp with Index <= lastIndex: accepted normally.
+	msgAppOK := raftpb.Message{
+		Type:    raftpb.MsgApp,
+		From:    2,
+		To:      1,
+		Index:   3,
+		LogTerm: 1,
+	}
+	data, err = msgAppOK.Marshal()
+	require.NoError(t, err)
+
+	resp, err = transport.Send(ctx, &transportv1.SendRequest{Payload: data})
+	require.NoError(t, err)
+	require.True(t, resp.Applied, "MsgApp with Index <= lastIndex should be accepted")
+}
+
+// TestSnapshotRecoveryAfterRestart validates the snapshot recovery path.
+// After a follower restarts with empty storage, the leader's progress tracker
+// has a stale match that prevents normal MsgApp catch-up (the match+1 floor
+// in MaybeDecrTo). The fix: the follower returns Applied=false for MsgApp it
+// can't match, the leader sends a snapshot, the follower applies it and its
+// committed index catches up to the leader's.
+func TestSnapshotRecoveryAfterRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+
+	// Attach TestHooks to all nodes so we can read committed indices.
+	hooks := make([]*TestHooks, 3)
+	for i := range hooks {
+		hooks[i] = &TestHooks{}
+	}
+
+	leaders := setupLockTestWithHooks(t, ctx, 3, hooks)
+
+	defer func() {
+		cancel()
+		for _, l := range leaders {
+			l.WaitForStopped(t, 10*time.Second)
+		}
+	}()
+
+	leader, followers := waitForAnyLeader(t, 30*time.Second, leaders...)
+
+	// Wait for the leader's committed index to advance past the initial
+	// ConfChange entries. The leader writes a no-op on election; once
+	// committed, followers must replicate to reach this index.
+	var leaderIdx int
+	for i, l := range leaders {
+		if l == leader {
+			leaderIdx = i
+			break
+		}
+	}
+	confChangeCount := uint64(len(leaders)) // one ConfChange per peer
+	require.Eventually(t, func() bool {
+		ci := hooks[leaderIdx].CommittedIndex()
+		return ci > confChangeCount
+	}, 10*time.Second, 50*time.Millisecond,
+		"leader committed index never advanced past ConfChange entries")
+	leaderCommit := hooks[leaderIdx].CommittedIndex()
+	t.Logf("leader %d committed index: %d (past %d ConfChanges)", leader.config.ID, leaderCommit, confChangeCount)
+
+	lagging := followers[0]
+	lagging.Stop()
+	lagging.WaitForStopped(t, 5*time.Second)
+
+	select {
+	case <-lagging.follower:
+	default:
+	}
+
+	t.Logf("restarting follower %d", lagging.config.ID)
+	lagging.Start(t, ctx)
+
+	// WaitForFollower only confirms the node initialized as a follower — it
+	// does NOT mean log replication succeeded. The real assertion is that the
+	// follower's committed index catches up to the leader's. Without the
+	// snapshot fix, committed stays at 3 (ConfChanges only) because the
+	// leader can't replicate past its stale match.
+	lagging.WaitForFollower(t, 30*time.Second)
+
+	// The follower's committed index must reach the leader's — this proves
+	// the snapshot was applied and replication succeeded. Without the fix,
+	// committed stays at the initial ConfChange count because the leader
+	// can't replicate past its stale match.
+	var laggingIdx int
+	for i, l := range leaders {
+		if l == lagging {
+			laggingIdx = i
+			break
+		}
+	}
+	require.Eventually(t, func() bool {
+		ci := hooks[laggingIdx].CommittedIndex()
+		t.Logf("follower %d committed index: %d (want >= %d)", lagging.config.ID, ci, leaderCommit)
+		return ci >= leaderCommit
+	}, 10*time.Second, 100*time.Millisecond,
+		"follower committed index never caught up to leader")
 }
 
 // stubNode is a minimal raft.Node implementation used by unit tests that
@@ -460,6 +594,10 @@ func waitForAnyLeader(t *testing.T, timeout time.Duration, leaders ...*testLeade
 }
 
 func setupLockTest(t *testing.T, ctx context.Context, n int) []*testLeader {
+	return setupLockTestWithHooks(t, ctx, n, nil)
+}
+
+func setupLockTestWithHooks(t *testing.T, ctx context.Context, n int, hooks []*TestHooks) []*testLeader {
 	if n <= 0 {
 		t.Fatalf("at least one lock configuration is required")
 	}
@@ -489,7 +627,7 @@ func setupLockTest(t *testing.T, ctx context.Context, n int) []*testLeader {
 		peers := []LockerNode{}
 		peers = append(peers, nodes...)
 
-		configs = append(configs, LockConfiguration{
+		cfg := LockConfiguration{
 			ID:                uint64(i + 1),
 			Address:           node.Address,
 			Peers:             peers,
@@ -499,7 +637,11 @@ func setupLockTest(t *testing.T, ctx context.Context, n int) []*testLeader {
 			ElectionTimeout:   1 * time.Second,
 			HeartbeatInterval: 100 * time.Millisecond,
 			Logger:            testLogger(t),
-		})
+		}
+		if hooks != nil && i < len(hooks) {
+			cfg.TestHooks = hooks[i]
+		}
+		configs = append(configs, cfg)
 	}
 
 	for _, config := range configs {

--- a/pkg/multicluster/leaderelection/raft.go
+++ b/pkg/multicluster/leaderelection/raft.go
@@ -315,10 +315,25 @@ func (t *grpcTransport) Send(ctx context.Context, req *transportv1.SendRequest) 
 		// raft node generates a proper MsgHeartbeatResp, keeping this
 		// peer active in the leader's progress tracker while normal
 		// MsgApp catch-up proceeds.
-		if msg.Type == raftpb.MsgHeartbeat {
+		// When a follower's log is behind the leader's commit (heartbeat) or
+		// prev entry (MsgApp), return Applied=false so the leader sends a
+		// snapshot instead. Without this, the follower either panics (heartbeat
+		// commitTo beyond lastIndex) or enters an infinite rejection loop
+		// (MsgApp rejection ignored due to stale match in the leader's progress
+		// tracker).
+		if msg.Type == raftpb.MsgHeartbeat || msg.Type == raftpb.MsgApp {
 			if s := t.getStorage(); s != nil {
-				if lastIdx, err := s.LastIndex(); err == nil && msg.Commit > lastIdx {
-					msg.Commit = lastIdx
+				lastIdx, err := s.LastIndex()
+				if err == nil {
+					reject := false
+					if msg.Type == raftpb.MsgHeartbeat && msg.Commit > lastIdx {
+						reject = true
+					} else if msg.Type == raftpb.MsgApp && msg.Index > lastIdx {
+						reject = true
+					}
+					if reject {
+						return &transportv1.SendResponse{Applied: false}, nil
+					}
 				}
 			}
 		}


### PR DESCRIPTION
So, looks like there were still issues with follower restarts in our multicluster raft implementation. This implements an extremely minimal snapshot restoration mechanism to attempt to catch up followers properly but without all of the issues we ran into with compaction + snapshots.