### PR TITLE
operator/multicluster: add defense-in-depth reconcile timeout

### DIFF
--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -85,6 +85,7 @@ type MulticlusterOptions struct {
 	UnbinderSelector pflagutil.LabelSelectorValue
 
 	ClusterConnectionTimeout time.Duration
+	ReconcileTimeout         time.Duration
 }
 
 func (o *MulticlusterOptions) validate() error {
@@ -177,6 +178,7 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.AllowPVRebinding, "allow-pv-rebinding", false, "controls whether or not PVs unbound by the PVCUnbinder have their .ClaimRef cleared, which allows them to be reused")
 	cmd.Flags().Var(&o.UnbinderSelector, "unbinder-label-selector", "if provided, a Kubernetes label selector that will filter Pods to be considered by the PVCUnbinder.")
 	cmd.Flags().DurationVar(&o.ClusterConnectionTimeout, "cluster-connection-timeout", 10*time.Second, "Timeout for internal clients used to connect to Redpanda clusters (admin API in particular)")
+	cmd.Flags().DurationVar(&o.ReconcileTimeout, "reconcile-timeout", 2*time.Minute, "Defense-in-depth ceiling on a single reconcile pass; on deadline the reconcile aborts with context.DeadlineExceeded and is requeued with backoff. Primary bounding should still come from per-call timeouts on downstream clients")
 }
 
 func Command() *cobra.Command {
@@ -346,7 +348,7 @@ func Run(
 
 	factory := internalclient.NewFactory(manager, nil).WithAdminClientTimeout(opts.ClusterConnectionTimeout)
 
-	if err := redpandacontrollers.SetupMulticlusterController(ctx, manager, redpandaImage, sidecarImage, cloudSecrets, factory); err != nil {
+	if err := redpandacontrollers.SetupMulticlusterController(ctx, manager, redpandaImage, sidecarImage, cloudSecrets, factory, opts.ReconcileTimeout); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Multicluster")
 		return err
 	}

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -70,6 +70,24 @@ type MulticlusterReconciler struct {
 	LifecycleClient *lifecycle.ResourceClient[lifecycle.StretchClusterWithPools, *lifecycle.StretchClusterWithPools]
 	ClientFactory   internalclient.ClientFactory
 	UseNodePools    bool
+
+	// ReconcileTimeout is a defense-in-depth ceiling on the wall time of a
+	// single reconcile pass — the primary mechanism is per-call timeouts
+	// on individual downstream clients. Zero (the default) applies
+	// defaultReconcileTimeout; ops may override via the operator's
+	// --reconcile-timeout flag, and tests may inject shorter values to
+	// exercise the deadline path without real latency.
+	ReconcileTimeout time.Duration
+}
+
+// reconcileDeadline returns the timeout to apply on the reconcile context.
+// Extracted from Reconcile so tests can cover the zero/override fallback
+// without standing up a full MulticlusterReconciler.
+func (r *MulticlusterReconciler) reconcileDeadline() time.Duration {
+	if r.ReconcileTimeout > 0 {
+		return r.ReconcileTimeout
+	}
+	return defaultReconcileTimeout
 }
 
 type stretchClusterReconciliationState struct {
@@ -93,6 +111,15 @@ type stretchClusterReconciliationFn func(ctx context.Context, state *stretchClus
 func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (result ctrl.Result, err error) {
 	start := time.Now()
 	l := log.FromContext(ctx).WithName("MulticlusterReconciler.Reconcile")
+
+	// Defense-in-depth ceiling on the reconcile pass. The primary line of
+	// defense is per-call timeouts on each downstream (admin API, peer K8s
+	// API, etc.); this wrapper catches anything we've missed. Healthy
+	// reconciles finish in well under a second, so the default 2-minute
+	// budget does not affect normal operation. See defaultReconcileTimeout
+	// for sizing rationale.
+	ctx, cancel := context.WithTimeout(ctx, r.reconcileDeadline())
+	defer cancel()
 
 	l.V(1).Info("Starting reconcile loop")
 	defer func() {
@@ -1338,7 +1365,7 @@ func (r *MulticlusterReconciler) setupLicense(ctx context.Context, sc *redpandav
 	return nil
 }
 
-func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, redpandaImage lifecycle.Image, sidecarImage lifecycle.Image, cloudSecrets lifecycle.CloudSecretsFlags, factory *internalclient.Factory) error {
+func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, redpandaImage lifecycle.Image, sidecarImage lifecycle.Image, cloudSecrets lifecycle.CloudSecretsFlags, factory *internalclient.Factory, reconcileTimeout time.Duration) error {
 	return mcbuilder.ControllerManagedBy(mgr).WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
 		// NB: This is gross, but currently the multicluster runtime doesn't hand this global option off to the controller
 		// registration properly, so we can't boot multiple controllers in test without doing this.
@@ -1350,9 +1377,10 @@ func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, 
 		mcbuilder.WithEngageWithProviderClusters(true)).
 		Complete(
 			&MulticlusterReconciler{
-				Manager:         mgr,
-				LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(redpandaImage, sidecarImage, cloudSecrets)),
-				ClientFactory:   factory,
+				Manager:          mgr,
+				LifecycleClient:  lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(redpandaImage, sidecarImage, cloudSecrets)),
+				ClientFactory:    factory,
+				ReconcileTimeout: reconcileTimeout,
 			},
 		)
 }

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -100,7 +100,7 @@ func (s *MulticlusterControllerSuite) SetupSuite() {
 		WatchAllNamespaces: true,
 		InstallCertManager: true,
 		SetupFn: func(mgr multicluster.Manager) error {
-			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, nil)
+			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, nil, 0)
 		},
 	})
 }

--- a/operator/internal/controller/redpanda/reconcile_timeout_test.go
+++ b/operator/internal/controller/redpanda/reconcile_timeout_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// reconcileDeadline must fall back to defaultReconcileTimeout when the
+// struct field is zero (production construction sites that don't plumb
+// the CLI flag should still get a safe default) and must honour the
+// field otherwise (tests and ops that want to override).
+func TestReconcileDeadline(t *testing.T) {
+	t.Run("zero field falls back to default", func(t *testing.T) {
+		r := &MulticlusterReconciler{}
+		require.Equal(t, defaultReconcileTimeout, r.reconcileDeadline())
+	})
+
+	t.Run("non-zero field wins", func(t *testing.T) {
+		r := &MulticlusterReconciler{ReconcileTimeout: 42 * time.Second}
+		require.Equal(t, 42*time.Second, r.reconcileDeadline())
+	})
+}
+
+// Sanity bounds on defaultReconcileTimeout — both ends are regression
+// guards. A value too small aborts healthy reconciles and defeats the
+// point; a value too large lets a single slow dependency hold the
+// reconcile worker hostage, which is the scenario this timeout exists
+// to prevent.
+func TestDefaultReconcileTimeoutBounds(t *testing.T) {
+	require.GreaterOrEqual(t, defaultReconcileTimeout, 30*time.Second,
+		"defaultReconcileTimeout must leave room for p99 healthy reconciles; %s is too aggressive",
+		defaultReconcileTimeout)
+	require.LessOrEqual(t, defaultReconcileTimeout, 10*time.Minute,
+		"defaultReconcileTimeout must bound the worker reasonably; %s will starve other work",
+		defaultReconcileTimeout)
+	require.Greater(t, defaultReconcileTimeout, periodicRequeue/2,
+		"defaultReconcileTimeout should exceed half the periodic requeue; otherwise back-to-back timeouts could dominate the budget")
+}

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -72,6 +72,18 @@ const (
 	// for which there's no change event we can latch onto).
 	periodicRequeue = 3 * time.Minute
 
+	// defaultReconcileTimeout is a defense-in-depth ceiling on a single
+	// reconcile pass when the reconciler struct leaves ReconcileTimeout at
+	// zero. The preferred discipline is that every downstream call sets its
+	// own context timeout; this wrapper exists because the reconciler
+	// fans out to many external endpoints (peer K8s API, admin API,
+	// etc.) and we've found several sites that historically had no bound
+	// of their own. On deadline, the reconcile aborts with
+	// context.DeadlineExceeded and controller-runtime requeues with
+	// backoff. Sized to comfortably exceed a healthy p99 reconcile
+	// (sub-second today) so healthy passes never hit it.
+	defaultReconcileTimeout = 2 * time.Minute
+
 	// the message when a cluster has no desired brokers
 	messageNoBrokers = "Cluster has no desired brokers"
 )

--- a/operator/pkg/client/stretch_cluster_test.go
+++ b/operator/pkg/client/stretch_cluster_test.go
@@ -107,7 +107,7 @@ func (s *StretchClusterFactorySuite) SetupSuite() {
 					return mc.DialContext(ctx, network, address)
 				},
 			)
-			return redpandacontrollers.SetupMulticlusterController(ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory)
+			return redpandacontrollers.SetupMulticlusterController(ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory, 0)
 		},
 	})
 	mc = s.mc


### PR DESCRIPTION
The StretchCluster reconciler has no reconcile-level context deadline. Combined with historically unbounded downstream calls (admin API, serial fanout sites), a single slow peer can hold the single-threaded reconcile worker for the sum of all inner-call timeouts. The primary discipline remains per-call timeouts on each downstream client — but as a belt-and-suspenders measure, wrap the reconcile's context with context.WithTimeout at the top of MulticlusterReconciler.Reconcile.

The ceiling is configurable:
  - defaultReconcileTimeout = 2m   (in redpanda_controller.go, shared
    constants; catches anything we've missed on individual calls while
    comfortably exceeding a healthy p99 reconcile)
  - MulticlusterReconciler.ReconcileTimeout   (zero → default; tests
    inject short values to exercise the deadline path without real
    latency)
  - --reconcile-timeout CLI flag on the multicluster binary (default
    2m) wired through SetupMulticlusterController

Unit tests cover the zero/override fallback and sanity bounds on the default. Existing call sites in stretch_cluster_test.go and multicluster_controller_test.go updated for the new signature.