### PR TITLE
Fix handling of externally-specified bootstrap user secrets

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20260421-150000.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260421-150000.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Fixed an issue where the bootstrap user password was not loaded from an externally-managed secret referenced via `auth.sasl.bootstrapUser.secretKeyRef`, causing SCRAM authentication to fail from the operator and other chart-owned clients.
+time: 2026-04-21T15:00:00.000000-04:00

--- a/.changes/unreleased/operator-Fixed-20260421-150000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260421-150000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed an issue where the operator failed to authenticate to the Redpanda cluster with SCRAM when `bootstrapUser.secretKeyRef` pointed at an externally-managed secret.
+time: 2026-04-21T15:00:00.000000-04:00

--- a/charts/redpanda/chart/templates/_render_state.go.tpl
+++ b/charts/redpanda/chart/templates/_render_state.go.tpl
@@ -5,22 +5,21 @@
 {{- $r := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- if (or (or (eq (toJson $r.Values.auth.sasl) "null") (not $r.Values.auth.sasl.enabled)) (ne (toJson $r.Values.auth.sasl.bootstrapUser.secretKeyRef) "null")) -}}
+{{- if (or (eq (toJson $r.Values.auth.sasl) "null") (not $r.Values.auth.sasl.enabled)) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (list)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $secretName := (printf "%s-bootstrap-user" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r")) -}}
-{{- $_76_existing_1_ok_2 := (get (fromJson (include "_shims.lookup" (dict "a" (list "v1" "Secret" $r.Release.Namespace $secretName)))) "r") -}}
+{{- $selector := (get (fromJson (include "redpanda.BootstrapUser.SecretKeySelector" (dict "a" (list $r.Values.auth.sasl.bootstrapUser (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
+{{- $_76_existing_1_ok_2 := (get (fromJson (include "_shims.lookup" (dict "a" (list "v1" "Secret" $r.Release.Namespace $selector.name)))) "r") -}}
 {{- $existing_1 := (index $_76_existing_1_ok_2 0) -}}
 {{- $ok_2 := (index $_76_existing_1_ok_2 1) -}}
 {{- if $ok_2 -}}
 {{- $_ := (set $existing_1 "immutable" true) -}}
 {{- $_ := (set $r "BootstrapUserSecret" $existing_1) -}}
-{{- $selector := (get (fromJson (include "redpanda.BootstrapUser.SecretKeySelector" (dict "a" (list $r.Values.auth.sasl.bootstrapUser (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
-{{- $_93_data_3_found_4 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $existing_1.data $selector.key (coalesce nil))))) "r") -}}
-{{- $data_3 := (index $_93_data_3_found_4 0) -}}
-{{- $found_4 := (index $_93_data_3_found_4 1) -}}
+{{- $_92_data_3_found_4 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $existing_1.data $selector.key (coalesce nil))))) "r") -}}
+{{- $data_3 := (index $_92_data_3_found_4 0) -}}
+{{- $found_4 := (index $_92_data_3_found_4 1) -}}
 {{- if $found_4 -}}
 {{- $_ := (set $r "BootstrapUserPassword" (toString $data_3)) -}}
 {{- end -}}
@@ -33,9 +32,9 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- if $r.Release.IsUpgrade -}}
-{{- $_108_existing_5_ok_6 := (get (fromJson (include "_shims.lookup" (dict "a" (list "apps/v1" "StatefulSet" $r.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
-{{- $existing_5 := (index $_108_existing_5_ok_6 0) -}}
-{{- $ok_6 := (index $_108_existing_5_ok_6 1) -}}
+{{- $_107_existing_5_ok_6 := (get (fromJson (include "_shims.lookup" (dict "a" (list "apps/v1" "StatefulSet" $r.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $r)))) "r"))))) "r") -}}
+{{- $existing_5 := (index $_107_existing_5_ok_6 0) -}}
+{{- $ok_6 := (index $_107_existing_5_ok_6 1) -}}
 {{- if (and $ok_6 (gt ((get (fromJson (include "_shims.len" (dict "a" (list $existing_5.spec.template.metadata.labels)))) "r") | int) (0 | int))) -}}
 {{- $_ := (set $r "StatefulSetPodLabels" $existing_5.spec.template.metadata.labels) -}}
 {{- $_ := (set $r "StatefulSetSelector" $existing_5.spec.selector.matchLabels) -}}
@@ -64,9 +63,9 @@
 {{- $adminTLS = (get (fromJson (include "redpanda.InternalTLS.ToCommonTLS" (dict "a" (list $r.Values.listeners.admin.tls $r $r.Values.tls)))) "r") -}}
 {{- end -}}
 {{- $adminAuth := (coalesce nil) -}}
-{{- $_156_adminAuthEnabled__ := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" (index $r.Values.config.cluster "admin_api_require_auth") false)))) "r") -}}
-{{- $adminAuthEnabled := (index $_156_adminAuthEnabled__ 0) -}}
-{{- $_ := (index $_156_adminAuthEnabled__ 1) -}}
+{{- $_155_adminAuthEnabled__ := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" (index $r.Values.config.cluster "admin_api_require_auth") false)))) "r") -}}
+{{- $adminAuthEnabled := (index $_155_adminAuthEnabled__ 0) -}}
+{{- $_ := (index $_155_adminAuthEnabled__ 1) -}}
 {{- if $adminAuthEnabled -}}
 {{- $adminAuth = (mustMergeOverwrite (dict) (dict "username" $username "passwordSecretRef" (mustMergeOverwrite (dict) (dict "namespace" $r.Release.Namespace "secretKeyRef" (mustMergeOverwrite (dict "key" "") (mustMergeOverwrite (dict) (dict "name" $passwordRef.name)) (dict "key" $passwordRef.key)))))) -}}
 {{- end -}}

--- a/charts/redpanda/render_state.go
+++ b/charts/redpanda/render_state.go
@@ -68,11 +68,11 @@ type RenderState struct {
 // FetchBootstrapUser attempts to locate an existing bootstrap user secret in
 // the cluster. If found, it is stored in [RenderState.BootstrapUserSecret
 func (r *RenderState) FetchBootstrapUser() {
-	if r.Values.Auth.SASL == nil || !r.Values.Auth.SASL.Enabled || r.Values.Auth.SASL.BootstrapUser.SecretKeyRef != nil {
+	if r.Values.Auth.SASL == nil || !r.Values.Auth.SASL.Enabled {
 		return
 	}
 
-	secretName := fmt.Sprintf("%s-bootstrap-user", Fullname(r))
+	selector := r.Values.Auth.SASL.BootstrapUser.SecretKeySelector(Fullname(r))
 
 	// Some tools don't correctly set .Release.Upgrade (ArgoCD, gotohelm, helm
 	// template) which has lead us to incorrectly re-generate the bootstrap
@@ -82,11 +82,10 @@ func (r *RenderState) FetchBootstrapUser() {
 	// TODO: Should we try to detect invalid configurations, panic, and request
 	// that a password be explicitly set?
 	// See also: https://github.com/redpanda-data/helm-charts/issues/1596
-	if existing, ok := helmette.Lookup[corev1.Secret](r.Dot, r.Release.Namespace, secretName); ok {
+	if existing, ok := helmette.Lookup[corev1.Secret](r.Dot, r.Release.Namespace, selector.Name); ok {
 		// make any existing secret immutable
 		existing.Immutable = ptr.To(true)
 		r.BootstrapUserSecret = existing
-		selector := r.Values.Auth.SASL.BootstrapUser.SecretKeySelector(Fullname(r))
 		if data, found := existing.Data[selector.Key]; found {
 			r.BootstrapUserPassword = string(data)
 		}

--- a/charts/redpanda/render_state_test.go
+++ b/charts/redpanda/render_state_test.go
@@ -12,9 +12,12 @@ package redpanda
 import (
 	"testing"
 
+	"github.com/redpanda-data/common-go/kube"
+	"github.com/redpanda-data/common-go/kube/kubetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
@@ -111,6 +114,108 @@ func TestCertificates(t *testing.T) {
 			require.Equal(t, c.ExpectedRootCertName, actualRootCertName)
 			require.Equal(t, c.ExpectedRootCertKey, actualRootCertKey)
 			require.Equal(t, c.ExpectedClientCertName, actualClientCertName)
+		})
+	}
+}
+
+func TestFetchBootstrapUser(t *testing.T) {
+	ctl := kubetest.NewEnv(t)
+	ctx := t.Context()
+
+	const namespace = "fetch-bootstrap-user"
+
+	_, err := kube.Create(ctx, ctl, corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	})
+	require.NoError(t, err)
+
+	// The chart-managed secret uses the default name format `<release>-bootstrap-user`.
+	_, err = kube.Create(ctx, ctl, corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "redpanda-bootstrap-user", Namespace: namespace},
+		Data:       map[string][]byte{"password": []byte("chart-managed-password")},
+	})
+	require.NoError(t, err)
+
+	// An externally-managed secret with a non-default key name.
+	_, err = kube.Create(ctx, ctl, corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-secret", Namespace: namespace},
+		Data:       map[string][]byte{"custom-key": []byte("user-provided-password")},
+	})
+	require.NoError(t, err)
+
+	makeState := func(sasl *SASLAuth) *RenderState {
+		return &RenderState{
+			Release: &helmette.Release{Name: "redpanda", Namespace: namespace},
+			Values:  Values{Auth: Auth{SASL: sasl}},
+			Dot:     &helmette.Dot{KubeConfig: ctl.RestConfig()},
+		}
+	}
+
+	cases := map[string]struct {
+		sasl         *SASLAuth
+		wantPassword string
+		wantSecret   bool
+	}{
+		"sasl nil": {
+			sasl: nil,
+		},
+		"sasl disabled": {
+			sasl: &SASLAuth{Enabled: false},
+		},
+		"chart-managed secret present": {
+			sasl:         &SASLAuth{Enabled: true},
+			wantPassword: "chart-managed-password",
+			wantSecret:   true,
+		},
+		"user-provided secret present": {
+			sasl: &SASLAuth{
+				Enabled: true,
+				BootstrapUser: BootstrapUser{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "user-secret"},
+						Key:                  "custom-key",
+					},
+				},
+			},
+			wantPassword: "user-provided-password",
+			wantSecret:   true,
+		},
+		"user-provided secret missing": {
+			sasl: &SASLAuth{
+				Enabled: true,
+				BootstrapUser: BootstrapUser{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "does-not-exist"},
+						Key:                  "password",
+					},
+				},
+			},
+		},
+		"user-provided secret wrong key": {
+			sasl: &SASLAuth{
+				Enabled: true,
+				BootstrapUser: BootstrapUser{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "user-secret"},
+						Key:                  "missing-key",
+					},
+				},
+			},
+			wantSecret: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			state := makeState(tc.sasl)
+			state.FetchBootstrapUser()
+
+			require.Equal(t, tc.wantPassword, state.BootstrapUserPassword)
+			if tc.wantSecret {
+				require.NotNil(t, state.BootstrapUserSecret)
+			} else {
+				require.Nil(t, state.BootstrapUserSecret)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This fixes an issue where specifying a bootstrap user secret in a Redpanda CRD makes the operator fail to auth against the cluster without also specifying superusers.