### PR TITLE
Multicluster cluster check subcommand

### DIFF
--- a/operator/cmd/rpk-k8s/k8s/multicluster/check.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/check.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package multicluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	clusterchecks "github.com/redpanda-data/redpanda-operator/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster"
+)
+
+// CheckConfig holds the configuration for the check command.
+type CheckConfig struct {
+	Connection ConnectionConfig
+	Name       string // StretchCluster resource name
+}
+
+// Per-cluster checks run in order. Later checks may depend on state
+// populated by earlier ones via CheckContext.
+var defaultClusterClusterChecks = []clusterchecks.ClusterCheck{
+	&clusterchecks.ResourceCheck{},
+	&clusterchecks.ConditionsCheck{},
+	&clusterchecks.PoolsCheck{},
+	&clusterchecks.SecretsCheck{},
+	&clusterchecks.BrokerHealthCheck{},
+}
+
+// Cross-cluster checks run once after all per-cluster checks complete.
+var defaultClusterCrossClusterChecks = []clusterchecks.CrossClusterCheck{
+	&clusterchecks.SpecConsistencyCheck{},
+	&clusterchecks.StatusAgreementCheck{},
+	&clusterchecks.BootstrapSecretConsistencyCheck{},
+	&clusterchecks.CASecretConsistencyCheck{},
+}
+
+// CheckResult holds the full output of a check run.
+type CheckResult struct {
+	Contexts       []*clusterchecks.CheckContext
+	ClusterResults [][]clusterchecks.Result
+	CrossResults   []clusterchecks.Result
+}
+
+// Run executes the cluster checks and writes formatted output to out.
+func (c *CheckConfig) Run(ctx context.Context, out io.Writer) (*CheckResult, error) {
+	conns, err := c.Connection.Resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	// Register the StretchCluster CRD scheme on each connection's client
+	// so we can read StretchCluster resources.
+	for _, conn := range conns {
+		if err := redpandav1alpha2.AddToScheme(conn.Ctl.Scheme()); err != nil {
+			return nil, fmt.Errorf("registering scheme for context %s: %w", conn.Name, err)
+		}
+	}
+
+	contexts := make([]*clusterchecks.CheckContext, len(conns))
+	clusterResults := make([][]clusterchecks.Result, len(conns))
+
+	for i, conn := range conns {
+		cc := &clusterchecks.CheckContext{
+			Context:   conn.Name,
+			Namespace: c.Connection.Namespace,
+			Name:      c.Name,
+			Ctl:       conn.Ctl,
+		}
+		contexts[i] = cc
+		clusterResults[i] = clusterchecks.RunClusterChecks(ctx, cc, defaultClusterClusterChecks)
+	}
+
+	crossResults := clusterchecks.RunCrossClusterChecks(contexts, defaultClusterCrossClusterChecks)
+
+	printCheckHeader(out, c.Name, c.Connection.Namespace, len(conns))
+	printConditionsTable(out, contexts)
+	printPoolsTable(out, contexts)
+	printCheckResults(out, contexts, clusterResults)
+	printCrossClusterCheckResults(out, crossResults)
+
+	return &CheckResult{
+		Contexts:       contexts,
+		ClusterResults: clusterResults,
+		CrossResults:   crossResults,
+	}, nil
+}
+
+func checkCommand() *cobra.Command {
+	var cfg CheckConfig
+
+	cmd := &cobra.Command{
+		Use:   "check <name>",
+		Short: "Check the health of a StretchCluster and its Redpanda brokers",
+		Long: `Checks the health of a StretchCluster resource across all participating
+Kubernetes clusters. Inspects status conditions, node pool readiness,
+cross-cluster spec consistency, and shared secret integrity.
+
+Connects to each specified Kubernetes context, reads the StretchCluster
+resource and its associated secrets, and validates consistency.`,
+		Example: `  # Check a StretchCluster across all clusters in a kubeconfig
+  rpk k8s multicluster check my-cluster --kubeconfig /path/to/kubeconfig
+
+  # Check specific clusters in a specific namespace
+  rpk k8s multicluster check my-cluster \
+    --context cluster-a --context cluster-b --context cluster-c \
+    --namespace redpanda`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg.Name = args[0]
+			_, err := cfg.Run(cmd.Context(), cmd.OutOrStdout())
+			return err
+		},
+	}
+
+	cfg.Connection.BindFlags(cmd)
+
+	return cmd
+}
+
+func printCheckHeader(w io.Writer, name, namespace string, clusters int) {
+	fmt.Fprintf(w, "STRETCH CLUSTER: %s  NAMESPACE: %s  CLUSTERS: %d\n", name, namespace, clusters)
+}
+
+func printConditionsTable(w io.Writer, contexts []*clusterchecks.CheckContext) {
+	// Use conditions from the first cluster that has them.
+	var conditions []metav1.Condition
+	for _, cc := range contexts {
+		if len(cc.Conditions) > 0 {
+			conditions = cc.Conditions
+			break
+		}
+	}
+	if len(conditions) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "CONDITION\tSTATUS\tREASON\tMESSAGE")
+	for _, cond := range conditions {
+		msg := cond.Message
+		if len(msg) > 80 {
+			msg = msg[:77] + "..."
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", cond.Type, cond.Status, cond.Reason, msg)
+	}
+	_ = tw.Flush()
+}
+
+func printPoolsTable(w io.Writer, contexts []*clusterchecks.CheckContext) {
+	// Collect all pools across all clusters.
+	type poolEntry struct {
+		context string
+		pool    redpandav1alpha2.EmbeddedNodePoolStatus
+	}
+	var entries []poolEntry
+	for _, cc := range contexts {
+		for _, pool := range cc.NodePools {
+			entries = append(entries, poolEntry{context: cc.Context, pool: pool})
+		}
+	}
+	if len(entries) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "CLUSTER\tPOOL\tDESIRED\tREPLICAS\tUP-TO-DATE\tOUT-OF-DATE\tDECOMMISSIONING")
+	for _, e := range entries {
+		name := e.pool.Name
+		if name == "" {
+			name = "(unnamed)"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%d\t%d\n",
+			e.context, name,
+			e.pool.DesiredReplicas, e.pool.Replicas,
+			e.pool.UpToDateReplicas, e.pool.OutOfDateReplicas,
+			e.pool.CondemnedReplicas)
+	}
+	_ = tw.Flush()
+}
+
+func printCheckResults(w io.Writer, contexts []*clusterchecks.CheckContext, results [][]clusterchecks.Result) {
+	// Skip the conditions check results in the per-cluster section since
+	// they're already shown in the conditions table. Only show non-pass
+	// results from other checks.
+	hasIssues := false
+	for _, rs := range results {
+		for _, r := range rs {
+			if r.Status == "fail" && r.Name != "conditions" {
+				hasIssues = true
+				break
+			}
+		}
+		if hasIssues {
+			break
+		}
+	}
+	if !hasIssues {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "ISSUES:")
+	for i, rs := range results {
+		for _, r := range rs {
+			if r.Name == "conditions" {
+				continue
+			}
+			if r.Status == "fail" {
+				fmt.Fprintf(w, "  ✗ %s: [%s] %s\n", contexts[i].Context, r.Name, r.Message)
+			}
+		}
+	}
+}
+
+func printCrossClusterCheckResults(w io.Writer, results []clusterchecks.Result) {
+	if len(results) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "CROSS-CLUSTER:")
+	for _, r := range results {
+		switch r.Status {
+		case "pass":
+			fmt.Fprintf(w, "  ✓ [%s] %s\n", r.Name, r.Message)
+		case "fail":
+			fmt.Fprintf(w, "  ✗ [%s] %s\n", r.Name, r.Message)
+		case "skip":
+			fmt.Fprintf(w, "  - [%s] %s\n", r.Name, r.Message)
+		}
+	}
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/checks.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/checks.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package cluster implements a pluggable check framework for validating the
+// health of a StretchCluster and its Redpanda brokers across multiple
+// Kubernetes clusters. This is distinct from the parent checks package which
+// validates the operator infrastructure (pods, raft, TLS).
+//
+// Checks come in two flavors:
+//   - ClusterCheck: runs once per Kubernetes cluster, given a shared
+//     CheckContext that accumulates state as checks execute. Checks run in
+//     registration order so later checks can depend on state from earlier ones.
+//   - CrossClusterCheck: runs once after all per-cluster checks complete,
+//     given all CheckContexts. Used for validations that compare state across
+//     clusters (e.g., spec consistency, secret agreement).
+package cluster
+
+import (
+	"context"
+
+	"github.com/redpanda-data/common-go/kube"
+	"github.com/redpanda-data/common-go/rpadmin"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// CheckContext holds shared state for a single cluster, accumulated as
+// checks execute. Earlier checks populate fields that later checks read.
+type CheckContext struct {
+	// Inputs — set before checks run.
+	Context   string // Kubernetes context name
+	Namespace string // Namespace for StretchCluster resources
+	Name      string // StretchCluster resource name
+	Ctl       *kube.Ctl
+
+	// Accumulated state — populated by checks for downstream consumers.
+	StretchCluster *redpandav1alpha2.StretchCluster
+	Conditions     []metav1.Condition
+	NodePools      []redpandav1alpha2.EmbeddedNodePoolStatus
+	BootstrapSecret *corev1.Secret
+	CASecrets       []*corev1.Secret
+
+	// Broker-level state — populated by BrokerHealthCheck.
+	AdminConnected bool
+	Health         *rpadmin.ClusterHealthOverview
+	Brokers        []rpadmin.Broker
+	ConfigStatus   []rpadmin.ConfigStatus
+}
+
+// Result is the outcome of a single validation.
+type Result struct {
+	// Name identifies the check that produced this result.
+	Name string
+	// Status is one of "pass", "fail", or "skip".
+	Status string
+	// Message describes what was checked or what went wrong.
+	Message string
+}
+
+// Pass returns a passing Result.
+func Pass(name, message string) Result {
+	return Result{Name: name, Status: "pass", Message: message}
+}
+
+// Fail returns a failing Result.
+func Fail(name, message string) Result {
+	return Result{Name: name, Status: "fail", Message: message}
+}
+
+// Skip returns a skipped Result.
+func Skip(name, message string) Result {
+	return Result{Name: name, Status: "skip", Message: message}
+}
+
+// ClusterCheck validates one aspect of a StretchCluster on a single
+// Kubernetes cluster.
+type ClusterCheck interface {
+	Name() string
+	Run(ctx context.Context, cc *CheckContext) []Result
+}
+
+// CrossClusterCheck validates consistency across all clusters.
+type CrossClusterCheck interface {
+	Name() string
+	Run(contexts []*CheckContext) []Result
+}
+
+// RunClusterChecks executes all per-cluster checks in order.
+func RunClusterChecks(ctx context.Context, cc *CheckContext, checks []ClusterCheck) []Result {
+	var results []Result
+	for _, check := range checks {
+		results = append(results, check.Run(ctx, cc)...)
+	}
+	return results
+}
+
+// RunCrossClusterChecks executes all cross-cluster checks.
+func RunCrossClusterChecks(contexts []*CheckContext, checks []CrossClusterCheck) []Result {
+	var results []Result
+	for _, check := range checks {
+		results = append(results, check.Run(contexts)...)
+	}
+	return results
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_broker_health.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_broker_health.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultAdminPort = 9644
+	adminPortName    = "admin"
+)
+
+// BrokerHealthCheck port-forwards to a running broker pod and queries the
+// Redpanda admin API for cluster health, broker list, and configuration
+// status. Only runs on the first cluster that has running pods (since the
+// admin API reflects the state of the entire Redpanda cluster regardless of
+// which broker is queried).
+//
+// Requires ResourceCheck and SecretsCheck to have run.
+type BrokerHealthCheck struct{}
+
+func (c *BrokerHealthCheck) Name() string { return "broker-health" }
+
+func (c *BrokerHealthCheck) Run(ctx context.Context, cc *CheckContext) []Result {
+	if cc.StretchCluster == nil {
+		return []Result{Skip(c.Name(), "StretchCluster not available")}
+	}
+
+	// Find a running broker pod.
+	pod, adminPort, err := findBrokerPod(ctx, cc)
+	if err != nil {
+		return []Result{Skip(c.Name(), fmt.Sprintf("no running broker pod found: %v", err))}
+	}
+
+	// Port-forward to the pod's admin API.
+	forwardedPorts, stop, err := cc.Ctl.PortForward(ctx, pod, io.Discard, io.Discard)
+	if err != nil {
+		return []Result{Fail(c.Name(), fmt.Sprintf("port-forward to %s failed: %v", pod.Name, err))}
+	}
+	defer stop()
+
+	var localPort uint16
+	for _, fp := range forwardedPorts {
+		if fp.Remote == adminPort {
+			localPort = fp.Local
+			break
+		}
+	}
+	if localPort == 0 {
+		return []Result{Fail(c.Name(), fmt.Sprintf("admin port %d not found in forwarded ports for pod %s", adminPort, pod.Name))}
+	}
+
+	// Build admin API client.
+	admin, err := buildAdminClient(cc, localPort)
+	if err != nil {
+		return []Result{Fail(c.Name(), fmt.Sprintf("admin API connection failed: %v", err))}
+	}
+	defer admin.Close()
+	cc.AdminConnected = true
+
+	var results []Result
+
+	// Health overview.
+	health, err := admin.GetHealthOverview(ctx)
+	if err != nil {
+		results = append(results, Fail(c.Name(), fmt.Sprintf("health check failed: %v", err)))
+	} else {
+		cc.Health = &health
+		if health.IsHealthy {
+			results = append(results, Pass(c.Name(),
+				fmt.Sprintf("cluster healthy (%d broker(s), %d down)", len(health.AllNodes), len(health.NodesDown))))
+		} else {
+			msg := fmt.Sprintf("cluster unhealthy (%d broker(s), %d down", len(health.AllNodes), len(health.NodesDown))
+			if len(health.LeaderlessPartitions) > 0 {
+				msg += fmt.Sprintf(", %d leaderless partition(s)", len(health.LeaderlessPartitions))
+			}
+			if len(health.UnderReplicatedPartitions) > 0 {
+				msg += fmt.Sprintf(", %d under-replicated partition(s)", len(health.UnderReplicatedPartitions))
+			}
+			msg += ")"
+			results = append(results, Fail(c.Name(), msg))
+		}
+	}
+
+	// Broker list.
+	if cc.Health != nil {
+		for _, brokerID := range cc.Health.AllNodes {
+			broker, err := admin.Broker(ctx, brokerID)
+			if err != nil {
+				results = append(results, Fail(c.Name(), fmt.Sprintf("cannot fetch broker %d: %v", brokerID, err)))
+				continue
+			}
+			cc.Brokers = append(cc.Brokers, broker)
+		}
+
+		// Check for decommissioning brokers.
+		for _, broker := range cc.Brokers {
+			if broker.MembershipStatus == rpadmin.MembershipStatusDraining {
+				status, err := admin.DecommissionBrokerStatus(ctx, broker.NodeID)
+				if err != nil {
+					results = append(results, Fail(c.Name(),
+						fmt.Sprintf("broker %d is decommissioning (cannot query progress: %v)", broker.NodeID, err)))
+				} else if !status.Finished {
+					results = append(results, Fail(c.Name(),
+						fmt.Sprintf("broker %d is decommissioning (%d partition(s) remaining)",
+							broker.NodeID, status.ReplicasLeft)))
+				}
+			}
+		}
+	}
+
+	// Config status.
+	configStatus, err := admin.ClusterConfigStatus(ctx, true)
+	if err != nil {
+		results = append(results, Fail(c.Name(), fmt.Sprintf("config status check failed: %v", err)))
+	} else {
+		cc.ConfigStatus = configStatus
+
+		var invalid, unknown []string
+		needsRestart := false
+		for _, s := range configStatus {
+			invalid = append(invalid, s.Invalid...)
+			unknown = append(unknown, s.Unknown...)
+			needsRestart = needsRestart || s.Restart
+		}
+
+		if len(invalid) > 0 {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("invalid config properties: %s", strings.Join(invalid, ", "))))
+		}
+		if len(unknown) > 0 {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("unknown config properties: %s", strings.Join(unknown, ", "))))
+		}
+		if needsRestart {
+			results = append(results, Fail(c.Name(), "one or more brokers need a restart to apply configuration changes"))
+		}
+		if len(invalid) == 0 && len(unknown) == 0 && !needsRestart {
+			results = append(results, Pass(c.Name(), "no configuration issues"))
+		}
+	}
+
+	return results
+}
+
+// findBrokerPod finds a running pod owned by the StretchCluster.
+func findBrokerPod(ctx context.Context, cc *CheckContext) (*corev1.Pod, uint16, error) {
+	var pods corev1.PodList
+	if err := cc.Ctl.List(ctx, cc.Namespace, &pods, client.MatchingLabels{
+		ownerLabel: cc.StretchCluster.Name,
+	}); err != nil {
+		return nil, 0, fmt.Errorf("listing pods: %w", err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		port := adminPortFromPod(pod)
+		if port > 0 {
+			return pod, port, nil
+		}
+	}
+
+	return nil, 0, fmt.Errorf("no running broker pod with admin port found in namespace %s", cc.Namespace)
+}
+
+// adminPortFromPod finds the admin API container port on a pod.
+func adminPortFromPod(pod *corev1.Pod) uint16 {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == adminPortName {
+				return uint16(port.ContainerPort)
+			}
+		}
+	}
+	return defaultAdminPort
+}
+
+// buildAdminClient creates an rpadmin.AdminAPI client pointed at a port-forwarded
+// local address. It reads TLS and auth credentials from the CheckContext.
+func buildAdminClient(cc *CheckContext, localPort uint16) (*rpadmin.AdminAPI, error) {
+	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
+
+	spec := cc.StretchCluster.Spec.DeepCopy()
+	spec.MergeDefaults()
+
+	tlsEnabled := false
+	if spec.Listeners != nil && spec.Listeners.Admin != nil {
+		tlsEnabled = spec.Listeners.Admin.IsTLSEnabled(spec.TLS)
+	}
+
+	var tlsConfig *tls.Config
+	if tlsEnabled {
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			// Port-forwarding goes to localhost — the cert's SAN won't match,
+			// so we skip server name verification but still load the CA pool
+			// for chain validation where possible.
+			InsecureSkipVerify: true, //nolint:gosec
+		}
+		for _, caSecret := range cc.CASecrets {
+			caCert, ok := caSecret.Data["ca.crt"]
+			if !ok {
+				continue
+			}
+			pool := x509.NewCertPool()
+			if pool.AppendCertsFromPEM(caCert) {
+				tlsConfig.RootCAs = pool
+				break
+			}
+		}
+	}
+
+	var auth rpadmin.Auth = &rpadmin.NopAuth{}
+	if cc.BootstrapSecret != nil {
+		pw, ok := cc.BootstrapSecret.Data[bootstrapUserPasswordKey]
+		if ok && len(pw) > 0 {
+			auth = &rpadmin.BasicAuth{
+				Username: "kubernetes-controller",
+				Password: string(pw),
+			}
+		}
+	}
+
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
+	urls := []string{fmt.Sprintf("%s://%s", scheme, addr)}
+
+	return rpadmin.NewAdminAPI(urls, auth, tlsConfig)
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_conditions.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_conditions.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionsCheck inspects the StretchCluster status conditions and reports
+// any that are not True. Requires ResourceCheck to have run.
+type ConditionsCheck struct{}
+
+func (c *ConditionsCheck) Name() string { return "conditions" }
+
+func (c *ConditionsCheck) Run(_ context.Context, cc *CheckContext) []Result {
+	if cc.StretchCluster == nil {
+		return []Result{Skip(c.Name(), "StretchCluster not available")}
+	}
+
+	if len(cc.Conditions) == 0 {
+		return []Result{Fail(c.Name(), "no status conditions found — cluster may not have been reconciled yet")}
+	}
+
+	var results []Result
+	for _, cond := range cc.Conditions {
+		if cond.Status == metav1.ConditionTrue {
+			results = append(results, Pass(c.Name(), fmt.Sprintf("%s: %s", cond.Type, cond.Reason)))
+		} else {
+			msg := fmt.Sprintf("%s: %s", cond.Type, cond.Reason)
+			if cond.Message != "" {
+				msg += " — " + cond.Message
+			}
+			results = append(results, Fail(c.Name(), msg))
+		}
+	}
+	return results
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_pools.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_pools.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+)
+
+// PoolsCheck inspects the node pool statuses and reports scaling issues,
+// unready pods, and out-of-date replicas. Requires ResourceCheck to have run.
+type PoolsCheck struct{}
+
+func (c *PoolsCheck) Name() string { return "pools" }
+
+func (c *PoolsCheck) Run(_ context.Context, cc *CheckContext) []Result {
+	if cc.StretchCluster == nil {
+		return []Result{Skip(c.Name(), "StretchCluster not available")}
+	}
+
+	if len(cc.NodePools) == 0 {
+		return []Result{Fail(c.Name(), "no node pools reported in status")}
+	}
+
+	var results []Result
+	for _, pool := range cc.NodePools {
+		name := pool.Name
+		if name == "" {
+			name = "(unnamed)"
+		}
+
+		// Check for scaling in progress.
+		if pool.Replicas != pool.DesiredReplicas {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("pool %s: scaling in progress (replicas: %d, desired: %d)", name, pool.Replicas, pool.DesiredReplicas)))
+			continue
+		}
+
+		// Check for out-of-date replicas.
+		if pool.OutOfDateReplicas > 0 {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("pool %s: %d out-of-date replica(s) pending rolling restart", name, pool.OutOfDateReplicas)))
+			continue
+		}
+
+		// Check for condemned replicas (being decommissioned).
+		if pool.CondemnedReplicas > 0 {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("pool %s: %d replica(s) being decommissioned", name, pool.CondemnedReplicas)))
+			continue
+		}
+
+		// Check for unready replicas.
+		ready := pool.UpToDateReplicas
+		if ready < pool.DesiredReplicas {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("pool %s: %d/%d replicas ready", name, ready, pool.DesiredReplicas)))
+			continue
+		}
+
+		results = append(results, Pass(c.Name(),
+			fmt.Sprintf("pool %s: %d/%d replicas ready", name, ready, pool.DesiredReplicas)))
+	}
+	return results
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_resource.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_resource.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redpanda-data/common-go/kube"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// ResourceCheck fetches the StretchCluster resource and populates cc.StretchCluster,
+// cc.Conditions, and cc.NodePools. Must run first.
+type ResourceCheck struct{}
+
+func (c *ResourceCheck) Name() string { return "resource" }
+
+func (c *ResourceCheck) Run(ctx context.Context, cc *CheckContext) []Result {
+	sc := &redpandav1alpha2.StretchCluster{}
+	if err := cc.Ctl.Get(ctx, kube.ObjectKey{Namespace: cc.Namespace, Name: cc.Name}, sc); err != nil {
+		return []Result{Fail(c.Name(), fmt.Sprintf("StretchCluster %s/%s not found: %v", cc.Namespace, cc.Name, err))}
+	}
+
+	cc.StretchCluster = sc
+	cc.Conditions = sc.Status.Conditions
+	cc.NodePools = sc.Status.NodePools
+
+	if !sc.DeletionTimestamp.IsZero() {
+		return []Result{Fail(c.Name(), fmt.Sprintf("StretchCluster %s/%s has a deletion timestamp — stuck in deletion", cc.Name, cc.Namespace))}
+	}
+
+	return []Result{Pass(c.Name(), fmt.Sprintf("StretchCluster %s/%s exists (generation %d)", cc.Name, cc.Namespace, sc.Generation))}
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_secrets.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cluster_secrets.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redpanda-data/common-go/kube"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	bootstrapUserSecretSuffix = "-bootstrap-user"
+	bootstrapUserPasswordKey  = "password"
+	caSecretSuffix            = "-root-certificate"
+	ownerLabel                = "cluster.redpanda.com/owner"
+)
+
+// SecretsCheck finds the bootstrap user secret and CA secrets for the
+// StretchCluster. Populates cc.BootstrapSecret and cc.CASecrets for
+// cross-cluster consistency checks. Requires ResourceCheck to have run.
+type SecretsCheck struct{}
+
+func (c *SecretsCheck) Name() string { return "secrets" }
+
+func (c *SecretsCheck) Run(ctx context.Context, cc *CheckContext) []Result {
+	if cc.StretchCluster == nil {
+		return []Result{Skip(c.Name(), "StretchCluster not available")}
+	}
+
+	var results []Result
+	scName := cc.StretchCluster.Name
+
+	// Check bootstrap user secret.
+	bootstrapName := scName + bootstrapUserSecretSuffix
+	bootstrapSecret := &corev1.Secret{}
+	if err := cc.Ctl.Get(ctx, kube.ObjectKey{Namespace: cc.Namespace, Name: bootstrapName}, bootstrapSecret); err != nil {
+		results = append(results, Fail(c.Name(), fmt.Sprintf("bootstrap user secret %s not found: %v", bootstrapName, err)))
+	} else {
+		cc.BootstrapSecret = bootstrapSecret
+		if _, ok := bootstrapSecret.Data[bootstrapUserPasswordKey]; !ok {
+			results = append(results, Fail(c.Name(), fmt.Sprintf("bootstrap user secret %s missing %q key", bootstrapName, bootstrapUserPasswordKey)))
+		} else {
+			results = append(results, Pass(c.Name(), fmt.Sprintf("bootstrap user secret %s exists", bootstrapName)))
+		}
+	}
+
+	// Find CA secrets by owner label.
+	var secrets corev1.SecretList
+	if err := cc.Ctl.List(ctx, cc.Namespace, &secrets, client.MatchingLabels{
+		ownerLabel: scName,
+	}); err != nil {
+		results = append(results, Fail(c.Name(), fmt.Sprintf("listing secrets: %v", err)))
+		return results
+	}
+
+	for i := range secrets.Items {
+		s := &secrets.Items[i]
+		if s.Type == corev1.SecretTypeTLS {
+			cc.CASecrets = append(cc.CASecrets, s)
+		}
+	}
+
+	if len(cc.CASecrets) > 0 {
+		results = append(results, Pass(c.Name(), fmt.Sprintf("%d CA secret(s) found", len(cc.CASecrets))))
+	} else if cc.StretchCluster.Spec.TLS != nil {
+		results = append(results, Fail(c.Name(), "TLS is configured but no CA secrets found"))
+	}
+
+	return results
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cross_cluster_secrets.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cross_cluster_secrets.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// BootstrapSecretConsistencyCheck verifies that the bootstrap user password
+// is identical across all clusters. Mismatches cause reconciliation to block
+// with a PasswordMismatch condition.
+type BootstrapSecretConsistencyCheck struct{}
+
+func (c *BootstrapSecretConsistencyCheck) Name() string { return "bootstrap-secret" }
+
+func (c *BootstrapSecretConsistencyCheck) Run(contexts []*CheckContext) []Result {
+	type entry struct {
+		context  string
+		password []byte
+	}
+
+	var entries []entry
+	for _, cc := range contexts {
+		if cc.BootstrapSecret == nil {
+			continue
+		}
+		pw, ok := cc.BootstrapSecret.Data[bootstrapUserPasswordKey]
+		if !ok || len(pw) == 0 {
+			continue
+		}
+		entries = append(entries, entry{context: cc.Context, password: pw})
+	}
+
+	if len(entries) < 2 {
+		return []Result{Skip(c.Name(), "bootstrap secret found on fewer than 2 clusters")}
+	}
+
+	reference := entries[0]
+	var mismatched []string
+	for _, e := range entries[1:] {
+		if !bytes.Equal(reference.password, e.password) {
+			mismatched = append(mismatched, e.context)
+		}
+	}
+
+	if len(mismatched) > 0 {
+		return []Result{Fail(c.Name(),
+			fmt.Sprintf("bootstrap user password differs from %s on: %s — delete the incorrect secret(s) and let the operator recreate them",
+				reference.context, strings.Join(mismatched, ", ")))}
+	}
+
+	return []Result{Pass(c.Name(),
+		fmt.Sprintf("bootstrap user password consistent across %d clusters", len(entries)))}
+}
+
+// CASecretConsistencyCheck verifies that CA certificate data is identical
+// across all clusters for each CA secret name.
+type CASecretConsistencyCheck struct{}
+
+func (c *CASecretConsistencyCheck) Name() string { return "ca-consistency" }
+
+func (c *CASecretConsistencyCheck) Run(contexts []*CheckContext) []Result {
+	// Group CA secrets by name across clusters.
+	type entry struct {
+		context string
+		data    []byte
+	}
+	byName := map[string][]entry{}
+
+	for _, cc := range contexts {
+		for _, s := range cc.CASecrets {
+			caCert, ok := s.Data["ca.crt"]
+			if !ok {
+				continue
+			}
+			byName[s.Name] = append(byName[s.Name], entry{context: cc.Context, data: caCert})
+		}
+	}
+
+	if len(byName) == 0 {
+		return []Result{Skip(c.Name(), "no CA secrets found on any cluster")}
+	}
+
+	var results []Result
+	for name, entries := range byName {
+		if len(entries) < 2 {
+			results = append(results, Skip(c.Name(),
+				fmt.Sprintf("CA secret %s found on only 1 cluster", name)))
+			continue
+		}
+
+		reference := entries[0]
+		var mismatched []string
+		for _, e := range entries[1:] {
+			if !bytes.Equal(reference.data, e.data) {
+				mismatched = append(mismatched, e.context)
+			}
+		}
+
+		if len(mismatched) > 0 {
+			results = append(results, Fail(c.Name(),
+				fmt.Sprintf("CA secret %s differs from %s on: %s",
+					name, reference.context, strings.Join(mismatched, ", "))))
+		} else {
+			results = append(results, Pass(c.Name(),
+				fmt.Sprintf("CA secret %s consistent across %d clusters", name, len(entries))))
+		}
+	}
+	return results
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cross_cluster_spec.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cross_cluster_spec.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// SpecConsistencyCheck verifies that the StretchCluster .spec is identical
+// across all clusters, mirroring the reconciler's spec drift detection.
+type SpecConsistencyCheck struct{}
+
+func (c *SpecConsistencyCheck) Name() string { return "spec-consistency" }
+
+func (c *SpecConsistencyCheck) Run(contexts []*CheckContext) []Result {
+	// Collect all clusters that have the StretchCluster.
+	var available []*CheckContext
+	for _, cc := range contexts {
+		if cc.StretchCluster != nil {
+			available = append(available, cc)
+		}
+	}
+
+	if len(available) < 2 {
+		return []Result{Skip(c.Name(), "fewer than 2 clusters have the StretchCluster — cannot compare specs")}
+	}
+
+	reference := available[0]
+	var drifted []string
+	for _, cc := range available[1:] {
+		if !apiequality.Semantic.DeepEqual(reference.StretchCluster.Spec, cc.StretchCluster.Spec) {
+			fields := specDiffFields(reference.StretchCluster.Spec, cc.StretchCluster.Spec)
+			drifted = append(drifted, fmt.Sprintf("%s (fields: %s)", cc.Context, strings.Join(fields, ", ")))
+		}
+	}
+
+	if len(drifted) > 0 {
+		return []Result{Fail(c.Name(),
+			fmt.Sprintf("spec differs from %s on: %s", reference.Context, strings.Join(drifted, "; ")))}
+	}
+
+	return []Result{Pass(c.Name(),
+		fmt.Sprintf("specs match across all %d clusters", len(available)))}
+}
+
+// specDiffFields returns the top-level JSON field names that differ between
+// two StretchClusterSpec values.
+func specDiffFields(a, b redpandav1alpha2.StretchClusterSpec) []string {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	t := av.Type()
+
+	var fields []string
+	for i := range t.NumField() {
+		if !apiequality.Semantic.DeepEqual(av.Field(i).Interface(), bv.Field(i).Interface()) {
+			name := t.Field(i).Name
+			if tag, ok := t.Field(i).Tag.Lookup("json"); ok {
+				if jsonName, _, _ := strings.Cut(tag, ","); jsonName != "" {
+					name = jsonName
+				}
+			}
+			fields = append(fields, name)
+		}
+	}
+	return fields
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cross_cluster_status.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster/cross_cluster_status.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+// StatusAgreementCheck verifies that the StretchCluster .status.conditions
+// are identical across all clusters. The reconciler writes status to every
+// reachable cluster, so disagreement indicates a cluster was unreachable
+// when the last status write occurred.
+type StatusAgreementCheck struct{}
+
+func (c *StatusAgreementCheck) Name() string { return "status-agreement" }
+
+func (c *StatusAgreementCheck) Run(contexts []*CheckContext) []Result {
+	var available []*CheckContext
+	for _, cc := range contexts {
+		if cc.StretchCluster != nil {
+			available = append(available, cc)
+		}
+	}
+
+	if len(available) < 2 {
+		return []Result{Skip(c.Name(), "fewer than 2 clusters have the StretchCluster — cannot compare status")}
+	}
+
+	reference := available[0]
+	var stale []string
+	for _, cc := range available[1:] {
+		if !apiequality.Semantic.DeepEqual(reference.Conditions, cc.Conditions) {
+			stale = append(stale, cc.Context)
+		}
+	}
+
+	if len(stale) > 0 {
+		return []Result{Fail(c.Name(),
+			fmt.Sprintf("status conditions differ from %s on: %s — these clusters may have been unreachable during the last status write",
+				reference.Context, strings.Join(stale, ", ")))}
+	}
+
+	return []Result{Pass(c.Name(),
+		fmt.Sprintf("status conditions agree across all %d clusters", len(available)))}
+}

--- a/operator/cmd/rpk-k8s/k8s/multicluster/multicluster.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/multicluster.go
@@ -23,6 +23,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(
 		bootstrapCommand(),
 		statusCommand(),
+		checkCommand(),
 	)
 
 	return cmd


### PR DESCRIPTION
This adds a diagnostic command to the plugin for checking StretchCluster health and trying to identify common scenarios requiring intervention as documented in the docs introduced in https://github.com/redpanda-data/redpanda-operator/pull/1457