### PR TITLE
operator: Create release process for k8s rpk plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,34 @@ jobs:
           echo "packaging chart at $chart_path"
           helm package -u --version "$version" "$(dirname "$chart_path")"
 
+      - name: build rpk-k8s binaries
+        continue-on-error: true
+        run: |
+          set -ex
+          tag="${{ steps.get_ref.outputs.ref_name }}"
+          # OPERATOR_VERSION — baked into the rpk-k8s binary via ldflags — is
+          # only meaningful for operator/v* tags, so skip for any other tag.
+          if [[ "$tag" != operator/v* ]]; then
+            echo "tag $tag is not an operator tag. skipping rpk-k8s build."
+            exit 0
+          fi
+
+          nix develop -c task ci:build:rpk-k8s
+
+          # Package each architecture's binary as its own tar.gz so the
+          # "create github release" step picks them up via the ./*.tar.gz glob.
+          version="$(basename "$tag")"
+          for bin in .build/rpk-k8s-*; do
+            [[ -f "$bin" ]] || continue
+            name="$(basename "$bin")"
+            # Use the binary's base name (without .exe) for the archive name
+            # so `rpk-k8s-windows-amd64.exe` becomes
+            # `rpk-k8s-windows-amd64-<version>.tar.gz` but still contains the
+            # .exe inside.
+            archive_base="${name%.exe}"
+            tar -czf "${archive_base}-${version}.tar.gz" -C .build "$name"
+          done
+
       - name: reformat change log
         run: |
           # Our CHANGE LOGS begin with '## VERSION - DATE', which is
@@ -105,6 +133,7 @@ jobs:
           # if a chart was packaged, we'll upload it to this release preserving helm's naming convention.
           files: |
             ./*.tgz
+            ./*.tar.gz
 
       # Trigger a workflow in the helm-charts repo to update the gh-pages index.yaml.
       # https://github.com/redpanda-data/helm-charts/blob/main/.github/workflows/release_from_operator.yaml

--- a/operator/cmd/rpk-k8s/k8s/k8s.go
+++ b/operator/cmd/rpk-k8s/k8s/k8s.go
@@ -24,6 +24,7 @@ func Command() *cobra.Command {
 
 	cmd.AddCommand(
 		multicluster.Command(),
+		versionCommand(),
 	)
 
 	return cmd

--- a/operator/cmd/rpk-k8s/k8s/version.go
+++ b/operator/cmd/rpk-k8s/k8s/version.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package k8s
+
+import (
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// These variables are populated via -ldflags at build time from the
+// OPERATOR_VERSION taskfile variable.
+var (
+	Version   string
+	commit    string
+	buildDate string
+)
+
+func versionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print build information",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Printf("Version: %s\n", Version)
+			cmd.Printf("Commit: %s\n", commit)
+			cmd.Printf("Go Version: %s\n", runtime.Version())
+			cmd.Printf("Build Date: %s\n", buildDate)
+		},
+	}
+}

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -141,6 +141,39 @@ tasks:
       - buildkite-agent artifact upload "{{.SRC_DIR}}/operator/{{.KUTTL_ARTIFACTS_DIR | base}}.tar.gz"
       - buildkite-agent artifact upload "{{.SRC_DIR}}/operator/{{.KUTTL_ARTIFACTS_DIR}}/kuttl-report.xml"
 
+  build:rpk-k8s:
+    desc: "Build the rpk-k8s plugin binary for multiple OS/arch combinations"
+    vars:
+      # Platforms to build the rpk-k8s binary for. Each entry must be in
+      # `<goos>/<goarch>` form. Callers can override by passing PLATFORMS as
+      # a task variable.
+      PLATFORMS: '{{ .PLATFORMS | default "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64" }}'
+      # Bake OPERATOR_VERSION (not a git tag) into the binary so `rpk k8s version`
+      # reports the same version that stamps the operator image.
+      LD_FLAGS: >-
+        -X "google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore"
+        -X "github.com/redpanda-data/redpanda-operator/operator/cmd/rpk-k8s/k8s.Version={{.OPERATOR_VERSION}}"
+        -X "github.com/redpanda-data/redpanda-operator/operator/cmd/rpk-k8s/k8s.commit={{.COMMIT}}"
+        -X "github.com/redpanda-data/redpanda-operator/operator/cmd/rpk-k8s/k8s.buildDate={{.TIMESTAMP}}"
+    cmds:
+      - |
+        set -euo pipefail
+        for platform in {{.PLATFORMS}}; do
+          goos="${platform%/*}"
+          goarch="${platform#*/}"
+          ext=""
+          if [ "$goos" = "windows" ]; then
+            ext=".exe"
+          fi
+          out="{{.BUILD_ROOT}}/rpk-k8s-${goos}-${goarch}${ext}"
+          echo "Building rpk-k8s for ${goos}/${goarch} -> ${out}"
+          CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+            go build -C ./operator \
+            -o "${out}" \
+            -ldflags='{{.LD_FLAGS}}' \
+            ./cmd/rpk-k8s
+        done
+
   publish-operator-image:
     deps:
       - :dev:create-buildx-builder


### PR DESCRIPTION
Attach multi-arch rpk-k8s plugin binaries to the GitHub release that
fires on an operator/v* tag so users can install the plugin without
building from source.

- Add a `version` subcommand to rpk-k8s that prints Version, commit,
  Go version and build date. Values are populated via -ldflags from
  the OPERATOR_VERSION, COMMIT and TIMESTAMP taskfile variables;
  OPERATOR_VERSION (not the git tag) is the source of truth for the
  binary version.
- Add `ci:build:rpk-k8s` to cross-compile the plugin for
  linux/darwin/windows × amd64/arm64 into
  .build/rpk-k8s-<goos>-<goarch>[.exe].
- In .github/workflows/release.yml, insert a `build rpk-k8s binaries`
  step (gated on `operator/v*`) that runs the task and packages each
  binary as rpk-k8s-<goos>-<goarch>-<version>.tar.gz, and extend the
  softprops/action-gh-release `files:` glob with ./*.tar.gz so the
  archives are attached alongside the helm chart .tgz.

## Manual try

I was able to perform successful release:
https://github.com/redpanda-data/redpanda-operator/actions/runs/24843595687/job/72724257830

https://github.com/redpanda-data/redpanda-operator/releases/tag/untagged-d8c379e2c59693bd7f35

<img width="1197" height="604" alt="Screenshot 2026-04-23 at 17 45 40" src="https://github.com/user-attachments/assets/1a39b716-cddb-4265-8b69-e955b54b5332" />

New version subcommand was added. After unpacking and moving plugin to `$HOME/.local/bin/.rpk.ac-k8s` location the output is as follows:
```
$ rpk k8s version
Version: v26.1.3
Commit: c09b922bc97d7981475657df3305c4f8c81b5cbb
Go Version: go1.26.1
Build Date: 2026-04-23T15:34:16:16Z
```

### Second attempt

Second attempt with tar.gz file extension failed, but it should work. I asked platform team to decipher github cli error.
<img width="1204" height="516" alt="Screenshot 2026-04-23 at 18 14 11" src="https://github.com/user-attachments/assets/2fe3ab3d-f168-4b84-a3b8-87394c3643aa" />

https://github.com/redpanda-data/redpanda-operator/actions/runs/24845109465/job/72729836543#step:10:32

https://github.com/redpanda-data/redpanda-operator/releases/tag/untagged-87c43be6e0d0f35d9dc1