### PR TITLE
operator: fix scale-up deadlock when cluster is unhealthy

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260429-000000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260429-000000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed a deadlock where an unhealthy cluster could not recover by adding more broker pods. Scale-up operations in node pools are no longer gated on cluster health; only scale-down (decommission) operations remain gated.
+time: 2026-04-29T00:00:00.000000Z

--- a/operator/internal/controller/vectorized/test/cluster_controller_scale_test.go
+++ b/operator/internal/controller/vectorized/test/cluster_controller_scale_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
@@ -237,6 +238,47 @@ var _ = Describe("Redpanda node pool scale", func() {
 
 			By("Deleting the cluster")
 			Expect(k8sClient.Delete(context.Background(), redpandaCluster)).Should(Succeed())
+		})
+	})
+
+	Context("When scaling up a cluster that is unhealthy", func() {
+		It("Should scale up a node pool even when cluster is unhealthy and in a restarting state", func() {
+			By("Creating a cluster with two node pools of 1 replica each")
+			key, cluster, adminAPI := getClusterWithNodePool("unhealthy-np-scaleup", 1, 1)
+			npFirstKey := types.NamespacedName{Name: "unhealthy-np-scaleup-first", Namespace: "default"}
+
+			Expect(k8sClient.Create(context.Background(), cluster)).Should(Succeed())
+
+			By("Waiting for the first node pool StatefulSet to appear at 1 replica")
+			adminAPI.AddBroker(rpadmin.Broker{NodeID: 0, MembershipStatus: rpadmin.MembershipStatusActive})
+			var sts appsv1.StatefulSet
+			Eventually(resourceDataGetter(npFirstKey, &sts, func() interface{} {
+				return *sts.Spec.Replicas
+			}), timeout, interval).Should(Equal(int32(1)))
+
+			By("Setting the cluster as unhealthy and in restarting state (simulating a stuck rolling update)")
+			adminAPI.SetClusterHealth(false)
+			Eventually(func() error {
+				if err := k8sClient.Get(context.Background(), key, cluster); err != nil {
+					return err
+				}
+				base := cluster.DeepCopy()
+				cluster.Status.SetRestarting(true)
+				return k8sClient.Status().Patch(context.Background(), cluster, client.MergeFrom(base))
+			}, timeout, interval).Should(Succeed())
+
+			By("Scaling up the first node pool to 3 replicas")
+			Eventually(clusterUpdater(key, func(c *vectorizedv1alpha1.Cluster) {
+				c.Spec.NodePools[0].Replicas = ptr.To(int32(3))
+			}), timeout, interval).Should(Succeed())
+
+			By("Verifying the first node pool StatefulSet scales up despite unhealthy cluster")
+			Eventually(resourceDataGetter(npFirstKey, &sts, func() interface{} {
+				return *sts.Spec.Replicas
+			}), timeout, interval).Should(Equal(int32(3)))
+
+			By("Deleting the cluster")
+			Expect(k8sClient.Delete(context.Background(), cluster)).Should(Succeed())
 		})
 	})
 })

--- a/operator/pkg/resources/statefulset.go
+++ b/operator/pkg/resources/statefulset.go
@@ -223,14 +223,23 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 	}
 
 	log.Info("Running update")
-	err = r.runUpdate(ctx, &sts, obj.(*appsv1.StatefulSet))
-	if err != nil {
-		return err
+	runUpdateErr := r.runUpdate(ctx, &sts, obj.(*appsv1.StatefulSet))
+	// Always run handleScaling even when runUpdate returned a RequeueAfterError
+	// (e.g. the cluster health check blocking a rolling update). Scale-up must
+	// not be gated on cluster health — only decommission (scale-down) is gated
+	// inside handleScaling itself.
+	var requeueAfterErr *RequeueAfterError
+	if runUpdateErr != nil && !errors.As(runUpdateErr, &requeueAfterErr) {
+		return runUpdateErr
 	}
 
 	log.Info("Running scale handler")
 	if err := r.handleScaling(ctx); err != nil {
 		return err
+	}
+
+	if runUpdateErr != nil {
+		return runUpdateErr
 	}
 
 	// Delete StatefulSets of deleted NodePools if the conditions are met.


### PR DESCRIPTION
## Summary

- The v1 operator had a deadlock where an unhealthy cluster could not recover by adding more broker pods
- When `status.restarting=true` (set during any rolling update), `shouldUpdate()` forces `runUpdate()` to run on every reconcile; `runUpdate()` calls `isClusterHealthy()` before performing a rolling update and returns a `RequeueAfterError` if unhealthy — this skipped `handleScaling()` entirely, preventing `CurrentReplicas` from being updated and blocking the scale-up
- Fix: let `handleScaling()` run even when `runUpdate()` returns a `RequeueAfterError`; scale-up has no dependency on cluster health — only decommission/scale-down (already gated inside `handleScaling()` itself) requires health checks
- Rolling pod template updates remain gated on cluster health as before

Jira: [CIAINFRA-2896](https://redpandadata.atlassian.net/browse/CIAINFRA-2896)

## Test plan

- [x] Added failing test: `"Should scale up a node pool even when cluster is unhealthy and in a restarting state"` — confirmed it fails before the fix (times out after 30s) and passes after (7s)
- [x] Full vectorized controller test suite passes (34/34 specs)
- [x] Full unit test suite passes (`task test:unit`)
- [x] Manually reproduced the deadlock on a running cluster using the pre-fix image (`slord769/redpanda-operator:ciainfra-2896` built from this branch for post-fix validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CIAINFRA-2896]: https://redpandadata.atlassian.net/browse/CIAINFRA-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ