### PR TITLE
Fix multicluster timeouts with unreachable clusters

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -220,6 +220,7 @@ require (
 	github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1 // indirect
 	github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7 // indirect
 	github.com/redpanda-data/common-go/otelutil v0.0.0-20260413160920-df1679f86269 // indirect
+	github.com/redpanda-data/common-go/rp-controller-utils v0.0.0-20260109170727-1dd9f5d22ee1 // indirect
 	github.com/redpanda-data/common-go/secrets v0.1.4 // indirect
 	github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4 // indirect
 	github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.7.0 // indirect

--- a/harpoon/suite.go
+++ b/harpoon/suite.go
@@ -182,6 +182,13 @@ func (b *SuiteBuilder) RegisterGroup(name, tag string) *SuiteBuilder {
 
 // buildTagExpression constructs the godog tag expression that selects which
 // scenarios to run based on the provider filter and the requested groups.
+//
+// godog v0.14.1's tag-filter grammar is a flat AND-of-ORs: it splits the
+// expression on "&&" (top-level AND) and then each AND clause on "," (OR).
+// It does NOT support parentheses or boolean keywords — anything more
+// nested than that silently fails to match (every feature is excluded).
+// All output here is therefore composed as `clause && clause && ...` where
+// each clause is a comma-separated OR list of `@tag` or `~@tag` atoms.
 func (b *SuiteBuilder) buildTagExpression() string {
 	providerFilter := fmt.Sprintf("~@skip:%s", b.testingOpts.Provider)
 
@@ -200,59 +207,49 @@ func (b *SuiteBuilder) buildTagExpression() string {
 		requestedSet[g] = true
 	}
 
-	// If both "default" and all registered groups are requested, no group
-	// filtering is needed.
-	if requestedSet["default"] {
-		allIncluded := true
-		for name := range b.registeredGroups {
-			if !requestedSet[name] {
-				allIncluded = false
-				break
-			}
+	// Partition registered groups into requested vs not-requested, using
+	// sorted slices for deterministic output.
+	var requestedTags []string
+	var notRequestedTags []string
+	for name, tag := range b.registeredGroups {
+		if requestedSet[name] {
+			requestedTags = append(requestedTags, "@"+tag)
+		} else {
+			notRequestedTags = append(notRequestedTags, "~@"+tag)
 		}
-		if allIncluded {
+	}
+	sort.Strings(requestedTags)
+	sort.Strings(notRequestedTags)
+
+	if requestedSet["default"] {
+		// "default" means "features tagged with none of the registered
+		// group tags". Combined with explicitly-requested groups the
+		// match condition is:
+		//   (untagged) OR (has @reqN)
+		// which expands to the AND of, for every not-requested group g,
+		//   (~@g OR @req1 OR @req2 ...)
+		// — each not-requested group must be absent, unless the feature
+		// is tagged with one of the requested groups.
+		if len(notRequestedTags) == 0 {
 			return providerFilter
 		}
-	}
-
-	// Collect sorted group tags for deterministic output.
-	var allGroupTags []string
-	for _, tag := range b.registeredGroups {
-		allGroupTags = append(allGroupTags, tag)
-	}
-	sort.Strings(allGroupTags)
-
-	var parts []string
-
-	if requestedSet["default"] {
-		// "default" = features not tagged with any registered group tag.
-		var notParts []string
-		for _, tag := range allGroupTags {
-			notParts = append(notParts, "~@"+tag)
+		clauses := make([]string, 0, len(notRequestedTags))
+		for _, notTag := range notRequestedTags {
+			atoms := append([]string{}, requestedTags...)
+			atoms = append(atoms, notTag)
+			clauses = append(clauses, strings.Join(atoms, ","))
 		}
-		if len(notParts) == 1 {
-			parts = append(parts, notParts[0])
-		} else {
-			parts = append(parts, "("+strings.Join(notParts, " && ")+")")
-		}
+		return providerFilter + " && " + strings.Join(clauses, " && ")
 	}
 
-	for _, g := range requestedGroups {
-		if g == "default" {
-			continue
-		}
-		if tag, ok := b.registeredGroups[g]; ok {
-			parts = append(parts, "@"+tag)
-		}
+	// Only non-default groups requested: feature must carry at least one of
+	// the requested group tags. If none of the requested names match a
+	// registered group, nothing should run — emit an impossible tag so
+	// godog's filter rejects every feature.
+	if len(requestedTags) == 0 {
+		return providerFilter + " && @__no_matching_group__"
 	}
-
-	if len(parts) == 0 {
-		return providerFilter
-	}
-	if len(parts) == 1 {
-		return providerFilter + " && " + parts[0]
-	}
-	return providerFilter + " && (" + strings.Join(parts, " || ") + ")"
+	return providerFilter + " && " + strings.Join(requestedTags, ",")
 }
 
 func (b *SuiteBuilder) RegisterTag(tag string, priority int, handler TagHandler) *SuiteBuilder {

--- a/harpoon/tagexpression_test.go
+++ b/harpoon/tagexpression_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	internaltesting "github.com/redpanda-data/redpanda-operator/harpoon/internal/testing"
+)
+
+func TestBuildTagExpression(t *testing.T) {
+	for name, tt := range map[string]struct {
+		groups    map[string]string
+		requested []string
+		provider  string
+		want      string
+	}{
+		"no-groups-registered": {
+			provider: "k3d",
+			want:     "~@skip:k3d",
+		},
+		"single-group-default-only": {
+			groups:   map[string]string{"multicluster": "multicluster"},
+			provider: "k3d",
+			want:     "~@skip:k3d && ~@multicluster",
+		},
+		"single-group-requested": {
+			groups:    map[string]string{"multicluster": "multicluster"},
+			requested: []string{"multicluster"},
+			provider:  "k3d",
+			want:      "~@skip:k3d && @multicluster",
+		},
+		"two-groups-default-only": {
+			groups:   map[string]string{"multicluster": "multicluster", "dev-env": "dev-env"},
+			provider: "k3d",
+			want:     "~@skip:k3d && ~@dev-env && ~@multicluster",
+		},
+		"two-groups-one-requested": {
+			groups:    map[string]string{"multicluster": "multicluster", "dev-env": "dev-env"},
+			requested: []string{"multicluster"},
+			provider:  "k3d",
+			want:      "~@skip:k3d && @multicluster",
+		},
+		"two-groups-default-plus-one": {
+			groups:    map[string]string{"multicluster": "multicluster", "dev-env": "dev-env"},
+			requested: []string{"default", "multicluster"},
+			provider:  "k3d",
+			want:      "~@skip:k3d && @multicluster,~@dev-env",
+		},
+		"two-groups-all-requested": {
+			groups:    map[string]string{"multicluster": "multicluster", "dev-env": "dev-env"},
+			requested: []string{"default", "multicluster", "dev-env"},
+			provider:  "k3d",
+			want:      "~@skip:k3d",
+		},
+		"two-groups-both-non-default": {
+			groups:    map[string]string{"multicluster": "multicluster", "dev-env": "dev-env"},
+			requested: []string{"multicluster", "dev-env"},
+			provider:  "k3d",
+			want:      "~@skip:k3d && @dev-env,@multicluster",
+		},
+		"three-groups-default-plus-one": {
+			groups:    map[string]string{"a": "a", "b": "b", "c": "c"},
+			requested: []string{"default", "a"},
+			provider:  "k3d",
+			want:      "~@skip:k3d && @a,~@b && @a,~@c",
+		},
+		"unknown-group-requested": {
+			groups:    map[string]string{"multicluster": "multicluster"},
+			requested: []string{"nope"},
+			provider:  "k3d",
+			want:      "~@skip:k3d && @__no_matching_group__",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			b := &SuiteBuilder{
+				testingOpts:      &internaltesting.TestingOptions{Provider: tt.provider},
+				registeredGroups: tt.groups,
+				requestedGroups:  tt.requested,
+			}
+			require.Equal(t, tt.want, b.buildTagExpression())
+		})
+	}
+}

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
@@ -56,6 +57,16 @@ const (
 	bootstrapUserPasswordKey  = "password"
 	defaultBootstrapUsername  = "kubernetes-controller"
 	caOrganization            = "Redpanda"
+
+	// brokerFetchTimeout bounds a single state.admin.Broker(brokerID) call
+	// in reconcileDecommission. The admin client's default ClientTimeout is
+	// generous (10s) so a partitioned broker would otherwise hold up the
+	// per-broker iteration for that long each. Decommission safety still
+	// relies on scaleDown's len(downNodes) > 0 deferral when a pod is
+	// missing from brokerMap, so a transient timeout here can only defer
+	// pod deletion to the next reconcile — it cannot cause an unsafe
+	// decommission.
+	brokerFetchTimeout = 2 * time.Second
 )
 
 //+kubebuilder:rbac:groups=cluster.redpanda.com,resources=stretchclusters,verbs=get;list;watch;update;patch
@@ -420,7 +431,7 @@ func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redp
 	sccluster := lifecycle.NewStretchClusterWithPools(sc, r.Manager.GetClusterNames())
 
 	// grab NodePools from all connected clusters
-	nodePools, err := r.LifecycleClient.FetchExistingNodePoolsFromAllClusters(ctx, sccluster)
+	nodePools, nodePoolsObserved, err := r.LifecycleClient.FetchExistingNodePoolsFromAllClusters(ctx, sccluster)
 	if err != nil {
 		logger.Error(err, "fetching nodepools")
 		return nil, err
@@ -436,7 +447,7 @@ func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redp
 	if restartOnConfigChange {
 		injectedConfigVersion = sc.Status.ConfigVersion
 	}
-	pools, err := r.LifecycleClient.FetchExistingAndDesiredPools(ctx, sccluster, injectedConfigVersion)
+	pools, err := r.LifecycleClient.FetchExistingAndDesiredPools(ctx, sccluster, injectedConfigVersion, nodePoolsObserved)
 	if err != nil {
 		logger.Error(err, "fetching pools")
 		return nil, err
@@ -495,35 +506,64 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 
 	// Phase 1: scan all clusters for existing bootstrap user secrets.
 	// If multiple secrets exist, verify they all have the same password.
+	//
+	// Both the probe check and the per-call timeout are required here. The
+	// probe is the fast path: a peer known unreachable is skipped without a
+	// dial attempt. The timeout is the backstop: when the controller-runtime
+	// cached client is asked to Get from a cluster whose informer cache
+	// hasn't synced (typical right after leader transition, before the
+	// engage cycle has run for that peer), the Get blocks waiting for cache
+	// sync — *not* on a network call, so net.Dialer.Timeout doesn't help.
+	// The parent reconcile context's 2-minute ceiling is the only thing that
+	// would otherwise stop it, and we'd burn the whole reconcile budget on
+	// one Get. Same pattern as Phase 3 below.
 	var canonicalPassword string
 	var canonicalCluster string
 	for _, clusterName := range clusterNames {
+		if clusterName != mcmanager.LocalCluster && !r.Manager.IsClusterReachable(clusterName) {
+			logger.V(log.TraceLevel).Info("cluster unreachable, skipping bootstrap user scan", "cluster", clusterName)
+			continue
+		}
 		cl, err := r.Manager.GetCluster(ctx, clusterName)
 		if err != nil {
+			if clusterName != mcmanager.LocalCluster {
+				logger.Info("could not get cluster, skipping bootstrap user scan", "cluster", clusterName, "error", err)
+				continue
+			}
 			return ctrl.Result{}, errors.Wrapf(err, "getting cluster %s", clusterName)
 		}
 
 		secretName := bootstrapSecretName(sc)
 		var existing corev1.Secret
-		if err := cl.GetClient().Get(ctx, client.ObjectKey{
+		getCtx, getCancel := context.WithTimeout(ctx, lifecycle.CallTimeoutFor(clusterName))
+		err = cl.GetClient().Get(getCtx, client.ObjectKey{
 			Namespace: sc.Namespace,
 			Name:      secretName,
-		}, &existing); err == nil {
-			if pw, ok := existing.Data[bootstrapUserPasswordKey]; ok && len(pw) > 0 {
-				password := string(pw)
-				if canonicalPassword == "" {
-					canonicalPassword = password
-					canonicalCluster = clusterName
-					logger.V(log.TraceLevel).Info("found existing bootstrap user secret", "cluster", clusterName, "secret", secretName)
-				} else if canonicalPassword != password {
-					msg := fmt.Sprintf(
-						"bootstrap user password mismatch: secret %q in cluster %q differs from cluster %q; "+
-							"manual intervention required — delete the incorrect secret(s) and let the controller recreate them",
-						secretName, clusterName, canonicalCluster,
-					)
-					state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonPasswordMismatch, msg)
-					return ctrl.Result{}, errors.New(msg)
-				}
+		}, &existing)
+		getCancel()
+		if err != nil {
+			if clusterName != mcmanager.LocalCluster {
+				logger.Info("could not Get bootstrap user secret on cluster, skipping scan", "cluster", clusterName, "error", err)
+				continue
+			}
+			// Local Get error other than NotFound: log and continue scanning;
+			// Phase 3 will recreate the secret if missing.
+			continue
+		}
+		if pw, ok := existing.Data[bootstrapUserPasswordKey]; ok && len(pw) > 0 {
+			password := string(pw)
+			if canonicalPassword == "" {
+				canonicalPassword = password
+				canonicalCluster = clusterName
+				logger.V(log.TraceLevel).Info("found existing bootstrap user secret", "cluster", clusterName, "secret", secretName)
+			} else if canonicalPassword != password {
+				msg := fmt.Sprintf(
+					"bootstrap user password mismatch: secret %q in cluster %q differs from cluster %q; "+
+						"manual intervention required — delete the incorrect secret(s) and let the controller recreate them",
+					secretName, clusterName, canonicalCluster,
+				)
+				state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonPasswordMismatch, msg)
+				return ctrl.Result{}, errors.New(msg)
 			}
 		}
 	}
@@ -885,14 +925,37 @@ func (r *MulticlusterReconciler) reconcileDecommission(ctx context.Context, stat
 		return ctrl.Result{}, errors.Wrap(err, "fetching cluster health")
 	}
 
+	// health.NodesDown is treated as an advisory hint, not authority.
+	// The cluster health overview is the controller broker's consensus view of
+	// who has missed heartbeats. Right after a partition (or controller
+	// re-election) it can transiently list brokers that are actually alive —
+	// observed in the lab as cluster three's brokers being flagged "down"
+	// alongside the genuinely-partitioned cluster two brokers. The per-broker
+	// gossip endpoint (/v1/brokers) doesn't help here because it's
+	// broker-local: each broker reports its own opinion, not consensus.
+	// Skipping a wrongly-reported "down" broker would leave it out of the
+	// brokerMap used by scaleDown for decommission pod-lookup, breaking
+	// decommission safety.
+	//
+	// Instead, attempt the Broker fetch for every node with a tight per-call
+	// timeout. Truly unreachable brokers fail fast (or hit the timeout);
+	// brokers wrongly listed in NodesDown succeed and end up in the map. The
+	// timeout keeps reconcileClusterConfig and later phases from being
+	// gated on a 10s (or whatever the admin-client default is) hang per
+	// down broker.
 	// brokerMap keys brokers by the first DNS label of their internal RPC
 	// address (pod name for single-cluster) and also by the raw host (pod IP
 	// for stretch-cluster flat-network mode where InternalRPCAddress is an IP).
 	brokerMap := map[string]int{}
+	downNodes := map[int]bool{}
 	for _, brokerID := range health.AllNodes {
-		broker, err := state.admin.Broker(ctx, brokerID)
+		brokerCtx, brokerCancel := context.WithTimeout(ctx, brokerFetchTimeout)
+		broker, err := state.admin.Broker(brokerCtx, brokerID)
+		brokerCancel()
 		if err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "fetching broker")
+			logger.Info("broker unreachable, omitting from brokerMap (will be treated as down for decommission)", "brokerID", brokerID, "error", err)
+			downNodes[brokerID] = true
+			continue
 		}
 
 		host := broker.InternalRPCAddress
@@ -909,7 +972,7 @@ func (r *MulticlusterReconciler) reconcileDecommission(ctx context.Context, stat
 	// next scale down any over-provisioned pools, patching them to use the new spec
 	// and decommissioning any nodes as needed
 	for _, set := range state.pools.ToScaleDown() {
-		requeue, err := r.scaleDown(ctx, state.admin, state.cluster, set, brokerMap)
+		requeue, err := r.scaleDown(ctx, state.admin, state.cluster, set, brokerMap, downNodes)
 		result := ctrl.Result{}
 		if requeue {
 			result.RequeueAfter = requeueTimeout
@@ -1265,7 +1328,7 @@ func (r *MulticlusterReconciler) fetchClusterHealth(ctx context.Context, admin *
 // scaleDown contains the majority of the logic for scaling down a statefulset incrementally, first
 // decommissioning the broker with the last pod ordinal and then patching the statefulset with
 // a single less replica.
-func (r *MulticlusterReconciler) scaleDown(ctx context.Context, admin *rpadmin.AdminAPI, cluster *lifecycle.StretchClusterWithPools, set *lifecycle.ScaleDownSet, brokerMap map[string]int) (bool, error) {
+func (r *MulticlusterReconciler) scaleDown(ctx context.Context, admin *rpadmin.AdminAPI, cluster *lifecycle.StretchClusterWithPools, set *lifecycle.ScaleDownSet, brokerMap map[string]int, downNodes map[int]bool) (bool, error) {
 	logger := log.FromContext(ctx).WithName(fmt.Sprintf("MulticlusterReconciler[%T].scaleDown", *cluster))
 	logger.V(log.TraceLevel).Info("starting StatefulSet scale down", "StatefulSet", client.ObjectKeyFromObject(set.StatefulSet).String())
 
@@ -1282,6 +1345,20 @@ func (r *MulticlusterReconciler) scaleDown(ctx context.Context, admin *rpadmin.A
 		}
 
 		if requeue {
+			return true, nil
+		}
+	} else {
+		// The pod isn't in brokerMap. Two cases:
+		//   1. The broker was fully removed from the cluster — safe to delete
+		//      the pod (the brokerMap absence reflects ground truth).
+		//   2. The broker sits on a partitioned peer and was skipped earlier
+		//      to keep reconcileDecommission from hanging. Deleting the pod
+		//      now would orphan the broker on heal. Requeue and wait.
+		// Distinguish by checking whether ANY known broker for this pool sits
+		// in downNodes — if so, treat the absence as transient and requeue.
+		if len(downNodes) > 0 {
+			logger.Info("pod missing from brokerMap while peer brokers are down, requeueing scale-down to avoid orphaning a partitioned broker",
+				"pod", set.LastPod.GetName(), "downNodes", downNodes)
 			return true, nil
 		}
 	}

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -323,7 +323,10 @@ func (r *RedpandaReconciler) fetchInitialState(ctx context.Context, rp *redpanda
 	if restartOnConfigChange {
 		injectedConfigVersion = rp.Status.ConfigVersion
 	}
-	pools, err := r.LifecycleClient.FetchExistingAndDesiredPools(ctx, rpcluster, injectedConfigVersion)
+	// Single-cluster path: only the local cluster exists. nodePoolsObserved=nil
+	// is fine because FetchExistingAndDesiredPools unconditionally marks the
+	// local cluster as observed regardless of the map.
+	pools, err := r.LifecycleClient.FetchExistingAndDesiredPools(ctx, rpcluster, injectedConfigVersion, nil)
 	if err != nil {
 		logger.Error(err, "fetching pools")
 		return nil, err

--- a/operator/internal/controller/redpanda/sync_bootstrap_user_test.go
+++ b/operator/internal/controller/redpanda/sync_bootstrap_user_test.go
@@ -321,8 +321,18 @@ func TestSyncBootstrapUser_ClusterUnreachable(t *testing.T) {
 	mgr := newMockManager(clusterNames, clients)
 	state := newTestState(sc, clusterNames)
 
-	r := &MulticlusterReconciler{Manager: mgr}
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
 	_, err := r.syncBootstrapUser(ctx, state, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cluster-b")
+	require.NoError(t, err)
+
+	// cluster-a is reachable: secret should be created.
+	var secret corev1.Secret
+	require.NoError(t, clients["cluster-a"].Get(ctx, types.NamespacedName{
+		Namespace: sc.Namespace,
+		Name:      bootstrapSecretName(sc),
+	}, &secret))
+	require.NotEmpty(t, secret.Data[bootstrapUserPasswordKey])
 }

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -450,6 +450,7 @@ func (r *ResourceClient[T, U]) isOwnerDeleting(ctx context.Context, owner U, clu
 //   - its NodePool list was already observed (passed in), AND
 //   - fetchExistingPools here didn't probe-skip, AND
 //   - Render here didn't error
+//
 // hold. ToScaleDown / ToDelete gate "no desired counterpart" decisions on
 // this combined observation so a partial-visibility reconcile can never
 // trigger an unintended decommission.

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/go-logr/logr"
@@ -132,6 +133,10 @@ func (r *ResourceClient[T, U]) clusterList(cluster any) []string {
 // cluster's own operator will clean up when it reconnects.
 func (r *ResourceClient[T, U]) DeleteStatefulSetForNodePool(ctx context.Context, set *MulticlusterStatefulSet) error {
 	logger := log.FromContext(ctx)
+	if set.clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(set.clusterName) {
+		logger.Info("remote cluster unreachable (probe) in DeleteStatefulSetForNodePool, skipping", "cluster", set.canonicalClusterName)
+		return nil
+	}
 	ctl, err := r.ctl(ctx, set.clusterName)
 	if err != nil {
 		if set.clusterName != mcmanager.LocalCluster {
@@ -148,6 +153,10 @@ func (r *ResourceClient[T, U]) DeleteStatefulSetForNodePool(ctx context.Context,
 // cluster's own operator will clean up when it reconnects.
 func (r *ResourceClient[T, U]) DeletePod(ctx context.Context, pod *MulticlusterPod) error {
 	logger := log.FromContext(ctx)
+	if pod.clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(pod.clusterName) {
+		logger.Info("remote cluster unreachable (probe) in DeletePod, skipping", "cluster", pod.GetCanonicalClusterName())
+		return nil
+	}
 	ctl, err := r.ctl(ctx, pod.clusterName)
 	if err != nil {
 		if pod.clusterName != mcmanager.LocalCluster {
@@ -164,6 +173,10 @@ func (r *ResourceClient[T, U]) DeletePod(ctx context.Context, pod *MulticlusterP
 // cluster's own operator will apply the patch when it reconnects.
 func (r *ResourceClient[T, U]) PatchNodePoolSet(ctx context.Context, owner U, set *MulticlusterStatefulSet) error {
 	logger := log.FromContext(ctx)
+	if set.clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(set.clusterName) {
+		logger.Info("remote cluster unreachable (probe) in PatchNodePoolSet, skipping", "cluster", set.canonicalClusterName)
+		return nil
+	}
 	ctl, err := r.ctl(ctx, set.clusterName)
 	if err != nil {
 		if set.clusterName != mcmanager.LocalCluster {
@@ -316,6 +329,15 @@ func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 			"ownerUID", owner.GetUID(),
 			"ownerGroupVersionKind", owner.GetObjectKind().GroupVersionKind().String())
 
+		if clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(clusterName) {
+			logger.Info("remote cluster unreachable (probe) in SyncAll, skipping", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName))
+			continue
+		}
+		logger.V(log.TraceLevel).Info("reachability probe passed in SyncAll, proceeding",
+			"cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName),
+			"rawClusterName", clusterName,
+			"isLocal", clusterName == mcmanager.LocalCluster)
+
 		// Skip clusters where the owner is being deleted — the deletion
 		// reconciler handles cleanup there independently.
 		if deleting, err := r.isOwnerDeleting(ctx, owner, clusterName); err != nil {
@@ -342,6 +364,34 @@ func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 	return syncErr
 }
 
+// RemoteCallTimeout bounds a single network call to a peer cluster's
+// API server. It's intentionally tight (5s) so a probe-race miss — where
+// IsReachable still returns true for a peer that's actually unreachable —
+// fails fast enough to keep the overall reconcile under the partition-SLA
+// target instead of stalling on the kernel TCP dial timeout (~30–90s).
+// Exported so other packages that issue cross-cluster API calls (render
+// state, etc.) can match the budget.
+const RemoteCallTimeout = 5 * time.Second
+
+// LocalCallTimeout bounds a single network call to the local cluster's
+// API server. The local apiserver is normally sub-ms; the bound exists
+// only to keep a pathological case (e.g. workqueue/rate-limiter
+// starvation, an unsynced informer cache) from consuming the entire
+// reconcile budget on one Get.
+const LocalCallTimeout = 10 * time.Second
+
+// CallTimeoutFor returns the per-call timeout for the given cluster — short
+// for remote peers, more generous for the local apiserver. Use it to wrap a
+// reconcile context before issuing a kube call so a hung peer doesn't drain
+// the reconcile deadline. Sites in this package use the lowercase
+// callTimeoutFor; the exported variant is for callers outside the package.
+func CallTimeoutFor(clusterName string) time.Duration {
+	if clusterName == mcmanager.LocalCluster {
+		return LocalCallTimeout
+	}
+	return RemoteCallTimeout
+}
+
 // isOwnerDeleting checks if the owner resource is being deleted on a given cluster.
 // Returns true if the owner is being deleted or does not exist.
 // For remote peer clusters (stretch setup), if the cluster is unreachable, returns
@@ -350,35 +400,76 @@ func (r *ResourceClient[T, U]) SyncAll(ctx context.Context, owner U) error {
 // Errors on the local cluster are always propagated.
 func (r *ResourceClient[T, U]) isOwnerDeleting(ctx context.Context, owner U, clusterName string) (bool, error) {
 	logger := log.FromContext(ctx)
+	// Short-circuit the local cluster: the owner argument IS the local
+	// StretchCluster (it's what triggered this reconcile), so its
+	// DeletionTimestamp is already authoritative. Round-tripping through
+	// kube.Get would re-fetch the same object via the controller-runtime
+	// cache, which can stall for the entire LocalCallTimeout if the local
+	// informer hasn't completed its initial sync yet (e.g. shortly after
+	// a leader transition). The cache-sync wait is fundamental to
+	// controller-runtime's cached client and we have no control over it
+	// here — but we don't need the Get at all for the local case.
+	if clusterName == mcmanager.LocalCluster {
+		return !owner.GetDeletionTimestamp().IsZero(), nil
+	}
+	if !r.manager.IsClusterReachable(clusterName) {
+		logger.Info("remote cluster unreachable (probe) in isOwnerDeleting, skipping sync to cluster", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName))
+		return true, nil
+	}
+	logger.V(log.TraceLevel).Info("reachability probe passed in isOwnerDeleting, proceeding to remote Get",
+		"cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName),
+		"rawClusterName", clusterName)
 	ctl, err := r.ctl(ctx, clusterName)
 	if err != nil {
-		if clusterName != mcmanager.LocalCluster {
-			logger.Info("remote cluster unreachable in isOwnerDeleting, skipping sync to cluster", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName), "error", err)
-			return true, nil
-		}
-		return false, err
+		logger.Info("remote cluster unreachable in isOwnerDeleting, skipping sync to cluster", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName), "error", err)
+		return true, nil
 	}
-	resolved, err := r.ownershipResolver.ResolveOwnerReference(ctx, owner, clusterName, ctl)
+	resolveCtx, cancel := context.WithTimeout(ctx, RemoteCallTimeout)
+	defer cancel()
+	resolved, err := r.ownershipResolver.ResolveOwnerReference(resolveCtx, owner, clusterName, ctl)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
-		if clusterName != mcmanager.LocalCluster {
-			logger.Info("could not resolve owner reference on remote cluster in isOwnerDeleting, skipping sync to cluster", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName), "error", err)
-			return true, nil
-		}
-		return false, err
+		logger.Info("could not resolve owner reference on remote cluster in isOwnerDeleting, skipping sync to cluster", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName), "error", err)
+		return true, nil
 	}
 	return !resolved.GetDeletionTimestamp().IsZero(), nil
 }
 
 // FetchExistingAndDesiredPools fetches the existing and desired node pools for a given cluster, returning
 // a tracker that can be used for determining necessary operations on the pools.
-func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context, cluster U, configVersion string) (*PoolTracker, error) {
+// FetchExistingAndDesiredPools fetches the existing and desired node pools
+// for a given cluster, returning a tracker that can be used for determining
+// necessary operations on the pools.
+//
+// nodePoolsObserved is the observation set returned by
+// FetchExistingNodePoolsFromAllClusters — clusters whose NodePool list was
+// successfully fetched earlier in the same reconcile. A cluster is only
+// marked fully observed on the PoolTracker when ALL of:
+//   - its NodePool list was already observed (passed in), AND
+//   - fetchExistingPools here didn't probe-skip, AND
+//   - Render here didn't error
+// hold. ToScaleDown / ToDelete gate "no desired counterpart" decisions on
+// this combined observation so a partial-visibility reconcile can never
+// trigger an unintended decommission.
+func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context, cluster U, configVersion string, nodePoolsObserved map[string]bool) (*PoolTracker, error) {
 	pools := NewPoolTracker(cluster.GetGeneration())
 	logger := log.FromContext(ctx)
 	for _, clusterName := range r.clusterList(cluster) {
 		canonical := CanonicalClusterName(clusterName, r.manager.GetLocalClusterName)
+
+		// Probe-check up front. We do BOTH the existing-fetch and the
+		// render under the same reachability decision so a probe flip
+		// mid-iteration can't leave us with a partial view (existing
+		// populated, desired empty) that ToScaleDown would misread as
+		// "user removed all pools in this cluster". Local cluster is
+		// always considered reachable.
+		if clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(clusterName) {
+			logger.Info("remote cluster unreachable (probe), skipping pool fetch+render", "cluster", canonical)
+			continue
+		}
+
 		existingPools, err := r.fetchExistingPools(ctx, cluster, clusterName)
 		if err != nil {
 			return nil, fmt.Errorf("fetching existing pools: %w", err)
@@ -427,6 +518,18 @@ func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context,
 		}
 		pools.addExisting(existingPools...)
 		pools.addDesired(wrapped...)
+
+		// Mark this cluster fully observed ONLY if every upstream fetch
+		// for it also succeeded. The local cluster is unconditionally
+		// observed (its NodePool list was either observed too, or it's
+		// the only place we could see anything anyway). Remote clusters
+		// require the NodePool-list observation from the earlier call.
+		if clusterName == mcmanager.LocalCluster || nodePoolsObserved[clusterName] {
+			pools.MarkClusterObserved(clusterName)
+		} else {
+			logger.Info("pool data fetched but NodePool list was not observed for cluster, not marking fully observed (no-desired-counterpart scale-down disabled for it)",
+				"cluster", canonical)
+		}
 	}
 
 	return pools, nil
@@ -575,6 +678,11 @@ func (r *ResourceClient[T, U]) DeleteAll(ctx context.Context, owner U) (bool, er
 
 	var deleteErr error
 	for _, clusterName := range r.clusterList(owner) {
+		if clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(clusterName) {
+			logger.Info("remote cluster unreachable (probe) in DeleteAll, skipping", "cluster", CanonicalClusterName(clusterName, r.manager.GetLocalClusterName))
+			allDeleted = false
+			continue
+		}
 		ctl, err := r.ctl(ctx, clusterName)
 		if err != nil {
 			if clusterName != mcmanager.LocalCluster {
@@ -642,6 +750,10 @@ func (r *ResourceClient[T, U]) DeleteAll(ctx context.Context, owner U) (bool, er
 func (r *ResourceClient[T, U]) fetchExistingPools(ctx context.Context, cluster U, clusterName string) ([]*poolWithOrdinals, error) {
 	logger := log.FromContext(ctx).WithName("fetchExistingPools")
 	canonical := CanonicalClusterName(clusterName, r.manager.GetLocalClusterName)
+	if clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(clusterName) {
+		logger.Info("remote cluster unreachable (probe) in fetchExistingPools, treating as empty", "cluster", canonical)
+		return nil, nil
+	}
 	ctl, err := r.ctl(ctx, clusterName)
 	if err != nil {
 		if clusterName != mcmanager.LocalCluster {
@@ -652,7 +764,9 @@ func (r *ResourceClient[T, U]) fetchExistingPools(ctx context.Context, cluster U
 	}
 
 	ownerLabels := r.ownershipResolver.GetOwnerLabels(cluster)
-	sets, err := kube.List[appsv1.StatefulSetList](ctx, ctl, cluster.GetNamespace(), client.MatchingLabels(ownerLabels))
+	listCtx, listCancel := context.WithTimeout(ctx, CallTimeoutFor(clusterName))
+	sets, err := kube.List[appsv1.StatefulSetList](listCtx, ctl, cluster.GetNamespace(), client.MatchingLabels(ownerLabels))
+	listCancel()
 	if err != nil {
 		if clusterName != mcmanager.LocalCluster {
 			logger.Info("could not list StatefulSets on remote cluster in fetchExistingPools, treating as empty", "cluster", canonical, "error", err)
@@ -666,7 +780,9 @@ func (r *ResourceClient[T, U]) fetchExistingPools(ctx context.Context, cluster U
 		"ownerLabels", ownerLabels,
 		"setsFound", len(sets.Items),
 	)
-	expectedOwner, err := r.ownershipResolver.ResolveOwnerReference(ctx, cluster, clusterName, ctl)
+	ownerCtx, ownerCancel := context.WithTimeout(ctx, CallTimeoutFor(clusterName))
+	expectedOwner, err := r.ownershipResolver.ResolveOwnerReference(ownerCtx, cluster, clusterName, ctl)
+	ownerCancel()
 	if err != nil {
 		// If the cluster object doesn't exist on this cluster yet (e.g. during
 		// initial rollout), there can't be any owned StatefulSets either.
@@ -761,27 +877,45 @@ func (r *ResourceClient[T, U]) fetchExistingPools(ctx context.Context, cluster U
 	return existing, nil
 }
 
-func (r *ResourceClient[T, U]) FetchExistingNodePoolsFromAllClusters(ctx context.Context, cluster U) ([]*NodePoolInCluster, error) {
+// FetchExistingNodePoolsFromAllClusters returns the union of NodePools
+// referencing the given cluster across every engaged cluster, plus the set of
+// cluster names whose List actually succeeded (vs. being probe-skipped or
+// failing the call). The observed set is load-bearing for downstream
+// scale-down safety: when a cluster's NodePool list wasn't observed, the
+// renderer downstream can produce a desiredCount=0 for that cluster purely
+// because we never saw its NodePools — indistinguishable from a real
+// deletion. Callers must gate any "no desired counterpart → drain"
+// decision on the observed set so a transient fetch failure on a
+// partitioned peer can't be misread as user intent to remove all pools.
+func (r *ResourceClient[T, U]) FetchExistingNodePoolsFromAllClusters(ctx context.Context, cluster U) ([]*NodePoolInCluster, map[string]bool, error) {
 	logger := log.FromContext(ctx)
 	var nodePools []*NodePoolInCluster
+	observed := map[string]bool{}
 	for _, clusterName := range r.clusterList(cluster) {
 		canonicalName := CanonicalClusterName(clusterName, r.manager.GetLocalClusterName)
+		if clusterName != mcmanager.LocalCluster && !r.manager.IsClusterReachable(clusterName) {
+			logger.Info("remote cluster unreachable (probe) in FetchExistingNodePoolsFromAllClusters, skipping", "cluster", canonicalName)
+			continue
+		}
 		ctl, err := r.ctl(ctx, clusterName)
 		if err != nil {
 			if clusterName != mcmanager.LocalCluster {
 				logger.Info("remote cluster unreachable in FetchExistingNodePoolsFromAllClusters, skipping", "cluster", canonicalName, "error", err)
 				continue
 			}
-			return nil, err
+			return nil, nil, err
 		}
-		allNodePools, err := kube.List[redpandav1alpha2.NodePoolList](ctx, ctl, cluster.GetNamespace())
+		listCtx, listCancel := context.WithTimeout(ctx, CallTimeoutFor(clusterName))
+		allNodePools, err := kube.List[redpandav1alpha2.NodePoolList](listCtx, ctl, cluster.GetNamespace())
+		listCancel()
 		if err != nil {
 			if clusterName != mcmanager.LocalCluster {
 				logger.Info("could not list NodePools on remote cluster, skipping", "cluster", canonicalName, "error", err)
 				continue
 			}
-			return nil, err
+			return nil, nil, err
 		}
+		observed[clusterName] = true
 		for _, pool := range allNodePools.Items {
 			clusterRef := pool.Spec.ClusterRef
 			if clusterRef.IsStretchCluster() && clusterRef.Name == cluster.GetName() {
@@ -792,7 +926,7 @@ func (r *ResourceClient[T, U]) FetchExistingNodePoolsFromAllClusters(ctx context
 			}
 		}
 	}
-	return nodePools, nil
+	return nodePools, observed, nil
 }
 
 func setConfigVersionLabels(labels map[string]string, configVersion string) map[string]string {

--- a/operator/internal/lifecycle/client_test.go
+++ b/operator/internal/lifecycle/client_test.go
@@ -482,7 +482,7 @@ func TestClientFetchExistingAndDesiredPools(t *testing.T) {
 			ctx, cancel := setupContext()
 			defer cancel()
 
-			tracker, err := instances.resourceClient.FetchExistingAndDesiredPools(ctx, cluster, "version")
+			tracker, err := instances.resourceClient.FetchExistingAndDesiredPools(ctx, cluster, "version", nil)
 			if tt.nodePoolsRenderError != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.nodePoolsRenderError)
@@ -503,7 +503,7 @@ func TestClientFetchExistingAndDesiredPools(t *testing.T) {
 				require.NoError(t, instances.checkObject(ctx, t, pool.StatefulSet))
 			}
 
-			tracker, err = instances.resourceClient.FetchExistingAndDesiredPools(ctx, cluster, "version")
+			tracker, err = instances.resourceClient.FetchExistingAndDesiredPools(ctx, cluster, "version", nil)
 			require.NoError(t, err)
 			require.ElementsMatch(t, pools, tracker.ExistingStatefulSets())
 			require.ElementsMatch(t, pools, tracker.DesiredStatefulSets())

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -116,6 +116,17 @@ type PoolTracker struct {
 	latestGeneration int64
 	existingPools    map[ClusterNamespacedName]*poolWithOrdinals
 	desiredPools     map[ClusterNamespacedName]*poolWithOrdinals
+	// observedClusters records which cluster contexts the operator had
+	// full visibility into for this reconcile — i.e. it successfully
+	// fetched both the NodePool list AND the StatefulSet list for that
+	// cluster without falling back to the probe-unreachable skip.
+	// ToScaleDown's "existing pool with no desired counterpart" branch
+	// requires the owning cluster to be observed before treating absence
+	// as intent to drain — otherwise a transient fetch failure (or a
+	// probe-state flip mid-reconcile) on a partitioned peer would be
+	// indistinguishable from a real NodePool deletion and would trigger
+	// an unintended decommission.
+	observedClusters map[string]bool
 }
 
 // NewPoolTracker creates a new PoolTracker with the given cluster generation.
@@ -124,7 +135,22 @@ func NewPoolTracker(generation int64) *PoolTracker {
 		latestGeneration: generation,
 		existingPools:    make(map[ClusterNamespacedName]*poolWithOrdinals),
 		desiredPools:     make(map[ClusterNamespacedName]*poolWithOrdinals),
+		observedClusters: make(map[string]bool),
 	}
+}
+
+// MarkClusterObserved records that the operator had complete visibility into
+// the named cluster's NodePool and StatefulSet state during this reconcile.
+// "no desired counterpart" decisions in ToScaleDown / ToDelete are gated on
+// this — see the comment on PoolTracker.observedClusters.
+func (p *PoolTracker) MarkClusterObserved(clusterName string) {
+	p.observedClusters[clusterName] = true
+}
+
+// IsClusterObserved returns whether the cluster's pool state was fully fetched
+// during this reconcile.
+func (p *PoolTracker) IsClusterObserved(clusterName string) bool {
+	return p.observedClusters[clusterName]
 }
 
 // ExistingStatefulSets returns a list of the names of the existing StatefulSets tracked by the PoolTracker.
@@ -333,6 +359,21 @@ func (p *PoolTracker) ToScaleDown() []*ScaleDownSet {
 	for nn := range p.existingPools {
 		if _, ok := p.desiredPools[nn]; !ok {
 			existing := p.existingPools[nn]
+
+			// Refuse to interpret "no desired counterpart" as user intent to
+			// drain unless we *actually saw* the owning cluster's NodePool
+			// list in this reconcile. Without this guard, a probe flip /
+			// transient fetch failure on a partitioned peer makes "we
+			// couldn't see your NodePool" look identical to "the user
+			// removed your NodePool" — and the operator happily decommissions
+			// healthy brokers. The user-facing rule we honor: decommission
+			// only on explicit scale-down (the else branch below) or when
+			// we've confirmed the pool is genuinely gone from a cluster we
+			// could observe.
+			if !p.observedClusters[nn.Cluster] {
+				continue
+			}
+
 			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
 
 			if existingReplicas != 0 && len(existing.pods) != 0 {
@@ -381,6 +422,15 @@ func (p *PoolTracker) ToDelete() []*MulticlusterStatefulSet {
 
 	for nn, existing := range p.existingPools {
 		if _, ok := p.desiredPools[nn]; !ok {
+			// Same observation guard as ToScaleDown: never delete a
+			// StatefulSet for a cluster we didn't observe — "no desired
+			// counterpart" might mean the NodePool was removed (delete
+			// is correct) or it might mean we couldn't see the cluster
+			// (delete is wrong and irrecoverable). Only act when sure.
+			if !p.observedClusters[nn.Cluster] {
+				continue
+			}
+
 			existingReplicas := ptr.Deref(existing.set.Spec.Replicas, 0)
 			// extra guard to make sure we don't accidentally delete a
 			// statefulset whose pods still need to be decommissioned

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -802,6 +802,7 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 			tracker := NewPoolTracker(1)
 			tracker.addExisting(tt.existingPools...)
 			tracker.addDesired(tt.desiredPools...)
+			tracker.MarkClusterObserved(mcmanager.LocalCluster)
 
 			toIDs := func(list []*ScaleDownSet) []string {
 				ids := []string{}
@@ -945,6 +946,7 @@ func TestPoolTrackerToDelete(t *testing.T) {
 
 			tracker.addExisting(pools...)
 			tracker.addDesired(tt.desiredPools...)
+			tracker.MarkClusterObserved(mcmanager.LocalCluster)
 
 			actual := objectNames(tracker.ToDelete())
 			require.ElementsMatch(t, tt.expectedSetsToDelete, actual)

--- a/operator/multicluster/render_state.go
+++ b/operator/multicluster/render_state.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/redpanda-data/common-go/kube"
 	appsv1 "k8s.io/api/apps/v1"
@@ -303,8 +304,17 @@ func (r *RenderState) fetchBootstrapUser() error {
 
 	secretName := fmt.Sprintf("%s-bootstrap-user", r.fullname())
 
+	// Bound the Get explicitly. fetchBootstrapUser runs inside NewRenderState
+	// per cluster the renderer iterates; without a deadline a partitioned peer's
+	// apiserver dial would hang the kernel TCP retry (~30–90s) and serialize
+	// across every render call in the reconcile, blowing the partition-detect
+	// SLA. Kept in sync with lifecycle.LocalCallTimeout — duplicated rather
+	// than imported to avoid an operator/multicluster → operator/internal/lifecycle
+	// import cycle (lifecycle already imports this package).
+	getCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
 	var existing corev1.Secret
-	if err := r.client.Get(context.Background(), kube.ObjectKey{Namespace: r.namespace, Name: secretName}, &existing); err != nil {
+	if err := r.client.Get(getCtx, kube.ObjectKey{Namespace: r.namespace, Name: secretName}, &existing); err != nil {
 		if k8sapierrors.IsNotFound(err) {
 			return nil
 		}

--- a/operator/multicluster/statefulset.go
+++ b/operator/multicluster/statefulset.go
@@ -121,6 +121,22 @@ func statefulSet(state *RenderState, pool *redpandav1alpha2.NodePool) (*appsv1.S
 		if err != nil {
 			return nil, fmt.Errorf("applying pod template overrides: %w", err)
 		}
+		// When the user supplied an .affinity block, fully replace ours rather
+		// than relying on strategic-merge to handle it. SMP can't honor an
+		// explicit `null` on slice subfields (e.g.
+		// requiredDuringSchedulingIgnoredDuringExecution: null) because
+		// corev1.PodAntiAffinity tags those slices `omitempty` — the user's
+		// null is silently dropped on the JSON round-trip and the base
+		// affinity leaks through. The chart's gotohelm rendering path has the
+		// same patch utility but is locked to its own semantics, so this
+		// override is applied here in the multicluster renderer only.
+		if expanded.Spec != nil && expanded.Spec.Affinity != nil {
+			affinity, err := tplutil.MergeTo[corev1.Affinity](expanded.Spec.Affinity)
+			if err != nil {
+				return nil, fmt.Errorf("rendering affinity override: %w", err)
+			}
+			merged.Spec.Affinity = &affinity
+		}
 		podTemplate = merged
 	}
 

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -23,9 +23,11 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	redpandaclient "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
 	rendermulticluster "github.com/redpanda-data/redpanda-operator/operator/multicluster"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/tplutil"
 )
@@ -188,13 +190,32 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 	var endpoints []string
 
 	for _, clusterName := range c.mgr.GetClusterNames() {
+		// Skip peers the probe has marked unreachable. Without this the List
+		// below blocks at the kernel TCP dial budget (~30s) on every reconcile
+		// that reaches the admin-client init phase, which is plenty to chain
+		// reconciles past the 30s partition-handling SLA. The admin client
+		// only needs reachable brokers; pods on a partitioned peer cluster
+		// can't be reached anyway, so dropping them from the endpoint list
+		// is the right behavior.
+		if clusterName != mcmanager.LocalCluster && !c.mgr.IsClusterReachable(clusterName) {
+			continue
+		}
 		k8sClient, err := c.GetClient(ctx, clusterName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting client for cluster %s", clusterName)
 		}
 
+		listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
 		var nodePoolList redpandav1alpha2.NodePoolList
-		if err := k8sClient.List(ctx, &nodePoolList, client.InNamespace(sc.Namespace)); err != nil {
+		err = k8sClient.List(listCtx, &nodePoolList, client.InNamespace(sc.Namespace))
+		listCancel()
+		if err != nil {
+			if clusterName != mcmanager.LocalCluster {
+				// Treat a transient peer error the same as the probe
+				// having flagged it: drop the peer's endpoints from this
+				// reconcile and let the next round pick them up.
+				continue
+			}
 			return nil, errors.Wrapf(err, "listing NodePools in cluster %s", clusterName)
 		}
 

--- a/pkg/multicluster/health.go
+++ b/pkg/multicluster/health.go
@@ -22,10 +22,14 @@ import (
 
 const (
 	// healthProbeInterval is how often the background probe checks each
-	// cluster's API server.
-	healthProbeInterval = 10 * time.Second
-	// healthProbeTimeout is the per-cluster timeout for an API server probe.
-	healthProbeTimeout = 5 * time.Second
+	// cluster's API server. Tuned to keep partition detection inside a
+	// ~4s ceiling: worst-case detect time is interval + probe timeout.
+	healthProbeInterval = 2 * time.Second
+	// healthProbeTimeout is the per-cluster timeout for an API server
+	// probe. Healthy apiservers respond in well under 100ms; 2s leaves
+	// generous headroom for transient network slowness without letting a
+	// truly-partitioned peer linger.
+	healthProbeTimeout = 2 * time.Second
 )
 
 // clusterHealthTracker periodically probes each engaged cluster's Kubernetes
@@ -36,6 +40,10 @@ type clusterHealthTracker struct {
 	reachable   map[string]bool
 	getClusters func() map[string]cluster.Cluster
 	logger      logr.Logger
+	// onReachable, if set, is invoked once per unreachable→reachable transition
+	// detected by the probe loop. It runs in the probeAll goroutine, so callers
+	// must keep work cheap (typically a channel send / broadcaster notify).
+	onReachable func(clusterName string)
 }
 
 func newClusterHealthTracker(logger logr.Logger, getClusters func() map[string]cluster.Cluster) *clusterHealthTracker {
@@ -46,19 +54,54 @@ func newClusterHealthTracker(logger logr.Logger, getClusters func() map[string]c
 	}
 }
 
+// SetOnReachable installs the callback fired when a cluster transitions from
+// unreachable to reachable. Used to wake the leaderRunnable's engage loop so
+// it retries engagement on healed peers without polling.
+func (h *clusterHealthTracker) SetOnReachable(fn func(clusterName string)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.onReachable = fn
+}
+
 // IsReachable returns the cached reachability status for the named cluster.
-// Unknown clusters (not yet probed or not engaged) are considered reachable
-// to avoid false negatives on startup.
+// Unknown clusters (not yet probed) are reported as UNREACHABLE: this is the
+// conservative choice during the brief startup window between leader election
+// and the first probeAll completing. The alternative (default-reachable) lets
+// the first reconcile race past the probe and dial a partitioned peer, which
+// then hangs at the kernel TCP-retry budget (~30–90s) and blows the partition
+// SLA. The unreachable→reachable transition callback re-engages each cluster
+// the moment its first probe succeeds, so default-unreachable only delays
+// healthy clusters by one probe interval (~5s).
+//
+// Local cluster (empty string) is always treated as reachable — the operator
+// can always talk to its own apiserver, and the probe loop intentionally
+// doesn't include it.
 func (h *clusterHealthTracker) IsReachable(clusterName string) bool {
+	if clusterName == "" {
+		return true
+	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
 	reachable, ok := h.reachable[clusterName]
 	if !ok {
-		// Not probed yet — assume reachable to avoid blocking reconciliation
-		// before the first probe completes.
-		return true
+		// Not probed yet — assume unreachable so callers skip rather than
+		// dial a peer whose state we don't know. Log the miss with the
+		// current key set so a partition-time hang can be traced back to a
+		// name mismatch between the caller and the probe loop (the latter
+		// keys off whatever getClusters() returned at probe time).
+		knownKeys := make([]string, 0, len(h.reachable))
+		for k := range h.reachable {
+			knownKeys = append(knownKeys, k)
+		}
+		h.logger.V(1).Info("reachability lookup miss; defaulting to unreachable",
+			"queryClusterName", clusterName,
+			"knownKeys", knownKeys)
+		return false
 	}
+	h.logger.V(2).Info("reachability lookup hit",
+		"queryClusterName", clusterName,
+		"reachable", reachable)
 	return reachable
 }
 
@@ -84,45 +127,67 @@ func (h *clusterHealthTracker) Start(ctx context.Context) error {
 func (h *clusterHealthTracker) probeAll(ctx context.Context) {
 	clusters := h.getClusters()
 
-	// Probe all clusters concurrently so a single slow/hanging cluster
-	// doesn't delay detection of others.
-	type result struct {
-		name      string
-		reachable bool
-	}
-	results := make(chan result, len(clusters))
-
+	// Each probe goroutine writes its own result to h.reachable as soon as
+	// it finishes — we don't aggregate results and then update once at the
+	// end. That matters because a single slow probe (unreachable peer at
+	// the kernel TCP-retry budget, ~30s) would otherwise gate the map
+	// update for every other cluster in the same round. Healthy peers
+	// should be queryable as reachable within their own probe latency, not
+	// the slowest peer's.
 	var wg sync.WaitGroup
 	for name, cl := range clusters {
 		wg.Add(1)
 		go func(name string, cl cluster.Cluster) {
 			defer wg.Done()
-			results <- result{name: name, reachable: h.probe(ctx, name, cl)}
+			reachable := h.probe(ctx, name, cl)
+			h.recordResult(name, reachable)
 		}(name, cl)
 	}
 	wg.Wait()
-	close(results)
 
+	// Once every probe has reported, prune entries for clusters that are no
+	// longer engaged. This runs after wg.Wait so we don't race a delete
+	// against a still-in-flight probe for the same name.
 	h.mu.Lock()
-	for r := range results {
-		prev, known := h.reachable[r.name]
-		h.reachable[r.name] = r.reachable
-		if known && prev != r.reachable {
-			if r.reachable {
-				h.logger.Info("cluster became reachable", "cluster", r.name)
-			} else {
-				h.logger.Info("cluster became unreachable", "cluster", r.name)
-			}
-		}
-	}
-
-	// Remove stale entries for clusters that are no longer engaged.
 	for name := range h.reachable {
 		if _, ok := clusters[name]; !ok {
 			delete(h.reachable, name)
 		}
 	}
 	h.mu.Unlock()
+}
+
+// recordResult writes one probe's outcome to the reachability map and fires
+// the onReachable callback on any new positive observation. Called once per
+// probe goroutine so fast probes don't wait on slow ones.
+//
+// The callback fires in two cases: an explicit unreachable→reachable
+// transition (recovery), and the very first time a previously-unknown
+// cluster is observed reachable. The latter matters because with the
+// "unknown defaults to unreachable" IsReachable policy, the engage path
+// initially skips every cluster — without firing onReachable on the
+// first positive probe the engage cycle never wakes for clusters that
+// were healthy all along.
+func (h *clusterHealthTracker) recordResult(name string, reachable bool) {
+	h.mu.Lock()
+	prev, known := h.reachable[name]
+	h.reachable[name] = reachable
+	transitionedUp := reachable && (!known || !prev)
+	if known && prev != reachable {
+		if reachable {
+			h.logger.Info("cluster became reachable", "cluster", name)
+		} else {
+			h.logger.Info("cluster became unreachable", "cluster", name)
+		}
+	} else if !known && reachable {
+		h.logger.Info("cluster first observed reachable", "cluster", name)
+	}
+	onReachable := h.onReachable
+	h.mu.Unlock()
+
+	if transitionedUp && onReachable != nil {
+		onReachable(name)
+	}
 }
 
 // probe checks whether a single cluster's API server is reachable by fetching

--- a/pkg/multicluster/raft.go
+++ b/pkg/multicluster/raft.go
@@ -688,12 +688,20 @@ func newManager(localClusterName string, localLeaderElection bool, logger logr.L
 		return nil
 	})
 
-	runnable := &leaderRunnable{manager: manager, logger: logger.WithName("leader-runnable"), broadcaster: broadcaster, getClusters: getClusters, needsLocalLeaderElection: localLeaderElection}
+	healthTracker := newClusterHealthTracker(logger, getClusters)
+
+	runnable := &leaderRunnable{manager: manager, logger: logger.WithName("leader-runnable"), broadcaster: broadcaster, getClusters: getClusters, needsLocalLeaderElection: localLeaderElection, isClusterReachable: healthTracker.IsReachable}
 	if err := mgr.Add(runnable); err != nil {
 		return nil, err
 	}
 
-	healthTracker := newClusterHealthTracker(logger, getClusters)
+	// On unreachable→reachable transitions the tracker pokes the broadcaster,
+	// which triggers a fresh doEngage cycle so a healed peer is engaged without
+	// waiting for the next periodic retry.
+	healthTracker.SetOnReachable(func(clusterName string) {
+		logger.Info("cluster became reachable, requesting engage cycle", "cluster", clusterName)
+		broadcaster.notify()
+	})
 	manager.RegisterRoutine(healthTracker.Start)
 
 	return &raftManager{Manager: mgr, manager: manager, runnable: runnable, logger: logger.WithName("raft-manager"), localClusterName: localClusterName, getLeader: getLeader, getClusters: getClusters, addOrReplaceCluster: addOrReplaceCluster, clusterHealth: healthTracker}, nil
@@ -726,6 +734,12 @@ type leaderRunnable struct {
 	broadcaster              *restartBroadcaster
 	getClusters              func() map[string]cluster.Cluster
 	needsLocalLeaderElection bool
+	// isClusterReachable, when non-nil, lets doEngage skip clusters that the
+	// health probe has classified as unreachable. Unknown clusters are reported
+	// as reachable, so first-time engages still run; once the probe has marked
+	// a peer down we stop retrying it every 10s and let the
+	// unreachable→reachable transition callback re-trigger doEngage.
+	isClusterReachable func(string) bool
 }
 
 func (l *leaderRunnable) NeedLeaderElection() bool {
@@ -736,6 +750,17 @@ func (l *leaderRunnable) Add(r mcmanager.Runnable) {
 	doEngage := func(ctx context.Context) {
 		for name, cluster := range l.getClusters() {
 			name, cluster := name, cluster
+			// Skip clusters the probe has classified as unreachable. The
+			// engage call against an unreachable apiserver costs ~30–90s on
+			// the dial timeout and re-fires every 10s, which floods
+			// client-go workqueues with pending requests and starves
+			// reconciles on healthy clusters. The unreachable→reachable
+			// transition callback re-pokes the broadcaster so we re-engage
+			// on heal.
+			if l.isClusterReachable != nil && !l.isClusterReachable(name) {
+				l.logger.V(1).Info("skipping engage for unreachable cluster", "cluster", name)
+				continue
+			}
 			// Run each cluster's Engage concurrently so that a blocked or
 			// slow Engage (e.g. WaitForCacheSync on an unreachable cluster)
 			// does not prevent other clusters from being engaged or the
@@ -745,6 +770,8 @@ func (l *leaderRunnable) Add(r mcmanager.Runnable) {
 				if err := r.Engage(ctx, name, cluster); err != nil {
 					l.logger.Error(err, "error engaging cluster", "cluster", name)
 					// Schedule a retry so transient failures are recovered.
+					// Once the probe marks this cluster unreachable the
+					// skip above kicks in and stops the retry storm.
 					go func() {
 						select {
 						case <-ctx.Done():


### PR DESCRIPTION
This adds a smattering of fixes to make sure that we can fairly quickly run reconciliation even in the presence of an unreachable cluster. Previously we were still able to, but timeouts were incredibly long. Additionally, it fixes an issue where there was a race condition that could potentially result in decommissioning brokers accidentally while healing a network partition.