### PR TITLE
leaderelection: fix raft DoSend stall when one peer silently black-holes

### DIFF
--- a/pkg/multicluster/leaderelection/chaos_test.go
+++ b/pkg/multicluster/leaderelection/chaos_test.go
@@ -144,9 +144,6 @@ ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 // in place so it will automatically start passing once the per-peer
 // fan-out work lands (see the fix PR for finding #1).
 func TestLeaderSurvives_AsymmetricSilentDropOnOnePeer(t *testing.T) {
-	t.Skip("known failure — see finding #1 in the resilience memo; " +
-		"expected to pass once the per-peer fan-out fix lands in the raft transport")
-
 // Wire a BlockIngress control into each node's TestHooks; we'll only
 	// flip the one on the isolated follower.
 	hooks := make([]*TestHooks, 3)

--- a/pkg/multicluster/leaderelection/chaos_test.go
+++ b/pkg/multicluster/leaderelection/chaos_test.go
@@ -62,7 +62,7 @@ func findLeader(t *testing.T, leaders []*testLeader, timeout time.Duration) (lea
 // the absence of faults. Any modification to the transport that causes
 // spurious re-elections will break this test.
 func TestLeaderRemainsStable_WhenAllPeersHealthy(t *testing.T) {
-ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	leaders := setupLockTest(t, ctx, 3)
@@ -100,7 +100,7 @@ ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 // Stopping both followers leaves the leader alone, and CheckQuorum must
 // fire — otherwise we'd silently be running without a real quorum.
 func TestLeaderStepsDown_WhenMinorityIsolated(t *testing.T) {
-ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	leaders := setupLockTest(t, ctx, 3)
@@ -144,7 +144,7 @@ ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 // in place so it will automatically start passing once the per-peer
 // fan-out work lands (see the fix PR for finding #1).
 func TestLeaderSurvives_AsymmetricSilentDropOnOnePeer(t *testing.T) {
-// Wire a BlockIngress control into each node's TestHooks; we'll only
+	// Wire a BlockIngress control into each node's TestHooks; we'll only
 	// flip the one on the isolated follower.
 	hooks := make([]*TestHooks, 3)
 	for i := range hooks {

--- a/pkg/multicluster/leaderelection/chaos_test.go
+++ b/pkg/multicluster/leaderelection/chaos_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package leaderelection
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests document higher-level raft behavior under network conditions
+// so regressions in the transport layer (especially the per-peer fan-out
+// work for finding #1 in the resilience memo) can be caught at the
+// state-machine level, not just at the DoSend unit-test level.
+//
+// Each test uses setupLockTestWithHooks to stand up a 3-node raft cluster
+// with real gRPC transports on localhost and short election timings
+// (100ms heartbeat, 1s election timeout), so full runs complete in
+// seconds.
+
+// findLeader returns the first node that reports IsLeader within timeout,
+// and the indices of the two followers. Fails the test if the cluster
+// has not converged on exactly one leader.
+func findLeader(t *testing.T, leaders []*testLeader, timeout time.Duration) (leaderIdx int, followerIdxs []int) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var leaderCount, found int
+		for i, l := range leaders {
+			if l.IsLeader() {
+				leaderCount++
+				found = i
+			}
+		}
+		if leaderCount == 1 {
+			followers := make([]int, 0, len(leaders)-1)
+			for i := range leaders {
+				if i != found {
+					followers = append(followers, i)
+				}
+			}
+			return found, followers
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("cluster did not converge on a single leader within %s", timeout)
+	return -1, nil
+}
+
+// TestLeaderRemainsStable_WhenAllPeersHealthy is the happy-path
+// regression control: once a leader is elected, it should not change in
+// the absence of faults. Any modification to the transport that causes
+// spurious re-elections will break this test.
+func TestLeaderRemainsStable_WhenAllPeersHealthy(t *testing.T) {
+ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	leaders := setupLockTest(t, ctx, 3)
+	defer func() {
+		for _, l := range leaders {
+			l.Stop()
+		}
+		for _, l := range leaders {
+			if !l.IsStopped() {
+				l.WaitForStopped(t, 5*time.Second)
+			}
+		}
+	}()
+
+	leaderIdx, _ := findLeader(t, leaders, 5*time.Second)
+
+	// Observe for 5 seconds. The initial leader must still be the leader,
+	// and no follower may have transitioned to leader at any point.
+	const observationWindow = 5 * time.Second
+	deadline := time.Now().Add(observationWindow)
+	for time.Now().Before(deadline) {
+		for i, l := range leaders {
+			if i == leaderIdx {
+				require.True(t, l.IsLeader(), "initial leader (idx=%d) lost leadership mid-window", i)
+			} else {
+				require.True(t, l.IsFollower(), "follower idx=%d became leader mid-window", i)
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestLeaderStepsDown_WhenMinorityIsolated is the negative control: raft
+// SHOULD relinquish leadership when the leader cannot reach a majority.
+// Stopping both followers leaves the leader alone, and CheckQuorum must
+// fire — otherwise we'd silently be running without a real quorum.
+func TestLeaderStepsDown_WhenMinorityIsolated(t *testing.T) {
+ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	leaders := setupLockTest(t, ctx, 3)
+	defer func() {
+		for _, l := range leaders {
+			l.Stop()
+		}
+		for _, l := range leaders {
+			if !l.IsStopped() {
+				l.WaitForStopped(t, 5*time.Second)
+			}
+		}
+	}()
+
+	leaderIdx, followerIdxs := findLeader(t, leaders, 5*time.Second)
+	leader := leaders[leaderIdx]
+
+	// Take both followers offline. The leader is now isolated and must
+	// step down within a few election-timeout intervals.
+	for _, idx := range followerIdxs {
+		leaders[idx].Stop()
+	}
+
+	require.Eventually(t, func() bool {
+		return leader.IsFollower()
+	}, 10*time.Second, 100*time.Millisecond,
+		"leader did not step down after losing contact with both followers")
+}
+
+// TestLeaderSurvives_AsymmetricSilentDropOnOnePeer characterises finding
+// #1 from the resilience memo. Inject a silent black-hole on exactly one
+// follower's ingress path (the follower's TCP listener still accepts
+// connections but its Send/Check handlers hang until the caller's context
+// is cancelled). A majority (the leader + the other follower) remains
+// fully reachable, so raft's correctness invariant says leadership must
+// not change.
+//
+// Today, because DoSend is synchronous in the Ready loop, one stuck peer
+// can starve heartbeats to the healthy peer, and CheckQuorum steps the
+// leader down despite a healthy majority. The test is intentionally left
+// in place so it will automatically start passing once the per-peer
+// fan-out work lands (see the fix PR for finding #1).
+func TestLeaderSurvives_AsymmetricSilentDropOnOnePeer(t *testing.T) {
+	t.Skip("known failure — see finding #1 in the resilience memo; " +
+		"expected to pass once the per-peer fan-out fix lands in the raft transport")
+
+// Wire a BlockIngress control into each node's TestHooks; we'll only
+	// flip the one on the isolated follower.
+	hooks := make([]*TestHooks, 3)
+	for i := range hooks {
+		hooks[i] = &TestHooks{BlockIngress: new(atomic.Bool)}
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	leaders := setupLockTestWithHooks(t, ctx, 3, hooks)
+	defer func() {
+		for _, l := range leaders {
+			l.Stop()
+		}
+		for _, l := range leaders {
+			if !l.IsStopped() {
+				l.WaitForStopped(t, 5*time.Second)
+			}
+		}
+	}()
+
+	leaderIdx, followerIdxs := findLeader(t, leaders, 5*time.Second)
+	isolated := followerIdxs[0]
+	healthy := followerIdxs[1]
+
+	// Silently black-hole the leader-to-isolated direction.
+	hooks[isolated].BlockIngress.Store(true)
+
+	// Observe for 15 seconds (comfortably exceeds the 1s election timeout
+	// configured in setupLockTest). Leader must remain leader; the healthy
+	// follower must remain a follower.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		require.True(t, leaders[leaderIdx].IsLeader(),
+			"leader (idx=%d) stepped down despite a healthy majority — the asymmetric drop on idx=%d stalled heartbeats to idx=%d (finding #1)",
+			leaderIdx, isolated, healthy)
+		require.True(t, leaders[healthy].IsFollower(),
+			"healthy follower (idx=%d) started an election — the leader failed to heartbeat it through the chaos (finding #1)",
+			healthy)
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/pkg/multicluster/leaderelection/lock.go
+++ b/pkg/multicluster/leaderelection/lock.go
@@ -294,12 +294,15 @@ func run(ctx context.Context, config LockConfiguration, transportCallback func(t
 	nodes := peersForNodes(config.Peers)
 	var transport *grpcTransport
 	var err error
+	// Bound each peer RPC to one heartbeat tick so a slow peer can't
+	// monopolise its worker goroutine past the expected cadence.
+	sendTimeout := config.HeartbeatInterval
 	if config.Insecure {
-		transport, err = newInsecureGRPCTransport(config.Meta, config.Address, nodes, config.Fetcher, config.GRPCMaxBackoff)
+		transport, err = newInsecureGRPCTransport(config.Meta, config.Address, nodes, config.Fetcher, config.GRPCMaxBackoff, sendTimeout)
 	} else if len(config.ServerTLSOptions) == 0 || len(config.ClientTLSOptions) == 0 {
-		transport, err = newGRPCTransport(config.Meta, config.Certificate, config.PrivateKey, config.CA, config.Address, nodes, config.Fetcher, config.GRPCMaxBackoff)
+		transport, err = newGRPCTransport(config.Meta, config.Certificate, config.PrivateKey, config.CA, config.Address, nodes, config.Fetcher, config.GRPCMaxBackoff, sendTimeout)
 	} else {
-		transport, err = newGRPCTransportWithOptions(config.Meta, config.ServerTLSOptions, config.ClientTLSOptions, config.Address, nodes, config.Fetcher, config.GRPCMaxBackoff)
+		transport, err = newGRPCTransportWithOptions(config.Meta, config.ServerTLSOptions, config.ClientTLSOptions, config.Address, nodes, config.Fetcher, config.GRPCMaxBackoff, sendTimeout)
 	}
 	if err != nil {
 		return err
@@ -493,6 +496,12 @@ func runRaft(ctx context.Context, transport *grpcTransport, config LockConfigura
 				}
 			}
 
+			// Hand each outbound message off to the destination peer's
+			// worker goroutine. EnqueueSend is non-blocking, so this loop
+			// finishes in microseconds regardless of peer health. The
+			// unreachable-report + snapshot-on-reject fallbacks that used
+			// to run inline now live in the worker (see runPeerSender /
+			// sendOneMessage in raft.go).
 			for _, msg := range rd.Messages {
 				if msg.To == config.ID {
 					if err := node.Step(ctx, msg); err != nil {
@@ -500,41 +509,7 @@ func runRaft(ctx context.Context, transport *grpcTransport, config LockConfigura
 					}
 					continue
 				}
-				applied, err := transport.DoSend(ctx, msg)
-				if err != nil || !applied {
-					if err != nil {
-						config.Logger.Infof("unreachable %d: %v", msg.To, err)
-					}
-					// If a MsgApp was rejected by the follower (Applied=false,
-					// no network error), the follower's log might be behind our
-					// progress tracker's match. Send a snapshot to reset the
-					// follower's state — the snapshot carries our ConfState and
-					// committed index, letting the follower catch up in one step.
-					if (msg.Type == raftpb.MsgApp || msg.Type == raftpb.MsgHeartbeat) && !applied && err == nil {
-						snap, snapErr := storage.Snapshot()
-						if snapErr != nil {
-							config.Logger.Errorf("failed to get snapshot for peer %d: %v", msg.To, snapErr)
-						} else if !raft.IsEmptySnap(snap) {
-							if _, sendErr := transport.DoSend(ctx, raftpb.Message{
-								Type:     raftpb.MsgSnap,
-								To:       msg.To,
-								From:     config.ID,
-								Snapshot: &snap,
-							}); sendErr != nil {
-								config.Logger.Infof("failed to send snapshot to %d: %v", msg.To, sendErr)
-							} else {
-								// Snapshot was accepted — the follower will send
-								// a MsgAppResp that fixes the progress tracker.
-								// Don't report unreachable.
-								if config.TestHooks != nil && config.TestHooks.OnSnapshotSent != nil {
-									config.TestHooks.OnSnapshotSent(msg.To)
-								}
-								continue
-							}
-						}
-					}
-					node.ReportUnreachable(msg.To)
-				}
+				transport.EnqueueSend(msg)
 			}
 
 			node.Advance()

--- a/pkg/multicluster/leaderelection/lock.go
+++ b/pkg/multicluster/leaderelection/lock.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.etcd.io/raft/v3"
@@ -103,6 +104,13 @@ type TestHooks struct {
 	// OnSnapshotSent is called on the leader when a snapshot is sent to a
 	// follower after a MsgApp rejection. The argument is the target peer ID.
 	OnSnapshotSent func(to uint64)
+
+	// BlockIngress, when non-nil and true at call time, causes incoming
+	// Send/Check RPCs on this node to block until the caller's context is
+	// cancelled. Chaos tests use this to simulate a silently unresponsive
+	// peer without tearing down the TCP listener (which would cause
+	// immediate connection-refused errors — a different failure mode).
+	BlockIngress *atomic.Bool
 
 	// transport is set by run() so tests can inspect storage state.
 	transport *grpcTransport
@@ -309,6 +317,7 @@ func run(ctx context.Context, config LockConfiguration, transportCallback func(t
 	transport.localID = config.ID
 	if config.TestHooks != nil {
 		config.TestHooks.transport = transport
+		transport.testHooks = config.TestHooks
 	}
 
 	for node, address := range nodes {

--- a/pkg/multicluster/leaderelection/raft.go
+++ b/pkg/multicluster/leaderelection/raft.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	transportv1 "github.com/redpanda-data/redpanda-operator/pkg/multicluster/leaderelection/proto/gen/transport/v1"
@@ -36,11 +37,30 @@ type peer struct {
 	client transportv1.TransportServiceClient
 }
 
+// raftKeepaliveParams are baseline HTTP/2 keepalive settings applied to every
+// peer gRPC connection. Without these, a silently black-holed TCP link (no
+// RST, packets dropped) would keep the connection "open" until the Linux TCP
+// retransmit ceiling (tcp_retries2 ≈ 15 minutes by default) and every
+// subsequent DoSend from the raft Ready loop would block on that orphan
+// stream. The keepalive closes the stream within Time + Timeout of the first
+// missed pong and a fresh connection is dialed on the next send, so the raft
+// loop recovers quickly even when the peer's TCP stack never notifies us.
+var raftKeepaliveParams = keepalive.ClientParameters{
+	Time:                10 * time.Second, // send a ping every 10s on idle
+	Timeout:             3 * time.Second,  // close if no pong in 3s
+	PermitWithoutStream: true,             // ping even when no active streams
+}
+
 func newPeer(addr string, credentials credentials.TransportCredentials, extraOpts ...grpc.DialOption) (*peer, error) {
 	if credentials == nil {
 		credentials = insecure.NewCredentials()
 	}
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(credentials)}, extraOpts...)
+	// Baseline options first; caller-supplied extraOpts can override.
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(credentials),
+		grpc.WithKeepaliveParams(raftKeepaliveParams),
+	}
+	opts = append(opts, extraOpts...)
 	conn, err := grpc.NewClient(addr, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/multicluster/leaderelection/raft.go
+++ b/pkg/multicluster/leaderelection/raft.go
@@ -35,7 +35,18 @@ import (
 type peer struct {
 	addr   string
 	client transportv1.TransportServiceClient
+
+	// sendCh feeds the per-peer worker goroutine. Bounded; full-queue
+	// drops are silently absorbed because raft re-sends every heartbeat
+	// tick anyway. Size chosen to comfortably absorb one burst of catch-
+	// up MsgApp entries for a fresh follower without dropping.
+	sendCh chan raftpb.Message
 }
+
+// peerSendQueueSize is the bounded capacity of each peer's send queue.
+// Sized to absorb one burst of catch-up entries for a fresh follower
+// (typical size: a few dozen) without dropping.
+const peerSendQueueSize = 256
 
 // raftKeepaliveParams are baseline HTTP/2 keepalive settings applied to every
 // peer gRPC connection. Without these, a silently black-holed TCP link (no
@@ -69,6 +80,7 @@ func newPeer(addr string, credentials credentials.TransportCredentials, extraOpt
 	return &peer{
 		addr:   addr,
 		client: transportv1.NewTransportServiceClient(conn),
+		sendCh: make(chan raftpb.Message, peerSendQueueSize),
 	}, nil
 }
 
@@ -169,10 +181,22 @@ type grpcTransport struct {
 	// BlockIngress) without touching the production code path.
 	testHooks *TestHooks
 
+	// sendTimeout bounds a single peer RPC issued by the per-peer worker
+	// goroutine. Without a ceiling, a silently black-holed TCP stream
+	// would block the worker until Linux TCP retransmit fires (~15 min).
+	// Zero applies defaultSendTimeout. Callers thread in the configured
+	// HeartbeatInterval so the worker can't sit on one send longer than
+	// one heartbeat tick.
+	sendTimeout time.Duration
+
 	logger raft.Logger
 
 	transportv1.UnimplementedTransportServiceServer
 }
+
+// defaultSendTimeout is the fallback ceiling for a single peer RPC when
+// the grpcTransport is constructed with sendTimeout=0.
+const defaultSendTimeout = 1 * time.Second
 
 // backoffDialOption returns a grpc.DialOption that caps the exponential
 // backoff between reconnection attempts at maxDelay. If maxDelay is zero
@@ -186,7 +210,7 @@ func backoffDialOption(maxDelay time.Duration) []grpc.DialOption {
 	return []grpc.DialOption{grpc.WithConnectParams(grpc.ConnectParams{Backoff: bc})}
 }
 
-func newGRPCTransport(meta []byte, certPEM, keyPEM, caPEM []byte, addr string, peers map[uint64]string, fetcher KubeconfigFetcher, grpcMaxBackoff time.Duration) (*grpcTransport, error) {
+func newGRPCTransport(meta []byte, certPEM, keyPEM, caPEM []byte, addr string, peers map[uint64]string, fetcher KubeconfigFetcher, grpcMaxBackoff, sendTimeout time.Duration) (*grpcTransport, error) {
 	serverCredentials, err := serverTLSConfig(certPEM, keyPEM, caPEM)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize server credentials: %w", err)
@@ -214,10 +238,11 @@ func newGRPCTransport(meta []byte, certPEM, keyPEM, caPEM []byte, addr string, p
 		clientCredentials: clientCredentials,
 		extraDialOptions:  extraOpts,
 		kubeconfigFetcher: fetcher,
+		sendTimeout:       sendTimeout,
 	}, nil
 }
 
-func newGRPCTransportWithOptions(meta []byte, serverOptions, clientOptions []func(*tls.Config), addr string, peers map[uint64]string, fetcher KubeconfigFetcher, grpcMaxBackoff time.Duration) (*grpcTransport, error) {
+func newGRPCTransportWithOptions(meta []byte, serverOptions, clientOptions []func(*tls.Config), addr string, peers map[uint64]string, fetcher KubeconfigFetcher, grpcMaxBackoff, sendTimeout time.Duration) (*grpcTransport, error) {
 	serverTLSConfig := &tls.Config{} // nolint:gosec // the tls version is configurable by calling code
 	for _, opt := range serverOptions {
 		opt(serverTLSConfig)
@@ -248,10 +273,11 @@ func newGRPCTransportWithOptions(meta []byte, serverOptions, clientOptions []fun
 		clientCredentials: clientCredentials,
 		extraDialOptions:  extraOpts,
 		kubeconfigFetcher: fetcher,
+		sendTimeout:       sendTimeout,
 	}, nil
 }
 
-func newInsecureGRPCTransport(meta []byte, addr string, peers map[uint64]string, fetcher KubeconfigFetcher, grpcMaxBackoff time.Duration) (*grpcTransport, error) {
+func newInsecureGRPCTransport(meta []byte, addr string, peers map[uint64]string, fetcher KubeconfigFetcher, grpcMaxBackoff, sendTimeout time.Duration) (*grpcTransport, error) {
 	extraOpts := backoffDialOption(grpcMaxBackoff)
 	initializedPeers := make(map[uint64]*peer, len(peers))
 	for id, peer := range peers {
@@ -268,6 +294,7 @@ func newInsecureGRPCTransport(meta []byte, addr string, peers map[uint64]string,
 		peers:             initializedPeers,
 		extraDialOptions:  extraOpts,
 		kubeconfigFetcher: fetcher,
+		sendTimeout:       sendTimeout,
 	}, nil
 }
 
@@ -304,6 +331,12 @@ func (t *grpcTransport) client() (transportv1.TransportServiceClient, error) {
 	return peer.client, nil
 }
 
+// DoSend issues one Send RPC synchronously and returns the applied flag
+// and any error. It is called from the per-peer worker goroutine
+// (runPeerSender) and — for MsgSnap fallbacks — directly by the worker's
+// snapshot path. The supplied ctx is wrapped with sendTimeout so a
+// silently black-holed stream can't stall longer than one heartbeat
+// tick regardless of the caller's ctx.
 func (t *grpcTransport) DoSend(ctx context.Context, msg raftpb.Message) (bool, error) {
 	peer, ok := t.peers[msg.To]
 	if !ok {
@@ -315,7 +348,14 @@ func (t *grpcTransport) DoSend(ctx context.Context, msg raftpb.Message) (bool, e
 		return false, fmt.Errorf("marshaling message for peer %q: %w", peer.addr, err)
 	}
 
-	resp, err := peer.client.Send(ctx, &transportv1.SendRequest{
+	timeout := t.sendTimeout
+	if timeout <= 0 {
+		timeout = defaultSendTimeout
+	}
+	sendCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	resp, err := peer.client.Send(sendCtx, &transportv1.SendRequest{
 		Payload: data,
 	})
 	if err != nil {
@@ -323,6 +363,94 @@ func (t *grpcTransport) DoSend(ctx context.Context, msg raftpb.Message) (bool, e
 	}
 
 	return resp.Applied, nil
+}
+
+// EnqueueSend hands a raftpb.Message off to the destination peer's
+// worker goroutine. Non-blocking: if the peer's send queue is full, the
+// message is dropped and raft will retransmit on the next tick. This is
+// the only send path the raft Ready loop uses — decoupling the loop
+// from any single slow peer.
+func (t *grpcTransport) EnqueueSend(msg raftpb.Message) {
+	peer, ok := t.peers[msg.To]
+	if !ok {
+		return
+	}
+	select {
+	case peer.sendCh <- msg:
+	default:
+		// Queue full. Raft re-sends on next tick; silent drop is
+		// cheaper than logging on every miss.
+	}
+}
+
+// runPeerSender is one worker goroutine per peer. It owns that peer's
+// send queue and calls DoSend sequentially. On failure it performs the
+// snapshot-on-reject fallback and reports the peer unreachable — all
+// work that used to happen inline in the raft Ready loop on the
+// caller's goroutine and blocked other peers' sends.
+func (t *grpcTransport) runPeerSender(ctx context.Context, id uint64, peer *peer) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-peer.sendCh:
+			if !ok {
+				return
+			}
+			t.sendOneMessage(ctx, id, peer, msg)
+		}
+	}
+}
+
+// sendOneMessage is the body of runPeerSender's loop. Split out so the
+// snapshot-on-reject path is easier to read without deeply-nested
+// control flow inside the select.
+func (t *grpcTransport) sendOneMessage(ctx context.Context, id uint64, peer *peer, msg raftpb.Message) {
+	applied, err := t.DoSend(ctx, msg)
+	if err == nil && applied {
+		return
+	}
+
+	if err != nil && t.logger != nil {
+		t.logger.Infof("unreachable %d: %v", id, err)
+	}
+
+	// If a MsgApp / MsgHeartbeat was rejected (Applied=false, no
+	// network error), the follower's log might be behind the leader's
+	// progress tracker. Send a snapshot to reset its state — the
+	// snapshot carries our ConfState and committed index, letting the
+	// follower catch up in one step.
+	if (msg.Type == raftpb.MsgApp || msg.Type == raftpb.MsgHeartbeat) && !applied && err == nil {
+		storage := t.getStorage()
+		if storage != nil {
+			snap, snapErr := storage.Snapshot()
+			if snapErr != nil && t.logger != nil {
+				t.logger.Errorf("failed to get snapshot for peer %d: %v", id, snapErr)
+			} else if !raft.IsEmptySnap(snap) {
+				if _, sendErr := t.DoSend(ctx, raftpb.Message{
+					Type:     raftpb.MsgSnap,
+					To:       id,
+					From:     t.localID,
+					Snapshot: &snap,
+				}); sendErr != nil {
+					if t.logger != nil {
+						t.logger.Infof("failed to send snapshot to %d: %v", id, sendErr)
+					}
+				} else {
+					if t.testHooks != nil && t.testHooks.OnSnapshotSent != nil {
+						t.testHooks.OnSnapshotSent(id)
+					}
+					// Snapshot accepted — follower will send a
+					// MsgAppResp that fixes the progress tracker.
+					return
+				}
+			}
+		}
+	}
+
+	if node := t.getNode(); node != nil {
+		node.ReportUnreachable(id)
+	}
 }
 
 func (t *grpcTransport) Send(ctx context.Context, req *transportv1.SendRequest) (*transportv1.SendResponse, error) {
@@ -489,6 +617,12 @@ func (t *grpcTransport) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to listen on %s: %w", t.addr, err)
 	}
 	defer lis.Close()
+
+	// One worker per peer. They drain per-peer send queues independently,
+	// so one slow/blackholed peer cannot delay sends to the others.
+	for id, p := range t.peers {
+		go t.runPeerSender(ctx, id, p)
+	}
 
 	done := make(chan struct{})
 	errs := make(chan error, 1)

--- a/pkg/multicluster/leaderelection/raft.go
+++ b/pkg/multicluster/leaderelection/raft.go
@@ -41,6 +41,12 @@ type peer struct {
 	// tick anyway. Size chosen to comfortably absorb one burst of catch-
 	// up MsgApp entries for a fresh follower without dropping.
 	sendCh chan raftpb.Message
+
+	// dropCount is the cumulative number of messages dropped because
+	// sendCh was full. Exported via the periodic logger
+	// (runDropLogger) so a chronically saturated peer is observable
+	// instead of silently invisible.
+	dropCount atomic.Uint64
 }
 
 // peerSendQueueSize is the bounded capacity of each peer's send queue.
@@ -378,8 +384,49 @@ func (t *grpcTransport) EnqueueSend(msg raftpb.Message) {
 	select {
 	case peer.sendCh <- msg:
 	default:
-		// Queue full. Raft re-sends on next tick; silent drop is
-		// cheaper than logging on every miss.
+		// Queue full. Raft re-sends on next tick. Bump the counter so
+		// runDropLogger can surface chronic saturation; logging on
+		// every miss would be too noisy on the hot path.
+		peer.dropCount.Add(1)
+	}
+}
+
+// dropLogInterval is how often runDropLogger samples each peer's
+// dropCount and emits a log line if the delta is non-zero. Tuned to be
+// short enough to catch transient saturation but quiet enough not to
+// flood logs on a healthy cluster (which never drops anything).
+const dropLogInterval = 30 * time.Second
+
+// runDropLogger periodically logs the per-peer EnqueueSend drop deltas
+// so a chronically saturated peer is operationally visible instead of
+// silently invisible. Healthy clusters never drop, so the goroutine is
+// log-silent in the common case. Exits on ctx cancellation.
+func (t *grpcTransport) runDropLogger(ctx context.Context) {
+	if t.logger == nil {
+		return
+	}
+	ticker := time.NewTicker(dropLogInterval)
+	defer ticker.Stop()
+
+	last := make(map[uint64]uint64, len(t.peers))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for id, p := range t.peers {
+				cur := p.dropCount.Load()
+				delta := cur - last[id]
+				if delta == 0 {
+					continue
+				}
+				last[id] = cur
+				t.logger.Infof(
+					"peer %d (%s): dropped %d raft messages in last %s due to full send queue (cumulative %d)",
+					id, p.addr, delta, dropLogInterval, cur,
+				)
+			}
+		}
 	}
 }
 
@@ -397,7 +444,7 @@ func (t *grpcTransport) runPeerSender(ctx context.Context, id uint64, peer *peer
 			if !ok {
 				return
 			}
-			t.sendOneMessage(ctx, id, peer, msg)
+			t.sendOneMessage(ctx, id, msg)
 		}
 	}
 }
@@ -405,7 +452,7 @@ func (t *grpcTransport) runPeerSender(ctx context.Context, id uint64, peer *peer
 // sendOneMessage is the body of runPeerSender's loop. Split out so the
 // snapshot-on-reject path is easier to read without deeply-nested
 // control flow inside the select.
-func (t *grpcTransport) sendOneMessage(ctx context.Context, id uint64, peer *peer, msg raftpb.Message) {
+func (t *grpcTransport) sendOneMessage(ctx context.Context, id uint64, msg raftpb.Message) {
 	applied, err := t.DoSend(ctx, msg)
 	if err == nil && applied {
 		return
@@ -623,6 +670,9 @@ func (t *grpcTransport) Run(ctx context.Context) error {
 	for id, p := range t.peers {
 		go t.runPeerSender(ctx, id, p)
 	}
+	// Periodically surface per-peer EnqueueSend drops so chronic queue
+	// saturation is visible without logging on every dropped message.
+	go t.runDropLogger(ctx)
 
 	done := make(chan struct{})
 	errs := make(chan error, 1)

--- a/pkg/multicluster/leaderelection/raft.go
+++ b/pkg/multicluster/leaderelection/raft.go
@@ -144,6 +144,11 @@ type grpcTransport struct {
 	clientCredentials credentials.TransportCredentials
 	extraDialOptions  []grpc.DialOption
 
+	// testHooks is nil in production. Chaos tests wire it in via the
+	// LockConfiguration so they can inject faults (currently
+	// BlockIngress) without touching the production code path.
+	testHooks *TestHooks
+
 	logger raft.Logger
 
 	transportv1.UnimplementedTransportServiceServer
@@ -301,6 +306,10 @@ func (t *grpcTransport) DoSend(ctx context.Context, msg raftpb.Message) (bool, e
 }
 
 func (t *grpcTransport) Send(ctx context.Context, req *transportv1.SendRequest) (*transportv1.SendResponse, error) {
+	if t.testHooks != nil && t.testHooks.BlockIngress != nil && t.testHooks.BlockIngress.Load() {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	if node := t.getNode(); node != nil {
 		var msg raftpb.Message
 		if err := msg.Unmarshal(req.Payload); err != nil {
@@ -364,6 +373,10 @@ func (t *grpcTransport) Send(ctx context.Context, req *transportv1.SendRequest) 
 }
 
 func (t *grpcTransport) Check(ctx context.Context, req *transportv1.CheckRequest) (*transportv1.CheckResponse, error) {
+	if t.testHooks != nil && t.testHooks.BlockIngress != nil && t.testHooks.BlockIngress.Load() {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	leader := t.leader.Load()
 	isLeader := t.isLeader.Load()
 	if leader != 0 {


### PR DESCRIPTION
## Summary
                                                                                                                                                                             
  Fixes finding #1 from the multicluster failure-modes memo: a leader                                                                                                        
  in a 3-node StretchCluster could step down despite a healthy majority
  when a single follower's network silently black-holed (TCP packets                                                                                                         
  dropped, no RST, no FIN). Reproduced live in vind by injecting 100%                                                                                                        
  packet loss with Pumba on the leader→follower_1 link; healthy                                                                                                              
  follower_2 was starved of heartbeats, CheckQuorum tripped, leader                                                                                                          
  stepped down.                                                                                                                                                              
                                                                                                                                                                             
  ## Root cause                                                                                                                                                              
                                                                                                                                                                             
  The raft Ready loop iterated `rd.Messages` serially and called the                                                                                                         
  gRPC `DoSend` synchronously. Without HTTP/2 keepalives, a
  silently-dropped TCP stream stayed "open" until Linux's tcp_retries2                                                                                                       
  ceiling (~15 min). Each `DoSend` to the broken peer therefore blocked                                                                                                      
  on the orphan stream, and **every other peer's send waited behind it**                                                                                                     
  — so the healthy follower never received heartbeats inside one                                                                                                             
  ElectionTimeout.                                                                                                                                                           
                                                                                                                                                                             
  ## Fix                                                                                                                                                                     
                             
  Three commits, each independently meaningful:
                                                                                                                                                                             
  1. **HTTP/2 keepalives on peer gRPC connections** (`a38a7677` →
     rebased) — close the orphan stream within ~13s of the first                                                                                                             
     missed pong instead of waiting 15 minutes. Necessary but not                                                                                                            
     sufficient: the loop still progresses at the slowest peer's pace.                                                                                                       
  2. **Per-peer fan-out** (`8c4b761b` → rebased) — each peer gets a                                                                                                          
     bounded send queue (256) and a dedicated worker. The Ready loop                                                                                                         
     does a non-blocking `EnqueueSend` per message and finishes in                                                                                                           
     microseconds regardless of peer health. Snapshot-on-reject and                                                                                                          
     `ReportUnreachable` move into the worker, behaviour-equivalent.                                                                                                         
  3. **Drop observability** (`b9ac8086` → rebased) — atomic per-peer                                                                                                         
     drop counter bumped on full-queue, with a 30s periodic logger                                                                                                           
     that surfaces non-zero deltas. Healthy clusters stay log-silent;                                                                                                        
     chronic saturation becomes visible in operator logs.                                                                                                                    
                                                                                                                                                                             
  A characterization-test commit precedes the fixes, including the                                                                                                           
  asymmetric-silent-drop regression test that's red without the                                                                                                              
  fan-out and green with it.                                                                                                                                                 
                                                                                                                                                                             
  ## Validation                                                                                                                                                              
                             
  - Full `pkg/multicluster/leaderelection` package passes in ~40s.
  - The `TestLeaderSurvives_AsymmetricSilentDropOnOnePeer` regression                                                                                                        
    test confirms the leader keeps its role through a 15s window of                                                                                                          
    asymmetric silent drop on one peer.                                                                                                                                      
  - Live re-run of `hack/multicluster/repro/finding-01-dosend-stall.sh`                                                                                                      
    on a fresh 3-node vind env: leader stayed stable for the full 180s                                                                                                       
    injection window, zero new elections, zero "became follower"                                                                                                             
    events.                                                                                                                                                                  
                                                                                                                                                                             
  ## Risks acknowledged                                                                                                                                                      
                             
  - Full-queue drops are silent on the hot path. Mitigated by the                                                                                                            
    per-peer counter + periodic log (commit 4).
  - `sendTimeout = HeartbeatInterval` bounds every RPC, not just                                                                                                             
    heartbeats; large MsgApp catch-up bursts on a slow link could                                                                                                            
    legitimately time out. Tradeoff accepted — a faster timeout is                                                                                                           
    the bug we're fixing.                                                                                                                                                    
  - No `defer recover()` in worker goroutines: a panic kills one                                                                                                             
    peer's send path silently. Conscious choice — surfaces                                                                                                                   
    programming bugs loudly instead of papering over them.           