### PR TITLE
charts: render ServiceMonitor scheme as lowercase (fixes #1511)

### DIFF
--- a/.changes/unreleased/charts-console-Fixed-20260511-100000.yaml
+++ b/.changes/unreleased/charts-console-Fixed-20260511-100000.yaml
@@ -1,0 +1,4 @@
+project: charts/console
+kind: Fixed
+body: Fixed `ServiceMonitor` rendering to emit `scheme: http` / `scheme: https` (lowercase) instead of the uppercase Go constant values that older `prometheus-operator` CRDs rejected with `spec.endpoints[0].scheme: Unsupported value`. Aligns with the same fix in `charts/redpanda`. Fixes #1511.
+time: 2026-05-11T10:00:00.000000-07:00

--- a/.changes/unreleased/charts-redpanda-Fixed-20260511-100000.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260511-100000.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Fixed
+body: Fixed `ServiceMonitor` rendering to emit `scheme: http` / `scheme: https` (lowercase) instead of the uppercase Go constant values that older `prometheus-operator` CRDs rejected with `spec.endpoints[0].scheme: Unsupported value`. Restores the case that chart 25.3.x and earlier produced. Fixes #1511.
+time: 2026-05-11T10:00:00.000000-07:00

--- a/charts/console/chart/templates/_console.servicemonitor.tpl
+++ b/charts/console/chart/templates/_console.servicemonitor.tpl
@@ -10,14 +10,14 @@
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $endpoint := (mustMergeOverwrite (dict) (dict "interval" $state.Values.monitoring.scrapeInterval "path" "/admin/metrics" "port" "http" "scheme" "HTTP")) -}}
+{{- $endpoint := (mustMergeOverwrite (dict) (dict "interval" $state.Values.monitoring.scrapeInterval "path" "/admin/metrics" "port" "http" "scheme" (toString "http"))) -}}
 {{- $tlsCertFilepath := (dig "server" "tls" "certFilepath" "" $state.Values.config) -}}
 {{- $tlsKeyFilepath := (dig "server" "tls" "keyFilepath" "" $state.Values.config) -}}
 {{- $tlsEnabled := (dig "server" "tls" "enabled" false $state.Values.config) -}}
 {{- if (and (and (get (fromJson (include "_shims.typeassertion" (dict "a" (list "bool" $tlsEnabled)))) "r") (ne $tlsCertFilepath "")) (ne $tlsKeyFilepath "")) -}}
 {{- $tlsConfig := (mustMergeOverwrite (dict "ca" (dict) "cert" (dict)) (mustMergeOverwrite (dict) (dict "certFile" (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $tlsCertFilepath)))) "r") "keyFile" (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $tlsKeyFilepath)))) "r"))) (dict)) -}}
 {{- $_ := (set $endpoint "tlsConfig" $tlsConfig) -}}
-{{- $_ := (set $endpoint "scheme" "HTTPS") -}}
+{{- $_ := (set $endpoint "scheme" (toString "https")) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict) "spec" (dict "endpoints" (coalesce nil) "selector" (dict) "namespaceSelector" (dict))) (mustMergeOverwrite (dict) (dict "apiVersion" "monitoring.coreos.com/v1" "kind" "ServiceMonitor")) (dict "metadata" (mustMergeOverwrite (dict) (dict "name" (get (fromJson (include "console.RenderState.FullName" (dict "a" (list $state)))) "r") "namespace" $state.Namespace "labels" (merge (dict) (get (fromJson (include "console.RenderState.Labels" (dict "a" (list $state (coalesce nil))))) "r") $state.Values.monitoring.labels))) "spec" (mustMergeOverwrite (dict "endpoints" (coalesce nil) "selector" (dict) "namespaceSelector" (dict)) (dict "endpoints" (list $endpoint) "selector" (mustMergeOverwrite (dict) (dict "matchLabels" (get (fromJson (include "console.RenderState.Labels" (dict "a" (list $state (coalesce nil))))) "r")))))))) | toJson -}}

--- a/charts/console/servicemonitor.go
+++ b/charts/console/servicemonitor.go
@@ -21,11 +21,16 @@ func ServiceMonitor(state *RenderState) *monitoringv1.ServiceMonitor {
 	if !state.Values.Monitoring.Enabled {
 		return nil
 	}
+	// Render the scheme as lowercase. The prometheus-operator typed constants
+	// (monitoringv1.SchemeHTTP / SchemeHTTPS) resolve to "HTTP" / "HTTPS",
+	// which older prometheus-operator CRDs reject with
+	// `spec.endpoints[0].scheme: Unsupported value`. Lowercase works on every
+	// version. See redpanda-operator#1511.
 	endpoint := monitoringv1.Endpoint{
 		Interval: state.Values.Monitoring.ScrapeInterval,
 		Path:     "/admin/metrics",
 		Port:     servicePortName,
-		Scheme:   ptr.To(monitoringv1.SchemeHTTP),
+		Scheme:   ptr.To(monitoringv1.Scheme("http")),
 	}
 	tlsCertFilepath := helmette.Dig(state.Values.Config, "", "server", "tls", "certFilepath")
 	tlsKeyFilepath := helmette.Dig(state.Values.Config, "", "server", "tls", "keyFilepath")
@@ -38,7 +43,7 @@ func ServiceMonitor(state *RenderState) *monitoringv1.ServiceMonitor {
 			},
 		}
 		endpoint.TLSConfig = tlsConfig
-		endpoint.Scheme = ptr.To(monitoringv1.SchemeHTTPS)
+		endpoint.Scheme = ptr.To(monitoringv1.Scheme("https"))
 	}
 
 	return &monitoringv1.ServiceMonitor{

--- a/charts/redpanda/chart/templates/_servicemonitor.go.tpl
+++ b/charts/redpanda/chart/templates/_servicemonitor.go.tpl
@@ -10,9 +10,9 @@
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $endpoint := (mustMergeOverwrite (dict) (dict "interval" $state.Values.monitoring.scrapeInterval "path" "/public_metrics" "port" "admin" "scheme" "HTTP")) -}}
+{{- $endpoint := (mustMergeOverwrite (dict) (dict "interval" $state.Values.monitoring.scrapeInterval "path" "/public_metrics" "port" "admin" "scheme" (toString "http"))) -}}
 {{- if (or (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $state.Values.listeners.admin.tls $state.Values.tls)))) "r") (ne (toJson $state.Values.monitoring.tlsConfig) "null")) -}}
-{{- $_ := (set $endpoint "scheme" "HTTPS") -}}
+{{- $_ := (set $endpoint "scheme" (toString "https")) -}}
 {{- $_ := (set $endpoint "tlsConfig" $state.Values.monitoring.tlsConfig) -}}
 {{- if (eq (toJson $endpoint.tlsConfig) "null") -}}
 {{- $_ := (set $endpoint "tlsConfig" (mustMergeOverwrite (dict "ca" (dict) "cert" (dict)) (mustMergeOverwrite (dict "ca" (dict) "cert" (dict)) (dict "insecureSkipVerify" true)) (dict))) -}}

--- a/charts/redpanda/servicemonitor.go
+++ b/charts/redpanda/servicemonitor.go
@@ -23,15 +23,22 @@ func ServiceMonitor(state *RenderState) *monitoringv1.ServiceMonitor {
 		return nil
 	}
 
+	// Render the scheme as lowercase. The prometheus-operator typed constants
+	// (monitoringv1.SchemeHTTP / SchemeHTTPS) resolve to "HTTP" / "HTTPS" —
+	// gotohelm faithfully emits those values, but older prometheus-operator
+	// CRDs only accept "http" / "https" in the Scheme enum and reject the
+	// rendered ServiceMonitor at apply time. Lowercase is accepted by every
+	// CRD version we support, so produce it explicitly via a string-typed
+	// conversion rather than the upstream constants. See #1511.
 	endpoint := monitoringv1.Endpoint{
 		Interval: state.Values.Monitoring.ScrapeInterval,
 		Path:     "/public_metrics",
 		Port:     "admin",
-		Scheme:   ptr.To(monitoringv1.SchemeHTTP),
+		Scheme:   ptr.To(monitoringv1.Scheme("http")),
 	}
 
 	if state.Values.Listeners.Admin.TLS.IsEnabled(&state.Values.TLS) || state.Values.Monitoring.TLSConfig != nil {
-		endpoint.Scheme = ptr.To(monitoringv1.SchemeHTTPS)
+		endpoint.Scheme = ptr.To(monitoringv1.Scheme("https"))
 		endpoint.TLSConfig = state.Values.Monitoring.TLSConfig
 
 		if endpoint.TLSConfig == nil {

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -18100,7 +18100,7 @@ spec:
   - interval: 30s
     path: /public_metrics
     port: admin
-    scheme: HTTP
+    scheme: http
   namespaceSelector: {}
   selector:
     matchLabels:
@@ -19554,7 +19554,7 @@ spec:
   - interval: 30s
     path: /public_metrics
     port: admin
-    scheme: HTTPS
+    scheme: https
     tlsConfig:
       ca: {}
       cert: {}
@@ -53736,7 +53736,7 @@ spec:
   - interval: 2m
     path: /public_metrics
     port: admin
-    scheme: HTTPS
+    scheme: https
     tlsConfig:
       ca: {}
       cert: {}
@@ -68204,7 +68204,7 @@ spec:
   - interval: 30s
     path: /public_metrics
     port: admin
-    scheme: HTTPS
+    scheme: https
     tlsConfig:
       ca: {}
       cert: {}
@@ -113982,7 +113982,7 @@ spec:
   - interval: 1m
     path: /admin/metrics
     port: http
-    scheme: HTTP
+    scheme: http
   namespaceSelector: {}
   selector:
     matchLabels:
@@ -115449,7 +115449,7 @@ spec:
   - interval: 30s
     path: /public_metrics
     port: admin
-    scheme: HTTPS
+    scheme: https
     tlsConfig:
       ca: {}
       cert: {}
@@ -116901,7 +116901,7 @@ spec:
   - interval: 30s
     path: /public_metrics
     port: admin
-    scheme: HTTP
+    scheme: http
   namespaceSelector: {}
   selector:
     matchLabels:
@@ -118474,7 +118474,7 @@ spec:
   - interval: 30s
     path: /public_metrics
     port: admin
-    scheme: HTTPS
+    scheme: https
     tlsConfig:
       ca: {}
       cert: {}

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -298,7 +298,7 @@ listeners:
 # ASSERT-STATEFULSET-ALL-VOLUMES-ARE-USED
 # ASSERT-STATEFULSET-VOLUME-MOUNTS-VERIFICATION
 # ASSERT-VALID-RPK-CONFIGURATION
-# ASSERT-FIELD-EQUALS ["monitoring.coreos.com/v1/ServiceMonitor", "default/redpanda", "{.spec.endpoints[0].scheme}", "HTTP"]
+# ASSERT-FIELD-EQUALS ["monitoring.coreos.com/v1/ServiceMonitor", "default/redpanda", "{.spec.endpoints[0].scheme}", "http"]
 monitoring:
   enabled: true
 
@@ -313,7 +313,7 @@ listeners:
 # ASSERT-STATEFULSET-ALL-VOLUMES-ARE-USED
 # ASSERT-STATEFULSET-VOLUME-MOUNTS-VERIFICATION
 # ASSERT-VALID-RPK-CONFIGURATION
-# ASSERT-FIELD-EQUALS ["monitoring.coreos.com/v1/ServiceMonitor", "default/redpanda-console", "{.spec.endpoints[0].scheme}", "HTTP"]
+# ASSERT-FIELD-EQUALS ["monitoring.coreos.com/v1/ServiceMonitor", "default/redpanda-console", "{.spec.endpoints[0].scheme}", "http"]
 console:
   enabled: true
   monitoring:
@@ -326,7 +326,7 @@ console:
 # ASSERT-STATEFULSET-ALL-VOLUMES-ARE-USED
 # ASSERT-STATEFULSET-VOLUME-MOUNTS-VERIFICATION
 # ASSERT-VALID-RPK-CONFIGURATION
-# ASSERT-FIELD-EQUALS ["monitoring.coreos.com/v1/ServiceMonitor", "default/redpanda", "{.spec.endpoints[0].scheme}", "HTTPS"]
+# ASSERT-FIELD-EQUALS ["monitoring.coreos.com/v1/ServiceMonitor", "default/redpanda", "{.spec.endpoints[0].scheme}", "https"]
 monitoring:
   enabled: true
 


### PR DESCRIPTION
## Summary

Fixes #1511.

The `redpanda` and `console` charts both render `scheme: HTTP` / `scheme: HTTPS` in their `ServiceMonitor`, which older `prometheus-operator` CRDs reject:

```
ServiceMonitor.monitoring.coreos.com "redpanda" is invalid:
spec.endpoints[0].scheme: Unsupported value: "HTTP":
  supported values: "http", "https"
```

Chart 25.3.x and earlier rendered lowercase. The regression was introduced by #1279 ("Upgrade go and controller-runtime versions"), which — incidental to the toolchain bump — changed the source from a literal `"http"` string to the typed prometheus-operator constants `monitoringv1.SchemeHTTP` / `monitoringv1.SchemeHTTPS`. Those constants have the values `"HTTP"` / `"HTTPS"`:

```go
// prometheus-operator v0.89.0 types.go
const (
    SchemeHTTP  Scheme = "HTTP"
    SchemeHTTPS Scheme = "HTTPS"
)
```

So `gotohelm` faithfully emitted uppercase — not a transpiler bug. The current upstream CRD enum `+kubebuilder:validation:Enum=http;https;HTTP;HTTPS` accepts both cases, but customers running older `prometheus-operator` only allow lowercase. Lowercase has been valid on every version, so render lowercase explicitly via a string-typed conversion rather than the upstream constants.

The same regression existed in `charts/console/servicemonitor.go` and is fixed identically.

## Changes

- `charts/redpanda/servicemonitor.go` — `Scheme: ptr.To(monitoringv1.Scheme("http"))` / `"https"` instead of `SchemeHTTP` / `SchemeHTTPS`.
- `charts/console/servicemonitor.go` — same change.
- Regenerated `charts/redpanda/chart/templates/_servicemonitor.go.tpl` and `charts/console/chart/templates/_console.servicemonitor.tpl` via `task charts:generate:redpanda` and `task charts:generate:console`.
- Updated inline `ASSERT-FIELD-EQUALS` cases in `charts/redpanda/testdata/template-cases.txtar` from `"HTTP"` / `"HTTPS"` to `"http"` / `"https"`.
- Regenerated `charts/redpanda/testdata/template-cases.golden.txtar` via `-update-golden`.
- Changie entries for `charts/redpanda` and `charts/console` under `.changes/unreleased/`.

## Reproduction (pre-fix)

```bash
helm pull redpanda/redpanda --version 26.1.3 --untar --untardir /tmp/rp
grep '"scheme"' /tmp/rp/redpanda/templates/_servicemonitor.go.tpl
# → ... "scheme" "HTTP" ...
# → ... "scheme" "HTTPS" ...
```

Compare with 25.3.5 (correct):

```bash
helm pull redpanda/redpanda --version 25.3.5 --untar --untardir /tmp/rp-25
grep '"scheme"' /tmp/rp-25/redpanda/templates/_servicemonitor.go.tpl
# → ... "scheme" "http" ...
# → ... "scheme" "https" ...
```

Then on a cluster running an older `prometheus-operator` (one whose CRD enum is just `http;https`):

```bash
helm install rp redpanda/redpanda --version 26.1.3 --set monitoring.enabled=true
# kubectl events show:
# Error: spec.endpoints[0].scheme: Unsupported value: "HTTP"
```

## Reproduction (post-fix)

```bash
git checkout fix/servicemonitor-scheme-lowercase
nix develop -c task charts:generate:redpanda
nix develop -c task charts:generate:console

grep '"scheme"' charts/redpanda/chart/templates/_servicemonitor.go.tpl
# → ... "scheme" (toString "http") ...
# → ... "scheme" (toString "https") ...

grep '"scheme"' charts/console/chart/templates/_console.servicemonitor.tpl
# → ... "scheme" (toString "http") ...
# → ... "scheme" (toString "https") ...
```

Render directly with helm and confirm:

```bash
nix develop -c helm dep build charts/redpanda/chart
nix develop -c helm template rp charts/redpanda/chart \
  --set monitoring.enabled=true \
  --set listeners.admin.tls.enabled=false \
  | yq '. | select(.kind == "ServiceMonitor") | .spec.endpoints[].scheme'
# → http

nix develop -c helm template rp charts/redpanda/chart \
  --set monitoring.enabled=true \
  | yq '. | select(.kind == "ServiceMonitor") | .spec.endpoints[].scheme'
# → https
```

## Test plan

- [x] `nix develop -c go test ./charts/redpanda -run TestTemplate -timeout 10m` — passes
- [x] `nix develop -c go test ./charts/console/chart -run TestTemplate -timeout 10m` — passes
- [x] `nix develop -c go test ./operator/chart -run TestTemplate -timeout 10m` — passes (operator chart embeds rendered redpanda chart; updated golden flows through)
- [x] `nix develop -c task generate` — clean (no further file diffs)
- [ ] Manual install on an older `prometheus-operator` CRD to verify the ServiceMonitor applies cleanly

## Related

- Regression introduced in #1279 — https://github.com/redpanda-data/redpanda-operator/pull/1279
