### PR TITLE
operator: emit v2 Redpanda Prometheus metrics

### DIFF
--- a/.changes/unreleased/operator-Added-20260428-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260428-120000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: V2 (cluster.redpanda.com/v1alpha2 Redpanda) Prometheus metrics — `redpandas_total`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters` — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
+time: 2026-04-28T12:00:00.000000000Z

--- a/.changes/unreleased/operator-Added-20260428-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260428-120000.yaml
@@ -1,4 +1,4 @@
 project: operator
 kind: Added
-body: V2 (cluster.redpanda.com/v1alpha2 Redpanda and StretchCluster) Prometheus metrics — `redpandas_total`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters`, all carrying a `kind` label that distinguishes Redpanda from StretchCluster — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
+body: V2 (cluster.redpanda.com/v1alpha2 Redpanda) Prometheus metrics — `redpandas_total`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters` — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
 time: 2026-04-28T12:00:00.000000000Z

--- a/.changes/unreleased/operator-Added-20260428-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260428-120000.yaml
@@ -1,4 +1,4 @@
 project: operator
 kind: Added
-body: V2 (cluster.redpanda.com/v1alpha2 Redpanda) Prometheus metrics — `redpandas_total`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters` — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
+body: V2 (cluster.redpanda.com/v1alpha2 Redpanda) Prometheus metrics — `redpandas`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters` — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
 time: 2026-04-28T12:00:00.000000000Z

--- a/.changes/unreleased/operator-Added-20260428-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260428-120000.yaml
@@ -1,4 +1,4 @@
 project: operator
 kind: Added
-body: V2 (cluster.redpanda.com/v1alpha2 Redpanda) Prometheus metrics — `redpandas_total`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters` — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
+body: V2 (cluster.redpanda.com/v1alpha2 Redpanda and StretchCluster) Prometheus metrics — `redpandas_total`, `redpanda_desired_nodes`, `redpanda_ready_nodes`, and `redpanda_misconfigured_clusters`, all carrying a `kind` label that distinguishes Redpanda from StretchCluster — mirroring the existing v1 ClusterMetricController so observability is at parity between the two operator modes.
 time: 2026-04-28T12:00:00.000000000Z

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -421,9 +421,10 @@ func Run(
 		}
 
 		// Metrics Reconciler — emits Prometheus gauges describing the v2
-		// Redpanda CRs the operator is managing, mirroring the v1
-		// ClusterMetricController for parity between operator versions.
-		if err := redpandacontrollers.NewRedpandaMetricsReconciler(mcmanager).SetupWithManager(mcmanager); err != nil {
+		// Redpanda and StretchCluster CRs the operator is managing,
+		// mirroring the v1 ClusterMetricController for parity between
+		// operator versions.
+		if err := redpandacontrollers.NewRedpandaMetricsReconciler(mcmanager).SetupWithManager(ctx, mcmanager, opts.namespace); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "RedpandaMetrics")
 			return err
 		}

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -421,10 +421,11 @@ func Run(
 		}
 
 		// Metrics Reconciler — emits Prometheus gauges describing the v2
-		// Redpanda and StretchCluster CRs the operator is managing,
-		// mirroring the v1 ClusterMetricController for parity between
-		// operator versions.
-		if err := redpandacontrollers.NewRedpandaMetricsReconciler(mcmanager).SetupWithManager(ctx, mcmanager, opts.namespace); err != nil {
+		// Redpanda CRs the operator is managing, mirroring the v1
+		// ClusterMetricController for parity between operator versions.
+		// Bound to the local manager because the Redpanda CRD only exists
+		// on the local cluster.
+		if err := redpandacontrollers.NewRedpandaMetricsReconciler(mgr).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "RedpandaMetrics")
 			return err
 		}

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -420,6 +420,14 @@ func Run(
 			}
 		}
 
+		// Metrics Reconciler — emits Prometheus gauges describing the v2
+		// Redpanda CRs the operator is managing, mirroring the v1
+		// ClusterMetricController for parity between operator versions.
+		if err := redpandacontrollers.NewRedpandaMetricsReconciler(mcmanager).SetupWithManager(mcmanager); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "RedpandaMetrics")
+			return err
+		}
+
 		// Console Reconciler.
 		if opts.enableConsoleController {
 			ctl, err := kube.FromRESTConfig(mgr.GetConfig(), kube.Options{

--- a/operator/internal/controller/redpanda/metric_controller.go
+++ b/operator/internal/controller/redpanda/metric_controller.go
@@ -11,48 +11,58 @@ package redpanda
 
 import (
 	"context"
-	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redpanda-data/common-go/otelutil/log"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 )
 
+// kind label values for the v2 metrics. They mirror the Kubernetes Kind name
+// of each CRD so a Prometheus query maps cleanly onto `kubectl get <kind>`.
+const (
+	kindRedpanda       = "Redpanda"
+	kindStretchCluster = "StretchCluster"
+)
+
 var (
-	redpandasTotal = prometheus.NewGauge(
+	redpandasTotal = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpandas_total",
-			Help: "Number of Redpanda clusters (cluster.redpanda.com/v1alpha2) managed by the operator",
-		},
+			Help: "Number of Redpanda clusters managed by the operator, by CRD kind",
+		}, []string{"kind"},
 	)
 	redpandaDesiredNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpanda_desired_nodes",
-			Help: "Desired number of broker pods per Redpanda cluster, summed across all node pools",
-		}, []string{"namespace", "name"},
+			Help: "Desired number of broker pods per cluster, summed across all node pools",
+		}, []string{"kind", "namespace", "name"},
 	)
 	redpandaReadyNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpanda_ready_nodes",
-			Help: "Number of broker pods reporting Ready per Redpanda cluster, summed across all node pools",
-		}, []string{"namespace", "name"},
+			Help: "Number of broker pods reporting Ready per cluster, summed across all node pools",
+		}, []string{"kind", "namespace", "name"},
 	)
 	redpandaMisconfiguredClusters = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpanda_misconfigured_clusters",
-			Help: "Number of Redpanda clusters whose ConfigurationApplied condition is not True, labeled by reason",
-		}, []string{"reason"},
+			Help: "Number of clusters whose ConfigurationApplied condition is not True, by kind and reason",
+		}, []string{"kind", "reason"},
 	)
 )
 
@@ -65,137 +75,201 @@ func init() {
 	)
 }
 
-// redpandaMetricKey identifies a Redpanda CR for the purpose of tracking
-// previously-observed Prometheus label values across reconciles. Cluster
-// names are not globally unique (the same name can exist in multiple
-// namespaces), so the namespace is part of the key.
+// redpandaMetricKey identifies a cluster CR for the purpose of tracking
+// previously-emitted Prometheus label values across reconciles. The kind is
+// part of the key because Redpanda and StretchCluster CRs share the same
+// gauge label set and could otherwise collide on (namespace, name).
 type redpandaMetricKey struct {
+	kind      string
 	namespace string
 	name      string
 }
 
-// RedpandaMetricsReconciler emits Prometheus metrics for the v2 Redpanda CRD,
-// providing the parallel of the v1 ClusterMetricController for the
-// cluster.redpanda.com/v1alpha2 Redpanda type. The reconciler ignores the
-// incoming request and recomputes the gauges from a fresh List so that
-// metrics stay accurate even when individual events are coalesced.
+type misconfigKey struct {
+	kind   string
+	reason string
+}
+
+// RedpandaMetricsReconciler emits Prometheus metrics for the v2 Redpanda and
+// StretchCluster CRDs, providing the parallel of the v1 ClusterMetricController.
+// The reconciler ignores the incoming request and recomputes gauges from a
+// fresh List so that values stay accurate even when individual events are
+// coalesced — matching the v1 pattern.
+//
+// One reconciler instance backs two controller-runtime controllers (one per
+// CRD), so a Reconcile triggered from a Redpanda event still also re-lists
+// StretchClusters, and vice versa. The mutex serializes those two trigger
+// paths so they do not race on gauge label cleanup.
 type RedpandaMetricsReconciler struct {
 	Manager multicluster.Manager
 
-	// labels previously emitted on the desired/ready GaugeVecs. We retain them
-	// across reconciles so that we can call DeleteLabelValues for Redpandas
-	// that have since been deleted — without this, prometheus would keep
-	// reporting their last value forever.
+	// mu serializes Reconcile invocations so the two controllers backing this
+	// reconciler do not race on label cleanup.
+	mu sync.Mutex
+
+	// Labels we previously emitted on per-cluster gauges. Retained so we can
+	// DeleteLabelValues for clusters that have since been deleted — without
+	// this, Prometheus would keep reporting their last value indefinitely.
 	currentLabels collections.Set[redpandaMetricKey]
 
-	// reasons previously emitted on the misconfigured GaugeVec. Same idea as
-	// currentLabels.
-	currentConfigurationLabels collections.Set[string]
+	// Misconfiguration reasons we previously emitted. Same idea as
+	// currentLabels but for the aggregated misconfigured gauge.
+	currentMisconfigReasons collections.Set[misconfigKey]
 }
 
 // NewRedpandaMetricsReconciler creates a RedpandaMetricsReconciler.
 func NewRedpandaMetricsReconciler(mgr multicluster.Manager) *RedpandaMetricsReconciler {
 	return &RedpandaMetricsReconciler{
-		Manager:                    mgr,
-		currentLabels:              collections.NewConcurrentSet[redpandaMetricKey](),
-		currentConfigurationLabels: collections.NewConcurrentSet[string](),
+		Manager:                 mgr,
+		currentLabels:           collections.NewSet[redpandaMetricKey](),
+		currentMisconfigReasons: collections.NewSet[misconfigKey](),
 	}
 }
 
-// Reconcile lists all Redpandas across every cluster known to the multicluster
-// Manager and updates the registered Prometheus gauges. The incoming request
-// is ignored: we always recompute totals from scratch.
+// Reconcile lists Redpandas and StretchClusters across every cluster known to
+// the multicluster Manager and updates the registered Prometheus gauges. The
+// incoming request is ignored.
+//
+// Per-cluster failures (unreachable, list error) are logged and skipped rather
+// than aborting the entire reconcile — partial metrics from healthy clusters
+// are more useful than no metrics at all. StretchCluster CRs are deduped by
+// (namespace, name) since the same StretchCluster is mirrored across every
+// participating k8s cluster.
 func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ mcreconcile.Request) (ctrl.Result, error) {
-	seenLabels := collections.NewSet[redpandaMetricKey]()
-	misconfiguredCounts := map[string]int{}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	var total int
+	logger := log.FromContext(ctx).WithName("RedpandaMetricsReconciler.Reconcile")
+
+	seenLabels := collections.NewSet[redpandaMetricKey]()
+	seenStretchKeys := collections.NewSet[redpandaMetricKey]()
+	misconfigCounts := map[misconfigKey]int{}
+
+	var redpandaCount, stretchClusterCount int
 
 	for _, clusterName := range r.Manager.GetClusterNames() {
+		if !r.Manager.IsClusterReachable(clusterName) {
+			logger.V(log.DebugLevel).Info("cluster unreachable, skipping for metrics", "cluster", clusterName)
+			continue
+		}
 		cl, err := r.Manager.GetCluster(ctx, clusterName)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("getting cluster %q: %w", clusterName, err)
+			logger.Info("cannot get cluster for metrics, skipping", "cluster", clusterName, "error", err)
+			continue
 		}
+		k8sClient := cl.GetClient()
 
 		var rps redpandav1alpha2.RedpandaList
-		if err := cl.GetClient().List(ctx, &rps); err != nil {
-			return ctrl.Result{}, fmt.Errorf("listing Redpandas in cluster %q: %w", clusterName, err)
+		if err := k8sClient.List(ctx, &rps); err != nil {
+			logger.Info("listing Redpandas failed, skipping", "cluster", clusterName, "error", err)
+		} else {
+			for i := range rps.Items {
+				rp := &rps.Items[i]
+				key := redpandaMetricKey{kind: kindRedpanda, namespace: rp.Namespace, name: rp.Name}
+				redpandaCount++
+				r.recordCluster(key, rp.Status.NodePools, rp.Status.Conditions, statuses.ClusterConfigurationApplied, misconfigCounts)
+				seenLabels.Add(key)
+			}
 		}
 
-		total += len(rps.Items)
-		for i := range rps.Items {
-			rp := &rps.Items[i]
-			key := redpandaMetricKey{namespace: rp.Namespace, name: rp.Name}
-
-			var desired, ready int32
-			for _, pool := range rp.Status.NodePools {
-				desired += pool.DesiredReplicas
-				ready += pool.ReadyReplicas
-			}
-
-			d, err := redpandaDesiredNodes.GetMetricWithLabelValues(key.namespace, key.name)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			d.Set(float64(desired))
-
-			a, err := redpandaReadyNodes.GetMetricWithLabelValues(key.namespace, key.name)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			a.Set(float64(ready))
-
-			seenLabels.Add(key)
-			r.currentLabels.Add(key)
-
-			if cond := apimeta.FindStatusCondition(rp.Status.Conditions, statuses.ClusterConfigurationApplied); cond != nil && cond.Status != metav1.ConditionTrue {
-				misconfiguredCounts[cond.Reason]++
+		var scs redpandav1alpha2.StretchClusterList
+		if err := k8sClient.List(ctx, &scs); err != nil {
+			logger.Info("listing StretchClusters failed, skipping", "cluster", clusterName, "error", err)
+		} else {
+			for i := range scs.Items {
+				sc := &scs.Items[i]
+				key := redpandaMetricKey{kind: kindStretchCluster, namespace: sc.Namespace, name: sc.Name}
+				// The same StretchCluster CR is replicated to every participating
+				// k8s cluster; dedup so it counts once and one cluster's view
+				// (the first one we see) wins for the gauge value.
+				if seenStretchKeys.HasAny(key) {
+					continue
+				}
+				seenStretchKeys.Add(key)
+				stretchClusterCount++
+				r.recordCluster(key, sc.Status.NodePools, sc.Status.Conditions, statuses.StretchClusterConfigurationApplied, misconfigCounts)
+				seenLabels.Add(key)
 			}
 		}
 	}
 
-	redpandasTotal.Set(float64(total))
+	redpandasTotal.WithLabelValues(kindRedpanda).Set(float64(redpandaCount))
+	redpandasTotal.WithLabelValues(kindStretchCluster).Set(float64(stretchClusterCount))
 
+	// Cleanup per-cluster gauge labels that no longer correspond to a live CR.
 	for _, key := range r.currentLabels.Values() {
 		if !seenLabels.HasAny(key) {
-			redpandaDesiredNodes.DeleteLabelValues(key.namespace, key.name)
-			redpandaReadyNodes.DeleteLabelValues(key.namespace, key.name)
+			redpandaDesiredNodes.DeleteLabelValues(key.kind, key.namespace, key.name)
+			redpandaReadyNodes.DeleteLabelValues(key.kind, key.namespace, key.name)
+			r.currentLabels.Delete(key)
 		}
 	}
 
-	for reason, count := range misconfiguredCounts {
-		g, err := redpandaMisconfiguredClusters.GetMetricWithLabelValues(reason)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		g.Set(float64(count))
-		r.currentConfigurationLabels.Add(reason)
+	// Update misconfigured gauge for each (kind, reason) seen this round and
+	// drop labels for reasons that no longer apply.
+	seenReasons := collections.NewSet[misconfigKey]()
+	for k, count := range misconfigCounts {
+		redpandaMisconfiguredClusters.WithLabelValues(k.kind, k.reason).Set(float64(count))
+		seenReasons.Add(k)
+		r.currentMisconfigReasons.Add(k)
 	}
-	for _, reason := range r.currentConfigurationLabels.Values() {
-		if _, exists := misconfiguredCounts[reason]; !exists {
-			redpandaMisconfiguredClusters.DeleteLabelValues(reason)
+	for _, k := range r.currentMisconfigReasons.Values() {
+		if !seenReasons.HasAny(k) {
+			redpandaMisconfiguredClusters.DeleteLabelValues(k.kind, k.reason)
+			r.currentMisconfigReasons.Delete(k)
 		}
 	}
 
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager registers the metrics reconciler with the multicluster
-// manager. It engages with both local and provider clusters so that
-// metrics reflect Redpandas across every cluster the operator manages.
-func (r *RedpandaMetricsReconciler) SetupWithManager(mgr multicluster.Manager) error {
-	return mcbuilder.ControllerManagedBy(mgr).
-		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
-			// SkipNameValidation matches the convention used by other v2
-			// controllers in this package — the multicluster runtime
-			// occasionally reuses controller names across registrations
-			// during tests, and this avoids a duplicate-name panic.
-			SkipNameValidation: ptr.To(true),
-		}).
-		For(
-			&redpandav1alpha2.Redpanda{},
-			mcbuilder.WithEngageWithLocalCluster(true),
-			mcbuilder.WithEngageWithProviderClusters(true),
-		).
-		Complete(r)
+// recordCluster sets the per-cluster desired/ready gauges and accumulates the
+// misconfiguration count for one CR. Factored out to keep the per-CRD list
+// loops in Reconcile readable.
+func (r *RedpandaMetricsReconciler) recordCluster(
+	key redpandaMetricKey,
+	pools []redpandav1alpha2.EmbeddedNodePoolStatus,
+	conditions []metav1.Condition,
+	configurationAppliedCondition string,
+	misconfigCounts map[misconfigKey]int,
+) {
+	var desired, ready int32
+	for _, pool := range pools {
+		desired += pool.DesiredReplicas
+		ready += pool.ReadyReplicas
+	}
+	redpandaDesiredNodes.WithLabelValues(key.kind, key.namespace, key.name).Set(float64(desired))
+	redpandaReadyNodes.WithLabelValues(key.kind, key.namespace, key.name).Set(float64(ready))
+	r.currentLabels.Add(key)
+
+	if cond := apimeta.FindStatusCondition(conditions, configurationAppliedCondition); cond != nil && cond.Status != metav1.ConditionTrue {
+		misconfigCounts[misconfigKey{kind: key.kind, reason: cond.Reason}]++
+	}
+}
+
+// SetupWithManager registers two controllers — one per watched CRD — that
+// share a single reconciler instance. The shared reconciler's mutex serializes
+// concurrent invocations from the two trigger paths.
+func (r *RedpandaMetricsReconciler) SetupWithManager(_ context.Context, mgr multicluster.Manager, namespace string) error {
+	register := func(name string, obj client.Object) error {
+		return mcbuilder.ControllerManagedBy(mgr).
+			Named(name).
+			WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+				// Matches the convention used by other v2 controllers in this
+				// package; avoids a duplicate-name panic when the multicluster
+				// runtime reuses controller names across registrations during
+				// tests.
+				SkipNameValidation: ptr.To(true),
+			}).
+			For(obj,
+				mcbuilder.WithEngageWithLocalCluster(true),
+				mcbuilder.WithEngageWithProviderClusters(true),
+			).
+			Complete(controller.FilterNamespaceReconciler(namespace, r))
+	}
+
+	if err := register("redpanda-metrics-redpanda", &redpandav1alpha2.Redpanda{}); err != nil {
+		return err
+	}
+	return register("redpanda-metrics-stretchcluster", &redpandav1alpha2.StretchCluster{})
 }

--- a/operator/internal/controller/redpanda/metric_controller.go
+++ b/operator/internal/controller/redpanda/metric_controller.go
@@ -11,29 +11,26 @@ package redpanda
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/redpanda-data/common-go/otelutil/log"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
-	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
-	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
-	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 )
 
 var (
-	redpandasTotal = prometheus.NewGauge(
+	redpandas = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "redpandas_total",
+			Name: "redpandas",
 			Help: "Number of Redpanda clusters (cluster.redpanda.com/v1alpha2) managed by the operator",
 		},
 	)
@@ -59,7 +56,7 @@ var (
 
 func init() {
 	metrics.Registry.MustRegister(
-		redpandasTotal,
+		redpandas,
 		redpandaDesiredNodes,
 		redpandaReadyNodes,
 		redpandaMisconfiguredClusters,
@@ -80,13 +77,11 @@ type redpandaMetricKey struct {
 // recomputes the gauges from a fresh List so that values stay accurate even
 // when individual events are coalesced — matching the v1 pattern.
 //
-// Scope: only the Redpanda CRD, intentionally not StretchCluster. The
-// StretchCluster CRD is only installed in multicluster operator mode
-// (`cmd/multicluster`), which has its own setup path; watching that type
-// from `cmd/run` would fail to start the cache because the API resource
-// does not exist there.
+// The reconciler runs against the local cluster's manager (Redpanda CRs only
+// live there); operator-mode StretchCluster metrics are out of scope and
+// would be added in a separate reconciler wired into `cmd/multicluster`.
 type RedpandaMetricsReconciler struct {
-	Manager multicluster.Manager
+	Client client.Client
 
 	// Labels we previously emitted on the per-cluster gauges. Retained so we
 	// can DeleteLabelValues for Redpandas that have since been deleted —
@@ -98,71 +93,52 @@ type RedpandaMetricsReconciler struct {
 	currentConfigurationLabels collections.Set[string]
 }
 
-// NewRedpandaMetricsReconciler creates a RedpandaMetricsReconciler.
-func NewRedpandaMetricsReconciler(mgr multicluster.Manager) *RedpandaMetricsReconciler {
+// NewRedpandaMetricsReconciler creates a RedpandaMetricsReconciler bound to
+// the local manager's client. Pass `mcmgr.GetLocalManager()` from a multicluster
+// manager.
+func NewRedpandaMetricsReconciler(mgr ctrl.Manager) *RedpandaMetricsReconciler {
 	return &RedpandaMetricsReconciler{
-		Manager:                    mgr,
+		Client:                     mgr.GetClient(),
 		currentLabels:              collections.NewConcurrentSet[redpandaMetricKey](),
 		currentConfigurationLabels: collections.NewConcurrentSet[string](),
 	}
 }
 
-// Reconcile lists all Redpandas across every cluster known to the multicluster
-// Manager and updates the registered Prometheus gauges. The incoming request
-// is ignored: we always recompute totals from scratch.
-//
-// Per-cluster failures (unreachable, list error) are logged and skipped rather
-// than aborting the whole reconcile — partial metrics from healthy clusters
-// are more useful than no metrics at all.
-func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ mcreconcile.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithName("RedpandaMetricsReconciler.Reconcile")
+// Reconcile lists every Redpanda known to the local manager and updates the
+// registered Prometheus gauges. The incoming request is ignored: we always
+// recompute totals from scratch so coalesced events do not produce stale
+// values.
+func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	var rps redpandav1alpha2.RedpandaList
+	if err := r.Client.List(ctx, &rps); err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing Redpandas: %w", err)
+	}
 
 	seenLabels := collections.NewSet[redpandaMetricKey]()
 	misconfiguredCounts := map[string]int{}
 
-	var total int
+	for i := range rps.Items {
+		rp := &rps.Items[i]
+		key := redpandaMetricKey{namespace: rp.Namespace, name: rp.Name}
 
-	for _, clusterName := range r.Manager.GetClusterNames() {
-		if !r.Manager.IsClusterReachable(clusterName) {
-			logger.V(log.DebugLevel).Info("cluster unreachable, skipping for metrics", "cluster", clusterName)
-			continue
-		}
-		cl, err := r.Manager.GetCluster(ctx, clusterName)
-		if err != nil {
-			logger.Info("cannot get cluster for metrics, skipping", "cluster", clusterName, "error", err)
-			continue
+		var desired, ready int32
+		for _, pool := range rp.Status.NodePools {
+			desired += pool.DesiredReplicas
+			ready += pool.ReadyReplicas
 		}
 
-		var rps redpandav1alpha2.RedpandaList
-		if err := cl.GetClient().List(ctx, &rps); err != nil {
-			logger.Info("listing Redpandas failed, skipping cluster", "cluster", clusterName, "error", err)
-			continue
-		}
+		redpandaDesiredNodes.WithLabelValues(key.namespace, key.name).Set(float64(desired))
+		redpandaReadyNodes.WithLabelValues(key.namespace, key.name).Set(float64(ready))
 
-		total += len(rps.Items)
-		for i := range rps.Items {
-			rp := &rps.Items[i]
-			key := redpandaMetricKey{namespace: rp.Namespace, name: rp.Name}
+		seenLabels.Add(key)
+		r.currentLabels.Add(key)
 
-			var desired, ready int32
-			for _, pool := range rp.Status.NodePools {
-				desired += pool.DesiredReplicas
-				ready += pool.ReadyReplicas
-			}
-
-			redpandaDesiredNodes.WithLabelValues(key.namespace, key.name).Set(float64(desired))
-			redpandaReadyNodes.WithLabelValues(key.namespace, key.name).Set(float64(ready))
-
-			seenLabels.Add(key)
-			r.currentLabels.Add(key)
-
-			if cond := apimeta.FindStatusCondition(rp.Status.Conditions, statuses.ClusterConfigurationApplied); cond != nil && cond.Status != metav1.ConditionTrue {
-				misconfiguredCounts[cond.Reason]++
-			}
+		if cond := apimeta.FindStatusCondition(rp.Status.Conditions, statuses.ClusterConfigurationApplied); cond != nil && cond.Status != metav1.ConditionTrue {
+			misconfiguredCounts[cond.Reason]++
 		}
 	}
 
-	redpandasTotal.Set(float64(total))
+	redpandas.Set(float64(len(rps.Items)))
 
 	for _, key := range r.currentLabels.Values() {
 		if !seenLabels.HasAny(key) {
@@ -186,24 +162,19 @@ func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ mcreconcile
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager registers the metrics reconciler with the multicluster
-// manager. It engages with both local and provider clusters so that metrics
-// reflect Redpandas across every cluster the operator manages, and is wrapped
-// with FilterNamespaceReconciler to honor the operator's --namespace flag,
-// matching the convention used by the other v2 controllers in this package.
-func (r *RedpandaMetricsReconciler) SetupWithManager(_ context.Context, mgr multicluster.Manager, namespace string) error {
-	return mcbuilder.ControllerManagedBy(mgr).
+// SetupWithManager registers the metrics reconciler with the local manager.
+// The operator's `--namespace` flag is honored implicitly: when set, the
+// manager's cache is restricted to that namespace (see `cmd/run`), which
+// scopes both the watch and the List in Reconcile.
+func (r *RedpandaMetricsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
 		Named("redpanda-metrics").
-		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+		For(&redpandav1alpha2.Redpanda{}).
+		WithOptions(ctrlcontroller.Options{
 			// Matches the convention used by other v2 controllers in this
-			// package; avoids a duplicate-name panic when the multicluster
-			// runtime reuses controller names across registrations during
-			// tests.
+			// package; avoids a duplicate-name panic when controller-runtime
+			// reuses controller names across registrations during tests.
 			SkipNameValidation: ptr.To(true),
 		}).
-		For(&redpandav1alpha2.Redpanda{},
-			mcbuilder.WithEngageWithLocalCluster(true),
-			mcbuilder.WithEngageWithProviderClusters(true),
-		).
-		Complete(controller.FilterNamespaceReconciler(namespace, r))
+		Complete(r)
 }

--- a/operator/internal/controller/redpanda/metric_controller.go
+++ b/operator/internal/controller/redpanda/metric_controller.go
@@ -11,7 +11,6 @@ package redpanda
 
 import (
 	"context"
-	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redpanda-data/common-go/otelutil/log"
@@ -19,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
@@ -32,37 +30,30 @@ import (
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 )
 
-// kind label values for the v2 metrics. They mirror the Kubernetes Kind name
-// of each CRD so a Prometheus query maps cleanly onto `kubectl get <kind>`.
-const (
-	kindRedpanda       = "Redpanda"
-	kindStretchCluster = "StretchCluster"
-)
-
 var (
-	redpandasTotal = prometheus.NewGaugeVec(
+	redpandasTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "redpandas_total",
-			Help: "Number of Redpanda clusters managed by the operator, by CRD kind",
-		}, []string{"kind"},
+			Help: "Number of Redpanda clusters (cluster.redpanda.com/v1alpha2) managed by the operator",
+		},
 	)
 	redpandaDesiredNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpanda_desired_nodes",
-			Help: "Desired number of broker pods per cluster, summed across all node pools",
-		}, []string{"kind", "namespace", "name"},
+			Help: "Desired number of broker pods per Redpanda cluster, summed across all node pools",
+		}, []string{"namespace", "name"},
 	)
 	redpandaReadyNodes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpanda_ready_nodes",
-			Help: "Number of broker pods reporting Ready per cluster, summed across all node pools",
-		}, []string{"kind", "namespace", "name"},
+			Help: "Number of broker pods reporting Ready per Redpanda cluster, summed across all node pools",
+		}, []string{"namespace", "name"},
 	)
 	redpandaMisconfiguredClusters = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redpanda_misconfigured_clusters",
-			Help: "Number of clusters whose ConfigurationApplied condition is not True, by kind and reason",
-		}, []string{"kind", "reason"},
+			Help: "Number of Redpanda clusters whose ConfigurationApplied condition is not True, labeled by reason",
+		}, []string{"reason"},
 	)
 )
 
@@ -75,77 +66,61 @@ func init() {
 	)
 }
 
-// redpandaMetricKey identifies a cluster CR for the purpose of tracking
-// previously-emitted Prometheus label values across reconciles. The kind is
-// part of the key because Redpanda and StretchCluster CRs share the same
-// gauge label set and could otherwise collide on (namespace, name).
+// redpandaMetricKey identifies a Redpanda CR for the purpose of tracking
+// previously-emitted Prometheus label values across reconciles. The namespace
+// is part of the key because v2 Redpanda names can collide across namespaces.
 type redpandaMetricKey struct {
-	kind      string
 	namespace string
 	name      string
 }
 
-type misconfigKey struct {
-	kind   string
-	reason string
-}
-
-// RedpandaMetricsReconciler emits Prometheus metrics for the v2 Redpanda and
-// StretchCluster CRDs, providing the parallel of the v1 ClusterMetricController.
-// The reconciler ignores the incoming request and recomputes gauges from a
-// fresh List so that values stay accurate even when individual events are
-// coalesced — matching the v1 pattern.
+// RedpandaMetricsReconciler emits Prometheus metrics for the v2
+// `cluster.redpanda.com/v1alpha2` Redpanda CRD, providing the parallel of the
+// v1 ClusterMetricController. The reconciler ignores the incoming request and
+// recomputes the gauges from a fresh List so that values stay accurate even
+// when individual events are coalesced — matching the v1 pattern.
 //
-// One reconciler instance backs two controller-runtime controllers (one per
-// CRD), so a Reconcile triggered from a Redpanda event still also re-lists
-// StretchClusters, and vice versa. The mutex serializes those two trigger
-// paths so they do not race on gauge label cleanup.
+// Scope: only the Redpanda CRD, intentionally not StretchCluster. The
+// StretchCluster CRD is only installed in multicluster operator mode
+// (`cmd/multicluster`), which has its own setup path; watching that type
+// from `cmd/run` would fail to start the cache because the API resource
+// does not exist there.
 type RedpandaMetricsReconciler struct {
 	Manager multicluster.Manager
 
-	// mu serializes Reconcile invocations so the two controllers backing this
-	// reconciler do not race on label cleanup.
-	mu sync.Mutex
-
-	// Labels we previously emitted on per-cluster gauges. Retained so we can
-	// DeleteLabelValues for clusters that have since been deleted — without
-	// this, Prometheus would keep reporting their last value indefinitely.
+	// Labels we previously emitted on the per-cluster gauges. Retained so we
+	// can DeleteLabelValues for Redpandas that have since been deleted —
+	// without this Prometheus would keep reporting their last value forever.
 	currentLabels collections.Set[redpandaMetricKey]
 
-	// Misconfiguration reasons we previously emitted. Same idea as
+	// Misconfiguration reasons we previously emitted; same idea as
 	// currentLabels but for the aggregated misconfigured gauge.
-	currentMisconfigReasons collections.Set[misconfigKey]
+	currentConfigurationLabels collections.Set[string]
 }
 
 // NewRedpandaMetricsReconciler creates a RedpandaMetricsReconciler.
 func NewRedpandaMetricsReconciler(mgr multicluster.Manager) *RedpandaMetricsReconciler {
 	return &RedpandaMetricsReconciler{
-		Manager:                 mgr,
-		currentLabels:           collections.NewSet[redpandaMetricKey](),
-		currentMisconfigReasons: collections.NewSet[misconfigKey](),
+		Manager:                    mgr,
+		currentLabels:              collections.NewConcurrentSet[redpandaMetricKey](),
+		currentConfigurationLabels: collections.NewConcurrentSet[string](),
 	}
 }
 
-// Reconcile lists Redpandas and StretchClusters across every cluster known to
-// the multicluster Manager and updates the registered Prometheus gauges. The
-// incoming request is ignored.
+// Reconcile lists all Redpandas across every cluster known to the multicluster
+// Manager and updates the registered Prometheus gauges. The incoming request
+// is ignored: we always recompute totals from scratch.
 //
 // Per-cluster failures (unreachable, list error) are logged and skipped rather
-// than aborting the entire reconcile — partial metrics from healthy clusters
-// are more useful than no metrics at all. StretchCluster CRs are deduped by
-// (namespace, name) since the same StretchCluster is mirrored across every
-// participating k8s cluster.
+// than aborting the whole reconcile — partial metrics from healthy clusters
+// are more useful than no metrics at all.
 func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ mcreconcile.Request) (ctrl.Result, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	logger := log.FromContext(ctx).WithName("RedpandaMetricsReconciler.Reconcile")
 
 	seenLabels := collections.NewSet[redpandaMetricKey]()
-	seenStretchKeys := collections.NewSet[redpandaMetricKey]()
-	misconfigCounts := map[misconfigKey]int{}
+	misconfiguredCounts := map[string]int{}
 
-	var redpandaCount, stretchClusterCount int
+	var total int
 
 	for _, clusterName := range r.Manager.GetClusterNames() {
 		if !r.Manager.IsClusterReachable(clusterName) {
@@ -157,119 +132,78 @@ func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ mcreconcile
 			logger.Info("cannot get cluster for metrics, skipping", "cluster", clusterName, "error", err)
 			continue
 		}
-		k8sClient := cl.GetClient()
 
 		var rps redpandav1alpha2.RedpandaList
-		if err := k8sClient.List(ctx, &rps); err != nil {
-			logger.Info("listing Redpandas failed, skipping", "cluster", clusterName, "error", err)
-		} else {
-			for i := range rps.Items {
-				rp := &rps.Items[i]
-				key := redpandaMetricKey{kind: kindRedpanda, namespace: rp.Namespace, name: rp.Name}
-				redpandaCount++
-				r.recordCluster(key, rp.Status.NodePools, rp.Status.Conditions, statuses.ClusterConfigurationApplied, misconfigCounts)
-				seenLabels.Add(key)
-			}
+		if err := cl.GetClient().List(ctx, &rps); err != nil {
+			logger.Info("listing Redpandas failed, skipping cluster", "cluster", clusterName, "error", err)
+			continue
 		}
 
-		var scs redpandav1alpha2.StretchClusterList
-		if err := k8sClient.List(ctx, &scs); err != nil {
-			logger.Info("listing StretchClusters failed, skipping", "cluster", clusterName, "error", err)
-		} else {
-			for i := range scs.Items {
-				sc := &scs.Items[i]
-				key := redpandaMetricKey{kind: kindStretchCluster, namespace: sc.Namespace, name: sc.Name}
-				// The same StretchCluster CR is replicated to every participating
-				// k8s cluster; dedup so it counts once and one cluster's view
-				// (the first one we see) wins for the gauge value.
-				if seenStretchKeys.HasAny(key) {
-					continue
-				}
-				seenStretchKeys.Add(key)
-				stretchClusterCount++
-				r.recordCluster(key, sc.Status.NodePools, sc.Status.Conditions, statuses.StretchClusterConfigurationApplied, misconfigCounts)
-				seenLabels.Add(key)
+		total += len(rps.Items)
+		for i := range rps.Items {
+			rp := &rps.Items[i]
+			key := redpandaMetricKey{namespace: rp.Namespace, name: rp.Name}
+
+			var desired, ready int32
+			for _, pool := range rp.Status.NodePools {
+				desired += pool.DesiredReplicas
+				ready += pool.ReadyReplicas
+			}
+
+			redpandaDesiredNodes.WithLabelValues(key.namespace, key.name).Set(float64(desired))
+			redpandaReadyNodes.WithLabelValues(key.namespace, key.name).Set(float64(ready))
+
+			seenLabels.Add(key)
+			r.currentLabels.Add(key)
+
+			if cond := apimeta.FindStatusCondition(rp.Status.Conditions, statuses.ClusterConfigurationApplied); cond != nil && cond.Status != metav1.ConditionTrue {
+				misconfiguredCounts[cond.Reason]++
 			}
 		}
 	}
 
-	redpandasTotal.WithLabelValues(kindRedpanda).Set(float64(redpandaCount))
-	redpandasTotal.WithLabelValues(kindStretchCluster).Set(float64(stretchClusterCount))
+	redpandasTotal.Set(float64(total))
 
-	// Cleanup per-cluster gauge labels that no longer correspond to a live CR.
 	for _, key := range r.currentLabels.Values() {
 		if !seenLabels.HasAny(key) {
-			redpandaDesiredNodes.DeleteLabelValues(key.kind, key.namespace, key.name)
-			redpandaReadyNodes.DeleteLabelValues(key.kind, key.namespace, key.name)
+			redpandaDesiredNodes.DeleteLabelValues(key.namespace, key.name)
+			redpandaReadyNodes.DeleteLabelValues(key.namespace, key.name)
 			r.currentLabels.Delete(key)
 		}
 	}
 
-	// Update misconfigured gauge for each (kind, reason) seen this round and
-	// drop labels for reasons that no longer apply.
-	seenReasons := collections.NewSet[misconfigKey]()
-	for k, count := range misconfigCounts {
-		redpandaMisconfiguredClusters.WithLabelValues(k.kind, k.reason).Set(float64(count))
-		seenReasons.Add(k)
-		r.currentMisconfigReasons.Add(k)
+	for reason, count := range misconfiguredCounts {
+		redpandaMisconfiguredClusters.WithLabelValues(reason).Set(float64(count))
+		r.currentConfigurationLabels.Add(reason)
 	}
-	for _, k := range r.currentMisconfigReasons.Values() {
-		if !seenReasons.HasAny(k) {
-			redpandaMisconfiguredClusters.DeleteLabelValues(k.kind, k.reason)
-			r.currentMisconfigReasons.Delete(k)
+	for _, reason := range r.currentConfigurationLabels.Values() {
+		if _, exists := misconfiguredCounts[reason]; !exists {
+			redpandaMisconfiguredClusters.DeleteLabelValues(reason)
+			r.currentConfigurationLabels.Delete(reason)
 		}
 	}
 
 	return ctrl.Result{}, nil
 }
 
-// recordCluster sets the per-cluster desired/ready gauges and accumulates the
-// misconfiguration count for one CR. Factored out to keep the per-CRD list
-// loops in Reconcile readable.
-func (r *RedpandaMetricsReconciler) recordCluster(
-	key redpandaMetricKey,
-	pools []redpandav1alpha2.EmbeddedNodePoolStatus,
-	conditions []metav1.Condition,
-	configurationAppliedCondition string,
-	misconfigCounts map[misconfigKey]int,
-) {
-	var desired, ready int32
-	for _, pool := range pools {
-		desired += pool.DesiredReplicas
-		ready += pool.ReadyReplicas
-	}
-	redpandaDesiredNodes.WithLabelValues(key.kind, key.namespace, key.name).Set(float64(desired))
-	redpandaReadyNodes.WithLabelValues(key.kind, key.namespace, key.name).Set(float64(ready))
-	r.currentLabels.Add(key)
-
-	if cond := apimeta.FindStatusCondition(conditions, configurationAppliedCondition); cond != nil && cond.Status != metav1.ConditionTrue {
-		misconfigCounts[misconfigKey{kind: key.kind, reason: cond.Reason}]++
-	}
-}
-
-// SetupWithManager registers two controllers — one per watched CRD — that
-// share a single reconciler instance. The shared reconciler's mutex serializes
-// concurrent invocations from the two trigger paths.
+// SetupWithManager registers the metrics reconciler with the multicluster
+// manager. It engages with both local and provider clusters so that metrics
+// reflect Redpandas across every cluster the operator manages, and is wrapped
+// with FilterNamespaceReconciler to honor the operator's --namespace flag,
+// matching the convention used by the other v2 controllers in this package.
 func (r *RedpandaMetricsReconciler) SetupWithManager(_ context.Context, mgr multicluster.Manager, namespace string) error {
-	register := func(name string, obj client.Object) error {
-		return mcbuilder.ControllerManagedBy(mgr).
-			Named(name).
-			WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
-				// Matches the convention used by other v2 controllers in this
-				// package; avoids a duplicate-name panic when the multicluster
-				// runtime reuses controller names across registrations during
-				// tests.
-				SkipNameValidation: ptr.To(true),
-			}).
-			For(obj,
-				mcbuilder.WithEngageWithLocalCluster(true),
-				mcbuilder.WithEngageWithProviderClusters(true),
-			).
-			Complete(controller.FilterNamespaceReconciler(namespace, r))
-	}
-
-	if err := register("redpanda-metrics-redpanda", &redpandav1alpha2.Redpanda{}); err != nil {
-		return err
-	}
-	return register("redpanda-metrics-stretchcluster", &redpandav1alpha2.StretchCluster{})
+	return mcbuilder.ControllerManagedBy(mgr).
+		Named("redpanda-metrics").
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			// Matches the convention used by other v2 controllers in this
+			// package; avoids a duplicate-name panic when the multicluster
+			// runtime reuses controller names across registrations during
+			// tests.
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.Redpanda{},
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(true),
+		).
+		Complete(controller.FilterNamespaceReconciler(namespace, r))
 }

--- a/operator/internal/controller/redpanda/metric_controller.go
+++ b/operator/internal/controller/redpanda/metric_controller.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/collections"
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
+)
+
+var (
+	redpandasTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "redpandas_total",
+			Help: "Number of Redpanda clusters (cluster.redpanda.com/v1alpha2) managed by the operator",
+		},
+	)
+	redpandaDesiredNodes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "redpanda_desired_nodes",
+			Help: "Desired number of broker pods per Redpanda cluster, summed across all node pools",
+		}, []string{"namespace", "name"},
+	)
+	redpandaReadyNodes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "redpanda_ready_nodes",
+			Help: "Number of broker pods reporting Ready per Redpanda cluster, summed across all node pools",
+		}, []string{"namespace", "name"},
+	)
+	redpandaMisconfiguredClusters = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "redpanda_misconfigured_clusters",
+			Help: "Number of Redpanda clusters whose ConfigurationApplied condition is not True, labeled by reason",
+		}, []string{"reason"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		redpandasTotal,
+		redpandaDesiredNodes,
+		redpandaReadyNodes,
+		redpandaMisconfiguredClusters,
+	)
+}
+
+// redpandaMetricKey identifies a Redpanda CR for the purpose of tracking
+// previously-observed Prometheus label values across reconciles. Cluster
+// names are not globally unique (the same name can exist in multiple
+// namespaces), so the namespace is part of the key.
+type redpandaMetricKey struct {
+	namespace string
+	name      string
+}
+
+// RedpandaMetricsReconciler emits Prometheus metrics for the v2 Redpanda CRD,
+// providing the parallel of the v1 ClusterMetricController for the
+// cluster.redpanda.com/v1alpha2 Redpanda type. The reconciler ignores the
+// incoming request and recomputes the gauges from a fresh List so that
+// metrics stay accurate even when individual events are coalesced.
+type RedpandaMetricsReconciler struct {
+	Manager multicluster.Manager
+
+	// labels previously emitted on the desired/ready GaugeVecs. We retain them
+	// across reconciles so that we can call DeleteLabelValues for Redpandas
+	// that have since been deleted — without this, prometheus would keep
+	// reporting their last value forever.
+	currentLabels collections.Set[redpandaMetricKey]
+
+	// reasons previously emitted on the misconfigured GaugeVec. Same idea as
+	// currentLabels.
+	currentConfigurationLabels collections.Set[string]
+}
+
+// NewRedpandaMetricsReconciler creates a RedpandaMetricsReconciler.
+func NewRedpandaMetricsReconciler(mgr multicluster.Manager) *RedpandaMetricsReconciler {
+	return &RedpandaMetricsReconciler{
+		Manager:                    mgr,
+		currentLabels:              collections.NewConcurrentSet[redpandaMetricKey](),
+		currentConfigurationLabels: collections.NewConcurrentSet[string](),
+	}
+}
+
+// Reconcile lists all Redpandas across every cluster known to the multicluster
+// Manager and updates the registered Prometheus gauges. The incoming request
+// is ignored: we always recompute totals from scratch.
+func (r *RedpandaMetricsReconciler) Reconcile(ctx context.Context, _ mcreconcile.Request) (ctrl.Result, error) {
+	seenLabels := collections.NewSet[redpandaMetricKey]()
+	misconfiguredCounts := map[string]int{}
+
+	var total int
+
+	for _, clusterName := range r.Manager.GetClusterNames() {
+		cl, err := r.Manager.GetCluster(ctx, clusterName)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("getting cluster %q: %w", clusterName, err)
+		}
+
+		var rps redpandav1alpha2.RedpandaList
+		if err := cl.GetClient().List(ctx, &rps); err != nil {
+			return ctrl.Result{}, fmt.Errorf("listing Redpandas in cluster %q: %w", clusterName, err)
+		}
+
+		total += len(rps.Items)
+		for i := range rps.Items {
+			rp := &rps.Items[i]
+			key := redpandaMetricKey{namespace: rp.Namespace, name: rp.Name}
+
+			var desired, ready int32
+			for _, pool := range rp.Status.NodePools {
+				desired += pool.DesiredReplicas
+				ready += pool.ReadyReplicas
+			}
+
+			d, err := redpandaDesiredNodes.GetMetricWithLabelValues(key.namespace, key.name)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			d.Set(float64(desired))
+
+			a, err := redpandaReadyNodes.GetMetricWithLabelValues(key.namespace, key.name)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			a.Set(float64(ready))
+
+			seenLabels.Add(key)
+			r.currentLabels.Add(key)
+
+			if cond := apimeta.FindStatusCondition(rp.Status.Conditions, statuses.ClusterConfigurationApplied); cond != nil && cond.Status != metav1.ConditionTrue {
+				misconfiguredCounts[cond.Reason]++
+			}
+		}
+	}
+
+	redpandasTotal.Set(float64(total))
+
+	for _, key := range r.currentLabels.Values() {
+		if !seenLabels.HasAny(key) {
+			redpandaDesiredNodes.DeleteLabelValues(key.namespace, key.name)
+			redpandaReadyNodes.DeleteLabelValues(key.namespace, key.name)
+		}
+	}
+
+	for reason, count := range misconfiguredCounts {
+		g, err := redpandaMisconfiguredClusters.GetMetricWithLabelValues(reason)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		g.Set(float64(count))
+		r.currentConfigurationLabels.Add(reason)
+	}
+	for _, reason := range r.currentConfigurationLabels.Values() {
+		if _, exists := misconfiguredCounts[reason]; !exists {
+			redpandaMisconfiguredClusters.DeleteLabelValues(reason)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the metrics reconciler with the multicluster
+// manager. It engages with both local and provider clusters so that
+// metrics reflect Redpandas across every cluster the operator manages.
+func (r *RedpandaMetricsReconciler) SetupWithManager(mgr multicluster.Manager) error {
+	return mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			// SkipNameValidation matches the convention used by other v2
+			// controllers in this package — the multicluster runtime
+			// occasionally reuses controller names across registrations
+			// during tests, and this avoids a duplicate-name panic.
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(
+			&redpandav1alpha2.Redpanda{},
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(true),
+		).
+		Complete(r)
+}


### PR DESCRIPTION
## Summary

Adds a v2 metrics reconciler that mirrors the existing v1 [`ClusterMetricController`](https://github.com/redpanda-data/redpanda-operator/blob/main/operator/internal/controller/vectorized/metric_controller.go) for the `cluster.redpanda.com/v1alpha2` `Redpanda` CRD. The v2 controllers in `operator/internal/controller/redpanda/` previously had **no** custom Prometheus metrics, leaving v2 deployments with only the kafka-client and build-info gauges that v1 deployments also have.

### Metrics added

| Metric | Type | Labels | Description |
| --- | --- | --- | --- |
| `redpandas` | Gauge | — | Number of Redpanda clusters managed by the operator |
| `redpanda_desired_nodes` | GaugeVec | `namespace`, `name` | Desired broker count per Redpanda (sum across pools) |
| `redpanda_ready_nodes` | GaugeVec | `namespace`, `name` | Ready broker count per Redpanda (sum across pools) |
| `redpanda_misconfigured_clusters` | GaugeVec | `reason` | Count of Redpandas whose `ConfigurationApplied` condition is not True, by reason |

### Design notes

- Watches **only the Redpanda CRD**. StretchCluster metrics are out of scope for this PR — see ["Why not StretchCluster?"](#why-not-stretchcluster) below.
- The reconciler runs against the **local manager** (`mcmgr.GetLocalManager()`), not the multicluster manager. The Redpanda CRD only lives on the local cluster, so the reconciler is just `r.Client.List(ctx, &rps)` against a single client; no per-cluster iteration, reachability checks, or partial-failure handling is needed.
- The reconciler ignores the incoming request and recomputes everything from a fresh `List` so values stay accurate even when individual events are coalesced — matching the v1 pattern.
- The operator's `--namespace` flag is honored implicitly: `cmd/run` configures the manager cache with `Cache.DefaultNamespaces`, which scopes both the controller's watch and the `List` in `Reconcile`. No `FilterNamespaceReconciler` wrapper is needed.
- Naming follows the Prometheus convention: `_total` is reserved for counters, so the cluster-count gauge is `redpandas` (the v1 metric `redpanda_clusters_total` predates this convention).
- The closest v2 equivalent of the v1 `Configured` condition is `ConfigurationApplied`; the misconfigured gauge tracks Redpandas where that condition is not `True`.
- A `namespace` label is included on per-Redpanda gauges (the v1 metric did not), since v2 Redpanda names can collide across namespaces.
- Existing RBAC on the v2 controller (`+kubebuilder:rbac:groups=cluster.redpanda.com,resources=redpandas,verbs=get;list;watch;...`) already covers what the metrics reconciler needs, so no RBAC or CRD regeneration is required.

### Why not StretchCluster?

An earlier revision of this PR also watched `redpandav1alpha2.StretchCluster` to give parity to the multicluster operator mode. That broke CI (build #13347): the StretchCluster CRD is installed only by the operator helm chart's multicluster path (`operator/cmd/crd/crd.go`'s `multiclusterCRDs`). Watching the type from `cmd/run` (the regular single-cluster operator) makes the controller-runtime cache informer fail to sync because the API resource does not exist there, the operator pod stays Not Ready, and every downstream test times out.

`operator/cmd/multicluster/multicluster.go` has its own setup flow and does not call this reconciler today, so the StretchCluster code path was never actually reachable in production anyway. The right way to add StretchCluster coverage is a follow-up that wires a separate registration alongside `SetupMulticlusterController` in `cmd/multicluster`, not in this PR.

## Configuring metrics

The operator's metrics endpoint is exposed by controller-runtime. Under the helm chart it is **on by default** (the chart unconditionally passes `--metrics-bind-address=:8443` regardless of `config.metrics.bindAddress` in `values.yaml`). The raw operator binary defaults to disabled.

### Operator flags

| Flag | Default (binary) | Effect |
| --- | --- | --- |
| `--metrics-bind-address` | `0` (disabled) | Bind address for the metrics server. Set `:8443` for HTTPS, `:8080` for HTTP, or leave `0` to disable. The chart hard-codes this to `:8443`. |
| `--metrics-secure` | `true` | When the endpoint is enabled, serve over HTTPS with the controller-runtime auth/authz filter (requires bearer-token + RBAC `get` on `/metrics`). Pass `--metrics-secure=false` for plain HTTP — only safe for local dev. |
| `--enable-redpanda-controllers` | `true` | v2 mode. **Required for this PR's metrics**: when v2 is on, the `RedpandaMetricsReconciler` is registered. |
| `--enable-vectorized-controllers` | `false` | v1 mode. When on, the v1 `ClusterMetricController` is also registered, alongside v2 if both are enabled. |
| `--namespace` | `""` (cluster-wide) | If set, the local manager's cache is scoped to that namespace, so the metrics reconciler only sees and counts CRs in it. |

### Helm chart (`operator/chart/values.yaml`)

```yaml
monitoring:
  enabled: false   # set true to render a ServiceMonitor that scrapes /metrics over HTTPS via the SA bearer token

crds:
  enabled: false   # MUST be true on a fresh install — the Console controller crashes without its CRD
```

When `monitoring.enabled=true` the chart emits a `ServiceMonitor` (`operator/chart/templates/_servicemonitor.go.tpl`) and a `Service` named `<release>-metrics-service` (port `https`, 8443). The ServiceMonitor uses `bearerTokenFile=/var/run/secrets/kubernetes.io/serviceaccount/token` and `insecureSkipVerify=true` for the self-signed cert. Prometheus-Operator or VictoriaMetrics-Operator will pick it up automatically.

## Enabling Operator metrics with a ServiceMonitor — step-by-step

The following walks through what was used to verify this PR end-to-end on a fresh local k3d cluster. The same steps work on any cluster that has the Prometheus-Operator CRDs installed.

### 1. Spin up a Kubernetes cluster

```bash
k3d cluster create rp-metrics-test \
  --image rancher/k3s:v1.32.13-k3s1 \
  --servers 1 --agents 0 --no-lb \
  --k3s-arg "--disable=traefik@server:0"
```

### 2. Install Prometheus + the `ServiceMonitor` CRD

`kube-prometheus-stack` ships the `monitoring.coreos.com` CRDs (including `ServiceMonitor`) and a Prometheus instance configured to discover them. The `*SelectorNilUsesHelmValues=false` flags below are important — without them Prometheus only picks up ServiceMonitors that carry the chart's `release` label, and the operator chart's ServiceMonitor does not.

```bash
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update

kubectl create namespace monitoring

helm install kube-prom prometheus-community/kube-prometheus-stack \
  --namespace monitoring \
  --set grafana.enabled=false \
  --set alertmanager.enabled=false \
  --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
  --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
  --set prometheus.prometheusSpec.scrapeInterval=15s \
  --wait --timeout 5m
```

### 3. Install cert-manager (operator dependency)

```bash
helm repo add jetstack https://charts.jetstack.io
helm install cert-manager jetstack/cert-manager \
  --namespace cert-manager --create-namespace \
  --version v1.17.2 \
  --set crds.enabled=true \
  --wait --timeout 5m
```

### 4. Build the operator image from this branch and load it into the cluster

```bash
git checkout operator-v2-metrics
nix develop -c bash -c 'BUILD_GOOS=linux BUILD_GOARCH=arm64 task build:operator build:alias'

docker buildx build \
  --platform linux/arm64 \
  --provenance false --sbom false \
  --file operator/Dockerfile \
  --target=manager \
  --tag localhost/redpanda-operator:metrics-test \
  --load \
  .build

k3d image import localhost/redpanda-operator:metrics-test -c rp-metrics-test
```

(Substitute `linux/amd64` for `linux/arm64` on x86 hosts.)

### 5. Install the operator helm chart with `monitoring.enabled=true`

```bash
helm install rp-operator operator/chart \
  --namespace redpanda-operator --create-namespace \
  --set image.repository=localhost/redpanda-operator \
  --set image.tag=metrics-test \
  --set image.pullPolicy=Never \
  --set monitoring.enabled=true \
  --set crds.enabled=true \
  --wait --timeout 5m
```

This creates:

- `Deployment/rp-operator` with `--metrics-bind-address=:8443 --metrics-secure=true`
- `Service/rp-operator-metrics-service` exposing port `https` (8443) → container port `https`
- `ServiceMonitor/rp-operator-metrics-monitor` (HTTPS scheme, bearer token, `insecureSkipVerify=true`)

### 6. Confirm Prometheus is scraping the operator

```bash
kubectl -n monitoring port-forward svc/kube-prom-kube-prometheus-prometheus 9090:9090 &

# Target should report health=up, no lastError
curl -s 'http://127.0.0.1:9090/api/v1/targets?state=active' \
  | jq -r '.data.activeTargets[] | select(.labels.service=="rp-operator-metrics-service") | "\(.health)  \(.scrapeUrl)  err=\(.lastError)"'
# → up  https://10.42.0.16:8443/metrics  err=

# Query each new metric
for q in redpandas redpanda_desired_nodes redpanda_ready_nodes redpanda_misconfigured_clusters; do
  echo "=== $q ==="
  curl -sG 'http://127.0.0.1:9090/api/v1/query' --data-urlencode "query=$q" \
    | jq -c '.data.result[] | {labels: .metric, value: .value[1]}'
done
```

You can also pull `/metrics` directly off the operator using the Prometheus SA bearer token:

```bash
TOKEN=$(kubectl -n monitoring create token kube-prom-kube-prometheus-prometheus)
kubectl -n redpanda-operator port-forward svc/rp-operator-metrics-service 18443:8443 &
curl -sk -H "Authorization: Bearer $TOKEN" https://127.0.0.1:18443/metrics | grep '^redpanda'
```

## End-to-end test results

Cluster: k3d on `rancher/k3s:v1.32.13-k3s1`. Operator built from the prior revision of this branch (commit `72250721`, `redpanda_operator_build_info` confirmed). The Prometheus target stayed `health=up` throughout every phase below. Metric values shown are the response from `http://prometheus:9090/api/v1/query?query=...`. (The cluster-count gauge was named `redpandas_total` at the time of these runs and has since been renamed to `redpandas` to follow the Prometheus convention; the values reported are unchanged.)

| Phase | `redpandas` | `redpanda_desired_nodes` | `redpanda_ready_nodes` | `redpanda_misconfigured_clusters` |
| --- | --- | --- | --- | --- |
| No Redpanda CR | `0` | — (no series) | — | — |
| 1-replica CR, broker OOM-crashing | `1` | `1` (rp-test/redpanda) | `0` | `{reason="NotReconciled"}=1` |
| 1-replica CR, broker `Ready=True` | `1` | `1` | `1` | — (cleared) |
| Scaled to 3, mid-rollout (1 of 3 ready) | `1` | `3` | `1` | — |
| Injected a bogus `cluster.config.*` setting | `1` | `1` | `1` | `{reason="TerminalError"}=1` |
| Removed the bogus setting | `1` | `1` | `1` | — (cleared) |

What this verifies:

- The chart correctly emits the `ServiceMonitor` and metrics `Service`, with selector labels that match.
- Prometheus discovers the ServiceMonitor and successfully scrapes the operator's `:8443/metrics` over HTTPS using its SA bearer token (`insecureSkipVerify` covers the self-signed cert).
- The new `redpanda-metrics` controller registers and reconciles (`controller=redpanda-metrics … Starting workers` in the operator log).
- All four PR metrics emit and update correctly. Per-cluster gauges carry `name=<cr>, namespace=<ns>` (Prometheus relabels the metric's `namespace` to `exported_namespace` to avoid colliding with the kubelet-injected pod namespace — Prometheus default behavior, not something this PR controls).
- `redpanda_misconfigured_clusters` correctly tracks the `ConfigurationApplied` condition's `reason`, including transitions out of misconfig (zero series → no `# HELP` / `# TYPE` lines emitted, which is correct GaugeVec semantics).

## What's emitted from where, when metrics are enabled

`/metrics` always exposes the controller-runtime, client-go, Go, and process baselines. Operator-specific metrics depend on which controller flag is set:

| Source | Metrics | Enabled when |
| --- | --- | --- |
| **`cmd/version` (always)** | `redpanda_operator_build_info{version,commit,go_version}` | Always — registered at `init()` time. |
| **`pkg/client` kgo hooks (always once a Kafka client is built)** | `redpanda_operator_kafka_requests_sent_total`, `redpanda_operator_kafka_sent_bytes`, `redpanda_operator_kafka_requests_received_total`, `redpanda_operator_kafka_received_bytes` | First time any controller (v1 or v2) opens a Kafka connection — Topic / User / ACL / Schema / Group / Role controllers, plus the v2 `RedpandaReconciler`. |
| **v1 `ClusterMetricController`** (`internal/controller/vectorized/metric_controller.go`) | `redpanda_clusters_total`, `desired_redpanda_nodes_total`, `actual_redpanda_nodes_total`, `redpanda_misconfigured_clusters_total` (note: pre-existing `_total`-suffixed gauges) | `--enable-vectorized-controllers=true` (v1 mode). |
| **v2 `RedpandaMetricsReconciler` (this PR)** (`internal/controller/redpanda/metric_controller.go`) | `redpandas`, `redpanda_desired_nodes{namespace,name}`, `redpanda_ready_nodes{namespace,name}`, `redpanda_misconfigured_clusters{reason}` | `--enable-redpanda-controllers=true` (v2 mode, the default). |
| **controller-runtime baseline** (always, from imports) | `controller_runtime_reconcile_total`, `controller_runtime_reconcile_errors_total`, `controller_runtime_reconcile_time_seconds`, `controller_runtime_active_workers`, `controller_runtime_max_concurrent_reconciles`, `workqueue_*`, `rest_client_*` | Always, contributed per controller registered (Redpanda / NodePool / Topic / User / Role / Group / Schema / Console / **RedpandaMetrics** / etc.). |
| **Go / process** (always) | `go_*`, `process_*` | Always — promhttp default collectors. |

Running with the chart defaults (`--enable-redpanda-controllers=true`, `--enable-vectorized-controllers=false`) you get the v2 metrics in this PR plus the always-on baselines, but **not** the v1 `_total`-suffixed gauges. Running both v1 and v2 (the side-by-side migration mode) gives you both metric families simultaneously — they don't share names, so no collision.

### Files

- `operator/internal/controller/redpanda/metric_controller.go` — new
- `operator/cmd/run/run.go` — wires the reconciler in beside the v2 NodePool/Console controllers
- `.changes/unreleased/operator-Added-20260428-120000.yaml` — changie entry

## Test plan

Static checks run locally inside `nix develop` (Go 1.26.1, golangci-lint v2):

- [x] `nix develop -c bash -c 'cd operator && go build ./...'` — passed
- [x] `nix develop -c bash -c 'cd operator && go vet ./...'` — passed
- [x] `nix develop -c bash -c 'cd operator && golangci-lint run ./internal/controller/redpanda/... ./cmd/run/...'` — 0 issues
- [x] `git diff --exit-code` — clean, no generated-file drift

Buildkite CI (build #13347) initially failed on integration / acceptance / kuttl-v1-nodepools because of an unconditional StretchCluster watcher in `cmd/run` (the StretchCluster CRD is only installed in multicluster mode, so the cache informer never synced and the operator pod stayed Not Ready). Fixed in `72250721` by removing StretchCluster from this PR's scope; awaiting a fresh CI run.

End-to-end on a local k3d cluster (steps and results above):

- [x] Run the operator with `--metrics-bind-address=:8443 --metrics-secure=true --enable-redpanda-controllers=true` and verify `/metrics` exposes the four new gauges
- [x] Install `kube-prometheus-stack` + the operator chart with `monitoring.enabled=true`; confirm the rendered `ServiceMonitor` is discovered and the target reports `health=up`
- [x] Scale a Redpanda CR up/down and confirm `redpanda_desired_nodes` / `redpanda_ready_nodes` track correctly (`1/1 → 3/1 mid-rollout`)
- [x] Force a misconfiguration and confirm `redpanda_misconfigured_clusters{reason="TerminalError"}` appears, then clears when the misconfig is removed
