### PR TITLE
hack/multicluster: add failure-injection repro scripts

### DIFF
--- a/hack/multicluster/repro/README.md
+++ b/hack/multicluster/repro/README.md
@@ -1,0 +1,84 @@
+# Multicluster operator — failure-injection repro scripts
+
+Standalone scripts that reproduce specific resilience bugs in the multicluster
+operator by injecting network faults with [Pumba](https://github.com/alexei-led/pumba)
+and reading back observable effects from operator logs / reconcile durations.
+
+Each script is an opinionated, one-shot demo: it picks a target, applies a
+specific fault, waits, measures, prints a PASS/FAIL verdict, and cleans up on
+exit (including Ctrl-C). No state is left behind in a healthy run.
+
+## What each script reproduces
+
+| Script | Finding | Injection |
+|---|---|---|
+| `finding-01-dosend-stall.sh`      | raft `DoSend` synchronous in Ready loop → leader churn under asymmetric silent drop | 100% packet loss on leader→peer tcp/9443 |
+| `finding-02-03-admin-unbounded.sh` | admin-client `ClientTimeout` dropped on StretchCluster path + reconcile has no `context.WithTimeout` | `netem delay 30s` on leader egress to admin tcp/9644 |
+| `finding-04-serial-fanout.sh`     | `syncStatus`/`setupLicense`/Phase-1 scans iterate clusters serially with no reachability check | `netem delay` on leader egress to one peer's K8s API |
+| `finding-05-probe-flap.sh`        | health probe has no hysteresis at marginal RTT → `SpecSynced` flaps | `netem delay 4.5s ± 500ms` on leader egress to one peer's K8s API |
+
+## Requirements
+
+- `kubectl`, with a context pointing at the cluster (or clusters) under test
+- A Linux node capable of running privileged pods with `hostPID` and a bind-mounted `/run` / `/var/lib` — this is fine on EKS/GKE/AKS standard node pools, k3s, k3d, and kind, but not on GKE Autopilot, EKS Fargate, or Bottlerocket (which lack the tc-netem kernel module)
+- Outbound internet from the target node to `ghcr.io` to pull `pumba:1.0.6` and `pumba-alpine-nettools:latest`
+
+The scripts deploy the Pumba Job and a privileged `netshoot` debug pod on the
+node that hosts the target operator, and clean both up on exit.
+
+## Running
+
+### Default: local vcluster-on-k3d dev env
+
+Stand up the repo's dev environment with:
+
+```bash
+task dev:setup-multicluster-dev-env
+```
+
+Then run any of the scripts with no flags — they auto-detect the three
+vcluster namespaces and the current raft leader:
+
+```bash
+./finding-05-probe-flap.sh
+```
+
+### Real multi-cluster (multi-cloud or multi-region)
+
+Pass comma-separated kube contexts, one per cluster:
+
+```bash
+./finding-01-dosend-stall.sh \
+  --contexts=eks-us-east-1,gke-us-central1,aks-eastus2 \
+  --namespace=redpanda \
+  --containerd-sock=/run/containerd/containerd.sock
+```
+
+The containerd socket defaults to k3s's `/run/k3s/containerd/containerd.sock`;
+standard EKS/GKE/AKS node pools use `/run/containerd/containerd.sock`.
+
+### All available flags
+
+Every script prints its full flag list with `--help`, including the common
+flags (`--contexts`, `--namespace`, `--operator-label`, `--operator-service`,
+`--containerd-sock`, `--pumba-image`, `--tc-image`).
+
+## How results are interpreted
+
+Each script prints a `RESULT:` line:
+
+- `CONFIRMED` — the bug was observed end-to-end (elections triggered, timeouts
+  fired, flaps observed, etc.)
+- `NOT REPRODUCED` — the observation window elapsed without the expected
+  signal. Either the fix is applied, the latency/duration is off, or the
+  filter missed. Each script suggests the first thing to bump.
+
+The scripts exit 0 on CONFIRMED and non-zero on NOT REPRODUCED, so they can
+drive CI when desired. In pure demo mode, the exit code can be ignored.
+
+## Limitations
+
+These are script-driven repros, not integration tests — they rely on Pumba,
+tc netem, and network-layer timing. They are meant to catch the *class* of
+bug rather than the *exact* line-of-code regression. Line-level regression
+coverage for each finding should live in unit tests alongside the fix.

--- a/hack/multicluster/repro/_lib.sh
+++ b/hack/multicluster/repro/_lib.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# Shared helpers for the finding-XX repro scripts. Source this file from
+# each script before parsing flags. Supports two discovery modes:
+#
+#   - vcluster-on-k3d (default):
+#         assumes `task dev:setup-multicluster-dev-env` has produced three
+#         vclusters under a single host k3d cluster, with host namespaces
+#         named `vc-<prefix>-{0,1,2}`.
+#
+#   - multi-context (real clusters):
+#         pass `--contexts=ctxA,ctxB,ctxC` on the script. Each context is
+#         used directly (EKS/GKE/AKS/kind/etc). The operator is assumed to
+#         live in namespace `$MC_NAMESPACE` (default `redpanda`) with the
+#         usual helm-chart label selector.
+#
+# All environment variables below are overridable; the defaults fit the
+# vcluster-on-k3d setup so the scripts work with no arguments.
+
+MC_NAMESPACE="${MC_NAMESPACE:-redpanda}"
+MC_OPERATOR_LABEL="${MC_OPERATOR_LABEL:-app.kubernetes.io/name=operator,app.kubernetes.io/instance=redpanda}"
+MC_OPERATOR_SERVICE="${MC_OPERATOR_SERVICE:-multicluster-operator}"
+MC_CONTAINERD_SOCK="${MC_CONTAINERD_SOCK:-/run/k3s/containerd/containerd.sock}"
+MC_PUMBA_IMAGE="${MC_PUMBA_IMAGE:-ghcr.io/alexei-led/pumba:1.0.6}"
+MC_PUMBA_TC_IMAGE="${MC_PUMBA_TC_IMAGE:-ghcr.io/alexei-led/pumba-alpine-nettools:latest}"
+MC_RAFT_PORT="${MC_RAFT_PORT:-9443}"
+MC_API_PORT="${MC_API_PORT:-443}"
+
+# Parallel arrays, populated by mc::discover. Index them together.
+MC_CLUSTER_LABELS=()   # human-readable label (context or host ns)
+MC_CLUSTER_CTXS=()     # kubectl context ("" = use current)
+MC_CLUSTER_NSS=()      # namespace where the operator pod lives (as visible to `kubectl`)
+MC_CLUSTER_PODS=()
+MC_CLUSTER_NODES=()
+MC_CLUSTER_RAFT_IPS=() # peer raft gRPC ClusterIP as other peers reach it
+MC_CLUSTER_API_IPS=()  # peer K8s API endpoint as other peers reach it
+
+log() { printf '[%s] %s\n' "${MC_SCRIPT_TAG:-mc}" "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# Run kubectl bound to the idx-th cluster's context (empty = current ctx).
+mc::kubectl() {
+  local idx="$1"; shift
+  local ctx="${MC_CLUSTER_CTXS[idx]:-}"
+  if [[ -n "${ctx}" ]]; then
+    kubectl --context="${ctx}" "$@"
+  else
+    kubectl "$@"
+  fi
+}
+
+# Populate the parallel arrays. Either $MC_CONTEXTS is set (CSV of contexts)
+# or we fall back to vcluster-on-k3d discovery via $MC_VC_PREFIX.
+mc::discover() {
+  if [[ -n "${MC_CONTEXTS:-}" ]]; then
+    mc::discover_contexts
+  else
+    mc::discover_vcluster
+  fi
+  (( ${#MC_CLUSTER_LABELS[@]} >= 2 )) || die "discovered fewer than 2 clusters — nothing to repro"
+}
+
+mc::discover_contexts() {
+  local ctxs=()
+  IFS=',' read -r -a ctxs <<<"${MC_CONTEXTS}"
+  (( ${#ctxs[@]} >= 2 )) || die "--contexts must list at least 2 contexts"
+  local ctx
+  for ctx in "${ctxs[@]}"; do
+    local pod
+    pod="$(kubectl --context="${ctx}" get pod -n "${MC_NAMESPACE}" -l "${MC_OPERATOR_LABEL}" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    [[ -n "${pod}" ]] || { log "WARN: no operator pod in ${ctx}/${MC_NAMESPACE} — skipping"; continue; }
+    local node
+    node="$(kubectl --context="${ctx}" get pod -n "${MC_NAMESPACE}" "${pod}" -o jsonpath='{.spec.nodeName}')"
+    local raft_ip
+    raft_ip="$(kubectl --context="${ctx}" get svc -n "${MC_NAMESPACE}" "${MC_OPERATOR_SERVICE}" \
+      -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+    [[ -n "${raft_ip}" ]] || die "no Service ${MC_NAMESPACE}/${MC_OPERATOR_SERVICE} in ctx=${ctx}"
+    # For peer K8s API, resolve the server URL from the context's kubeconfig.
+    # This is what the leader operator will dial when it reaches out via the
+    # peer kubeconfig cache.
+    local api_url api_host api_ip
+    api_url="$(kubectl --context="${ctx}" config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || true)"
+    api_host="$(printf '%s' "${api_url}" | sed -E 's|^https?://([^:/]+).*|\1|')"
+    if [[ "${api_host}" =~ ^[0-9.]+$ ]]; then
+      api_ip="${api_host}"
+    else
+      api_ip="$(getent ahostsv4 "${api_host}" 2>/dev/null | awk '/STREAM/ { print $1; exit }' || true)"
+      [[ -n "${api_ip}" ]] || api_ip="${api_host}"
+    fi
+    MC_CLUSTER_LABELS+=("${ctx}")
+    MC_CLUSTER_CTXS+=("${ctx}")
+    MC_CLUSTER_NSS+=("${MC_NAMESPACE}")
+    MC_CLUSTER_PODS+=("${pod}")
+    MC_CLUSTER_NODES+=("${node}")
+    MC_CLUSTER_RAFT_IPS+=("${raft_ip}")
+    MC_CLUSTER_API_IPS+=("${api_ip}")
+  done
+}
+
+mc::discover_vcluster() {
+  if [[ -z "${MC_VC_PREFIX:-}" ]]; then
+    MC_VC_PREFIX="$(kubectl get ns -o name 2>/dev/null \
+      | sed -n 's|^namespace/\(vc-[a-z0-9]*\)-0$|\1|p' | head -1)"
+    [[ -n "${MC_VC_PREFIX}" ]] || die "cannot auto-detect vcluster prefix — pass --vc-prefix= or --contexts="
+  fi
+  local suffix
+  for suffix in 0 1 2; do
+    local ns="${MC_VC_PREFIX}-${suffix}"
+    local pod
+    pod="$(kubectl get pod -n "${ns}" -l "${MC_OPERATOR_LABEL}" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    [[ -n "${pod}" ]] || continue
+    local node
+    node="$(kubectl get pod -n "${ns}" "${pod}" -o jsonpath='{.spec.nodeName}')"
+    local raft_ip api_ip
+    raft_ip="$(kubectl get svc -n "${ns}" "${MC_OPERATOR_SERVICE}-x-default-x-${ns}" \
+      -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+    api_ip="$(kubectl get svc -n "${ns}" "${ns}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+    MC_CLUSTER_LABELS+=("${ns}")
+    MC_CLUSTER_CTXS+=("")
+    MC_CLUSTER_NSS+=("${ns}")
+    MC_CLUSTER_PODS+=("${pod}")
+    MC_CLUSTER_NODES+=("${node}")
+    MC_CLUSTER_RAFT_IPS+=("${raft_ip}")
+    MC_CLUSTER_API_IPS+=("${api_ip}")
+  done
+}
+
+# Return the index of the cluster currently driving MulticlusterReconciler.
+# grep -c is used instead of grep -q because pipefail trips on SIGPIPE when
+# grep -q exits early.
+mc::find_leader_idx() {
+  local i
+  for i in "${!MC_CLUSTER_LABELS[@]}"; do
+    local count
+    set +o pipefail
+    count="$(mc::kubectl "${i}" logs -n "${MC_CLUSTER_NSS[i]}" "${MC_CLUSTER_PODS[i]}" --tail=400 2>/dev/null \
+      | grep -c 'MulticlusterReconciler\.Reconcile')"
+    set -o pipefail
+    if (( ${count:-0} > 0 )); then
+      printf '%s\n' "${i}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Refresh pod/node info for one index. Useful after leadership moves and we
+# want to target whichever operator pod is currently leader.
+mc::refresh_idx() {
+  local i="$1"
+  local pod
+  pod="$(mc::kubectl "${i}" get pod -n "${MC_CLUSTER_NSS[i]}" -l "${MC_OPERATOR_LABEL}" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  [[ -n "${pod}" ]] || return 1
+  MC_CLUSTER_PODS[i]="${pod}"
+  MC_CLUSTER_NODES[i]="$(mc::kubectl "${i}" get pod -n "${MC_CLUSTER_NSS[i]}" "${pod}" -o jsonpath='{.spec.nodeName}')"
+}
+
+# Ensure a privileged netshoot pod exists on the same cluster+node as the
+# idx-th operator. Used to nsenter into the operator pod's netns for tc
+# cleanup. Idempotent.
+mc::debug_pod_ensure() {
+  local idx="$1"
+  local pod_name="$2"
+  if ! mc::kubectl "${idx}" get pod -n default "${pod_name}" >/dev/null 2>&1; then
+    mc::kubectl "${idx}" apply -f - >/dev/null <<EOF
+apiVersion: v1
+kind: Pod
+metadata: { name: ${pod_name}, namespace: default }
+spec:
+  nodeName: ${MC_CLUSTER_NODES[idx]}
+  hostPID: true
+  hostNetwork: true
+  containers:
+  - name: debug
+    image: nicolaka/netshoot
+    command: ["sleep","3600"]
+    securityContext: { privileged: true }
+EOF
+  fi
+  mc::kubectl "${idx}" wait --for=condition=Ready pod/"${pod_name}" -n default --timeout=90s >/dev/null
+}
+
+# Delete any residual tc qdisc on the operator pod's netns in the cluster
+# that the debug pod belongs to.
+mc::debug_pod_clear_tc() {
+  local idx="$1"
+  local pod_name="$2"
+  mc::kubectl "${idx}" exec -n default "${pod_name}" -- sh -c '
+    for p in $(pgrep -f "^/redpanda-operator"); do
+      nsenter -t $p -n tc qdisc del dev eth0 root 2>/dev/null || true
+    done
+  ' >/dev/null 2>&1 || true
+}
+
+# Launch a Pumba Job pinned to the idx-th cluster's leader node, passing
+# the remaining arguments verbatim as the pumba binary args. The Job is
+# deployed in the `default` namespace of that cluster.
+#
+# Usage: mc::pumba_launch <idx> <job_name> <pumba_arg> [pumba_arg...]
+#
+# The --runtime/--containerd-socket/--containerd-namespace prefix is added
+# automatically so callers only supply the chaos-specific args (netem /
+# iptables / etc.).
+mc::pumba_launch() {
+  local idx="$1"; shift
+  local job_name="$1"; shift
+
+  local -a full_args
+  full_args=(
+    "--log-level" "info"
+    "--runtime"   "containerd"
+    "--containerd-socket"    "${MC_CONTAINERD_SOCK}"
+    "--containerd-namespace" "k8s.io"
+    "$@"
+  )
+
+  local args_yaml=""
+  local a
+  for a in "${full_args[@]}"; do
+    args_yaml+="            - \"${a}\"
+"
+  done
+
+  mc::kubectl "${idx}" apply -f - >/dev/null <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: default
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: Never
+      nodeName: ${MC_CLUSTER_NODES[idx]}
+      hostPID: true
+      containers:
+        - name: pumba
+          image: ${MC_PUMBA_IMAGE}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          args:
+${args_yaml}
+          volumeMounts:
+            - name: run
+              mountPath: /run
+              mountPropagation: Bidirectional
+            - name: var-lib
+              mountPath: /var/lib
+              mountPropagation: Bidirectional
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: run
+          hostPath: { path: /run, type: Directory }
+        - name: var-lib
+          hostPath: { path: /var/lib, type: Directory }
+        - name: tmp
+          emptyDir: {}
+EOF
+}
+
+mc::pumba_wait_ready() {
+  local idx="$1" job_name="$2"
+  local _
+  for _ in 1 2 3 4 5; do
+    if mc::kubectl "${idx}" get pod -n default -l job-name="${job_name}" 2>/dev/null | grep -q .; then break; fi
+    sleep 2
+  done
+  # 5 min covers first-time image pull on a cold node (Pumba ~100MB).
+  mc::kubectl "${idx}" wait --for=condition=Ready pod -n default -l job-name="${job_name}" --timeout=300s >/dev/null \
+    || die "Pumba job ${job_name} never became Ready"
+}
+
+mc::pumba_stop() {
+  local idx="$1" job_name="$2"
+  mc::kubectl "${idx}" delete job -n default "${job_name}" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
+}
+
+# Parse flags shared by every repro script. Call BEFORE script-specific
+# flags are parsed; pass the original argv. This sets MC_CONTEXTS and
+# MC_VC_PREFIX and consumes matching args; remaining args are re-emitted on
+# stdout for the caller to re-parse.
+mc::parse_common_flags() {
+  local out=()
+  while (( $# > 0 )); do
+    case "$1" in
+      --contexts=*)         MC_CONTEXTS="${1#*=}" ;;
+      --vc-prefix=*)        MC_VC_PREFIX="${1#*=}" ;;
+      --namespace=*)        MC_NAMESPACE="${1#*=}" ;;
+      --operator-label=*)   MC_OPERATOR_LABEL="${1#*=}" ;;
+      --operator-service=*) MC_OPERATOR_SERVICE="${1#*=}" ;;
+      --containerd-sock=*)  MC_CONTAINERD_SOCK="${1#*=}" ;;
+      --pumba-image=*)      MC_PUMBA_IMAGE="${1#*=}" ;;
+      --tc-image=*)         MC_PUMBA_TC_IMAGE="${1#*=}" ;;
+      *) out+=("$1") ;;
+    esac
+    shift
+  done
+  if (( ${#out[@]} > 0 )); then
+    printf '%s\n' "${out[@]}"
+  fi
+}
+
+# Print the shared-flags help snippet. Each script calls this at the top of
+# its own usage block.
+mc::print_common_flags() {
+  cat <<'EOF'
+Common flags (any mode):
+  --contexts=<csv>          CSV of kube contexts, one per cluster. Enables multi-context
+                            (real multi-cloud) mode. If omitted, script auto-detects a
+                            vcluster-on-k3d layout under ~/.kube/config's current context.
+  --vc-prefix=<prefix>      Override vcluster prefix (e.g. "vc-xyz"). Default: auto-detect.
+  --namespace=<ns>          Operator namespace in each cluster. Default: redpanda.
+  --operator-label=<sel>    Operator label selector. Default: app.kubernetes.io/name=operator,
+                            app.kubernetes.io/instance=redpanda.
+  --operator-service=<name> Operator gRPC Service name. Default: multicluster-operator.
+  --containerd-sock=<path>  Host path to containerd socket. Default: /run/k3s/containerd/
+                            containerd.sock (k3s/k3d). Use /run/containerd/containerd.sock
+                            on EKS/GKE/AKS standard node pools.
+  --pumba-image=<img>       Pumba image. Default: ghcr.io/alexei-led/pumba:1.0.6.
+  --tc-image=<img>          Pumba sidecar tc-image. Default: ghcr.io/alexei-led/pumba-alpine-nettools:latest.
+
+Environment variable equivalents: MC_NAMESPACE, MC_OPERATOR_LABEL,
+MC_OPERATOR_SERVICE, MC_CONTAINERD_SOCK, MC_PUMBA_IMAGE, MC_PUMBA_TC_IMAGE.
+EOF
+}

--- a/hack/multicluster/repro/finding-01-dosend-stall.sh
+++ b/hack/multicluster/repro/finding-01-dosend-stall.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Reproduces finding #1 (DoSend stall + CheckQuorum-driven leader churn under
+# asymmetric silent packet loss on the raft gRPC link).
+#
+# Scenario: silently drop leader→peer traffic on the raft gRPC port (default
+# 9443), leaving the reverse direction intact. Because `DoSend` in the raft
+# Ready loop is synchronous and has no per-RPC timeout, a blackholed TCP
+# write blocks the entire raft loop, including heartbeats to the OTHER
+# peer. With CheckQuorum=true, the leader steps down even though a majority
+# is healthy.
+#
+# Expected outcomes (unfixed code):
+#   - At least one raft election ("starting a new election") in the window
+#   - Leader identity changes (term increments) while only one peer is impaired
+#
+# Expected outcomes (if fixes are applied):
+#   - gRPC keepalive + per-RPC deadline lets the leader fail fast on the
+#     impaired peer and continue heartbeating the healthy one
+#   - Zero or one stepdown; leadership stays stable
+
+set -euo pipefail
+MC_SCRIPT_TAG="finding-01"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${HERE}/_lib.sh"
+
+WINDOW_SECONDS=180
+JOB_NAME="pumba-finding-01"
+DEBUG_POD="tc-debug-finding-01"
+
+# Parse common flags first (consumes --contexts, --namespace, etc.) and
+# re-run argv parsing on the leftovers for script-specific flags.
+remaining="$(mc::parse_common_flags "$@" || true)"
+set --
+if [[ -n "${remaining}" ]]; then
+  while IFS= read -r a; do set -- "$@" "${a}"; done <<<"${remaining}"
+fi
+
+while (( $# > 0 )); do
+  case "$1" in
+    --window-seconds=*) WINDOW_SECONDS="${1#*=}" ;;
+    -h|--help)
+      cat <<EOF
+Reproduces finding #1 — asymmetric silent drop on the raft gRPC port causes
+leader stepdown / election churn, even though a majority of peers are fine.
+
+Usage: $(basename "$0") [--window-seconds=<N>] [common flags]
+
+$(mc::print_common_flags)
+EOF
+      exit 0
+      ;;
+    *) die "unknown flag: $1 (run --help)" ;;
+  esac
+  shift
+done
+
+mc::discover
+
+leader_idx="$(mc::find_leader_idx)" || die "no raft leader found across discovered clusters"
+log "leader: ${MC_CLUSTER_LABELS[leader_idx]} pod=${MC_CLUSTER_PODS[leader_idx]} node=${MC_CLUSTER_NODES[leader_idx]}"
+
+# Pick a peer — the first non-leader entry.
+peer_idx=-1
+for i in "${!MC_CLUSTER_LABELS[@]}"; do
+  if (( i != leader_idx )); then peer_idx="${i}"; break; fi
+done
+(( peer_idx >= 0 )) || die "failed to pick a peer"
+peer_raft_ip="${MC_CLUSTER_RAFT_IPS[peer_idx]}"
+[[ -n "${peer_raft_ip}" ]] || die "peer raft IP empty for ${MC_CLUSTER_LABELS[peer_idx]}"
+log "impairing leader→${MC_CLUSTER_LABELS[peer_idx]} raft: ${peer_raft_ip}:${MC_RAFT_PORT}"
+
+mc::debug_pod_ensure "${leader_idx}" "${DEBUG_POD}"
+
+cleanup() {
+  local rc=$?
+  log "cleaning up"
+  mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+  mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+
+# Snapshot pre-injection election counts per cluster.
+declare -a pre_elections
+for i in "${!MC_CLUSTER_LABELS[@]}"; do
+  set +o pipefail
+  c="$(mc::kubectl "${i}" logs -n "${MC_CLUSTER_NSS[i]}" "${MC_CLUSTER_PODS[i]}" --since=10m 2>/dev/null \
+    | grep -c 'starting a new election')"
+  set -o pipefail
+  pre_elections[i]="${c:-0}"
+done
+
+regex="re2:.*${MC_CLUSTER_PODS[leader_idx]}.*"
+log "launching Pumba netem loss 100% on leader → peer raft (asymmetric silent drop)"
+mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+mc::pumba_launch "${leader_idx}" "${JOB_NAME}" \
+  netem \
+  --duration "$(( WINDOW_SECONDS + 30 ))s" \
+  --tc-image "${MC_PUMBA_TC_IMAGE}" \
+  --target "${peer_raft_ip}/32" \
+  --ingress-port "${MC_RAFT_PORT}" \
+  loss --percent 100 "${regex}"
+mc::pumba_wait_ready "${leader_idx}" "${JOB_NAME}"
+log "Pumba Ready. Observing ${#MC_CLUSTER_LABELS[@]} operators for ${WINDOW_SECONDS}s"
+sleep "${WINDOW_SECONDS}"
+
+total_new_elections=0
+summary=""
+for i in "${!MC_CLUSTER_LABELS[@]}"; do
+  set +o pipefail
+  cur="$(mc::kubectl "${i}" logs -n "${MC_CLUSTER_NSS[i]}" "${MC_CLUSTER_PODS[i]}" --since=10m 2>/dev/null \
+    | grep -c 'starting a new election')"
+  set -o pipefail
+  cur="${cur:-0}"
+  pre="${pre_elections[i]:-0}"
+  delta=$(( cur - pre ))
+  summary+=" ${MC_CLUSTER_LABELS[i]}:+${delta}"
+  total_new_elections=$(( total_new_elections + delta ))
+done
+
+set +o pipefail
+stepdowns="$(mc::kubectl "${leader_idx}" logs -n "${MC_CLUSTER_NSS[leader_idx]}" "${MC_CLUSTER_PODS[leader_idx]}" --since="${WINDOW_SECONDS}s" 2>/dev/null \
+  | grep -cE 'became follower at term|stepped down')"
+set -o pipefail
+stepdowns="${stepdowns:-0}"
+
+echo
+echo "=================== Finding #1 repro ==================="
+echo "Window:                       ${WINDOW_SECONDS}s"
+echo "Injected:                     100% packet loss on leader→${MC_CLUSTER_LABELS[peer_idx]}:${MC_RAFT_PORT}"
+echo "Leader (pre-injection):       ${MC_CLUSTER_LABELS[leader_idx]} / ${MC_CLUSTER_PODS[leader_idx]}"
+echo "New raft elections by cluster:${summary}"
+echo "Total new elections:          ${total_new_elections}"
+echo "Leader 'became follower':     ${stepdowns}"
+echo
+if (( total_new_elections >= 1 || stepdowns >= 1 )); then
+  echo "RESULT: CONFIRMED — asymmetric silent drop on a single peer link caused"
+  echo "        leader election / stepdown on the CURRENT leader, even though a"
+  echo "        majority of peers (2/3) remained reachable. This is the DoSend/"
+  echo "        CheckQuorum behaviour described in finding #1."
+  echo "========================================================"
+  exit 0
+else
+  echo "RESULT: NOT REPRODUCED — leader stayed stable through the window."
+  echo "Consider --window-seconds=300 or verify tc filter is applied on leader."
+  echo "========================================================"
+  exit 1
+fi

--- a/hack/multicluster/repro/finding-02-03-admin-unbounded.sh
+++ b/hack/multicluster/repro/finding-02-03-admin-unbounded.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Reproduces findings #2 (AdminClientForStretch drops ClientTimeout) and
+# #3 (reconcile has no WithTimeout).
+#
+# One injection exercises both: apply tc-netem delay on the leader operator's
+# egress to every broker's admin HTTP port (default 9644). Then look at the
+# leader's StretchCluster reconcile "elapsed" field.
+#
+# Expected outcomes (unfixed code):
+#   - Baseline reconcile elapsed: well under 1s.
+#   - Chaotic reconcile elapsed: >= 10s. Commonly ~30s because rpadmin's
+#     internal default http.Client.Timeout of 10s fires on each retry and
+#     the client retries ~3× across the broker seed list.
+#   - "Client.Timeout exceeded while awaiting headers" appears in operator
+#     error logs — proves the operator-configured --admin-client-timeout is
+#     not in effect on the Stretch path.
+#
+# Expected outcomes (if fixes are applied):
+#   - Reconcile fails with `context.DeadlineExceeded` once the reconcile-level
+#     WithTimeout fires (<= 2m).
+#   - rpadmin's own timeout is overridden by the operator's configured value
+#     (e.g. 10s, or whatever --admin-client-timeout is).
+
+set -euo pipefail
+MC_SCRIPT_TAG="finding-02-03"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${HERE}/_lib.sh"
+
+WINDOW_SECONDS=100
+LATENCY_MS=30000
+ADMIN_PORT="${MC_ADMIN_PORT:-9644}"
+JOB_NAME="pumba-finding-02-03"
+DEBUG_POD="tc-debug-finding-02-03"
+
+remaining="$(mc::parse_common_flags "$@" || true)"
+set --
+if [[ -n "${remaining}" ]]; then
+  while IFS= read -r a; do set -- "$@" "${a}"; done <<<"${remaining}"
+fi
+
+while (( $# > 0 )); do
+  case "$1" in
+    --window-seconds=*) WINDOW_SECONDS="${1#*=}" ;;
+    --latency-ms=*)     LATENCY_MS="${1#*=}" ;;
+    --admin-port=*)     ADMIN_PORT="${1#*=}" ;;
+    -h|--help)
+      cat <<EOF
+Reproduces findings #2 and #3 — admin-client timeout on the Stretch path and
+missing reconcile-level deadline. A single latency injection surfaces both.
+
+Usage: $(basename "$0") [--window-seconds=<N>] [--latency-ms=<M>] [--admin-port=<P>] [common flags]
+
+$(mc::print_common_flags)
+EOF
+      exit 0
+      ;;
+    *) die "unknown flag: $1 (run --help)" ;;
+  esac
+  shift
+done
+
+mc::discover
+leader_idx="$(mc::find_leader_idx)" || die "no raft leader found"
+log "leader: ${MC_CLUSTER_LABELS[leader_idx]} pod=${MC_CLUSTER_PODS[leader_idx]} node=${MC_CLUSTER_NODES[leader_idx]}"
+log "targeting tcp/${ADMIN_PORT} outbound from the leader operator"
+
+mc::debug_pod_ensure "${leader_idx}" "${DEBUG_POD}"
+
+cleanup() {
+  local rc=$?
+  log "cleaning up"
+  mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+  mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+
+regex="re2:.*${MC_CLUSTER_PODS[leader_idx]}.*"
+log "launching Pumba netem delay ${LATENCY_MS}ms on leader egress (port ${ADMIN_PORT})"
+mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+mc::pumba_launch "${leader_idx}" "${JOB_NAME}" \
+  netem \
+  --duration "$(( WINDOW_SECONDS + 30 ))s" \
+  --tc-image "${MC_PUMBA_TC_IMAGE}" \
+  --ingress-port "${ADMIN_PORT}" \
+  delay --time "${LATENCY_MS}" "${regex}"
+mc::pumba_wait_ready "${leader_idx}" "${JOB_NAME}"
+log "Pumba Ready. Observing leader for ${WINDOW_SECONDS}s"
+sleep "${WINDOW_SECONDS}"
+
+set +o pipefail
+elapsed_raw="$(mc::kubectl "${leader_idx}" logs -n "${MC_CLUSTER_NSS[leader_idx]}" "${MC_CLUSTER_PODS[leader_idx]}" --since="${WINDOW_SECONDS}s" 2>/dev/null \
+  | grep 'MulticlusterReconciler.Reconcile' | grep 'Finished reconciling' \
+  | grep -oE '"elapsed":[0-9.]+' | cut -d: -f2 | sort -nr | head -1)"
+set -o pipefail
+elapsed_raw="${elapsed_raw:-0}"
+
+set +o pipefail
+admin_err_count="$(mc::kubectl "${leader_idx}" logs -n "${MC_CLUSTER_NSS[leader_idx]}" "${MC_CLUSTER_PODS[leader_idx]}" --since="${WINDOW_SECONDS}s" 2>/dev/null \
+  | grep -c 'Client\.Timeout exceeded while awaiting headers')"
+set -o pipefail
+admin_err_count="${admin_err_count:-0}"
+
+echo
+echo "=================== Findings #2 + #3 repro ==================="
+echo "Window:                    ${WINDOW_SECONDS}s"
+echo "Injected delay:            ${LATENCY_MS}ms on leader→admin (tcp/${ADMIN_PORT})"
+echo "Leader:                    ${MC_CLUSTER_LABELS[leader_idx]} / ${MC_CLUSTER_PODS[leader_idx]}"
+echo "Longest reconcile elapsed: ${elapsed_raw}s"
+echo "Client.Timeout errors:     ${admin_err_count}"
+echo
+
+elapsed_int="${elapsed_raw%%.*}"
+elapsed_int="${elapsed_int:-0}"
+if (( elapsed_int >= 10 )); then
+  echo "RESULT: Finding #3 CONFIRMED — reconcile wall time (${elapsed_raw}s) exceeds 10s"
+  echo "        with no reconcile-level deadline firing."
+  if (( admin_err_count > 0 )); then
+    echo "        Finding #2 CONFIRMED — 'Client.Timeout exceeded' confirms rpadmin's"
+    echo "        internal 10s default is the only ceiling; --admin-client-timeout is"
+    echo "        bypassed on the Stretch path."
+  fi
+  echo "==============================================================="
+  exit 0
+else
+  echo "RESULT: NOT REPRODUCED — longest reconcile was ${elapsed_raw}s (<10s)."
+  echo "Try a longer --latency-ms or ensure --admin-port matches the cluster."
+  echo "==============================================================="
+  exit 1
+fi

--- a/hack/multicluster/repro/finding-04-serial-fanout.sh
+++ b/hack/multicluster/repro/finding-04-serial-fanout.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Reproduces finding #4 (serial fanout across clusters in several reconcile
+# phases — status writes, license lookup, Phase 1 scans — with no
+# reachability check).
+#
+# Scenario: apply moderate latency (3s default) on ONE peer's K8s API
+# ClusterIP only. If the reconcile iterates clusters serially, adding the
+# delay on just one peer blows up total reconcile wall time by a multiple
+# of the injected delay. A parallel implementation would cap at roughly
+# max(per-cluster-latency).
+#
+# Expected outcomes (unfixed code):
+#   injected reconcile wall time >> baseline; usually >= 2× the per-hop
+#   injected delay, because the slow peer is hit from multiple serial sites.
+#
+# Expected outcomes (if fanout was parallelised with errgroup):
+#   injected reconcile wall time ≈ baseline + injected latency.
+
+set -euo pipefail
+MC_SCRIPT_TAG="finding-04"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${HERE}/_lib.sh"
+
+WINDOW_SECONDS=180
+LATENCY_MS=3000
+JOB_NAME="pumba-finding-04"
+DEBUG_POD="tc-debug-finding-04"
+# Tail pause after the main window — serial fanout can produce single
+# reconciles that take 90-120s. Without a tail pause our `kubectl logs`
+# query fires before the long reconcile has written its Finished line.
+TAIL_PAUSE_SECONDS="${TAIL_PAUSE_SECONDS:-180}"
+
+remaining="$(mc::parse_common_flags "$@" || true)"
+set --
+if [[ -n "${remaining}" ]]; then
+  while IFS= read -r a; do set -- "$@" "${a}"; done <<<"${remaining}"
+fi
+
+while (( $# > 0 )); do
+  case "$1" in
+    --window-seconds=*)    WINDOW_SECONDS="${1#*=}" ;;
+    --latency-ms=*)        LATENCY_MS="${1#*=}" ;;
+    --tail-pause-seconds=*) TAIL_PAUSE_SECONDS="${1#*=}" ;;
+    -h|--help)
+      cat <<EOF
+Reproduces finding #4 — serial fanout across clusters. Injects latency on
+one peer's K8s API and measures how much reconcile wall time blows up.
+
+Usage: $(basename "$0") [--window-seconds=<N>] [--latency-ms=<M>] [--tail-pause-seconds=<T>] [common flags]
+
+$(mc::print_common_flags)
+EOF
+      exit 0
+      ;;
+    *) die "unknown flag: $1 (run --help)" ;;
+  esac
+  shift
+done
+
+mc::discover
+leader_idx="$(mc::find_leader_idx)" || die "no raft leader found"
+log "leader: ${MC_CLUSTER_LABELS[leader_idx]} pod=${MC_CLUSTER_PODS[leader_idx]} node=${MC_CLUSTER_NODES[leader_idx]}"
+
+# Pick a peer — first non-leader entry.
+peer_idx=-1
+for i in "${!MC_CLUSTER_LABELS[@]}"; do
+  if (( i != leader_idx )); then peer_idx="${i}"; break; fi
+done
+(( peer_idx >= 0 )) || die "failed to pick a peer"
+peer_api_ip="${MC_CLUSTER_API_IPS[peer_idx]}"
+[[ -n "${peer_api_ip}" ]] || die "peer API IP empty for ${MC_CLUSTER_LABELS[peer_idx]}"
+log "impairing leader→${MC_CLUSTER_LABELS[peer_idx]} K8s API: ${peer_api_ip}:${MC_API_PORT} (+${LATENCY_MS}ms)"
+
+# Baseline: median elapsed from recent reconciles. Median is more robust
+# against a stale outlier that may linger in logs from prior chaos.
+set +o pipefail
+baseline_samples="$(mc::kubectl "${leader_idx}" logs -n "${MC_CLUSTER_NSS[leader_idx]}" "${MC_CLUSTER_PODS[leader_idx]}" --since=2m 2>/dev/null \
+  | grep 'MulticlusterReconciler.Reconcile' | grep 'Finished reconciling' \
+  | grep -oE '"elapsed":[0-9.]+' | cut -d: -f2)"
+set -o pipefail
+if [[ -z "${baseline_samples}" ]]; then
+  baseline_max=0
+else
+  baseline_max="$(printf '%s\n' "${baseline_samples}" | sort -n | awk '
+    { a[NR]=$1 }
+    END { if (NR==0) { print 0; exit } print a[int((NR+1)/2)] }
+  ')"
+fi
+log "pre-injection median reconcile elapsed (last 2m): ${baseline_max}s"
+
+mc::debug_pod_ensure "${leader_idx}" "${DEBUG_POD}"
+
+cleanup() {
+  local rc=$?
+  log "cleaning up"
+  # Clean on every cluster in case leadership moved during chaos and a
+  # different cluster wound up with a tc qdisc from a transient nsenter.
+  for i in "${!MC_CLUSTER_LABELS[@]}"; do
+    mc::pumba_stop "${i}" "${JOB_NAME}" || true
+  done
+  mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+
+regex="re2:.*${MC_CLUSTER_PODS[leader_idx]}.*"
+log "launching Pumba netem delay ${LATENCY_MS}ms on leader egress to ${MC_CLUSTER_LABELS[peer_idx]} API"
+mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+# Pumba duration must cover window + tail-pause so chaos stays active while
+# long reconciles in flight finish and write their elapsed.
+mc::pumba_launch "${leader_idx}" "${JOB_NAME}" \
+  netem \
+  --duration "$(( WINDOW_SECONDS + TAIL_PAUSE_SECONDS + 30 ))s" \
+  --tc-image "${MC_PUMBA_TC_IMAGE}" \
+  --target "${peer_api_ip}/32" \
+  --ingress-port "${MC_API_PORT}" \
+  delay --time "${LATENCY_MS}" "${regex}"
+mc::pumba_wait_ready "${leader_idx}" "${JOB_NAME}"
+
+# Pumba sidecar takes a few seconds to attach tc. Pad the start timestamp
+# to avoid counting pre-chaos reconciles.
+sleep 10
+start_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+log "tc active since ~${start_ts}. Observing leader for ${WINDOW_SECONDS}s, then tail-pause ${TAIL_PAUSE_SECONDS}s"
+sleep "${WINDOW_SECONDS}"
+
+# Tail pause: give any in-flight reconcile that started during the main
+# window time to actually finish and flush its Finished-reconciling log.
+# Otherwise --since-time=start_ts returns a StretchCluster reconcile with
+# Starting but no matching Finished line.
+log "waiting an extra ${TAIL_PAUSE_SECONDS}s for long reconciles to finish"
+sleep "${TAIL_PAUSE_SECONDS}"
+
+# Scan ALL discovered clusters. A moderate delay on one peer is enough to
+# occasionally trip CheckQuorum (finding #1) and move leadership — in that
+# case the long reconcile recorded by the NEW leader is what we want.
+injected_max=0
+winning_label=""
+for i in "${!MC_CLUSTER_LABELS[@]}"; do
+  mc::refresh_idx "${i}" || continue
+  set +o pipefail
+  m="$(mc::kubectl "${i}" logs -n "${MC_CLUSTER_NSS[i]}" "${MC_CLUSTER_PODS[i]}" --since-time="${start_ts}" 2>/dev/null \
+    | grep 'MulticlusterReconciler.Reconcile' | grep 'Finished reconciling' \
+    | grep -oE '"elapsed":[0-9.]+' | cut -d: -f2 | sort -nr | head -1)"
+  set -o pipefail
+  m="${m:-0}"
+  is_bigger=$(awk -v a="${m}" -v b="${injected_max}" 'BEGIN { print (a+0 > b+0) ? 1 : 0 }')
+  if (( is_bigger == 1 )); then
+    injected_max="${m}"
+    winning_label="${MC_CLUSTER_LABELS[i]}"
+  fi
+done
+
+latency_s=$(awk -v l="${LATENCY_MS}" 'BEGIN { printf "%.3f", l/1000 }')
+ratio=$(awk -v a="${injected_max}" -v b="${baseline_max}" 'BEGIN {
+  if (b+0==0) { print "inf"; exit }
+  printf "%.1f", a/b
+}')
+multiple_of_delay=$(awk -v a="${injected_max}" -v l="${LATENCY_MS}" 'BEGIN {
+  printf "%.1f", a/(l/1000)
+}')
+
+echo
+echo "=================== Finding #4 repro ==================="
+echo "Window / tail-pause:           ${WINDOW_SECONDS}s + ${TAIL_PAUSE_SECONDS}s"
+echo "Injected:                      ${LATENCY_MS}ms delay on leader→${MC_CLUSTER_LABELS[peer_idx]} API (${peer_api_ip}:${MC_API_PORT})"
+echo "Baseline median reconcile:     ${baseline_max}s"
+echo "Injected max reconcile:        ${injected_max}s (from ${winning_label:-n/a})"
+echo "Ratio (injected/baseline):     ${ratio}×"
+echo "Injected / per-hop delay:      ${multiple_of_delay}×  (serial fanout ⇒ >1.5)"
+echo
+
+very_slow=$(awk -v l="${LATENCY_MS}" 'BEGIN { printf "%.3f", (l/1000)*2.0 }')
+slow_thresh=$(awk -v l="${LATENCY_MS}" 'BEGIN { printf "%.3f", (l/1000)*1.5 }')
+
+awk -v a="${injected_max}" -v vs="${very_slow}" -v st="${slow_thresh}" -v l="${latency_s}" '
+BEGIN {
+  if (a+0 >= vs+0) {
+    print "RESULT: CONFIRMED — reconcile wall time is >=2× the per-hop delay, which"
+    print "        means multiple serial sites (syncStatus, setupLicense, Phase 1"
+    print "        scans) blocked on the single slow peer. Parallel fanout would"
+    print "        have capped the reconcile near " l "s."
+    exit 0
+  } else if (a+0 >= st+0) {
+    print "RESULT: LIKELY CONFIRMED — reconcile took more than the pure per-hop"
+    print "        delay but less than 2×. Either one serial site + background"
+    print "        cost, or parallel with some sequential waits. Run a longer"
+    print "        window or bump --latency-ms to tighten the signal."
+    exit 0
+  } else {
+    print "RESULT: NOT REPRODUCED — reconcile stayed near the per-hop delay (" l "s)."
+    print "        Could mean the serial sites are short-circuiting, or the filter"
+    print "        missed. Verify the peer API IP traffic using tc counters."
+    exit 1
+  }
+}'
+status=$?
+echo "========================================================"
+exit "${status}"

--- a/hack/multicluster/repro/finding-05-probe-flap.sh
+++ b/hack/multicluster/repro/finding-05-probe-flap.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Reproduces finding #5 (health-probe flap hazard at marginal RTT).
+#
+# Scenario: inject ~4.5s ± 500ms latency on the multicluster leader's egress
+# to ONE peer's Kubernetes API server. The health probe at
+# `pkg/multicluster/health.go` uses a 5s timeout and a 10s interval. With
+# RTT sitting right at the threshold, some probes succeed and some don't,
+# causing the "reachable / unreachable" status for that peer to flap.
+
+set -euo pipefail
+MC_SCRIPT_TAG="finding-05"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib.sh
+source "${HERE}/_lib.sh"
+
+WINDOW_SECONDS=120
+LATENCY_MS=4500
+JITTER_MS=500
+JOB_NAME="pumba-finding-05"
+DEBUG_POD="tc-debug-finding-05"
+
+remaining="$(mc::parse_common_flags "$@" || true)"
+set --
+if [[ -n "${remaining}" ]]; then
+  while IFS= read -r a; do set -- "$@" "${a}"; done <<<"${remaining}"
+fi
+
+while (( $# > 0 )); do
+  case "$1" in
+    --window-seconds=*) WINDOW_SECONDS="${1#*=}" ;;
+    --latency-ms=*)     LATENCY_MS="${1#*=}" ;;
+    --jitter-ms=*)      JITTER_MS="${1#*=}" ;;
+    -h|--help)
+      cat <<EOF
+Reproduces finding #5 — health probe flaps between reachable/unreachable
+when peer RTT sits near the 5s probe timeout.
+
+Usage: $(basename "$0") [--window-seconds=<N>] [--latency-ms=<M>] [--jitter-ms=<J>] [common flags]
+
+$(mc::print_common_flags)
+EOF
+      exit 0
+      ;;
+    *) die "unknown flag: $1 (run --help)" ;;
+  esac
+  shift
+done
+
+mc::discover
+leader_idx="$(mc::find_leader_idx)" || die "no raft leader found"
+log "leader: ${MC_CLUSTER_LABELS[leader_idx]} pod=${MC_CLUSTER_PODS[leader_idx]} node=${MC_CLUSTER_NODES[leader_idx]}"
+
+peer_idx=-1
+for i in "${!MC_CLUSTER_LABELS[@]}"; do
+  if (( i != leader_idx )); then peer_idx="${i}"; break; fi
+done
+(( peer_idx >= 0 )) || die "failed to pick a peer"
+peer_api_ip="${MC_CLUSTER_API_IPS[peer_idx]}"
+[[ -n "${peer_api_ip}" ]] || die "peer API IP empty for ${MC_CLUSTER_LABELS[peer_idx]}"
+log "slowing leader→${MC_CLUSTER_LABELS[peer_idx]} K8s API: ${peer_api_ip}:${MC_API_PORT} (+${LATENCY_MS}±${JITTER_MS}ms)"
+
+mc::debug_pod_ensure "${leader_idx}" "${DEBUG_POD}"
+
+cleanup() {
+  local rc=$?
+  log "cleaning up"
+  mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+  mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+mc::debug_pod_clear_tc "${leader_idx}" "${DEBUG_POD}"
+
+set +o pipefail
+pre_count="$(mc::kubectl "${leader_idx}" logs -n "${MC_CLUSTER_NSS[leader_idx]}" "${MC_CLUSTER_PODS[leader_idx]}" --since=5m 2>/dev/null \
+  | grep -cE 'cluster became (reachable|unreachable)')"
+set -o pipefail
+pre_count="${pre_count:-0}"
+log "pre-injection transition count (last 5m): ${pre_count}"
+
+regex="re2:.*${MC_CLUSTER_PODS[leader_idx]}.*"
+log "launching Pumba netem delay ${LATENCY_MS}ms ± ${JITTER_MS}ms on leader egress to peer API"
+mc::pumba_stop "${leader_idx}" "${JOB_NAME}"
+if (( JITTER_MS > 0 )); then
+  mc::pumba_launch "${leader_idx}" "${JOB_NAME}" \
+    netem \
+    --duration "$(( WINDOW_SECONDS + 30 ))s" \
+    --tc-image "${MC_PUMBA_TC_IMAGE}" \
+    --target "${peer_api_ip}/32" \
+    --ingress-port "${MC_API_PORT}" \
+    delay --time "${LATENCY_MS}" --jitter "${JITTER_MS}" "${regex}"
+else
+  mc::pumba_launch "${leader_idx}" "${JOB_NAME}" \
+    netem \
+    --duration "$(( WINDOW_SECONDS + 30 ))s" \
+    --tc-image "${MC_PUMBA_TC_IMAGE}" \
+    --target "${peer_api_ip}/32" \
+    --ingress-port "${MC_API_PORT}" \
+    delay --time "${LATENCY_MS}" "${regex}"
+fi
+mc::pumba_wait_ready "${leader_idx}" "${JOB_NAME}"
+log "Pumba Ready. Observing leader for ${WINDOW_SECONDS}s"
+sleep "${WINDOW_SECONDS}"
+
+set +o pipefail
+post_count="$(mc::kubectl "${leader_idx}" logs -n "${MC_CLUSTER_NSS[leader_idx]}" "${MC_CLUSTER_PODS[leader_idx]}" --since="${WINDOW_SECONDS}s" 2>/dev/null \
+  | grep -cE 'cluster became (reachable|unreachable)')"
+set -o pipefail
+post_count="${post_count:-0}"
+
+echo
+echo "=================== Finding #5 repro ==================="
+echo "Window:                 ${WINDOW_SECONDS}s"
+echo "Injected delay:         ${LATENCY_MS}ms ± ${JITTER_MS}ms"
+echo "Leader:                 ${MC_CLUSTER_LABELS[leader_idx]} / ${MC_CLUSTER_PODS[leader_idx]}"
+echo "Peer being slowed:      ${MC_CLUSTER_LABELS[peer_idx]} (API=${peer_api_ip})"
+echo "Transitions in window:  ${post_count}"
+echo
+if (( post_count >= 2 )); then
+  echo "RESULT: CONFIRMED — SpecSynced reachable/unreachable flapped ${post_count}x"
+  echo "========================================================"
+  exit 0
+else
+  echo "RESULT: NOT REPRODUCED — expected >=2 transitions, got ${post_count}"
+  echo "Try a different --latency-ms around 4000-5000 and rerun."
+  echo "========================================================"
+  exit 1
+fi


### PR DESCRIPTION
Four standalone scripts under hack/multicluster/repro/ that reproduce specific resilience bugs in the multicluster operator by injecting network faults via Pumba and reading observable effects from operator logs / reconcile durations.

Coverage:
- finding-01-dosend-stall.sh      raft DoSend synchronous in Ready loop;
                                  leader churn under asymmetric silent
                                  drop (pkg/multicluster/leaderelection)
- finding-02-03-admin-unbounded.sh admin-client ClientTimeout dropped on
                                  StretchCluster path + reconcile has no
                                  context.WithTimeout
- finding-04-serial-fanout.sh     syncStatus / setupLicense / Phase-1
                                  scans iterate clusters serially with
                                  no reachability check
- finding-05-probe-flap.sh        health probe has no hysteresis at
                                  marginal RTT; SpecSynced flaps

Each script auto-detects the local vcluster-on-k3d dev env (set up via task dev:setup-multicluster-dev-env) when run with no arguments, or accepts --contexts=ctxA,ctxB,ctxC to target a real multi-cluster setup. Common flags (--namespace, --operator-service, --containerd-sock, etc.) let the scripts run against any operator deployment that follows the chart conventions.

A README.md in the directory documents requirements, modes, flags, and how to interpret the PASS/FAIL verdict.

These are not integration tests — line-level regression coverage for each finding should live in unit tests alongside the fix. The scripts are meant to catch the class of bug end-to-end, and to drive customer- facing demos of multi-cloud resilience.