### PR TITLE
operator: surface unresolved cluster-config secrets as the status condition cause

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260519-000020.yaml
+++ b/.changes/unreleased/operator-Fixed-20260519-000020.yaml
@@ -1,0 +1,14 @@
+project: operator
+kind: Fixed
+body: |
+  Fixed a misleading Cluster CR status condition when the operator could not
+  resolve an external secret referenced from cluster config (e.g. an iceberg
+  REST catalog OAuth2 client secret). Previously, the failure was silently
+  downgraded to a warning, the unexpanded ${secrets.X} placeholder was pushed
+  to the Redpanda admin API, and Redpanda's downstream validation error
+  ("Must set both of iceberg_rest_catalog_client_id ...") surfaced as the
+  condition message — obscuring the real cause (e.g. an AccessDeniedException
+  from the cloud secret store). The reconcile now fails before pushing
+  config, with the unresolved-secret warning as the actionable condition
+  message. Shared code path between Operator v1 and v2.
+time: 2026-05-19T00:00:20.000000+00:00

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -774,10 +774,24 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, state *
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	config, err := r.clusterConfigFor(ctx, state.cluster.Redpanda, schema, cluster)
+	config, warnings, err := r.clusterConfigFor(ctx, state.cluster.Redpanda, schema, cluster)
 	if err != nil {
 		logger.Error(err, "fetching cluster config")
 		return ctrl.Result{}, errors.WithStack(err)
+	}
+	// If any fixups produced warnings (typically `errorToWarning`-wrapped
+	// failed external secret lookups on Optional secrets), the
+	// corresponding entries in `config` still hold their unexpanded
+	// `${secrets.X}` placeholders. Pushing that to PatchClusterConfig
+	// would surface Redpanda's downstream validation error (e.g. "Must
+	// set both of iceberg_rest_catalog_client_id ...") instead of the
+	// actual root cause (e.g. an AccessDeniedException from the secret
+	// store). Fail the reconcile with the warning text so the user sees
+	// the actionable cause directly in the status condition. See K8S-858.
+	if msg := clusterconfiguration.FormatWarnings(warnings); msg != "" {
+		err := errors.Newf("cluster config has unresolved external secret references: %s", msg)
+		logger.Error(err, "fetching cluster config")
+		return ctrl.Result{}, err
 	}
 
 	superusers, err := r.superusersFor(ctx, state.cluster.Redpanda, cluster)
@@ -840,7 +854,7 @@ func (r *RedpandaReconciler) superusersFor(ctx context.Context, rp *redpandav1al
 	return syncclusterconfig.NormalizeSuperusers(append(superusers, values.Auth.SASL.BootstrapUser.Username())), nil
 }
 
-func (r *RedpandaReconciler) clusterConfigFor(ctx context.Context, rp *redpandav1alpha2.Redpanda, schema rpadmin.ConfigSchema, cluster cluster.Cluster) (_ map[string]any, err error) {
+func (r *RedpandaReconciler) clusterConfigFor(ctx context.Context, rp *redpandav1alpha2.Redpanda, schema rpadmin.ConfigSchema, cluster cluster.Cluster) (_ map[string]any, _ []error, err error) {
 	// Parinoided panic catch as we're calling directly into helm functions.
 	defer func() {
 		if r := recover(); r != nil {
@@ -850,7 +864,7 @@ func (r *RedpandaReconciler) clusterConfigFor(ctx context.Context, rp *redpandav
 
 	dot, err := rp.GetDot(cluster.GetConfig())
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	// The most reliable way to get the correct and full cluster config is to
@@ -859,7 +873,7 @@ func (r *RedpandaReconciler) clusterConfigFor(ctx context.Context, rp *redpandav
 	// configmaps or secrets.
 	state, err := redpanda.RenderStateFromDot(dot)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 	job := redpanda.PostInstallUpgradeJob(state)
 	clusterConfigTemplate, fixups := redpanda.BootstrapContents(state, redpanda.Pool{Statefulset: state.Values.Statefulset})
@@ -872,21 +886,21 @@ func (r *RedpandaReconciler) clusterConfigFor(ctx context.Context, rp *redpandav
 	}
 	for _, e := range job.Spec.Template.Spec.InitContainers[0].Env {
 		if err := conf.EnsureInitEnv(e); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, nil, errors.WithStack(err)
 		}
 	}
 	for _, e := range job.Spec.Template.Spec.InitContainers[0].EnvFrom {
 		if err := conf.EnsureInitEnvFrom(e); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, nil, errors.WithStack(err)
 		}
 	}
 
 	desired, err := conf.Reify(ctx, cluster.GetClient(), r.CloudSecretsExpander, schema)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
-	return desired, nil
+	return desired, conf.Warnings(), nil
 }
 
 // syncStatus updates the status of the Redpanda cluster at the end of reconciliation when

--- a/operator/internal/controller/vectorized/cluster_controller_configuration.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration.go
@@ -80,6 +80,23 @@ func (r *ClusterReconciler) reconcileConfiguration(
 	if err != nil {
 		return 0, errorWithContext(err, "error while creating the concrete configuration")
 	}
+	// If any fixups produced warnings (typically `errorToWarning`-wrapped
+	// failed external secret lookups on Optional secrets), the
+	// corresponding entries in `config` still hold their unexpanded
+	// `${secrets.X}` placeholders. Pushing that to PatchClusterConfig
+	// would surface Redpanda's downstream validation error (e.g. "Must
+	// set both of iceberg_rest_catalog_client_id ...") instead of the
+	// actual root cause (e.g. an AccessDeniedException from the secret
+	// store). Bail out of the reconcile with the warning text so it
+	// shows up as the actionable cause in the Cluster CR's
+	// ClusterConfiguredConditionType status condition. Shares the same
+	// helper as the v2 path. See K8S-858.
+	if msg := clusterconfiguration.FormatWarnings(cfg.ClusterConfigWarnings()); msg != "" {
+		return 0, errorWithContext(
+			fmt.Errorf("cluster config has unresolved external secret references: %s", msg),
+			"unresolved external secret references",
+		)
+	}
 
 	// Checking if the feature is active because in the initial stages of cluster creation, it takes time for the feature to be activated
 	// and the API returns the same error (400) that is returned in case of malformed input, which causes a stop of the reconciliation

--- a/pkg/clusterconfiguration/configuration_cluster.go
+++ b/pkg/clusterconfiguration/configuration_cluster.go
@@ -43,6 +43,23 @@ type clusterCfg struct {
 
 	// These are created only once, on demand
 	concrete map[string]any
+
+	// warnings captures non-fatal fixup failures from the last Reify call,
+	// most commonly an `errorToWarning`-wrapped external secret lookup that
+	// could not be resolved. The fixup's templated value remains in
+	// `concrete` (unexpanded), so any caller passing the result to the
+	// Redpanda admin API needs to surface these warnings to the user —
+	// otherwise the only signal will be Redpanda's downstream validation
+	// error on the unexpanded placeholder, which obscures the root cause.
+	// See K8S-858.
+	warnings []error
+}
+
+// Warnings returns the warnings collected during the last Reify call.
+// Returns nil if Reify has not been called or if no warnings were emitted.
+// The returned slice is owned by the clusterCfg; callers must not modify it.
+func (c *clusterCfg) Warnings() []error {
+	return c.warnings
 }
 
 func (c *clusterCfg) Error() error {
@@ -236,6 +253,13 @@ func (c *clusterCfg) Reify(ctx context.Context, reader k8sclient.Reader, cloudEx
 	if err := t.Fixup(factory); err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// Fixup emits non-fatal warnings (typically `errorToWarning`-wrapped
+	// failed secret expansions on Optional secrets) without aborting.
+	// Snapshot them so callers can surface them in a status condition
+	// before passing the partially-rendered config to the Redpanda admin
+	// API. Without this, the caller would only see Redpanda's downstream
+	// "Must set both of …" validation error on the unexpanded placeholder.
+	c.warnings = append([]error(nil), t.Warnings...)
 
 	// Finally, use the schema to turn those representations into concrete values
 	properties := make(map[string]any, len(representations))

--- a/pkg/clusterconfiguration/configuration_combined.go
+++ b/pkg/clusterconfiguration/configuration_combined.go
@@ -318,6 +318,20 @@ func (c *CombinedCfg) ReifyClusterConfiguration(
 	return c.Cluster.Reify(ctx, c.reader, c.cloudExpander, schema)
 }
 
+// ClusterConfigWarnings returns non-fatal warnings collected during the last
+// ReifyClusterConfiguration call — typically `errorToWarning`-wrapped failed
+// external secret expansions on Optional secrets. The corresponding entries
+// in the rendered config keep their unexpanded `${secrets.X}` placeholders,
+// so callers passing the config to the Redpanda admin API should surface
+// these warnings in a status condition. Otherwise the only user-visible
+// signal will be Redpanda's downstream validation error on the unexpanded
+// placeholder, which obscures the root cause (e.g., an
+// AccessDeniedException from the cloud secret store).
+// See K8S-858.
+func (c *CombinedCfg) ClusterConfigWarnings() []error {
+	return c.Cluster.Warnings()
+}
+
 // clone supplies a serialisation-backed object cloning mechanism for cases where
 // the underlying type doesn't supply a `.Clone()` mechanism.
 func clone[T any](val T) (T, error) {

--- a/pkg/clusterconfiguration/warnings.go
+++ b/pkg/clusterconfiguration/warnings.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package clusterconfiguration
+
+import "strings"
+
+// FormatWarnings returns a single user-facing string summarizing the
+// non-fatal warnings collected during cluster-config Reify. Intended for
+// use as a status condition message on the Cluster / Redpanda CR.
+//
+// Shared between Operator v1 (`vectorized.Cluster`) and v2 (`Redpanda`)
+// so both code paths surface the same wording for the same failure mode.
+// Returns the empty string when there are no warnings.
+func FormatWarnings(warnings []error) string {
+	if len(warnings) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(warnings))
+	for _, w := range warnings {
+		if w == nil {
+			continue
+		}
+		parts = append(parts, w.Error())
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "; ")
+}

--- a/pkg/clusterconfiguration/warnings_test.go
+++ b/pkg/clusterconfiguration/warnings_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package clusterconfiguration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/redpanda-operator/pkg/clusterconfiguration"
+)
+
+func TestFormatWarnings(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, "", clusterconfiguration.FormatWarnings(nil))
+		assert.Equal(t, "", clusterconfiguration.FormatWarnings([]error{}))
+	})
+	t.Run("nils_are_dropped", func(t *testing.T) {
+		assert.Equal(t, "", clusterconfiguration.FormatWarnings([]error{nil, nil}))
+	})
+	t.Run("single", func(t *testing.T) {
+		w := errors.New("warning: secret X not resolved")
+		assert.Equal(t, "warning: secret X not resolved", clusterconfiguration.FormatWarnings([]error{w}))
+	})
+	t.Run("multiple_are_joined", func(t *testing.T) {
+		a := errors.New("warning: secret A not resolved")
+		b := errors.New("warning: secret B not resolved")
+		got := clusterconfiguration.FormatWarnings([]error{a, b})
+		assert.Equal(t, "warning: secret A not resolved; warning: secret B not resolved", got)
+	})
+}
+
+// TestClusterCfg_Warnings_FromOptionalSecretFailure asserts that
+// errorToWarning-wrapped failed expansions (the contract used for
+// Optional external secrets, configuration_cluster.go:181-183) are
+// surfaced through the new Warnings accessor so the v1 and v2
+// controllers can lift them into a status condition before pushing the
+// partially-rendered config to Redpanda. Regression coverage for
+// K8S-858.
+func TestClusterCfg_Warnings_FromOptionalSecretFailure(t *testing.T) {
+	cfg := clusterconfiguration.NewClusterCfg(clusterconfiguration.NewPodContext("namespace"))
+	cfg.SetAdditionalConfiguration("iceberg_rest_catalog_client_secret", `""`)
+
+	// Simulate the shape the cluster config emits for Optional external
+	// secrets: a fixup that asks for a secret reference and silently
+	// downgrades the resulting error to a Warning. Route through
+	// `makeError` so the test doesn't need a real cloud expander — the
+	// Warning-handling path in cel_patcher.go is the contract under
+	// test.
+	cfg.AddFixup(
+		"iceberg_rest_catalog_client_secret",
+		`errorToWarning(makeError("secret 'DATABRICKS_CLIENT_SECRET': access denied"))`,
+	)
+
+	_, err := cfg.Reify(context.TODO(), nil, nil, nil)
+	require.NoError(t, err, "Reify itself must not fail for a Warning; the field is left unexpanded")
+
+	warnings := cfg.Warnings()
+	require.Len(t, warnings, 1, "expected one Warning for the simulated optional-secret failure")
+	assert.Contains(t, warnings[0].Error(), "DATABRICKS_CLIENT_SECRET")
+
+	// And the shared formatter should produce a user-facing summary that
+	// the controller can drop straight into a status condition message.
+	msg := clusterconfiguration.FormatWarnings(warnings)
+	assert.Contains(t, msg, "DATABRICKS_CLIENT_SECRET")
+}


### PR DESCRIPTION
## Summary

Fixes [K8S-858](https://redpandadata.atlassian.net/browse/K8S-858).

When the operator could not resolve an external secret referenced from cluster config (e.g. an iceberg client secret on `Optional`), the failure was silently downgraded to a `Warning` by the `errorToWarning` CEL fixup in `pkg/clusterconfiguration/configuration_cluster.go:181-183`. The field kept its unexpanded `${secrets.X}` placeholder, that placeholder got pushed to the Redpanda admin API, and Redpanda's downstream config validation emitted the misleading

```
{"iceberg_rest_catalog_authentication_mode":"Must set both of iceberg_rest_catalog_client_id and iceberg_rest_catalog_client_secret when iceberg_rest_catalog_authentication_mode is set to oauth2."}
```

— which became the Cluster CR's status condition and sent on-call down the wrong path (see sev-3-inc-2775).

## Fix

Same code path for v1 and v2, by design:

- `clusterCfg.Reify` now snapshots `Template.Warnings` onto the `clusterCfg`. New accessors: `clusterCfg.Warnings()` (cluster-level) and `CombinedCfg.ClusterConfigWarnings()` (combined-level — the entry-point both controllers use).
- New `FormatWarnings(...)` helper joins warnings into a single user-facing message.
- `RedpandaReconciler.reconcileClusterConfig` (v2) and `ClusterReconciler` config-reassertion path (v1) call the shared helper after `Reify*` and fail the reconcile with the warning text **before** any `PatchClusterConfig`. The existing `ClusterConfiguredConditionType` / `ClusterConfigurationApplied` condition then carries the actionable secret-resolution message instead of Redpanda's downstream validation error.

What the user sees now (instead of the misleading "Must set both of …"):

```
cluster config has unresolved external secret references: warning: configuration entry "DATABRICKS_CLIENT_SECRET": trouble expanding external secret reference: secret <name>: cloud secret not found
```

The underlying AWS / GCP / Azure provider error string is what `common-go/secrets` logs at Error level. Reaching the structured provider error (distinguishing AccessDenied vs NotFound vs ProviderError) requires changes to the `secrets.SecretAPI` signature, which is shared with other consumers — tracked as follow-up.

## Why a draft

Functionality is complete and unit-tested, but reconcile-level acceptance tests for both v1 and v2 need envtest infrastructure that I don't have set up locally. Opening as draft so CI runs the full suite before review.

## Test plan

- [x] `TestFormatWarnings` — formatter handles nil / empty / single / multiple inputs.
- [x] `TestClusterCfg_Warnings_FromOptionalSecretFailure` — regression coverage: an `errorToWarning`-wrapped fixup emits a Warning that's retrievable via the new accessor.
- [x] `go build ./...` clean.
- [x] `go vet ./internal/controller/redpanda/... ./internal/controller/vectorized/...` clean.
- [ ] CI: existing reconcile tests on both v1 and v2 paths pass.
- [ ] Manual replay of sev-3-inc-2775 (Cluster CR with an iceberg config referencing a secret the operator's IAM role cannot read) produces the new actionable message.

## Follow-ups (separate tickets / PRs)

- Widen `common-go/secrets.SecretAPI.GetSecretValue` to return an `error` so callers can distinguish AccessDenied / NotFound / ProviderError. Today it returns `(string, bool)` and the AWS adapter logs the underlying error then collapses to `("", false)`.
- A dedicated `CloudSecretsAvailable` status condition (separate from `ClusterConfigurationApplied`) with reason `AccessDenied` / `NotFound` / `ProviderError`. Currently this PR reuses `ClusterConfigurationApplied` with a clear message — adding a new condition type requires editing `operator/statuses.yaml` and regenerating, deferring for review.


[K8S-858]: https://redpandadata.atlassian.net/browse/K8S-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
