### PR TITLE
operator: keep rolling restart to one broker pod per reconcile

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260520-100000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260520-100000.yaml
@@ -1,0 +1,11 @@
+project: operator
+kind: Fixed
+body: |
+  Tightened the rolling restart gate so a single reconcile never deletes more than
+  one broker pod. The "pod has no matching broker in cluster view" branch used to
+  delete and continue, which meant a transient admin-API blip or address-format
+  mismatch could classify every pod as orphan and tear them all down in one pass —
+  now we delete one and requeue. The brokerMap parser also now strips a "host:port"
+  suffix and keys by both the first DNS label and the raw host, so a freshly-restarted
+  broker advertising "pod.svc:33145" is recognized instead of being misclassified.
+time: 2026-05-20T10:00:00.000000-07:00

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 	"time"
@@ -512,6 +513,13 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, state *c
 		return ctrl.Result{}, errors.Wrap(err, "fetching cluster health")
 	}
 
+	// brokerMap keys brokers by the first DNS label of their internal RPC
+	// address (pod name when InternalRPCAddress is the per-pod FQDN).
+	// InternalRPCAddress can also come back as "host:port" (advertised RPC
+	// port suffix) or — in rarer misconfigurations — as a bare IP. Strip
+	// the port if present, then key by both the first label (pod-name
+	// lookup) and the raw host, so the roll loop below doesn't silently
+	// misclassify a registered broker as orphan and delete its pod.
 	brokerMap := map[string]int{}
 	for _, brokerID := range health.AllNodes {
 		broker, err := state.admin.Broker(ctx, brokerID)
@@ -519,8 +527,12 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, state *c
 			return ctrl.Result{}, errors.Wrap(err, "fetching broker")
 		}
 
-		brokerTokens := strings.Split(broker.InternalRPCAddress, ".")
-		brokerMap[brokerTokens[0]] = brokerID
+		host := broker.InternalRPCAddress
+		if h, _, splitErr := net.SplitHostPort(broker.InternalRPCAddress); splitErr == nil {
+			host = h
+		}
+		brokerMap[strings.SplitN(host, ".", 2)[0]] = brokerID
+		brokerMap[host] = brokerID
 	}
 
 	// next scale down any over-provisioned pools, patching them to use the new spec
@@ -563,10 +575,15 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, state *c
 		shouldRoll, continueExecution := false, false
 
 		if _, ok := brokerMap[pod.GetName()]; !ok {
-			// we don't actually have this broker in the cluster
-			// anymore, which means it's always safe to delete
-			// the pod and continue with the next operations
-			shouldRoll, continueExecution = true, true
+			// The pod has no matching broker in our cluster view. That's
+			// usually safe to delete (orphan, ghost broker, mis-named
+			// replica), but treating *every* unmapped pod that way in a
+			// single reconcile would tear them all down at once if the
+			// mismatch is transient — slow admin API on a just-restarted
+			// broker, advertised-address format the parser missed, etc.
+			// Delete this one and requeue so we re-evaluate against a
+			// fresh view before touching the next pod.
+			shouldRoll, continueExecution = true, false
 		} else if health.IsHealthy {
 			// TODO: don't just check overall cluster health, but use
 			// scoped API endpoints for rolling a broker

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -1131,3 +1131,114 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 		})
 	}
 }
+
+// TestHasRecentlyReplacedPods pins the gate semantics that prevent the rolling
+// restart loop from deleting a second pod while a just-replaced peer is still
+// coming up — the window where Redpanda's cluster health view lags behind pod
+// state, so two pods can end up Terminating concurrently without it.
+func TestHasRecentlyReplacedPods(t *testing.T) {
+	pool := &MulticlusterStatefulSet{
+		clusterName: mcmanager.LocalCluster,
+		StatefulSet: &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "pool"}},
+	}
+	revisions := []*appsv1.ControllerRevision{
+		{ObjectMeta: metav1.ObjectMeta{Name: "old"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "new"}},
+	}
+
+	readyPod := func(name, rev string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{appsv1.StatefulSetRevisionLabel: rev},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+	}
+	notReadyPod := func(name, rev string) *corev1.Pod {
+		p := readyPod(name, rev)
+		p.Status.Conditions[0].Status = corev1.ConditionFalse
+		return p
+	}
+	terminatingPod := func(name, rev string) *corev1.Pod {
+		p := readyPod(name, rev)
+		now := metav1.Now()
+		p.DeletionTimestamp = &now
+		// Pods being deleted often retain Ready=True briefly while
+		// preStop hooks run; the gate must catch them anyway.
+		p.Finalizers = []string{"keep-alive-during-test"}
+		return p
+	}
+
+	for name, tt := range map[string]struct {
+		pods     []*corev1.Pod
+		expected bool
+	}{
+		"no pods": {},
+		"all pods on old revision are not 'recently replaced'": {
+			pods: []*corev1.Pod{
+				readyPod("pod-0", "old"),
+				readyPod("pod-1", "old"),
+			},
+			expected: false,
+		},
+		"all pods Ready on new revision is the post-roll steady state": {
+			pods: []*corev1.Pod{
+				readyPod("pod-0", "new"),
+				readyPod("pod-1", "new"),
+				readyPod("pod-2", "new"),
+			},
+			expected: false,
+		},
+		"just-replaced pod on new revision but not yet Ready blocks the next roll": {
+			pods: []*corev1.Pod{
+				notReadyPod("pod-0", "new"),
+				readyPod("pod-1", "old"),
+				readyPod("pod-2", "old"),
+			},
+			expected: true,
+		},
+		"any pod with a DeletionTimestamp blocks regardless of revision": {
+			pods: []*corev1.Pod{
+				terminatingPod("pod-0", "old"),
+				readyPod("pod-1", "old"),
+				readyPod("pod-2", "old"),
+			},
+			expected: true,
+		},
+		"new-revision pod stuck in Pending blocks": {
+			pods: []*corev1.Pod{
+				func() *corev1.Pod {
+					p := readyPod("pod-0", "new")
+					p.Status.Phase = corev1.PodPending
+					return p
+				}(),
+				readyPod("pod-1", "old"),
+			},
+			expected: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			withOrdinals := make([]*podsWithOrdinals, 0, len(tt.pods))
+			for i, p := range tt.pods {
+				withOrdinals = append(withOrdinals, &podsWithOrdinals{ordinal: i, pod: p})
+			}
+
+			tracker := NewPoolTracker(0)
+			tracker.addExisting(&poolWithOrdinals{
+				pods:      withOrdinals,
+				set:       pool,
+				revisions: revisions,
+			})
+
+			require.Equal(t, tt.expected, tracker.HasRecentlyReplacedPods())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two latent paths in the rolling restart loop could delete more than one
broker pod in a single reconcile. Both are now closed.

- **brokerMap parsing.** Brokers were keyed by
  `strings.Split(broker.InternalRPCAddress, \".\")[0]`. That produces
  the wrong key when the admin API returns the address as `host:port`
  (advertised RPC port suffix) or as a bare IP — the lookup
  `brokerMap[pod.GetName()]` then misses, and the pod is silently
  treated as orphan. Now we strip the port via `net.SplitHostPort` and
  key by both the first DNS label and the raw host.

- **\"Pod not in brokerMap\" branch.** The controller deleted the pod
  and set `continueExecution=true`, so every unmapped pod in `rollSet`
  was deleted in the same reconcile pass. Combined with the
  parsing bug above (or any transient cause that empties `AllNodes` —
  rolling controller leadership, brief admin-API 503s, NodeID flip
  after PVC reset), this is the only single-reconcile path that
  produces multiple brokers literally in \`Terminating\` at the same
  time. Now the branch deletes one pod and requeues, so each pod's
  state is re-evaluated against fresh broker-map data before the next
  one is touched.

Added \`TestHasRecentlyReplacedPods\` to pin the existing safety-gate
contract — Redpanda's cluster health view lags pod state during a
roll, and without the gate two pods can end up unavailable
concurrently. (Pre-existing on `main`; introduced by #1446. Not the
same path as the parallel-deletion fix above — see Scope below.)

## Scope

This PR addresses the only code path in the single-cluster controller
that can delete multiple broker pods in one reconcile: the
\`!inBrokerMap\` branch, which previously kept iterating after each
delete. The fix is unambiguously correctness:

1. **Parsing change** — \`net.SplitHostPort\` + dual-key (first label
   *and* raw host) means a freshly-restarted broker advertising
   \`pod.svc:33145\` is no longer misclassified as orphan, even if some
   broker still advertises the older format. Strict superset of the
   previous keyspace; no regression for FQDN-only deployments.
2. **One-at-a-time** — the orphan branch is itself low-risk per pod,
   but acting on *every* orphan in a single reconcile means a transient
   admin-API state (rolling leadership, mid-restart \`AllNodes\` window,
   address-format mismatch) tears down the whole pool. After this PR
   we delete one and requeue, so the next pod is judged against an
   updated map.

Probe-scheduling lag between cluster-\`IsHealthy=true\` and pod
\`PodReady=True\` is a separate concern handled by
\`HasRecentlyReplacedPods\` (already on \`main\`). The unit test added
here pins that contract but is not the customer-facing fix.

## Follow-ups (not in this PR)

- **ENG-222** (per-broker prestart-risk API). The proper long-term fix
  replaces the cluster-\`IsHealthy\` heuristic with the per-broker risks
  endpoint introduced in core 25.1
  (\`rf1_offline\`, \`full_acks_produce_unavailable\`, \`unavailable\`,
  \`acks1_data_loss\`). The rpadmin client bindings are in
  [common-go#170](https://github.com/redpanda-data/common-go/pull/170);
  the operator-side wiring follows once that lands.

- **Backport to \`release/v26.1.x\`.** That branch is missing
  \`HasRecentlyReplacedPods\` entirely (added in #1446). The smaller
  cherry-pick I'd propose is the gate + the two fixes in this PR.
  Production code applies cleanly to v25.2.x / v25.3.x / v26.1.x; the
  new unit test only compiles on v26.1.x because v25.x lacks the
  \`MulticlusterStatefulSet\` type used in the table. Will open the
  v26.1.x backport once this lands.

## Test plan

- [x] \`go test ./operator/internal/lifecycle/... -count=1\` — including
  the new \`TestHasRecentlyReplacedPods\`
- [x] \`go vet ./operator/internal/controller/redpanda/...
  ./operator/internal/lifecycle/...\`
- [x] \`golangci-lint run --fast-only ./internal/controller/redpanda/...
  ./internal/lifecycle/...\` — 0 issues
