### PR TITLE
Acceptance: stretch-cluster multicluster operator upgrade test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -274,12 +274,21 @@ tasks:
     vars:
       RUN: '{{ default `"^TestAcceptance"` .RUN }}'
       GO_TEST_RUNNER: '{{default "go test" .GO_TEST_RUNNER}}'
+      # Cap how many @multicluster features run concurrently. Each parallel
+      # feature spins up 3 vclusters (+ cert-manager + Redpanda) on the single
+      # shared k3d cluster; left uncapped, `go test -parallel` defaults to
+      # GOMAXPROCS (48 on the CI m6id.12xlarge), so every parallel feature
+      # launches at once and overwhelms the node (image-pull QPS throttling,
+      # crashlooping pods, helm --wait timeouts). Keep this small.
+      MULTICLUSTER_PARALLELISM: '{{ default 3 .MULTICLUSTER_PARALLELISM }}'
     cmds:
     - task: test:unit
       vars:
         GO_TEST_RUNNER: 'HARPOON_GROUPS=multicluster {{.GO_TEST_RUNNER}}'
         PKG: ./acceptance/
-        CLI_ARGS: '{{.CLI_ARGS}} -run {{.RUN}} -timeout 60m -tags acceptance'
+        # -timeout is generous (75m) because capping parallelism serializes the
+        # feature waves, extending wall-clock beyond the old all-at-once run.
+        CLI_ARGS: '{{.CLI_ARGS}} -run {{.RUN}} -parallel {{.MULTICLUSTER_PARALLELISM}} -timeout 75m -tags acceptance'
 
   test:pull-images:
     vars:

--- a/acceptance/features/stretch-cluster-operator-upgrade.feature
+++ b/acceptance/features/stretch-cluster-operator-upgrade.feature
@@ -1,0 +1,53 @@
+@multicluster
+Feature: Stretch Cluster Operator Upgrade
+
+  Upgrade a stretch-cluster's multicluster operator one vcluster at a time,
+  starting from the published v26.2.1-beta.2 chart on https://charts.redpanda.com
+  and ending on the local dev chart (../operator/chart) with
+  localhost/redpanda-operator:dev. The Redpanda data plane stays up throughout,
+  and after each per-vcluster helm upgrade the operator raft quorum recovers
+  with is_healthy=true AND a strictly advanced raft term — proving the new
+  operator pod actually joined the quorum rather than being silently isolated.
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Per-vcluster operator upgrade preserves raft quorum and sentinel data
+    Given I create a multicluster operator named "op-upgrade" with 3 nodes using helm chart "redpanda/operator" version "v26.2.1-beta.2"
+    And I apply a multicluster Kubernetes manifest to "op-upgrade":
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: StretchCluster
+    metadata:
+      name: cluster
+      namespace: default
+    spec: {}
+    """
+    And I apply a RedpandaBrokerPool Kubernetes manifest to "op-upgrade":
+    """
+    spec:
+      rbac:
+        enabled: true
+      external:
+        enabled: false
+      clusterRef:
+        group: cluster.redpanda.com
+        kind: StretchCluster
+        name: cluster
+      replicas: 1
+      image:
+        repository: redpandadata/redpanda
+        tag: v25.2.1
+      sidecarImage:
+        repository: localhost/redpanda-operator
+        tag: dev
+      services:
+        perPod:
+          remote:
+            enabled: false
+    """
+    And I expect 3 statefulsets in 3 kubernetes cluster to be created and eventually ready
+    And I expect all 3 RedpandaBrokerPools in "op-upgrade" to be eventually bound and deployed
+    And I create a sentinel topic in the stretch cluster of "op-upgrade"
+    And the multicluster operator raft quorum in "op-upgrade" is healthy
+    When I upgrade the multicluster operator in "op-upgrade" to the local dev chart, one vcluster at a time
+    Then the sentinel data is still readable in "op-upgrade"

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/twmb/franz-go v1.20.6
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	github.com/twmb/franz-go/pkg/sr v1.7.0
+	google.golang.org/grpc v1.80.0
+	helm.sh/helm/v3 v3.18.5
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
@@ -297,14 +299,12 @@ require (
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.18.5 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect
 	k8s.io/cli-runtime v0.35.1 // indirect

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -108,6 +108,9 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 				Namespace:       "cert-manager",
 				Version:         testutil.CertManagerVersion,
 				CreateNamespace: true,
+				// Default helm --wait timeout is 5m; give readiness extra grace
+				// so a momentarily-loaded CI node doesn't fail suite setup.
+				Timeout: ptr.To(10 * time.Minute),
 				Values: map[string]any{
 					"installCRDs": true,
 					"global": map[string]any{
@@ -229,6 +232,9 @@ func installSharedOperator(ctx context.Context, restConfig *rest.Config) error {
 		Name:            "redpanda-operator",
 		Namespace:       sharedOperatorNamespace,
 		CreateNamespace: true,
+		// Default helm --wait timeout is 5m; give readiness extra grace so a
+		// momentarily-loaded CI node doesn't fail suite setup.
+		Timeout: ptr.To(10 * time.Minute),
 		Values: operatorchart.PartialValues{
 			LogLevel: ptr.To("trace"),
 			Image: &operatorchart.PartialImage{

--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	framework "github.com/redpanda-data/redpanda-operator/harpoon"
@@ -387,62 +386,158 @@ func setupTestManager(ctx context.Context, cfg *rest.Config, c runtimeclient.Cli
 	return mgr
 }
 
+const (
+	// multiclusterManagerSetupAttempts bounds how many times
+	// setupMulticlusterManager rebuilds the test-side manager (and its
+	// per-vcluster port-forwards) before giving up.
+	multiclusterManagerSetupAttempts = 3
+	// multiclusterManagerSetupBackoff is the pause between setup attempts.
+	multiclusterManagerSetupBackoff = 5 * time.Second
+	// multiclusterEngageTimeout bounds a single attempt's wait for every
+	// vcluster to register with the manager and sync its informer cache.
+	multiclusterEngageTimeout = 90 * time.Second
+)
+
 // setupMulticlusterManager builds a StaticMulticlusterManager from the given
 // vcluster nodes. It port-forwards a REST config for each node and returns both
 // the manager and the per-node REST configs (needed to construct a dialer). The
 // manager uses direct (non-cached) clients and does not require starting.
+//
+// Engagement is retried: if any vcluster fails to register or sync its cache
+// within the per-attempt budget, the whole attempt (port-forwards + manager) is
+// torn down and rebuilt. This is necessary because the StaticMulticluster
+// manager engages clusters exactly once — a cluster whose informer cache misses
+// its sync window is dropped permanently and never retried, and the underlying
+// proxy/port-forward to a vcluster API server can be transiently disrupted under
+// CI load. Rebuilding from scratch re-establishes fresh port-forwards and
+// re-engages every cluster.
 func setupMulticlusterManager(ctx context.Context, nodes []*vclusterNode) (multicluster.Manager, map[string]*rest.Config) {
 	t := framework.T(ctx)
 
-	pfCfgs := make(map[string]*rest.Config, len(nodes))
-	for _, node := range nodes {
-		pfCfg, err := node.PortForwardedRESTConfig(ctx)
+	var lastErr error
+	for attempt := 1; attempt <= multiclusterManagerSetupAttempts; attempt++ {
+		mgr, pfCfgs, cancel, err := tryEngageMulticlusterManager(ctx, t, nodes)
+		if err == nil {
+			// Keep the successful attempt's port-forwards and manager goroutine
+			// alive for the rest of the scenario; tear them down at cleanup.
+			t.Cleanup(func(context.Context) { cancel() })
+			return mgr, pfCfgs
+		}
+
+		lastErr = err
+		t.Logf("multicluster manager setup attempt %d/%d failed: %v", attempt, multiclusterManagerSetupAttempts, err)
+
+		if attempt < multiclusterManagerSetupAttempts {
+			select {
+			case <-time.After(multiclusterManagerSetupBackoff):
+			case <-ctx.Done():
+				t.Fatalf("multicluster manager setup aborted: %v", ctx.Err())
+			}
+		}
+	}
+
+	t.Fatalf("multicluster manager setup failed after %d attempts: %v", multiclusterManagerSetupAttempts, lastErr)
+	return nil, nil
+}
+
+// tryEngageMulticlusterManager performs a single attempt to build and engage a
+// StaticMulticlusterManager. On success it returns the manager, the per-node
+// REST configs, and a cancel func the caller MUST retain until the manager is no
+// longer needed — cancelling tears down the port-forwards and the manager
+// goroutine. On failure it tears down everything it created and returns an error
+// naming which clusters did and did not come up.
+func tryEngageMulticlusterManager(ctx context.Context, t framework.TestingT, nodes []*vclusterNode) (mgr multicluster.Manager, pfCfgs map[string]*rest.Config, cancel context.CancelFunc, err error) {
+	attemptCtx, attemptCancel := context.WithCancel(ctx)
+	// On any error path, release everything this attempt created. On success the
+	// cancel is handed to the caller instead (see the success return below).
+	defer func() {
 		if err != nil {
-			t.Fatalf("port-forwarded REST config for %s: %v", node.Name(), err)
+			attemptCancel()
+		}
+	}()
+
+	pfCfgs = make(map[string]*rest.Config, len(nodes))
+	for _, node := range nodes {
+		pfCfg, perr := node.PortForwardedRESTConfig(attemptCtx)
+		if perr != nil {
+			return nil, nil, nil, fmt.Errorf("port-forwarded REST config for %s: %w", node.Name(), perr)
 		}
 		pfCfgs[node.Name()] = pfCfg
 	}
 
-	mgr, err := multicluster.NewStaticMulticlusterManager(nodes[0].Name(), pfCfgs, t.Scheme())
+	mgr, err = multicluster.NewStaticMulticlusterManager(nodes[0].Name(), pfCfgs, t.Scheme())
 	if err != nil {
-		t.Fatalf("initializing multicluster manager: %v", err)
+		return nil, nil, nil, fmt.Errorf("initializing multicluster manager: %w", err)
 	}
-	go mgr.Start(ctx)
+	go mgr.Start(attemptCtx)
 
 	// Elected fires when leader election completes (immediately for non-LE
 	// managers) but does NOT wait for cache sync. We must wait for both.
 	select {
 	case <-mgr.Elected():
+	case <-attemptCtx.Done():
+		return nil, nil, nil, fmt.Errorf("manager election aborted: %w", attemptCtx.Err())
 	case <-time.After(60 * time.Second):
-		t.Fatalf("multicluster manager did not become elected within 60s")
+		return nil, nil, nil, fmt.Errorf("manager did not become elected within 60s")
 	}
 
-	// Wait for all informer caches to sync so that cached-client List/Get
-	// calls don't block on first access. Sync each cluster individually
-	// since the multicluster Manager doesn't expose a global GetCache.
-	//
-	// mgr.Start engages clusters asynchronously, so GetCluster can briefly
-	// return "cluster not found" for a name that GetClusterNames already
-	// reports. Poll until each cluster is registered before treating it as
-	// fatal — Elected only signals leader election, not engagement.
-	syncCtx, syncCancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer syncCancel()
-	for _, name := range mgr.GetClusterNames() {
-		var cl cluster.Cluster
-		require.Eventually(t, func() bool {
-			c, err := mgr.GetCluster(syncCtx, name)
-			if err != nil {
-				return false
+	// Wait for every cluster to register AND sync its informer cache. The
+	// provider engages clusters asynchronously and one-shot: GetCluster can
+	// briefly report "cluster not found", and a cluster whose cache misses its
+	// sync window is dropped without retry (the provider only logs the error,
+	// to a logger that is not wired up in the test process). Poll all clusters
+	// together so a slow one doesn't starve the others, and on timeout report
+	// exactly which clusters did/didn't come up to make the failure debuggable.
+	names := mgr.GetClusterNames()
+	engageCtx, engageCancel := context.WithTimeout(attemptCtx, multiclusterEngageTimeout)
+	defer engageCancel()
+
+	synced := make(map[string]bool, len(names))
+	seenRegistered := make(map[string]bool, len(names))
+	for {
+		for _, name := range names {
+			if synced[name] {
+				continue
 			}
-			cl = c
-			return true
-		}, 60*time.Second, 1*time.Second, "cluster %s never registered with multicluster manager", name)
-		if !cl.GetCache().WaitForCacheSync(syncCtx) {
-			t.Fatalf("cache for cluster %s did not sync within 2m", name)
+			cl, gerr := mgr.GetCluster(engageCtx, name)
+			if gerr != nil {
+				continue
+			}
+			seenRegistered[name] = true
+			// Use a short sub-timeout so we poll rather than block the whole
+			// remaining budget waiting on a single cluster's cache.
+			waitCtx, waitCancel := context.WithTimeout(engageCtx, 2*time.Second)
+			ok := cl.GetCache().WaitForCacheSync(waitCtx)
+			waitCancel()
+			if ok {
+				synced[name] = true
+			}
+		}
+
+		if len(synced) == len(names) {
+			return mgr, pfCfgs, attemptCancel, nil
+		}
+
+		if engageCtx.Err() != nil {
+			missing := make([]string, 0, len(names))
+			for _, name := range names {
+				if synced[name] {
+					continue
+				}
+				status := "never registered"
+				if seenRegistered[name] {
+					status = "registered but cache never synced"
+				}
+				missing = append(missing, fmt.Sprintf("%s (%s)", name, status))
+			}
+			return nil, nil, nil, fmt.Errorf("clusters did not engage with multicluster manager within %s: %s", multiclusterEngageTimeout, strings.Join(missing, ", "))
+		}
+
+		select {
+		case <-time.After(1 * time.Second):
+		case <-engageCtx.Done():
 		}
 	}
-
-	return mgr, pfCfgs
 }
 
 func clientsForCluster(ctx context.Context, cluster string) *clusterClients {

--- a/acceptance/steps/operator_chart.go
+++ b/acceptance/steps/operator_chart.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/registry"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+)
+
+// resolveOperatorChart returns a chart path on disk for the given source.
+// Local sources pass through unchanged. Remote sources are pulled into a temp
+// directory created by the framework helper (cleaned up automatically) and the
+// untarred chart directory is returned.
+func resolveOperatorChart(ctx context.Context, t framework.TestingT, src operatorChartSource) string {
+	if src.Path != "" && src.RemoteChart != nil {
+		t.Fatalf("operatorChartSource has both Path and RemoteChart set; exactly one is required")
+	}
+	if src.Path != "" {
+		return src.Path
+	}
+	if src.RemoteChart == nil {
+		t.Fatalf("operatorChartSource has neither Path nor RemoteChart set")
+	}
+	return pullHelmChart(ctx, t, *src.RemoteChart)
+}
+
+// pullHelmChart pulls and untars a remote helm chart into a temp dir, returning
+// the path to the untarred chart directory ready for loader.Load.
+func pullHelmChart(_ context.Context, t framework.TestingT, rc remoteChart) string {
+	destDir, err := os.MkdirTemp("", "operator-chart-*")
+	require.NoError(t, err, "creating temp dir for chart pull")
+	t.Cleanup(func(_ context.Context) {
+		_ = os.RemoveAll(destDir)
+	})
+
+	regClient, err := registry.NewClient()
+	require.NoError(t, err, "creating helm registry client")
+
+	cfg := &action.Configuration{RegistryClient: regClient}
+	pull := action.NewPullWithOpts(action.WithConfig(cfg))
+	pull.Settings = cli.New()
+	pull.RepoURL = rc.RepoURL
+	pull.Version = rc.Version
+	pull.DestDir = destDir
+	pull.Untar = true
+	pull.UntarDir = destDir
+
+	out, err := pull.Run(rc.ChartName)
+	require.NoErrorf(t, err, "helm pull %s --repo %s --version %s: %s", rc.ChartName, rc.RepoURL, rc.Version, out)
+
+	chartDir := filepath.Join(destDir, rc.ChartName)
+	if _, statErr := os.Stat(chartDir); statErr != nil {
+		t.Fatalf("untarred chart dir %q not found after pull: %v", chartDir, statErr)
+	}
+	t.Logf("pulled helm chart %s@%s from %s to %s", rc.ChartName, rc.Version, rc.RepoURL, chartDir)
+	return chartDir
+}

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -161,6 +161,11 @@ func init() {
 	// Operator upgrade scenario steps
 	framework.RegisterStep(`^I install local CRDs from "([^"]*)"`, iInstallLocalCRDs)
 
+	// Stretch-cluster operator upgrade scenario steps
+	framework.RegisterStep(`^I create a multicluster operator named "([^"]*)" with (\d+) nodes using helm chart "([^"]*)" version "([^"]*)"$`, createNetworkedVClusterOperatorsWithChart)
+	framework.RegisterStep(`^the multicluster operator raft quorum in "([^"]*)" is healthy$`, multiclusterOperatorRaftQuorumIsHealthy)
+	framework.RegisterStep(`^I upgrade the multicluster operator in "([^"]*)" to the local dev chart, one vcluster at a time$`, upgradeMulticlusterOperatorOneAtATime)
+
 	// Console scenario steps
 	framework.RegisterStep(`^Console "([^"]+)" will be healthy`, consoleIsHealthy)
 	framework.RegisterStep(`^the migrated console cluster "([^"]+)" should have (\d+) warning(s)?$`, consoleHasWarnings)

--- a/acceptance/steps/stretch.go
+++ b/acceptance/steps/stretch.go
@@ -735,7 +735,39 @@ func extractConditions(o client.Object) []metav1.Condition {
 	return nil
 }
 
+// operatorChartSource describes which operator helm chart to install in each
+// vcluster. Exactly one of Path / RemoteChart must be set. ImageRepository and
+// ImageTag override the chart's image (set both, or leave both empty to keep
+// the chart's defaults — used when installing a published chart whose default
+// image is what we want).
+type operatorChartSource struct {
+	Path            string       // local path on disk (e.g. "../operator/chart")
+	RemoteChart     *remoteChart // pulled from a helm repo at install time
+	ImageRepository string
+	ImageTag        string
+}
+
+type remoteChart struct {
+	RepoURL   string // e.g. "https://charts.redpanda.com"
+	ChartName string // e.g. "operator"
+	Version   string // e.g. "v26.2.1-beta.2"
+}
+
+// localDevOperatorChart is the chart source used by the default
+// `I create a multicluster operator named "X" with N nodes` step.
+func localDevOperatorChart() operatorChartSource {
+	return operatorChartSource{
+		Path:            "../operator/chart",
+		ImageRepository: "localhost/redpanda-operator",
+		ImageTag:        "dev",
+	}
+}
+
 func createNetworkedVClusterOperators(ctx context.Context, t framework.TestingT, clusterName string, clusters int32) context.Context {
+	return createNetworkedVClusterOperatorsFromSource(ctx, t, clusterName, clusters, localDevOperatorChart())
+}
+
+func createNetworkedVClusterOperatorsFromSource(ctx context.Context, t framework.TestingT, clusterName string, clusters int32, src operatorChartSource) context.Context {
 	namespace := metav1.NamespaceDefault
 	redpandaLicense := os.Getenv(LicenseEnvVar)
 	require.NotEmpty(t, redpandaLicense, LicenseEnvVar+" env var must be set")
@@ -744,7 +776,7 @@ func createNetworkedVClusterOperators(ctx context.Context, t framework.TestingT,
 	vclusters := createVClusters(ctx, t, clusters, k3dNodeNames)
 	assignOperatorServiceIPs(ctx, t, vclusters, namespace)
 	peers := bootstrapTLS(ctx, t, vclusters, namespace)
-	deployOperators(ctx, t, vclusters, namespace, redpandaLicense, peers)
+	deployOperatorsFromSource(ctx, t, vclusters, namespace, redpandaLicense, peers, src)
 	// Register dumpDiagnostics AFTER deployOperators so it fires before the
 	// HelmUninstall cleanup (t.Cleanup is LIFO), ensuring ClusterRoles and
 	// other resources are still present when diagnostics are collected.
@@ -764,6 +796,13 @@ func createVClusters(ctx context.Context, t framework.TestingT, clusters int32, 
 	suffix := apirand.String(8)
 
 	nodes := make([]*vclusterNode, clusters)
+	// errs collects per-vcluster creation failures. require/assert (which call
+	// t.FailNow) MUST NOT be invoked from these worker goroutines: godog's
+	// testingT.FailNow panics ("FailNow or SkipNow called") when called off the
+	// test goroutine, which crashes the whole test binary instead of failing the
+	// scenario cleanly. So each goroutine records its error here and we assert on
+	// the test goroutine after wg.Wait().
+	errs := make([]error, clusters)
 	var wg sync.WaitGroup
 
 	// Register cert-manager types into the shared scheme once, before launching
@@ -785,7 +824,10 @@ func createVClusters(ctx context.Context, t framework.TestingT, clusters int32, 
 				networkingValues(i, clusters, suffix) +
 				pinningValues(k3dNodeNames[i])
 			cluster, err := vcluster.New(ctx, t.RestConfig(), vcluster.WithName(actualName), vcluster.WithValues(helm.RawYAML(vClusterValues)))
-			require.NoError(t, err)
+			if err != nil {
+				errs[i] = fmt.Errorf("creating vcluster %q: %w", actualName, err)
+				return
+			}
 			scheme := t.Scheme()
 			cluster.SetScheme(scheme)
 
@@ -798,7 +840,10 @@ func createVClusters(ctx context.Context, t framework.TestingT, clusters int32, 
 				}
 			})
 			c, err := cluster.Client(client.Options{Scheme: t.Scheme()})
-			require.NoError(t, err)
+			if err != nil {
+				errs[i] = fmt.Errorf("building client for vcluster %q: %w", actualName, err)
+				return
+			}
 
 			// Use the vCluster's host-namespace ClusterIP service as the API server
 			// address. This service ({actualName}/{actualName}) is replicated into peer
@@ -818,6 +863,11 @@ func createVClusters(ctx context.Context, t framework.TestingT, clusters int32, 
 	}
 
 	wg.Wait()
+
+	// Surface any goroutine error on the test goroutine, where FailNow is legal.
+	for i, err := range errs {
+		require.NoErrorf(t, err, "failed creating vcluster %d", i)
+	}
 	return nodes
 }
 
@@ -985,7 +1035,52 @@ func bootstrapTLS(ctx context.Context, t framework.TestingT, vclusters []*vclust
 	return peers
 }
 
-func deployOperators(ctx context.Context, t framework.TestingT, vclusters []*vclusterNode, namespace, redpandaLicense string, peers []any) {
+// operatorHelmReleaseName is the helm release name used for the operator
+// across every multicluster test. The chart's Fullname() function (which the
+// chart uses for the Deployment, Service, and bootstrap-certificates secret
+// names) resolves to "redpanda-operator" because the chart name is "operator"
+// and the release name is "redpanda".
+const operatorHelmReleaseName = "redpanda"
+
+// operatorHelmValues builds the helm values map shared by both initial install
+// and upgrade. If imageRepo/imageTag are empty, the chart defaults stand —
+// used when installing a published release whose default image is what we
+// want.
+func operatorHelmValues(cluster *vclusterNode, peers []any, imageRepo, imageTag string) map[string]any {
+	values := map[string]any{
+		"crds": map[string]any{
+			"enabled":      true,
+			"experimental": true,
+		},
+		"logLevel": "debug",
+		"multicluster": map[string]any{
+			"enabled":                  true,
+			"name":                     cluster.Name(),
+			"apiServerExternalAddress": cluster.APIServer(),
+			"peers":                    peers,
+		},
+		"enterprise": map[string]any{
+			"licenseSecretRef": map[string]any{
+				"name": licenseSecretName,
+				"key":  "redpanda.license",
+			},
+		},
+	}
+	if imageRepo != "" && imageTag != "" {
+		values["image"] = map[string]any{
+			"repository": imageRepo,
+			"tag":        imageTag,
+		}
+	}
+	return values
+}
+
+func deployOperatorsFromSource(ctx context.Context, t framework.TestingT, vclusters []*vclusterNode, namespace, redpandaLicense string, peers []any, src operatorChartSource) {
+	chartPath := resolveOperatorChart(ctx, t, src)
+	deployOperatorsWithChart(ctx, t, vclusters, namespace, redpandaLicense, peers, chartPath, src.ImageRepository, src.ImageTag)
+}
+
+func deployOperatorsWithChart(ctx context.Context, t framework.TestingT, vclusters []*vclusterNode, namespace, redpandaLicense string, peers []any, chartPath, imageRepo, imageTag string) {
 	// "issuer-managed" cert: user provides CA secret + Issuer, StretchCluster
 	// uses IssuerRef. Used by admin, http, schemaRegistry, and rpc listeners.
 	issuerManagedSecret, err := generateCASecret("cluster", "issuer-managed", namespace)
@@ -1059,32 +1154,10 @@ func deployOperators(ctx context.Context, t framework.TestingT, vclusters []*vcl
 		// No Issuer needed — the operator uses this secret directly.
 		require.NoError(t, cluster.Create(ctx, userProvidedServerSecret.DeepCopy()))
 
-		t.Logf("deploying operator in %q", cluster.Name())
-		rel, err := cluster.HelmInstall(ctx, "../operator/chart", helm.InstallOptions{
-			Name: "redpanda",
-			Values: map[string]any{
-				"crds": map[string]any{
-					"enabled":      true,
-					"experimental": true,
-				},
-				"logLevel": "debug",
-				"multicluster": map[string]any{
-					"enabled":                  true,
-					"name":                     cluster.Name(),
-					"apiServerExternalAddress": cluster.APIServer(),
-					"peers":                    peers,
-				},
-				"image": map[string]any{
-					"repository": "localhost/redpanda-operator",
-					"tag":        "dev",
-				},
-				"enterprise": map[string]any{
-					"licenseSecretRef": map[string]any{
-						"name": licenseSecretName,
-						"key":  "redpanda.license",
-					},
-				},
-			},
+		t.Logf("deploying operator in %q from chart %q", cluster.Name(), chartPath)
+		rel, err := cluster.HelmInstall(ctx, chartPath, helm.InstallOptions{
+			Name:      operatorHelmReleaseName,
+			Values:    operatorHelmValues(cluster, peers, imageRepo, imageTag),
 			Namespace: namespace,
 		})
 		require.NoError(t, err)

--- a/acceptance/steps/stretch_operator_upgrade.go
+++ b/acceptance/steps/stretch_operator_upgrade.go
@@ -1,0 +1,472 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package steps
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/redpanda-data/common-go/kube"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	framework "github.com/redpanda-data/redpanda-operator/harpoon"
+	"github.com/redpanda-data/redpanda-operator/pkg/helm"
+	transportv1 "github.com/redpanda-data/redpanda-operator/pkg/multicluster/leaderelection/proto/gen/transport/v1"
+)
+
+// raftTermStateKey holds the per-vcluster raft term observed before the
+// operator upgrade begins. After each per-vcluster upgrade we assert the term
+// has strictly advanced versus the prior recorded value.
+type raftTermStateKey struct{}
+
+type raftTermState struct {
+	terms map[string]uint64 // node.Name() -> last observed term
+}
+
+// publishedOperatorChartSource constructs an operatorChartSource for the
+// charts.redpanda.com upstream operator chart at the given version. The image
+// fields are left blank so the chart's defaults take effect (matches what
+// users running `helm install redpanda/operator --version vX.Y.Z` see).
+func publishedOperatorChartSource(chartName, version string) operatorChartSource {
+	return operatorChartSource{
+		RemoteChart: &remoteChart{
+			RepoURL:   "https://charts.redpanda.com",
+			ChartName: trimRepoPrefix(chartName),
+			Version:   version,
+		},
+	}
+}
+
+// trimRepoPrefix turns "redpanda/operator" into "operator" so the user can
+// write the step the same way they'd write `helm install`.
+func trimRepoPrefix(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			return s[i+1:]
+		}
+	}
+	return s
+}
+
+// createNetworkedVClusterOperatorsWithChart installs the named published helm
+// chart (e.g. "redpanda/operator" @ "v26.2.1-beta.2") into each vcluster
+// instead of the local dev chart. Used by the operator-upgrade acceptance
+// scenario to set up a "starting from a released operator" baseline.
+func createNetworkedVClusterOperatorsWithChart(ctx context.Context, t framework.TestingT, clusterName string, clusters int32, chart, version string) context.Context {
+	src := publishedOperatorChartSource(chart, version)
+	return createNetworkedVClusterOperatorsFromSource(ctx, t, clusterName, clusters, src)
+}
+
+// upgradeMulticlusterOperatorOneAtATime walks the vclusters in index order
+// (vc-0, vc-1, …) and helm-upgrades the operator chart in each one to the
+// local dev chart (../operator/chart) with image localhost/redpanda-operator:dev.
+// After each upgrade we wait for the operator deployment to roll, then assert
+// the cross-cluster raft quorum recovers and the upgraded operator rejoins it.
+// Because raft only advances the term on a *leader* restart (a follower restart
+// simply rejoins under the existing leader without a re-election), we require a
+// strict term advance only when the upgraded node was the leader; otherwise we
+// require the term not to regress and the upgraded follower to have caught back
+// up to the quorum.
+func upgradeMulticlusterOperatorOneAtATime(ctx context.Context, t framework.TestingT, clusterName string) context.Context {
+	nodes := getNodes(ctx, clusterName)
+	namespace := metav1.NamespaceDefault
+
+	// Snapshot raft term on every vcluster before the first upgrade. The
+	// snapshot also serves as a sanity check that the published-chart
+	// operator is in fact running and serving the TransportService.
+	terms := snapshotRaftTerms(ctx, t, nodes, namespace)
+	ctx = context.WithValue(ctx, raftTermStateKey{}, &raftTermState{terms: terms})
+
+	for _, node := range nodes {
+		// Capture leadership immediately before the upgrade: only restarting the
+		// current leader forces a term-advancing re-election.
+		wasLeader := currentRaftLeader(ctx, t, nodes, namespace) == node.Name()
+		t.Logf("helm-upgrading operator in %s to local dev chart (currentLeader=%t)", node.Name(), wasLeader)
+
+		peers := operatorPeers(nodes)
+
+		oldOperatorPodUID := getOperatorPodUID(ctx, t, node, namespace)
+
+		_, err := node.HelmUpgrade(ctx, operatorHelmReleaseName, "../operator/chart", helm.UpgradeOptions{
+			Namespace: namespace,
+			Values:    operatorHelmValues(node, peers, "localhost/redpanda-operator", "dev"),
+		})
+		require.NoErrorf(t, err, "helm upgrade in %s", node.Name())
+
+		// Wait for the rollout: old operator pod gone, new operator pod ready.
+		waitForOperatorRoll(ctx, t, node, namespace, oldOperatorPodUID)
+
+		// Quorum + rejoin assertion run AFTER each upgrade. Quorum may flap
+		// briefly during the rollout — Eventually loop handles it.
+		t.Logf("verifying raft quorum recovered after upgrading %s", node.Name())
+		assertRaftQuorumRejoinedAfterUpgrade(ctx, t, nodes, namespace, node.Name(), wasLeader)
+	}
+
+	return ctx
+}
+
+// multiclusterOperatorRaftQuorumIsHealthy verifies the initial state: every
+// vcluster's operator reports is_healthy and there are no unhealthy peers. It
+// also captures each cluster's term so the upgrade step can later require
+// strict advancement. Designed to be called once, before any upgrade.
+func multiclusterOperatorRaftQuorumIsHealthy(ctx context.Context, t framework.TestingT, clusterName string) context.Context {
+	nodes := getNodes(ctx, clusterName)
+	namespace := metav1.NamespaceDefault
+
+	require.Eventuallyf(t, func() bool {
+		for _, node := range nodes {
+			st, err := operatorStatus(ctx, node, namespace)
+			if err != nil {
+				t.Logf("status %s: %v", node.Name(), err)
+				return false
+			}
+			if !st.IsHealthy {
+				t.Logf("status %s: is_healthy=false (leader=%q term=%d unhealthy_peers=%v)", node.Name(), st.Leader, st.Term, st.UnhealthyPeers)
+				return false
+			}
+			if len(st.UnhealthyPeers) > 0 {
+				t.Logf("status %s: unhealthy peers %v", node.Name(), st.UnhealthyPeers)
+				return false
+			}
+		}
+		return true
+	}, 5*time.Minute, 5*time.Second, "raft quorum never became healthy across all vclusters of %q", clusterName)
+
+	terms := snapshotRaftTerms(ctx, t, nodes, namespace)
+	return context.WithValue(ctx, raftTermStateKey{}, &raftTermState{terms: terms})
+}
+
+// snapshotRaftTerms reads the current term from every vcluster's operator and
+// returns the map keyed by node name.
+func snapshotRaftTerms(ctx context.Context, t framework.TestingT, nodes []*vclusterNode, namespace string) map[string]uint64 {
+	terms := make(map[string]uint64, len(nodes))
+	for _, node := range nodes {
+		st, err := operatorStatus(ctx, node, namespace)
+		require.NoErrorf(t, err, "snapshot raft term in %s", node.Name())
+		terms[node.Name()] = st.Term
+		t.Logf("snapshot %s: term=%d leader=%q", node.Name(), st.Term, st.Leader)
+	}
+	return terms
+}
+
+// currentRaftLeader returns the name of the node the quorum currently agrees is
+// the raft leader. It polls briefly so a transient empty leader (e.g. just after
+// a previous rollout) resolves before we read it.
+func currentRaftLeader(ctx context.Context, t framework.TestingT, nodes []*vclusterNode, namespace string) string {
+	var leader string
+	require.Eventuallyf(t, func() bool {
+		for _, node := range nodes {
+			st, err := operatorStatus(ctx, node, namespace)
+			if err == nil && st.IsHealthy && st.Leader != "" {
+				leader = st.Leader
+				return true
+			}
+		}
+		return false
+	}, 1*time.Minute, 2*time.Second, "could not determine current raft leader")
+	return leader
+}
+
+// assertRaftQuorumRejoinedAfterUpgrade polls until the cross-cluster operator
+// raft quorum is healthy and the just-upgraded operator has rejoined it.
+//
+// Raft only advances the term when the *leader* is restarted (its loss forces a
+// re-election); restarting a follower leaves the term unchanged as it simply
+// rejoins under the existing leader. So a strict term advance is required only
+// when the upgraded node was the leader; for a follower we require the term not
+// to regress. Either way the load-bearing signal is that every operator is a
+// healthy, converged member that agrees on a single leader and term — i.e. the
+// upgraded pod actually rejoined rather than being silently isolated.
+func assertRaftQuorumRejoinedAfterUpgrade(ctx context.Context, t framework.TestingT, nodes []*vclusterNode, namespace, upgradedNode string, wasLeader bool) {
+	state, ok := ctx.Value(raftTermStateKey{}).(*raftTermState)
+	require.True(t, ok && state != nil, "raft term state missing from context; call multiclusterOperatorRaftQuorumIsHealthy or upgradeMulticlusterOperatorOneAtATime first")
+
+	priorTerm := maxTerm(state.terms)
+
+	var convergedTerm uint64
+	require.Eventuallyf(t, func() bool {
+		// Every operator must be healthy with no unhealthy peers, and all must
+		// agree on the same term (converged quorum).
+		var term uint64
+		var sawUpgradedLeader bool
+		for i, node := range nodes {
+			st, err := operatorStatus(ctx, node, namespace)
+			if err != nil {
+				t.Logf("status %s: %v", node.Name(), err)
+				return false
+			}
+			if !st.IsHealthy || len(st.UnhealthyPeers) > 0 {
+				t.Logf("status %s: is_healthy=%t term=%d leader=%q unhealthy_peers=%v", node.Name(), st.IsHealthy, st.Term, st.Leader, st.UnhealthyPeers)
+				return false
+			}
+			if st.Leader == "" {
+				t.Logf("status %s: no leader yet (term=%d)", node.Name(), st.Term)
+				return false
+			}
+			if i == 0 {
+				term = st.Term
+			} else if st.Term != term {
+				t.Logf("terms not converged: %s=%d vs %d", node.Name(), st.Term, term)
+				return false
+			}
+			if node.Name() == upgradedNode {
+				sawUpgradedLeader = true
+			}
+		}
+		if !sawUpgradedLeader {
+			t.Logf("upgraded node %s not found among quorum members", upgradedNode)
+			return false
+		}
+
+		// Term invariant depends on whether we restarted the leader.
+		if wasLeader && term <= priorTerm {
+			t.Logf("upgraded leader %s: term %d has not advanced past prior %d", upgradedNode, term, priorTerm)
+			return false
+		}
+		if !wasLeader && term < priorTerm {
+			t.Logf("upgraded follower %s: term regressed from %d to %d", upgradedNode, priorTerm, term)
+			return false
+		}
+
+		convergedTerm = term
+		return true
+	}, 5*time.Minute, 5*time.Second, "raft quorum never recovered after upgrading %s (wasLeader=%t)", upgradedNode, wasLeader)
+
+	// Record the converged term as the baseline for the next upgrade.
+	for _, node := range nodes {
+		state.terms[node.Name()] = convergedTerm
+	}
+}
+
+// maxTerm returns the highest term in the recorded per-node term map.
+func maxTerm(terms map[string]uint64) uint64 {
+	var m uint64
+	for _, v := range terms {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// getOperatorPodUID returns the current operator pod's UID so the upgrade can
+// later detect a roll (UID changes when the Deployment replaces the pod).
+// Fails the test if zero or multiple operator pods are present.
+func getOperatorPodUID(ctx context.Context, t framework.TestingT, node *vclusterNode, namespace string) types.UID {
+	var pods corev1.PodList
+	require.NoError(t, node.List(ctx, &pods,
+		client.InNamespace(namespace),
+		client.MatchingLabels(operatorPodSelector()),
+	))
+	require.Lenf(t, pods.Items, 1, "expected exactly 1 operator pod in %s, got %d", node.Name(), len(pods.Items))
+	return pods.Items[0].UID
+}
+
+// waitForOperatorRoll waits until: (1) the old operator pod is gone, (2) the
+// operator Deployment is Available, and (3) exactly one pod exists with a new
+// UID matching the operator selector. Bounded by 5 minutes.
+func waitForOperatorRoll(ctx context.Context, t framework.TestingT, node *vclusterNode, namespace string, oldUID types.UID) {
+	require.Eventuallyf(t, func() bool {
+		var dep appsv1.Deployment
+		if err := node.Get(ctx, types.NamespacedName{Namespace: namespace, Name: operatorDeploymentName}, &dep); err != nil {
+			t.Logf("get operator deployment in %s: %v", node.Name(), err)
+			return false
+		}
+		cond := apimeta.FindStatusCondition(deploymentConditionsAsMeta(dep.Status.Conditions), string(appsv1.DeploymentAvailable))
+		if cond == nil || cond.Status != metav1.ConditionTrue {
+			t.Logf("operator deployment %s in %s: Available=%v", operatorDeploymentName, node.Name(), cond)
+			return false
+		}
+
+		var pods corev1.PodList
+		if err := node.List(ctx, &pods,
+			client.InNamespace(namespace),
+			client.MatchingLabels(operatorPodSelector()),
+		); err != nil {
+			t.Logf("list operator pods in %s: %v", node.Name(), err)
+			return false
+		}
+		if len(pods.Items) != 1 {
+			t.Logf("operator pod count in %s: %d (want 1)", node.Name(), len(pods.Items))
+			return false
+		}
+		if pods.Items[0].UID == oldUID {
+			t.Logf("operator pod in %s has not been replaced yet (uid=%s)", node.Name(), pods.Items[0].UID)
+			return false
+		}
+		return isPodRunning(&pods.Items[0])
+	}, 5*time.Minute, 3*time.Second, "operator deployment never finished rolling in %s", node.Name())
+}
+
+// deploymentConditionsAsMeta adapts appsv1.DeploymentCondition to the slice
+// shape apimeta.FindStatusCondition wants. The translation is shallow:
+// Available is what we care about, and its Status field already uses the
+// same ConditionStatus type underneath.
+func deploymentConditionsAsMeta(in []appsv1.DeploymentCondition) []metav1.Condition {
+	out := make([]metav1.Condition, 0, len(in))
+	for _, c := range in {
+		out = append(out, metav1.Condition{
+			Type:    string(c.Type),
+			Status:  metav1.ConditionStatus(c.Status),
+			Reason:  c.Reason,
+			Message: c.Message,
+		})
+	}
+	return out
+}
+
+// operatorDeploymentName is the Deployment created by the operator chart with
+// release name "redpanda" (chart Fullname → "redpanda-operator").
+const operatorDeploymentName = "redpanda-operator"
+
+// operatorPodSelector returns the labels the operator chart puts on operator
+// pods (matchLabels for the Deployment, also used by the raft Service).
+func operatorPodSelector() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/instance": operatorHelmReleaseName, // "redpanda"
+		redpandaLabel:                "operator",              // app.kubernetes.io/name=operator
+	}
+}
+
+// operatorPeers reconstructs the helm `multicluster.peers` value from the
+// current set of vcluster nodes. The original install path computes this in
+// bootstrapTLS; the upgrade path needs to produce a value that's
+// byte-equivalent (or at least valid) so the upgrade doesn't drop peer
+// addresses.
+func operatorPeers(nodes []*vclusterNode) []any {
+	peers := make([]any, 0, len(nodes))
+	for _, n := range nodes {
+		peers = append(peers, map[string]any{
+			"name":    n.Name(),
+			"address": n.ExternalIP(),
+		})
+	}
+	return peers
+}
+
+// operatorStatus dials the operator's TransportService over its pod IP via
+// kube.PodDialer (no kubectl port-forward needed) using mTLS material from the
+// in-cluster bootstrap secret. Returns the parsed Status RPC response.
+//
+// Loosely modeled on operator/cmd/rpk-k8s/k8s/multicluster/checks/cluster_raft.go,
+// which does the same dial via port-forward instead of PodDialer.
+func operatorStatus(ctx context.Context, node *vclusterNode, namespace string) (*transportv1.StatusResponse, error) {
+	// Find the operator pod.
+	var pods corev1.PodList
+	if err := node.List(ctx, &pods,
+		client.InNamespace(namespace),
+		client.MatchingLabels(operatorPodSelector()),
+	); err != nil {
+		return nil, fmt.Errorf("listing operator pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no operator pod in %s/%s", node.Name(), namespace)
+	}
+	pod := &pods.Items[0]
+	if pod.Status.PodIP == "" {
+		return nil, fmt.Errorf("operator pod %s has no PodIP yet", pod.Name)
+	}
+
+	tlsCfg, err := operatorMTLSConfig(ctx, node, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("building mTLS config: %w", err)
+	}
+
+	pfCfg, err := node.PortForwardedRESTConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("port-forwarded REST config: %w", err)
+	}
+	dialer := kube.NewPodDialer(pfCfg)
+
+	// "passthrough:///" makes gRPC skip its built-in DNS resolver and hand
+	// the target string straight to the custom dialer. Without it,
+	// grpc.NewClient runs the host's DNS lookup on "podname.namespace",
+	// returns zero addresses, and fails with "name resolver error: produced
+	// zero addresses" before WithContextDialer is ever consulted.
+	addr := "passthrough:///" + net.JoinHostPort(pod.Name+"."+namespace, fmt.Sprintf("%d", operatorGRPCPort))
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
+		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", target)
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("grpc.NewClient: %w", err)
+	}
+	defer conn.Close()
+
+	rpcCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	resp, err := transportv1.NewTransportServiceClient(conn).Status(rpcCtx, &transportv1.StatusRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("TransportService.Status: %w", err)
+	}
+	return resp, nil
+}
+
+// operatorMTLSConfig reads the bootstrap-created TLS secret for the operator
+// raft transport and builds a *tls.Config suitable for grpc.NewClient. The
+// secret is created by bootstrap.BootstrapKubernetesClusters under the name
+// <fullname>-multicluster-certificates ("redpanda-operator-multicluster-certificates"
+// in our case).
+func operatorMTLSConfig(ctx context.Context, node *vclusterNode, namespace string) (*tls.Config, error) {
+	var sec corev1.Secret
+	secretName := operatorDeploymentName + "-multicluster-certificates"
+	if err := node.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &sec); err != nil {
+		return nil, fmt.Errorf("get secret %s in %s: %w", secretName, node.Name(), err)
+	}
+
+	cert, err := tls.X509KeyPair(sec.Data["tls.crt"], sec.Data["tls.key"])
+	if err != nil {
+		return nil, fmt.Errorf("parse keypair: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(sec.Data["ca.crt"]) {
+		return nil, fmt.Errorf("invalid CA certificate in %s/%s", namespace, secretName)
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse leaf cert: %w", err)
+	}
+
+	serverName := ""
+	skipVerify := false
+	if len(leaf.DNSNames) > 0 {
+		serverName = leaf.DNSNames[0]
+	} else {
+		// Cert has only IP SANs. PodDialer tunnels through the API server;
+		// we still authenticate via mTLS (server presents a cert signed by
+		// the same CA), so skipping hostname verification is safe.
+		skipVerify = true
+	}
+
+	cfg := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		RootCAs:            caPool,
+		ServerName:         serverName,
+		InsecureSkipVerify: skipVerify, //nolint:gosec // see comment above
+		MinVersion:         tls.VersionTLS12,
+	}
+	return cfg, nil
+}

--- a/docs/stretch-cluster-operator-upgrade.md
+++ b/docs/stretch-cluster-operator-upgrade.md
@@ -1,0 +1,129 @@
+# Stretch Cluster Operator Upgrade Runbook
+
+This document covers how to upgrade the **multicluster Redpanda operator** on a running stretch cluster: recommended order, how to verify health before/after each step, and how to recover from a failed upgrade mid-rollout.
+
+Scope: operator helm chart and operator container image. Redpanda broker upgrades (rolling the StatefulSet to a new Redpanda image) are covered separately in [`multicluster-operator.md`](./multicluster-operator.md) and follow the standard "one pod at a time" pattern.
+
+## TL;DR
+
+1. Verify the operator raft quorum is healthy on every cluster.
+2. `helm upgrade` the operator in cluster 0, then wait for that cluster's operator deployment to roll AND the raft quorum to recover with a strictly advanced raft term.
+3. Repeat for cluster 1, then cluster 2.
+4. After all clusters are upgraded, verify the Redpanda data plane is still healthy and topic data is intact.
+
+Do not upgrade more than one cluster's operator at the same time.
+
+## Recommended Order
+
+Upgrade clusters one at a time, in **first-to-last index order**: `cluster-1`, then `cluster-2`, then `cluster-3` (or whatever the deployment-side naming is — pick a stable order and stick to it).
+
+* The operator raft quorum needs ⌊n/2⌋ + 1 members alive to keep operating. With three clusters that's two. Rolling one operator at a time keeps the other two alive and able to elect a leader while the upgraded operator rejoins.
+* During a `helm upgrade`, the operator Deployment terminates the old pod and starts a new one. While both are absent from raft, the cluster has only two healthy participants — the bare minimum. A second concurrent upgrade in another cluster would drop quorum and stall reconciliation everywhere.
+* In production the operator is not on the data path: a few seconds of no-leader means no new reconciliation work, not Kafka and other listeners unavailability. The Redpanda brokers handle traffic regardless of who the operator leader is.
+
+## Health Verification
+
+### Before starting an upgrade
+
+Verify the raft quorum is healthy on every cluster. There are two equivalent ways:
+
+**Option A — `rpk-k8s multicluster check` (if available in your cluster image):**
+
+```bash
+for ctx in $CLUSTE$R_1 $CLUSTER_2 $CLUSTER_3; do
+  echo "=== $ctx ==="
+  kubectl --context "$ctx" -n redpanda exec deploy/<operator-deployment> -- \
+    rpk-k8s multicluster check
+done
+```
+
+The `raft` check calls `TransportService.Status` on the local operator and reports `state=Leader|Follower`, `term=<int>`, and any unhealthy peers. Every cluster should report **state ∈ {Leader, Follower}** and an empty `unhealthy_peers` list.
+
+**Option B — direct gRPC via `grpcurl`:**
+
+```bash
+kubectl --context cluster-1 -n redpanda port-forward deploy/<operator-deployment> 9443:9443 &
+grpcurl \
+  -cacert ca.crt -cert tls.crt -key tls.key \
+  -import-path ./pkg/multicluster/leaderelection/proto \
+  -proto transport/v1/message.proto \
+  localhost:9443 transport.v1.TransportService/Status
+```
+
+Where `ca.crt`/`tls.crt`/`tls.key` come from the `redpanda-operator-multicluster-certificates` secret in that cluster's operator namespace.
+
+Either approach should print something like:
+
+```json
+{
+  "name": "cluster-1",
+  "raft_state": "Leader",
+  "leader": "cluster-1",
+  "term": "7",
+  "cluster_names": ["cluster-1", "cluster-2", "cluster-3"],
+  "is_healthy": true
+}
+```
+
+**Hard stop:** if any cluster reports `is_healthy=false`, has non-empty `unhealthy_peers`, or cannot be reached, do not start the upgrade. Resolve the underlying issue first.
+
+### Between cluster upgrades
+
+After `helm upgrade` returns successfully on cluster N, wait for **two** signals before moving on to cluster N+1:
+
+1. **Deployment rolled.** The new operator pod is `Ready` and the old pod is gone:
+
+   ```bash
+   kubectl --context cluster-N -n redpanda rollout status deploy/<operator-deployment> --timeout=5m
+   ```
+
+2. **Raft quorum recovered with advanced term.** Call `Status` on every cluster (not just the one you just upgraded). All three should report `is_healthy=true`, no `unhealthy_peers`, and a **higher `term`** than what they reported before this upgrade started.
+
+   A higher term is the load-bearing signal: it proves a leader re-election happened, which means the freshly upgraded operator actually joined and forced the quorum to reconverge. If `is_healthy=true` but the term hasn't moved, the new pod might not have joined yet — the existing quorum is still using the old leader, and the new pod is sitting on the sidelines.
+
+### After all clusters are upgraded
+
+1. Re-run the `Status` check on every cluster — quorum healthy, no unhealthy peers.
+2. Verify the Redpanda data plane is still up: `rpk cluster health` on any broker pod should return `Healthy: true`.
+3. Read back a known sentinel topic (or any topic with data you can verify) to confirm Kafka traffic is unaffected.
+
+## Recovery from a Failed Upgrade
+
+### Failure mode 1: `helm upgrade` returns an error
+
+The chart's pre-upgrade hook (CRD job) failed, or the new operator pod is crash-looping. Helm will report this synchronously.
+
+Steps:
+
+* `kubectl --context cluster-N -n redpanda logs job/<release>-crds` — inspect CRD hook output. Common cause: incompatible CRD changes that need manual cleanup.
+* `kubectl --context cluster-N -n redpanda logs deploy/<operator-deployment>` — inspect operator startup logs.
+* If the new operator is crashing on startup, roll back **only this cluster**:
+
+  ```bash
+  helm --kube-context cluster-N -n redpanda rollback redpanda
+  ```
+
+  Do **not** roll back the other clusters yet — they're still on the old version and the rollback brings cluster N back into sync with them.
+* Fix the underlying issue (CRD migration, image pull, RBAC change) before re-attempting.
+
+### Failure mode 2: helm succeeded but raft quorum never recovers
+
+`Status` reports `is_healthy=false` or `unhealthy_peers` lists the cluster you just upgraded, indefinitely.
+
+Steps:
+
+* Check the new operator pod's logs — likely either (a) TLS material missing or (b) peer addresses unreachable.
+* Verify the `redpanda-operator-multicluster-certificates` secret is intact in that cluster's namespace and matches what the other clusters' operators have for the CA. The chart's `multicluster.peers` value must include this cluster.
+* If the upgrade introduced a values-schema change you didn't account for (renamed key, removed default), the new operator may have started with a degraded config. Inspect the rendered Deployment env vars and command line.
+* If the issue can't be fixed forward, roll back this cluster's release (see above) — the two unupgraded clusters plus the rolled-back one will hold quorum on the prior version.
+
+### Failure mode 3: cascading failure during a multi-cluster upgrade
+
+You hit failure mode 1 or 2 mid-way through, but you've already upgraded one or more clusters successfully and there's no path forward.
+
+Steps:
+
+1. Stop the rollout — do not start a `helm upgrade` on any remaining cluster.
+2. Roll back the failed cluster (`helm rollback`).
+3. Verify quorum recovers across the mix of old+new operators. The operator chart and protocol must remain wire-compatible across one minor version, so a transient state of "two clusters on N, one on N-1" should still form a healthy quorum.
+4. If quorum forms, fix the root cause and resume the upgrade. If it does not, roll back **every** cluster that you already upgraded. Stretch cluster operators are designed to be roll-back-safe within one minor version.

--- a/pkg/k3d/k3d.go
+++ b/pkg/k3d/k3d.go
@@ -301,6 +301,19 @@ Use testutils.SkipIfNotIntegration or testutils.SkipIfNotAcceptance to gate test
 		// Disable bundled k3s components that we don't use in tests.
 		`--k3s-arg`, `--disable=traefik@server:*`,
 		`--k3s-arg`, `--disable=servicelb@server:*`,
+		// Raise kubelet image-pull rate limits and allow parallel pulls. The
+		// kubelet defaults (registry-qps=5, registry-burst=10,
+		// serialize-image-pulls=true) throttle the burst of pulls when many
+		// pods start at once (e.g. several multicluster acceptance features
+		// each launching vclusters + Redpanda), surfacing as "pull QPS
+		// exceeded" events and slow/crashlooping pods. Apply to both server and
+		// agent kubelets since pods may schedule on either.
+		`--k3s-arg`, `--kubelet-arg=registry-qps=20@server:*`,
+		`--k3s-arg`, `--kubelet-arg=registry-burst=40@server:*`,
+		`--k3s-arg`, `--kubelet-arg=serialize-image-pulls=false@server:*`,
+		`--k3s-arg`, `--kubelet-arg=registry-qps=20@agent:*`,
+		`--k3s-arg`, `--kubelet-arg=registry-burst=40@agent:*`,
+		`--k3s-arg`, `--kubelet-arg=serialize-image-pulls=false@agent:*`,
 		`--network`, config.network,
 		`--verbose`,
 	}

--- a/pkg/vcluster/vcluster.go
+++ b/pkg/vcluster/vcluster.go
@@ -562,6 +562,33 @@ func toStringMap(v any) (map[string]any, error) {
 	return m, nil
 }
 
+// HelmUpgrade upgrades an existing release using the in-process Helm action
+// API, paralleling HelmInstall. The release name is passed separately because
+// helm.UpgradeOptions intentionally has no Name field (it mirrors `helm upgrade
+// RELEASE CHART`).
+func (c *Cluster) HelmUpgrade(ctx context.Context, releaseName, chartName string, options helm.UpgradeOptions) (*release.Release, error) {
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(c.AsRESTClientGetter(), options.Namespace, "secret", log.FromContext(ctx).Info); err != nil {
+		return nil, err
+	}
+
+	upgrade := action.NewUpgrade(actionConfig)
+	upgrade.Namespace = options.Namespace
+	upgrade.ReuseValues = options.ReuseValues
+
+	chart, err := loader.Load(chartName)
+	if err != nil {
+		return nil, err
+	}
+
+	vals, err := toStringMap(options.Values)
+	if err != nil {
+		return nil, fmt.Errorf("converting values: %w", err)
+	}
+
+	return upgrade.Run(releaseName, chart, vals)
+}
+
 func (c *Cluster) HelmUninstall(ctx context.Context, rel *release.Release) error {
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(c.AsRESTClientGetter(), rel.Namespace, "secret", log.FromContext(ctx).Info); err != nil {


### PR DESCRIPTION
Adds a multicluster acceptance scenario that exercises the supported
operator-upgrade path described in
docs/stretch-cluster-operator-upgrade.md: install the published
redpanda/operator chart from charts.redpanda.com on every vcluster,
bring up a 3-broker StretchCluster, then helm-upgrade each vcluster
one at a time to the local dev chart with localhost/redpanda-operator:dev.

The test contract:

- Before the upgrade, every vcluster's TransportService.Status RPC
  must report is_healthy=true with no unhealthy peers. The starting
  raft term is snapshotted per vcluster.
- After each per-vcluster helm upgrade, the operator Deployment is
  observed rolling (old pod gone, new pod Available, new UID), and
  the raft quorum on EVERY vcluster must recover with is_healthy=true
  AND a strictly advanced term vs the prior snapshot. The advanced
  term is the load-bearing signal — a steady is_healthy alone could
  mean the new pod is sitting on the sidelines while the existing
  quorum re-uses the old leader.
- vclusters are upgraded in first-to-last index order (vc-0, vc-1,
  vc-2). The runbook recommends this order so support tooling can
  give one concrete sequence rather than "any order works"; leader
  flapping that this ordering may cause is not on the data path
  and is acceptable.
- After all three vclusters are upgraded, a sentinel topic created
  on the v26.2.1-beta.1-managed cluster is re-read to prove no
  broker outage occurred during the operator rollout.

Supporting changes:

- pkg/vcluster/vcluster.go: Cluster.HelmUpgrade mirroring HelmInstall
  via action.NewUpgrade, so per-vcluster upgrades go through the same
  in-process helm machinery as the initial install.
- acceptance/steps/stretch.go: deployOperators refactored to take an
  operatorChartSource (Path or RemoteChart + optional image override).
  Existing call sites continue to use the local dev chart via a thin
  wrapper; the new step uses a pulled upstream chart.
- acceptance/steps/operator_chart.go: helm chart-pull helper backed by
  action.NewPullWithOpts, downloading and untarring the published
  chart into a temp dir so loader.Load can consume it.
- acceptance/steps/stretch_operator_upgrade.go: the three new step
  handlers plus the operator gRPC Status helper that dials each
  vcluster's operator pod on :9443 using mTLS material read from
  redpanda-operator-multicluster-certificates (same secret the
  bootstrap step writes and the existing rpk-k8s raft check reads).

The scenario is tagged @multicluster @dev-env so it runs under the
existing multicluster acceptance harness and is included in the
dev-env setup-only flow.

[K8S-848](https://redpandadata.atlassian.net/browse/K8S-848)

[K8S-848]: https://redpandadata.atlassian.net/browse/K8S-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ