### PR TITLE
[release/v26.1.x] Backport deterministic sort

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260423-224719.yaml
+++ b/.changes/unreleased/operator-Fixed-20260423-224719.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed an issue where in-use features from an enterprise cluster did not have deterministic sort order and could cause reconciliation storms due to status changes.
+time: 2026-04-23T22:47:19.373877-04:00

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -673,6 +674,10 @@ func (r *RedpandaReconciler) reconcileLicense(ctx context.Context, state *cluste
 				inUseFeatures = append(inUseFeatures, feature.Name)
 			}
 		}
+		// features.Features iterates a map under the hood; sort the
+		// resulting slice so repeated reconciles produce byte-identical
+		// status.
+		sort.Strings(inUseFeatures)
 
 		status := &redpandav1alpha2.RedpandaLicenseStatus{
 			InUseFeatures: inUseFeatures,


### PR DESCRIPTION
Backports deterministic sorting fix in https://github.com/redpanda-data/redpanda-operator/pull/1480 to 26.1.x