### PR TITLE
operator: Fix hot reconcile loop on healthy clusters

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260417-140000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260417-140000.yaml
@@ -1,0 +1,11 @@
+project: operator
+kind: Fixed
+body: |
+  Fixed a hot reconcile loop on healthy Redpanda clusters where the operator would
+  re-enqueue itself every ~2 seconds instead of settling into the 3-minute periodic
+  requeue interval. The setStatusCondition helper treated a zero rate limit as
+  "force an update" (because time.Since(anything) > 0 is always true), which bumped
+  lastTransitionTime on every pass and triggered a status write for conditions that
+  had not actually changed. Rate-limited heartbeats for License and Configuration
+  conditions are preserved.
+time: 2026-04-17T14:00:00.000000+00:00

--- a/ci/rp-controller-gen.nix
+++ b/ci/rp-controller-gen.nix
@@ -6,16 +6,16 @@
 
 buildGo126Module rec {
   pname = "rp-controller-gen";
-  version = "f50515c8d09311681834eaeed1a9a9ffe6ec1397";
+  version = "59451d668eb28f01f91354a2463d766866148ef4";
 
   src = fetchFromGitHub {
     owner = "redpanda-data";
     repo = "common-go";
     rev = "${version}";
-    hash = "sha256-adNxpa+XoF+dC5MMbu1X83XdMRwLPpxF2ZQ0ofvAO44=";
+    hash = "sha256-34oDV8HFbTd5w34Kf1bVVuRIo3nXnVJlkQnbwh9A5GQ=";
   };
 
-  vendorHash = "sha256-Xn0nFCW1YmlQhB0aKU8TSFphBLcWs7ns+ircgJbnSl4=";
+  vendorHash = "sha256-PIKAvpLy0tTYkkzxg1UvHhDMhQGysPQ06k1J+5llN84=";
 
   sourceRoot = "source/rp-controller-gen";
 

--- a/ci/rp-controller-gen.nix
+++ b/ci/rp-controller-gen.nix
@@ -12,7 +12,7 @@ buildGo126Module rec {
     owner = "redpanda-data";
     repo = "common-go";
     rev = "${version}";
-    hash = "sha256-34oDV8HFbTd5w34Kf1bVVuRIo3nXnVJlkQnbwh9A5GQ=";
+    hash = "sha256-KoVBYGE0pkXpcPb+8145Wmu0m8lex8hc8c0QzFVzhho=";
   };
 
   vendorHash = "sha256-PIKAvpLy0tTYkkzxg1UvHhDMhQGysPQ06k1J+5llN84=";

--- a/operator/internal/statuses/rate_limit_test.go
+++ b/operator/internal/statuses/rate_limit_test.go
@@ -1,3 +1,12 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package statuses
 
 import (

--- a/operator/internal/statuses/rate_limit_test.go
+++ b/operator/internal/statuses/rate_limit_test.go
@@ -1,0 +1,253 @@
+package statuses
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// TestSetStatusCondition_RateZero_NoChangeWhenIdentical covers the regression from
+// https://github.com/redpanda-data/redpanda-operator/issues/1455: conditions with a
+// zero rate (the default) must not be forced-dirty on every reconcile. If they are,
+// a healthy cluster writes its status back to the API server on every pass and
+// triggers a hot reconcile loop.
+func TestSetStatusCondition_RateZero_NoChangeWhenIdentical(t *testing.T) {
+	existing := metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Ready",
+		Message:            "all good",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+	}
+	conditions := []metav1.Condition{existing}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "all good",
+			ObservedGeneration: 1,
+		},
+		rate: 0,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.False(t, changed, "identical condition with rate=0 must not mark the status dirty")
+	assert.Equal(t, existing.LastTransitionTime, conditions[0].LastTransitionTime, "LastTransitionTime must be preserved when nothing changes")
+}
+
+func TestSetStatusCondition_RateZero_ChangedOnStatusUpdate(t *testing.T) {
+	oldTime := metav1.NewTime(time.Now().Add(-time.Hour))
+	conditions := []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		Reason:             "NotReady",
+		Message:            "waiting",
+		ObservedGeneration: 1,
+		LastTransitionTime: oldTime,
+	}}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "all good",
+			ObservedGeneration: 1,
+		},
+		rate: 0,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.True(t, changed, "real status change must be detected regardless of rate")
+	assert.Equal(t, metav1.ConditionTrue, conditions[0].Status)
+	assert.True(t, conditions[0].LastTransitionTime.After(oldTime.Time), "LastTransitionTime must advance on real change")
+}
+
+func TestSetStatusCondition_RateZero_ChangedOnReasonUpdate(t *testing.T) {
+	oldTime := metav1.NewTime(time.Now().Add(-time.Hour))
+	conditions := []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Ready",
+		Message:            "all good",
+		ObservedGeneration: 1,
+		LastTransitionTime: oldTime,
+	}}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "DifferentReason",
+			Message:            "all good",
+			ObservedGeneration: 1,
+		},
+		rate: 0,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.True(t, changed, "reason change must be detected regardless of rate")
+}
+
+func TestSetStatusCondition_RateZero_ChangedOnMessageUpdate(t *testing.T) {
+	conditions := []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Ready",
+		Message:            "initial",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+	}}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "updated",
+			ObservedGeneration: 1,
+		},
+		rate: 0,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.True(t, changed, "message change must be detected regardless of rate")
+}
+
+func TestSetStatusCondition_RateZero_ChangedOnGenerationUpdate(t *testing.T) {
+	conditions := []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Ready",
+		Message:            "all good",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+	}}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "all good",
+			ObservedGeneration: 2,
+		},
+		rate: 0,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.True(t, changed, "observed generation change must be detected regardless of rate")
+}
+
+func TestSetStatusCondition_RateLimited_NoHeartbeatBeforeElapsed(t *testing.T) {
+	existing := metav1.Condition{
+		Type:               ClusterLicenseValid,
+		Status:             metav1.ConditionTrue,
+		Reason:             string(ClusterLicenseValidReasonValid),
+		Message:            "valid",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+	}
+	conditions := []metav1.Condition{existing}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               ClusterLicenseValid,
+			Status:             metav1.ConditionTrue,
+			Reason:             string(ClusterLicenseValidReasonValid),
+			Message:            "valid",
+			ObservedGeneration: 1,
+		},
+		rate: time.Minute,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.False(t, changed, "identical rate-limited condition within the rate window must not be marked dirty")
+	assert.Equal(t, existing.LastTransitionTime, conditions[0].LastTransitionTime)
+}
+
+func TestSetStatusCondition_RateLimited_HeartbeatAfterElapsed(t *testing.T) {
+	oldTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	conditions := []metav1.Condition{{
+		Type:               ClusterLicenseValid,
+		Status:             metav1.ConditionTrue,
+		Reason:             string(ClusterLicenseValidReasonValid),
+		Message:            "valid",
+		ObservedGeneration: 1,
+		LastTransitionTime: oldTime,
+	}}
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               ClusterLicenseValid,
+			Status:             metav1.ConditionTrue,
+			Reason:             string(ClusterLicenseValidReasonValid),
+			Message:            "valid",
+			ObservedGeneration: 1,
+		},
+		rate: time.Minute,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.True(t, changed, "rate-limited heartbeat must fire once the rate window has elapsed")
+	assert.True(t, conditions[0].LastTransitionTime.After(oldTime.Time), "LastTransitionTime must advance on heartbeat")
+}
+
+func TestSetStatusCondition_AppendsWhenExistingIsNil(t *testing.T) {
+	var conditions []metav1.Condition
+
+	incoming := ratelimitedCondition{
+		condition: metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Ready",
+			Message:            "all good",
+			ObservedGeneration: 1,
+		},
+		rate: 0,
+	}
+
+	changed := setStatusCondition(&conditions, incoming)
+	assert.True(t, changed, "appending a new condition must return changed")
+	require.Len(t, conditions, 1)
+	assert.False(t, conditions[0].LastTransitionTime.IsZero(), "LastTransitionTime must be populated")
+}
+
+// TestUpdateConditions_IdempotentOnHealthyCluster reproduces the end-to-end
+// behavior from issue #1455: on a healthy cluster nothing is actually changing,
+// so calling UpdateConditions twice with the same inputs should return false the
+// second time. Before the fix this returned true every pass because rate=0 was
+// always treated as "force an update."
+func TestUpdateConditions_IdempotentOnHealthyCluster(t *testing.T) {
+	obj := &redpandav1alpha2.Redpanda{}
+	obj.Generation = 1
+
+	buildStatus := func() *ClusterStatus {
+		s := NewCluster()
+		s.SetReady(ClusterReadyReasonReady, "ready")
+		s.SetHealthy(ClusterHealthyReasonHealthy, "healthy")
+		s.SetLicenseValid(ClusterLicenseValidReasonValid, "valid")
+		s.SetResourcesSynced(ClusterResourcesSyncedReasonSynced, "synced")
+		s.SetConfigurationApplied(ClusterConfigurationAppliedReasonApplied, "applied")
+		return s
+	}
+
+	// First pass: all conditions are new, so changes must be reported.
+	changed := buildStatus().UpdateConditions(obj)
+	require.True(t, changed, "first UpdateConditions call should populate conditions")
+	require.NotEmpty(t, obj.Status.Conditions)
+
+	// Second pass: identical inputs against the populated object. Only
+	// rate-limited conditions should potentially flip, and only after their rate
+	// window elapses — which has not happened here. Nothing else should change.
+	changed = buildStatus().UpdateConditions(obj)
+	assert.False(t, changed, "idempotent UpdateConditions call on healthy cluster must not mark status dirty")
+}

--- a/operator/internal/statuses/zz_generated_status.go
+++ b/operator/internal/statuses/zz_generated_status.go
@@ -1894,8 +1894,11 @@ func setStatusCondition(conditions *[]metav1.Condition, newCondition ratelimited
 		}
 	}
 
-	// we force an update of the transition time for the condition
-	if newCondition.rate >= 0 && (time.Since(existingCondition.LastTransitionTime.Time) > newCondition.rate) {
+	// we force an update of the transition time for the condition if an explicit
+	// rate limit is configured (rate > 0). A zero rate means "no rate-limited
+	// heartbeat" — without this guard, time.Since(anything) > 0 would mark the
+	// condition dirty on every reconcile, causing a hot reconcile loop.
+	if newCondition.rate > 0 && (time.Since(existingCondition.LastTransitionTime.Time) > newCondition.rate) {
 		setTransitionTime()
 		changed = true
 	}


### PR DESCRIPTION
## Summary

Fixes #1455. On a healthy Redpanda cluster the v2 controller reconciled every ~2 seconds instead of settling into the 3-minute `periodicRequeue` interval, driving up API-server traffic and CloudWatch audit-log costs on EKS.

### Root cause

`setStatusCondition` in `operator/internal/statuses/zz_generated_status.go` (introduced in 71dada0c, v25.2.1) has a rate-limited "heartbeat" branch:

```go
if newCondition.rate >= 0 && (time.Since(existingCondition.LastTransitionTime.Time) > newCondition.rate) {
    setTransitionTime()
    changed = true
}
```

`getRateLimit` returns `0` for every condition except `ClusterLicenseValid` and `ClusterConfigurationApplied`. For those zero-rate conditions:

- `0 >= 0` is true
- `time.Since(anything) > 0` is always true

→ every reconcile marks the condition dirty, bumps `lastTransitionTime`, writes status back to the API server, triggers a watch event, and immediately re-enqueues reconciliation.

### Fix

Change the guard from `rate >= 0` to `rate > 0`. The forced-update branch is meant to be a heartbeat for conditions with an explicit rate window; a zero rate means "no heartbeat." Real content changes (Status, Reason, Message, ObservedGeneration) continue to mark the condition dirty via the other branches below.

### Upstream fix

`zz_generated_status.go` is generated from `status.tpl` in `common-go/rp-controller-gen`, so the same fix is needed there: [redpanda-data/common-go#166](https://github.com/redpanda-data/common-go/pull/166). This PR bumps the `rp-controller-gen` pin in `ci/rp-controller-gen.nix` to the branch SHA (`59451d6`) so `task generate` reproduces the fixed output and CI's `git diff --exit-code` step is clean. Once common-go#166 merges, the pin should be moved to the merged-main SHA in a follow-up.

## Test plan

- [x] New unit tests in `operator/internal/statuses/rate_limit_test.go`:
  - `TestSetStatusCondition_RateZero_NoChangeWhenIdentical` — the regression test; fails against the buggy code.
  - `TestSetStatusCondition_RateZero_ChangedOnStatusUpdate` / `...OnReasonUpdate` / `...OnMessageUpdate` / `...OnGenerationUpdate` — real content changes are still detected.
  - `TestSetStatusCondition_RateLimited_NoHeartbeatBeforeElapsed` / `...HeartbeatAfterElapsed` — rate-limited heartbeat for License/Configuration still works as designed.
  - `TestSetStatusCondition_AppendsWhenExistingIsNil` — new-condition path unchanged.
  - `TestUpdateConditions_IdempotentOnHealthyCluster` — end-to-end: calling `UpdateConditions` twice with identical inputs returns `false` the second time (before the fix it returned `true`).
- [x] Verified tests fail on the unpatched code and pass with the fix.
- [x] `go test ./operator/internal/statuses/...` — all tests (generated + new) pass.
- [x] `golangci-lint run ./operator/internal/statuses/...` — clean.
- [x] `task generate` regenerates `zz_generated_status.go` to the fixed content from the upstream template (no diff vs. committed file).
