### PR TITLE
ci: drop Buildkite Test Engine analytics token

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,6 @@ steps:
     plugins:
       - seek-oss/aws-sm#v2.3.2: &aws-sm-plugin
           json-to-env:
-            - secret-id: sdlc/prod/buildkite/buildkite_analytics_token
             - secret-id: sdlc/prod/buildkite/buildkite_api_token
             - secret-id: sdlc/prod/buildkite/dockerhub
             - secret-id: sdlc/prod/buildkite/gh_token
@@ -97,7 +96,6 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - secret-id: sdlc/prod/buildkite/active_directory
-            - secret-id: sdlc/prod/buildkite/buildkite_analytics_token
             - secret-id: sdlc/prod/buildkite/buildkite_api_token
             - secret-id: sdlc/prod/buildkite/cdt_gcp
             - secret-id: sdlc/prod/buildkite/cdt_runner_aws


### PR DESCRIPTION
## Summary
- Remove the `sdlc/prod/buildkite/buildkite_analytics_token` secret-id from both plugin blocks in `.buildkite/pipeline.yml` (`release-nightly` and `operator-release` steps).
- Buildkite is changing the Test Engine pricing policy, so we are dropping the integration.
- **The token was never actually used by any test suite in this repo.** It was only injected into the env of the two release steps above (which don't run tests), and the generated `.buildkite/testsuite.yml` — which defines every actual test suite (unit, integration, acceptance, multicluster, acceptance-multicluster, kuttl-v1, kuttl-v1-nodepools) — never referenced it. There is no `buildkite-test-collector` dependency, no `BUILDKITE_ANALYTICS_TOKEN` consumer in scripts or Go code, and no JUnit upload step targeting BKTE. The `junit-annotate-buildkite-plugin` present in `testsuite.yml` is a separate build-annotation plugin and is unaffected.

Refs [DEVPROD-4194](https://redpandadata.atlassian.net/browse/DEVPROD-4194).

[DEVPROD-4194]: https://redpandadata.atlassian.net/browse/DEVPROD-4194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ