### PR TITLE
Pb/fix admin client timeout stretch

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260424-091534.yaml
+++ b/.changes/unreleased/operator-Fixed-20260424-091534.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: StretchCluster admin API client now honours the Factory.WithAdminClientTimeout setting on all code paths (previously silently dropped) and the multicluster binary exposes a --cluster-connection-timeout flag to configure it.
+time: 2026-04-24T09:15:34.075775705+02:00

--- a/charts/redpanda/client/client.go
+++ b/charts/redpanda/client/client.go
@@ -67,7 +67,7 @@ func AdminClient(state *redpanda.RenderState, dialer DialContextFunc, opts ...rp
 	return client, nil
 }
 
-func AdminClientForStretch(dialer DialContextFunc, hosts []string, username, password string, tlsConfig *tls.Config) (*rpadmin.AdminAPI, error) {
+func AdminClientForStretch(dialer DialContextFunc, hosts []string, username, password string, tlsConfig *tls.Config, opts ...rpadmin.Opt) (*rpadmin.AdminAPI, error) {
 	var auth rpadmin.Auth
 	if username != "" {
 		auth = &rpadmin.BasicAuth{
@@ -79,7 +79,7 @@ func AdminClientForStretch(dialer DialContextFunc, hosts []string, username, pas
 	}
 
 	// NB: rpadmin automatically infers http or https, if not provided, based on the tlsConfig.
-	c, err := rpadmin.NewAdminAPIWithDialer(hosts, auth, tlsConfig, dialer)
+	c, err := rpadmin.NewAdminAPIWithDialer(hosts, auth, tlsConfig, dialer, opts...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/charts/redpanda/client/client_test.go
+++ b/charts/redpanda/client/client_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/common-go/rpadmin"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for the StretchCluster admin-client timeout bug: before the fix,
+// AdminClientForStretch silently dropped rpadmin.Opt values, so the operator's
+// configured ClientTimeout never took effect on the Stretch path. Requests
+// would hang for the full rpadmin default (10s) instead of the configured
+// shorter value.
+func TestAdminClientForStretch_AppliesClientTimeout(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	const configuredTimeout = 200 * time.Millisecond
+	// MaxRetries(1) isolates the per-attempt timeout: rpadmin's retry client
+	// otherwise multiplies ClientTimeout by the retry count plus its own
+	// backoff, muddying the signal. Without the fix in AdminClientForStretch
+	// the opts below would be ignored entirely and the call would hang for
+	// rpadmin's default 10s ClientTimeout.
+	adminClient, err := AdminClientForStretch(nil, []string{host}, "", "", nil,
+		rpadmin.ClientTimeout(configuredTimeout),
+		rpadmin.MaxRetries(1),
+	)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = adminClient.GetFeatures(context.Background())
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "request against the hanging server must fail")
+	// A pre-fix build would stall here for ~10s (the rpadmin default). The
+	// 3s ceiling is generous enough for CI jitter but catches the regression.
+	require.LessOrEqual(t, elapsed, 3*time.Second,
+		"AdminClientForStretch did not apply the configured ClientTimeout (%s); request took %s",
+		configuredTimeout, elapsed)
+}

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -83,6 +83,8 @@ type MulticlusterOptions struct {
 	UnbindPVCsAfter  time.Duration
 	AllowPVRebinding bool
 	UnbinderSelector pflagutil.LabelSelectorValue
+
+	ClusterConnectionTimeout time.Duration
 }
 
 func (o *MulticlusterOptions) validate() error {
@@ -174,6 +176,7 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&o.UnbindPVCsAfter, "unbind-pvcs-after", 0, "if not zero, runs the PVCUnbinder controller which attempts to 'unbind' the PVCs' of Pods that are Pending for longer than the given duration")
 	cmd.Flags().BoolVar(&o.AllowPVRebinding, "allow-pv-rebinding", false, "controls whether or not PVs unbound by the PVCUnbinder have their .ClaimRef cleared, which allows them to be reused")
 	cmd.Flags().Var(&o.UnbinderSelector, "unbinder-label-selector", "if provided, a Kubernetes label selector that will filter Pods to be considered by the PVCUnbinder.")
+	cmd.Flags().DurationVar(&o.ClusterConnectionTimeout, "cluster-connection-timeout", 10*time.Second, "Timeout for internal clients used to connect to Redpanda clusters (admin API in particular)")
 }
 
 func Command() *cobra.Command {
@@ -341,7 +344,7 @@ func Run(
 		Tag:        opts.BaseTag,
 	}
 
-	factory := internalclient.NewFactory(manager, nil).WithAdminClientTimeout(10 * time.Second)
+	factory := internalclient.NewFactory(manager, nil).WithAdminClientTimeout(opts.ClusterConnectionTimeout)
 
 	if err := redpandacontrollers.SetupMulticlusterController(ctx, manager, redpandaImage, sidecarImage, cloudSecrets, factory); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Multicluster")

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -71,7 +71,7 @@ func (c *Factory) redpandaAdminForStretchCluster(ctx context.Context, sc *redpan
 		return nil, errors.Wrap(err, "reading auth credentials")
 	}
 
-	adminClient, err := redpandaclient.AdminClientForStretch(c.dialer, endpoints, username, password, tlsConfig)
+	adminClient, err := redpandaclient.AdminClientForStretch(c.dialer, endpoints, username, password, tlsConfig, rpadmin.ClientTimeout(c.adminClientTimeout))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating admin client")
 	}

--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -63,6 +63,6 @@ tasks:
 
   setup-multicluster-dev-env:
     - 'echo "--- Setting up multicluster dev env using k3s and vCluster(s)"'
-    - task: :test:acceptance
+    - task: :test:acceptance-multicluster
       vars:
         CLI_ARGS: '{{.CLI_ARGS}} -v -count=1 -multi-cluster-setup-only'


### PR DESCRIPTION
## Summary                                                                                                                                                                 
   
  Fixes a wiring bug that silently dropped the operator's admin-client timeout on the StretchCluster path. `AdminClientForStretch` accepted no `rpadmin.Opt` values, so      
  `ClientTimeout` set via `Factory.WithAdminClientTimeout(...)` never took effect and every admin call fell back to rpadmin's internal 10 s default × ~3 retries ≈ 30 s per
  reconcile — with no operator-visible knob to tune it.                                                                                                                      
                                                            
  ## Problem

  - `charts/redpanda/client/client.go` — `AdminClientForStretch` had no variadic `opts ...rpadmin.Opt` parameter and called `rpadmin.NewAdminAPIWithDialer(...)` without     
  forwarding any options. Its sibling `AdminClient` already forwards `opts...` correctly.
  - `operator/pkg/client/stretch_cluster.go` — `Factory.redpandaAdminForStretchCluster` built an admin client without passing `rpadmin.ClientTimeout(c.adminClientTimeout)`, 
  unlike every other admin-client construction in the Factory (spec, rpk, cluster paths).                                                                                    
   
  Combined effect: admin calls from the StretchCluster reconciler were bounded only by rpadmin's hardcoded default. A slow broker would stall reconciliation for ~30 s       
  regardless of what anyone set on the factory.             
                                                                                                                                                                             
  ## Solution                                               

  Plumb `opts ...rpadmin.Opt` through `AdminClientForStretch` and forward them to `rpadmin.NewAdminAPIWithDialer`. Have `Factory.redpandaAdminForStretchCluster` pass        
  `rpadmin.ClientTimeout(c.adminClientTimeout)` — the same field the Redpanda-CR path already uses.
                                                                                                                                                                             
  ## Bonus fixes                                            

  Two adjacent issues surfaced while verifying the main fix; they live in this PR because the main fix is unobservable without them:                                         
   
  - **`operator/cmd/multicluster/multicluster.go` didn't expose a CLI flag for the timeout.** `WithAdminClientTimeout(10*time.Second)` was a literal constant, so even after 
  the main fix there was no way for operators to configure the ceiling. The `run` binary already has `--cluster-connection-timeout`. Add the same flag to the multicluster
  binary (default 10 s, matching) and wire it in. The helm chart already merges `--flag=value` entries from `values.additionalCmdFlags`, so no chart schema change is        
  required — operators can set it via helm values.          
  - **`taskfiles/dev.yml`** — `dev:setup-multicluster-dev-env` now invokes `:test:acceptance-multicluster` instead of `:test:acceptance`, so the setup-only mode exercises
  the same pipeline CI uses for multicluster tests.                                                                                                                          
   
  ## Verification                                                                                                                                                            
                                                            
  **Unit test** (`charts/redpanda/client/client_test.go`): starts an `httptest.NewServer` whose handler hangs forever, configures `AdminClientForStretch` with               
  `rpadmin.ClientTimeout(200ms)` + `MaxRetries(1)`, asserts the call fails within a 3 s ceiling.
                                                                                                                                                                             
  - With the fix: **0.20 s** elapsed — the configured timeout takes effect.                                                                                                  
  - Simulated regression (drop `opts...` from the forward call): **33.14 s** elapsed — rpadmin's 10 s default × retries kicks back in.
                                                                                                                                                                             
  The 3 s ceiling is generous enough for CI jitter but cleanly rejects the pre-fix behaviour.                                                                                
                                                                                                                                                                             
  **Manual check** against a local multicluster dev env with `--cluster-connection-timeout=3s` set via `additionalCmdFlags`, and 30 s of egress latency injected on the      
  leader operator's traffic to the broker admin API (port 9644):
                                                                                                                                                                             
  | Metric | Pre-fix | Post-fix |                           
  |---|---|---|
  | Max StretchCluster reconcile `elapsed` | 30.42 s | **7.52 s** (≈ 3 s × retries) |
  | Operator pod restarts during chaos | 0 | 0 |                                                                                                                             
  | `--cluster-connection-timeout` effect | ignored | honoured |
                                                                                                                                                                             
  ## Test plan                                              
                                                                                                                                                                             
  - [ ] `go test ./charts/redpanda/client/` — new regression test passes.
  - [ ] `nix develop -c task test:unit` — broader unit suite still green.
  - [ ] Smoke the multicluster dev env via `task dev:setup-multicluster-dev-env` and confirm the operator pods come up with the expected args.                               
                                                                                                                                                                             
  ## Notes                                                                                                                                                                   
                                                                                                                                                                             
  Pure plumbing; no behaviour change for anyone happy with the 10 s default. Only observable effect on existing deployments is that the timeout knob now actually works.