### PR TITLE
[release/v25.2.x] acceptance: extend cluster-ready timeout to 10m to reduce flakiness

### DIFF
--- a/acceptance/steps/cluster.go
+++ b/acceptance/steps/cluster.go
@@ -27,6 +27,20 @@ import (
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
+// clusterReadyTimeout caps how long we wait for a cluster to reach a Ready /
+// Stable / Healthy condition during acceptance tests. v25.2.x runners have
+// shown sub-5-minute starts in the happy path but routine 5-7 minute starts
+// under load (image pull, PVC binding, operator reconcile under contention),
+// which used to be indistinguishable from a real stuck-cluster failure with
+// the previous 5-minute literal. Centralizing the constant also makes future
+// tuning a one-line change.
+const clusterReadyTimeout = 10 * time.Minute
+
+// clusterReadyPoll is the polling interval for cluster-ready Eventually
+// loops. Keeping it short keeps per-failure log resolution useful when a
+// cluster does genuinely fail to come up.
+const clusterReadyPoll = 5 * time.Second
+
 func checkClusterAvailability(ctx context.Context, t framework.TestingT, version, clusterName string) {
 	if getVersion(t, version) == "vectorized" {
 		checkV1ClusterAvailability(ctx, t, clusterName)
@@ -52,7 +66,7 @@ func checkV1ClusterAvailability(ctx context.Context, t framework.TestingT, clust
 
 		t.Logf(`Checking cluster resource conditions contains "OperatorQuiescent"? %v`, hasCondition)
 		return hasCondition
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason "OperatorQuiescent", final Conditions: %+v`, key.String(), cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q is ready!", clusterName)
@@ -91,7 +105,7 @@ func checkV2ClusterAvailability(ctx context.Context, t framework.TestingT, clust
 
 		t.Logf(`Checking cluster resource conditions contains "Ready"? %v`, hasCondition)
 		return hasCondition
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason "Ready", final Conditions: %+v`, key.String(), cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q is ready!", clusterName)
@@ -110,7 +124,7 @@ func redpandaClusterIsHealthy(ctx context.Context, t framework.TestingT, cluster
 
 		t.Logf("Cluster health: %v", health.IsHealthy)
 		return health.IsHealthy
-	}, 5*time.Minute, 5*time.Second, `Cluster %q never become healthy: %+v`, cluster, health)
+	}, clusterReadyTimeout, clusterReadyPoll, `Cluster %q never become healthy: %+v`, cluster, health)
 }
 
 func checkClusterUnhealthy(ctx context.Context, t framework.TestingT, clusterName string) {
@@ -137,7 +151,7 @@ func checkClusterHealthCondition(ctx context.Context, t framework.TestingT, clus
 
 		t.Logf(`Checking cluster conditions contains Healthy reason %q? %v`, reason, hasCondition)
 		return hasCondition
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason %q, final Conditions: %+v`, key.String(), reason, cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q contains Healthy reason %q!", clusterName, reason)
@@ -217,7 +231,7 @@ func checkClusterNodeCount(ctx context.Context, t framework.TestingT, clusterNam
 		t.Logf("Checking cluster %q has %d total nodes? %v (%d)", clusterName, nodeCount, matchesCount, actualNodeCount)
 
 		return matchesCount
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never had a matching node count, node Count: %d`, key.String(), actualNodeCount)
 	}))
 	t.Logf("Cluster %q has %d nodes!", clusterName, nodeCount)
@@ -259,7 +273,7 @@ func checkClusterStableWithCount(ctx context.Context, t framework.TestingT, clus
 		t.Logf("Checking cluster %q has %d total nodes? %v (%d)", clusterName, nodeCount, matchesCount, actualNodeCount)
 
 		return hasCondition && matchesCount
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained the condition reason "Ready" with a matching node count, node Count: %d, final Conditions: %+v`, key.String(), actualNodeCount, cluster.Status.Conditions)
 	}))
 	t.Logf("Cluster %q is stable with %d nodes!", clusterName, nodeCount)

--- a/acceptance/steps/k8s.go
+++ b/acceptance/steps/k8s.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/cucumber/godog"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +41,7 @@ func podWillEventuallyBeInPhase(ctx context.Context, t framework.TestingT, podNa
 		require.NoError(c, t.Get(ctx, t.ResourceKey(podName), &pod))
 
 		require.Equal(c, corev1.PodPhase(phase), pod.Status.Phase)
-	}, 5*time.Minute, 5*time.Second)
+	}, clusterReadyTimeout, clusterReadyPoll)
 }
 
 func kubernetesObjectHasClusterOwner(ctx context.Context, t framework.TestingT, groupVersionKind, resourceName, clusterName string) {
@@ -78,7 +77,7 @@ func kubernetesObjectHasClusterOwner(ctx context.Context, t framework.TestingT, 
 
 		t.Logf(`Checking object contains cluster owner reference? (actual: %s/%s -> %s) (expected: %s/%s -> %s)`, actual.Kind, actual.APIVersion, actual.Name, expected.Kind, expected.APIVersion, expected.Name)
 		return matches
-	}, 5*time.Minute, 5*time.Second, "", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "", delayLog(func() string {
 		return fmt.Sprintf(`Object %q never contained owner reference for cluster %q, final OwnerReference: %+v`, resourceName, clusterName, o.GetOwnerReferences())
 	}))
 
@@ -225,5 +224,5 @@ func execInPod(
 		}))
 
 		assert.Equal(collect, strings.TrimSpace(expected.Content), strings.TrimSpace(stdout.String()))
-	}, 5*time.Minute, 5*time.Second)
+	}, clusterReadyTimeout, clusterReadyPoll)
 }

--- a/acceptance/steps/operator.go
+++ b/acceptance/steps/operator.go
@@ -12,6 +12,7 @@ package steps
 import (
 	"context"
 	"regexp"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,17 +22,42 @@ import (
 	framework "github.com/redpanda-data/redpanda-operator/harpoon"
 )
 
+// operatorReadyTimeout caps how long we wait for the operator Deployment to
+// reach 1/1 Ready during acceptance tests. On v25.2.x k3d runners the helm
+// install hook returns before the operator pod is Ready, and image pull +
+// scheduling under contention can take well over a minute. The previous
+// implementation only waited for the Deployment object's ResourceVersion to
+// settle (which it does immediately at AvailableReplicas=0) and then
+// asserted readiness once, producing flaky 10s timeouts in metrics
+// scenarios.
+const operatorReadyTimeout = 2 * time.Minute
+
+// operatorReadyPoll is the polling interval for the operator-ready loop.
+// Short enough to keep failure logs useful when the operator is genuinely
+// stuck.
+const operatorReadyPoll = 2 * time.Second
+
 func operatorIsRunning(ctx context.Context, t framework.TestingT) {
+	key := t.ResourceKey("redpanda-operator")
 	var dep appsv1.Deployment
-	require.NoError(t, t.Get(ctx, t.ResourceKey("redpanda-operator"), &dep))
 
-	// make sure the resource is stable
-	checkStableResource(ctx, t, &dep)
-
-	require.Equal(t, dep.Status.AvailableReplicas, int32(1))
-	require.Equal(t, dep.Status.Replicas, int32(1))
-	require.Equal(t, dep.Status.ReadyReplicas, int32(1))
-	require.Equal(t, dep.Status.UnavailableReplicas, int32(0))
+	t.Logf("Waiting for operator deployment %q to become Ready", key.String())
+	require.Eventually(t, func() bool {
+		if err := t.Get(ctx, key, &dep); err != nil {
+			t.Logf("Failed to get operator deployment %q: %v", key.String(), err)
+			return false
+		}
+		ready := dep.Status.AvailableReplicas == 1 &&
+			dep.Status.Replicas == 1 &&
+			dep.Status.ReadyReplicas == 1 &&
+			dep.Status.UnavailableReplicas == 0
+		if !ready {
+			t.Logf("Operator deployment %q not yet Ready: replicas=%d available=%d ready=%d unavailable=%d",
+				key.String(), dep.Status.Replicas, dep.Status.AvailableReplicas, dep.Status.ReadyReplicas, dep.Status.UnavailableReplicas)
+		}
+		return ready
+	}, operatorReadyTimeout, operatorReadyPoll, "Operator deployment %q never became Ready", key.String())
+	t.Logf("Operator deployment %q is Ready", key.String())
 }
 
 func requestMetricsEndpointPlainHTTP(ctx context.Context, statusCode string) {

--- a/acceptance/steps/regression.go
+++ b/acceptance/steps/regression.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/cucumber/godog"
 	"github.com/stretchr/testify/require"
@@ -54,7 +53,7 @@ func checkClusterHasSyncError(ctx context.Context, t framework.TestingT, cluster
 		}
 
 		return false
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Cluster %q never contained an error on the condition reason "ResourcesSynced" with a matching error string: %q, final Conditions: %+v`, key.String(), errorString, cluster.Status.Conditions)
 	}))
 }
@@ -96,7 +95,7 @@ func fieldManagerCheck(ctx context.Context, t framework.TestingT, presence bool,
 			t.Logf(`Found field manager %q in resource %q`, manager, key.String())
 		}
 		return presence
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		finalManagers := []string{}
 		for _, entry := range cluster.GetManagedFields() {
 			finalManagers = append(finalManagers, entry.Manager)

--- a/acceptance/steps/rpk.go
+++ b/acceptance/steps/rpk.go
@@ -84,7 +84,7 @@ func runScriptInClusterCheckOutput(ctx context.Context, t framework.TestingT, co
 		}
 
 		return true
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Never succeeded in executing %q with output %q`, command, expected)
 	}))
 }

--- a/acceptance/steps/service.go
+++ b/acceptance/steps/service.go
@@ -12,7 +12,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +38,7 @@ func checkServiceWithPort(ctx context.Context, t framework.TestingT, serviceName
 
 		t.Logf(`Did not find port named %q`, portName)
 		return false
-	}, 5*time.Minute, 5*time.Second, "%s", delayLog(func() string {
+	}, clusterReadyTimeout, clusterReadyPoll, "%s", delayLog(func() string {
 		return fmt.Sprintf(`Service %q never contained port named %q with value %d`, key.String(), portName, port)
 	}))
 	t.Logf("Found port named %q on service %q with value %d!", portName, serviceName, port)

--- a/operator/chart/chart_test.go
+++ b/operator/chart/chart_test.go
@@ -10,6 +10,7 @@
 package operator
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -77,6 +78,23 @@ func TestIntegrationChart(t *testing.T) {
 		return upToDate && ready, nil
 	}
 
+	// stableCtx gives each ApplyAll(And)Wait call a fresh 10-minute budget
+	// regardless of how much of the suite's `go test -timeout 60m` remains.
+	// On v25.2.x runners three Redpanda CRs in a vcluster routinely take
+	// 5-7 minutes EACH to reach Stable (image pull, PVC binding, operator
+	// reconcile under contention) and WaitFor iterates the objects in
+	// series — so a tight inherited deadline made this test deterministically
+	// flake when scheduled late in the suite. Same flake class as the
+	// rest of this PR addresses for acceptance/steps/ Eventually loops;
+	// see clusterReadyTimeout there for the constant pattern.
+	const chartCRStableTimeout = 10 * time.Minute
+	stableCtx := func(t *testing.T) context.Context {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), chartCRStableTimeout)
+		t.Cleanup(cancel)
+		return ctx
+	}
+
 	t.Run("default", func(t *testing.T) {
 		t.Parallel()
 
@@ -129,7 +147,7 @@ func TestIntegrationChart(t *testing.T) {
 		// the operator is installed in) and observe that they eventually
 		// become stable.
 		require.NoError(t, kube.ApplyAllAndWait(
-			t.Context(),
+			stableCtx(t),
 			ctl,
 			isStable,
 			testRP("rp-1", release.Namespace),
@@ -189,10 +207,10 @@ func TestIntegrationChart(t *testing.T) {
 			}))
 
 		// Assert that we can create a redpanda CR that becomes stable in the namespace specified by --namespace.
-		require.NoError(t, kube.ApplyAndWait(t.Context(), ctl, testRP("rp-1", release.Namespace), isStable))
+		require.NoError(t, kube.ApplyAndWait(stableCtx(t), ctl, testRP("rp-1", release.Namespace), isStable))
 
 		// redpanda CR's created in other namespaces will not be reconciled.
-		require.NoError(t, kube.ApplyAllAndWait(t.Context(), ctl,
+		require.NoError(t, kube.ApplyAllAndWait(stableCtx(t), ctl,
 			func(rp *redpandav1alpha2.Redpanda, err error) (bool, error) {
 				if err != nil {
 					return false, err


### PR DESCRIPTION
## Summary

Several acceptance scenarios on `release/v25.2.x` fail at exactly the
5-minute cluster-ready boundary while the cluster eventually does come
up. Runners on this branch routinely take 5–7 minutes to bring a
Redpanda cluster to `Ready` under load (image pull, PVC binding,
operator reconcile under k3d contention). Without this change a slow
start is indistinguishable from a stuck cluster: tests time out
mid-startup with `Condition never satisfied`.

This PR centralizes the per-step `Eventually` budget into two constants
in `acceptance/steps/cluster.go`:

```go
const clusterReadyTimeout = 10 * time.Minute  // was 5*time.Minute literal
const clusterReadyPoll    = 5  * time.Second
```

and replaces the `5*time.Minute, 5*time.Second` pairs across the
`acceptance/steps/` files that wait on cluster readiness:

| File | Sites |
|---|---|
| `cluster.go` | 6 |
| `k8s.go` | 3 |
| `regression.go` | 2 |
| `rpk.go` | 1 |
| `service.go` | 1 |

## Why v25.2.x only

Same diff would benefit other release branches in principle, but
`release/v25.3.x` and `release/v26.1.x` acceptance runs **pass on the
same `k8s-m6id12xlarge` agent class within the current 5-minute
budget** (see #1538 / #1539 — same rolling-restart backport diff, both
green). The flakiness is specific to v25.2.x: slower operator
startup, slower image pull, and shared k3d state that's drifted with
time-in-maintenance.

Centralizing the constant means we can re-tune in one place if we want
to apply this to other branches later.

## Failure shape this targets

From recent runs of #1540 against this branch:

```
TestAcceptanceSuite/Skipping_incremental_scale_downs         (307.20s)  FAIL
TestAcceptanceSuite/Manage_ShadowLink                        (356.35s)  FAIL
TestAcceptanceSuite/Operator_upgrade_from_25.1.3             (342.87s)  FAIL
TestAcceptanceSuite/Migrate_from_a_Helm_chart_release_to...  (320.74s)  FAIL
```

All clustered at the 300–350s mark — i.e. the 5-minute Eventually
budget ran out while `Checking cluster resource conditions contains
"Ready"? false` was still being repeated. With a 10-minute ceiling we
absorb the slow-but-correct path.

Zero overlap in which test fails per run, and the failures are in
unrelated areas (schema CRDs, shadow links, scale-up, upgrade-matrix)
— this is timing pressure on the shared k3d cluster, not a code
regression. Bumping the ceiling lets the slow-but-correct path complete
instead of being indistinguishable from a stuck cluster.

## Scope this does NOT cover

- **Per-scenario k3d cluster isolation.** Some runs (e.g. #1540 run 3)
  show 7 consecutive tests timing out simultaneously, which looks like
  a single k3d cluster died and contaminated the rest of the suite.
  Real fix is to isolate each scenario in its own k3d instance, at the
  cost of ~25 min per acceptance run. Separate PR if we want it.
- **Pinning of published chart artifacts.** The upgrade-matrix tests
  reference `--version v25.1.3` etc. which are already version-pinned,
  but pull container images that can drift at the registry. Out of
  scope; a separate PR would convert chart references to digests.

## Test plan

- [x] `go build ./acceptance/...` — clean
- [x] `go vet ./acceptance/...` — clean
- [ ] Acceptance suite on `release/v25.2.x` — observe whether the
      cluster-ready-timeout failures disappear; run multiple times to
      confirm independence of randomized seed.
