### PR TITLE
feat(operator): make TopicReconciler synchronization interval configurable

### DIFF
--- a/operator/chart/deployment.go
+++ b/operator/chart/deployment.go
@@ -347,6 +347,10 @@ func operatorArguments(dot *helmette.Dot) []string {
 		"--enable-vectorized-controllers": fmt.Sprintf("%t", values.VectorizedControllers.Enabled),
 	}
 
+	if !helmette.Empty(values.TopicSyncInterval) {
+		defaults["--topic-sync-interval"] = values.TopicSyncInterval
+	}
+
 	addLicenseFilePathArg(defaults, values)
 
 	if values.Webhook.Enabled {

--- a/operator/chart/multicluster_deployment.go
+++ b/operator/chart/multicluster_deployment.go
@@ -193,6 +193,10 @@ func multiclusterOperatorArguments(dot *helmette.Dot) []string {
 		"--kubeconfig-name":           ServiceAccountName(dot),
 	}
 
+	if !helmette.Empty(values.TopicSyncInterval) {
+		defaults["--topic-sync-interval"] = values.TopicSyncInterval
+	}
+
 	if values.Webhook.Enabled {
 		defaults["--webhook-cert-path"] = webhookCertificatePath + "/tls.crt"
 		defaults["--webhook-key-path"] = webhookCertificatePath + "/tls.key"

--- a/operator/chart/templates/_deployment.go.tpl
+++ b/operator/chart/templates/_deployment.go.tpl
@@ -174,6 +174,9 @@
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $defaults := (dict "--health-probe-bind-address" ":8081" "--metrics-bind-address" ":8443" "--leader-elect" "" "--enable-console" "true" "--log-level" $values.logLevel "--webhook-enabled" (printf "%t" $values.webhook.enabled) "--configurator-tag" (get (fromJson (include "operator.containerTag" (dict "a" (list $dot)))) "r") "--configurator-base-image" $values.image.repository "--enable-vectorized-controllers" (printf "%t" $values.vectorizedControllers.enabled)) -}}
+{{- if (not (empty $values.topicSyncInterval)) -}}
+{{- $_ := (set $defaults "--topic-sync-interval" $values.topicSyncInterval) -}}
+{{- end -}}
 {{- $_ := (get (fromJson (include "operator.addLicenseFilePathArg" (dict "a" (list $defaults $values)))) "r") -}}
 {{- if $values.webhook.enabled -}}
 {{- $_ := (set $defaults "--webhook-cert-path" "/tmp/k8s-webhook-server/serving-certs") -}}

--- a/operator/chart/templates/_multicluster_deployment.go.tpl
+++ b/operator/chart/templates/_multicluster_deployment.go.tpl
@@ -87,6 +87,9 @@
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $defaults := (dict "--health-probe-bind-address" ":8081" "--metrics-bind-address" ":8443" "--log-level" $values.logLevel "--name" $values.multicluster.name "--base-tag" (get (fromJson (include "operator.containerTag" (dict "a" (list $dot)))) "r") "--base-image" $values.image.repository "--raft-address" "0.0.0.0:9443" "--ca-file" "/tls/ca.crt" "--certificate-file" "/tls/tls.crt" "--private-key-file" "/tls/tls.key" "--kubernetes-api-address" $values.multicluster.apiServerExternalAddress "--kubeconfig-namespace" $dot.Release.Namespace "--kubeconfig-name" (get (fromJson (include "operator.ServiceAccountName" (dict "a" (list $dot)))) "r")) -}}
+{{- if (not (empty $values.topicSyncInterval)) -}}
+{{- $_ := (set $defaults "--topic-sync-interval" $values.topicSyncInterval) -}}
+{{- end -}}
 {{- if $values.webhook.enabled -}}
 {{- $_ := (set $defaults "--webhook-cert-path" (printf "%s%s" "/tmp/k8s-webhook-server/serving-certs" "/tls.crt")) -}}
 {{- $_ := (set $defaults "--webhook-key-path" (printf "%s%s" "/tmp/k8s-webhook-server/serving-certs" "/tls.key")) -}}

--- a/operator/chart/testdata/template-cases.txtar
+++ b/operator/chart/testdata/template-cases.txtar
@@ -180,6 +180,9 @@ multicluster:
     type: ClusterIP
     mcs: true
 
+-- topic-sync-interval --
+topicSyncInterval: "30s"
+
 -- multicluster service loadbalancer --
 crds:
   enabled: true

--- a/operator/chart/values.go
+++ b/operator/chart/values.go
@@ -110,6 +110,7 @@ type Values struct {
 	Config                Config                        `json:"config"`
 	ImagePullSecrets      []corev1.LocalObjectReference `json:"imagePullSecrets"`
 	LogLevel              string                        `json:"logLevel"`
+	TopicSyncInterval     string                        `json:"topicSyncInterval,omitempty"`
 	RBAC                  RBAC                          `json:"rbac"`
 	Webhook               Webhook                       `json:"webhook"`
 	ServiceAccount        ServiceAccountConfig          `json:"serviceAccount"`

--- a/operator/chart/values.schema.json
+++ b/operator/chart/values.schema.json
@@ -6527,6 +6527,9 @@
         }
       ]
     },
+    "topicSyncInterval": {
+      "type": "string"
+    },
     "vectorizedControllers": {
       "additionalProperties": false,
       "properties": {

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -66,6 +66,13 @@ imagePullSecrets: []
 # Valid values (from least to most verbose) are: `warn`, `info`, `debug`, and `trace`.
 logLevel: "info"
 
+# -- Default reconciliation interval for Topic resources.
+# Controls how often the operator opens a Kafka connection per topic to check for drift
+# between a Topic CR and the actual Kafka topic config. Lower values detect config drift
+# faster but generate more connections (one per topic per interval)
+# If unset, the operator built-in default of 3s is used.
+# topicSyncInterval: "30s"
+
 # -- Role-based Access Control (RBAC) configuration for the Redpanda Operator.
 rbac:
   # -- Enables the creation of additional RBAC roles.

--- a/operator/chart/values_partial.gen.go
+++ b/operator/chart/values_partial.gen.go
@@ -28,6 +28,7 @@ type PartialValues struct {
 	Config                *PartialConfig                "json:\"config,omitempty\""
 	ImagePullSecrets      []corev1.LocalObjectReference "json:\"imagePullSecrets,omitempty\""
 	LogLevel              *string                       "json:\"logLevel,omitempty\""
+	TopicSyncInterval     *string                       "json:\"topicSyncInterval,omitempty\""
 	RBAC                  *PartialRBAC                  "json:\"rbac,omitempty\""
 	Webhook               *PartialWebhook               "json:\"webhook,omitempty\""
 	ServiceAccount        *PartialServiceAccountConfig  "json:\"serviceAccount,omitempty\""

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -113,6 +113,7 @@ type RunOptions struct {
 	metricsCertKey                      string
 	enableGhostBrokerDecommissioner     bool
 	ghostBrokerDecommissionerSyncPeriod time.Duration
+	topicSyncInterval                   time.Duration
 	cloudSecretsEnabled                 bool
 	cloudSecretsPrefix                  string
 	cloudSecretsConfig                  pkgsecrets.ExpanderCloudConfiguration
@@ -162,6 +163,7 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.autoDeletePVCs, "auto-delete-pvcs", false, "Use StatefulSet PersistentVolumeClaimRetentionPolicy to auto delete PVCs on scale down and Cluster resource delete.")
 	cmd.Flags().BoolVar(&o.enableGhostBrokerDecommissioner, "enable-ghost-broker-decommissioner", false, "Enable ghost broker decommissioner.")
 	cmd.Flags().DurationVar(&o.ghostBrokerDecommissionerSyncPeriod, "ghost-broker-decommissioner-sync-period", time.Minute*5, "Ghost broker sync period. The Ghost Broker Decommissioner is guaranteed to be called after this period.")
+	cmd.Flags().DurationVar(&o.topicSyncInterval, "topic-sync-interval", 3*time.Second, "Default reconciliation interval for Topic resources. Controls how often the operator checks for drift between a Topic CR and the actual Kafka topic config. Per-resource overrides via spec.synchronizationInterval take precedence. Lower values detect drift faster but open more Kafka connections (one per topic per interval).")
 
 	// Secret store related flags.
 	cmd.Flags().BoolVar(&o.cloudSecretsEnabled, "enable-cloud-secrets", false, "Set to true if config values can reference secrets from cloud secret store")
@@ -459,7 +461,7 @@ func Run(
 		return err
 	}
 
-	if err := redpandacontrollers.SetupTopicController(ctx, mcmanager, cloudExpander, v1Controllers, v2Controllers, opts.namespace); err != nil {
+	if err := redpandacontrollers.SetupTopicController(ctx, mcmanager, cloudExpander, v1Controllers, v2Controllers, opts.namespace, opts.topicSyncInterval); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Topic")
 		return err
 	}

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -59,6 +59,9 @@ type TopicReconciler struct {
 	Manager      multicluster.Manager
 	Factory      internalclient.ClientFactory
 	RecordEvents bool
+	// SynchronizationInterval is the reconcile interval used when a Topic CR does not
+	// set spec.synchronizationInterval. Defaults to 3s if zero.
+	SynchronizationInterval time.Duration
 }
 
 //+kubebuilder:rbac:groups=cluster.redpanda.com,resources=topics,verbs=get;list;watch;update;patch
@@ -140,10 +143,11 @@ func (r *TopicReconciler) getRecorder(c cluster.Cluster) record.EventRecorder {
 	return nil
 }
 
-func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expander *secrets.CloudExpander, includeV1, includeV2 bool, namespace string) error {
+func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expander *secrets.CloudExpander, includeV1, includeV2 bool, namespace string, defaultSyncInterval time.Duration) error {
 	r := &TopicReconciler{
-		Manager: mgr,
-		Factory: internalclient.NewFactory(mgr, expander),
+		Manager:                 mgr,
+		Factory:                 internalclient.NewFactory(mgr, expander),
+		SynchronizationInterval: defaultSyncInterval,
 	}
 
 	builder := mcbuilder.ControllerManagedBy(mgr).
@@ -173,7 +177,10 @@ func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expande
 func (r *TopicReconciler) reconcile(ctx context.Context, recorder record.EventRecorder, topic *redpandav1alpha2.Topic, l logr.Logger) (*redpandav1alpha2.Topic, ctrl.Result, error) {
 	l = l.WithName("reconcile")
 
-	interval := metav1.Duration{Duration: time.Second * 3}
+	interval := metav1.Duration{Duration: r.SynchronizationInterval}
+	if interval.Duration == 0 {
+		interval.Duration = 3 * time.Second
+	}
 	if topic.Spec.SynchronizationInterval != nil {
 		interval = *topic.Spec.SynchronizationInterval
 	}

--- a/operator/internal/controller/redpanda/topic_controller_test.go
+++ b/operator/internal/controller/redpanda/topic_controller_test.go
@@ -912,6 +912,78 @@ func TestReconcile(t *testing.T) { // nolint:funlen // These tests have clear su
 		err = c.Get(ctx, key, &topic)
 		assert.True(t, apierrors.IsNotFound(err), "topic should be deleted after finalizer removal")
 	})
+	t.Run("reconciler_sync_interval_used_when_topic_does_not_override", func(t *testing.T) {
+		// Verify that TopicReconciler.SynchronizationInterval is used as the requeue
+		// interval when the Topic CR does not set spec.synchronizationInterval.
+		topicName := "reconciler-sync-interval-topic"
+
+		trCustomInterval := TopicReconciler{
+			Manager:                 mgr,
+			Factory:                 factory,
+			SynchronizationInterval: 45 * time.Second,
+		}
+
+		topic := redpandav1alpha2.Topic{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      topicName,
+				Namespace: testNamespace,
+			},
+			Spec: redpandav1alpha2.TopicSpec{
+				Partitions:        ptr.To(1),
+				ReplicationFactor: ptr.To(1),
+				KafkaAPISpec: &redpandav1alpha2.KafkaAPISpec{
+					Brokers: []string{seedBroker},
+				},
+				// SynchronizationInterval intentionally not set — reconciler default should apply.
+			},
+		}
+
+		err := c.Create(ctx, &topic)
+		require.NoError(t, err)
+
+		key := types.NamespacedName{Name: topicName, Namespace: testNamespace}
+		req := mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}, ClusterName: mcmanager.LocalCluster}
+
+		result, err := trCustomInterval.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, 45*time.Second, result.RequeueAfter)
+	})
+	t.Run("topic_spec_sync_interval_overrides_reconciler_default", func(t *testing.T) {
+		// Verify that spec.synchronizationInterval on the Topic CR takes precedence
+		// over TopicReconciler.SynchronizationInterval.
+		topicName := "topic-spec-interval-override"
+
+		trCustomInterval := TopicReconciler{
+			Manager:                 mgr,
+			Factory:                 factory,
+			SynchronizationInterval: 45 * time.Second,
+		}
+
+		topic := redpandav1alpha2.Topic{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      topicName,
+				Namespace: testNamespace,
+			},
+			Spec: redpandav1alpha2.TopicSpec{
+				Partitions:              ptr.To(1),
+				ReplicationFactor:       ptr.To(1),
+				SynchronizationInterval: &metav1.Duration{Duration: 10 * time.Second},
+				KafkaAPISpec: &redpandav1alpha2.KafkaAPISpec{
+					Brokers: []string{seedBroker},
+				},
+			},
+		}
+
+		err := c.Create(ctx, &topic)
+		require.NoError(t, err)
+
+		key := types.NamespacedName{Name: topicName, Namespace: testNamespace}
+		req := mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}, ClusterName: mcmanager.LocalCluster}
+
+		result, err := trCustomInterval.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	})
 }
 
 func TestUnsetStorageMode(t *testing.T) {


### PR DESCRIPTION
## Summary
Add a --topic-sync-interval CLI flag (default 3s, matching prior behaviour) that sets the reconcile interval for all Topic CRs when spec.synchronizationInterval is not set on the individual resource. Expose the flag as topicSyncInterval in the operator Helm chart values so it can be tuned without modifying every Topic CR.

Per-topic overrides via spec.synchronizationInterval continue to take precedence.

## Context
- I faced [this issue](https://github.com/redpanda-data/redpanda/issues/30385)
- Then I opened [this other PR](https://github.com/redpanda-data/redpanda-operator/pull/1503)
- Then I opened the current PR you are reading

Thank you!