### PR TITLE
charts/redpanda: surface lifecycle-hook timeouts in pod logs

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20260521-130000.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260521-130000.yaml
@@ -1,0 +1,15 @@
+project: charts/redpanda
+kind: Fixed
+body: |
+  Made StatefulSet lifecycle-hook timeouts visible in pod logs. The wrapper
+  previously ended every hook with `; true`, which swallowed timeout exit codes
+  (124 SIGTERM-on-timeout, 137 SIGKILL-on-timeout) and made the failure
+  indistinguishable from a clean run. When a hook is killed by `timeout`, the
+  wrapper now emits a clearly-marked line containing "TIMEOUT after Ns" with
+  the hook name (`pre-stop` or `post-start`) and exit code, so an operator
+  scanning pod logs after an ungraceful broker shutdown can immediately see
+  that the maintenance-mode drain (preStop) or the maintenance-mode clear
+  (postStart) didn't complete in its budget. The trailing `true` is retained
+  so non-zero exits don't poison container lifecycle on transient hook
+  issues — the TIMEOUT marker is the diagnostic signal.
+time: 2026-05-21T13:00:00.000000-07:00

--- a/charts/redpanda/chart/templates/_statefulset.go.tpl
+++ b/charts/redpanda/chart/templates/_statefulset.go.tpl
@@ -370,8 +370,9 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $wrapped := (join " " $cmd) -}}
+{{- $script := (printf (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" (printf "%s%s" `timeout -v %d %s 2>&1 | sed "s/^/lifecycle-hook %s $(date): /" | tee /proc/1/fd/1` "\n") `ec=${PIPESTATUS[0]}`) "\n") `if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then`) "\n") `  echo "lifecycle-hook %s $(date): TIMEOUT after %ds — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1`) "\n") `fi`) "\n") `true`) $timeoutSeconds $wrapped $hook $hook $timeoutSeconds) -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list "bash" "-c" (printf "timeout -v %d %s 2>&1 | sed \"s/^/lifecycle-hook %s $(date): /\" | tee /proc/1/fd/1; true" $timeoutSeconds $wrapped $hook))) | toJson -}}
+{{- (dict "r" (list "bash" "-c" $script)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -624,18 +624,18 @@ func StatefulSetContainers(state *RenderState, pool Pool) []corev1.Container {
 }
 
 // wrapLifecycleHook wraps the given command in an attempt to make it more friendly for Kubernetes' lifecycle hooks.
-// - It attaches a maximum time limit by wrapping the command with `timeout -v <timeout>`
-// - It redirect stderr to stdout so all logs from cmd get the same treatment.
-// - It prepends the "lifecycle-hook $(hook) $(date)" to al lines emitted by the hook for easy identification.
-// - It tees the output to fd 1 of pid 1 so it shows up in kubectl logs.
-// - When the wrapped command exceeds the time budget, it emits a clearly-marked
-//   TIMEOUT line — `timeout`'s own message can be sparse, and the trailing
-//   `true` below previously made the failure invisible to anyone scanning pod
-//   logs for a reason the broker shut down ungracefully. PIPESTATUS[0] is
-//   read for timeout's exit code (124 = SIGTERM sent, 137 = SIGKILL).
-// - It still terminates the entire command with "true" so non-zero exits
-//   don't poison container lifecycle on transient hook issues. The TIMEOUT
-//   marker above is the diagnostic signal operators grep for.
+//   - It attaches a maximum time limit by wrapping the command with `timeout -v <timeout>`
+//   - It redirect stderr to stdout so all logs from cmd get the same treatment.
+//   - It prepends the "lifecycle-hook $(hook) $(date)" to al lines emitted by the hook for easy identification.
+//   - It tees the output to fd 1 of pid 1 so it shows up in kubectl logs.
+//   - When the wrapped command exceeds the time budget, it emits a clearly-marked
+//     TIMEOUT line — `timeout`'s own message can be sparse, and the trailing
+//     `true` below previously made the failure invisible to anyone scanning pod
+//     logs for a reason the broker shut down ungracefully. PIPESTATUS[0] is
+//     read for timeout's exit code (124 = SIGTERM sent, 137 = SIGKILL).
+//   - It still terminates the entire command with "true" so non-zero exits
+//     don't poison container lifecycle on transient hook issues. The TIMEOUT
+//     marker above is the diagnostic signal operators grep for.
 func wrapLifecycleHook(hook string, timeoutSeconds int64, cmd []string) []string {
 	wrapped := helmette.Join(" ", cmd)
 	script := fmt.Sprintf(

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -627,11 +627,27 @@ func StatefulSetContainers(state *RenderState, pool Pool) []corev1.Container {
 // - It attaches a maximum time limit by wrapping the command with `timeout -v <timeout>`
 // - It redirect stderr to stdout so all logs from cmd get the same treatment.
 // - It prepends the "lifecycle-hook $(hook) $(date)" to al lines emitted by the hook for easy identification.
-// - It tees the output to fd 1 of pid 1 so it shows up in kubectl logs
-// - It terminates the entire command with "true" so it never fails which would cause the Pod to get killed.
+// - It tees the output to fd 1 of pid 1 so it shows up in kubectl logs.
+// - When the wrapped command exceeds the time budget, it emits a clearly-marked
+//   TIMEOUT line — `timeout`'s own message can be sparse, and the trailing
+//   `true` below previously made the failure invisible to anyone scanning pod
+//   logs for a reason the broker shut down ungracefully. PIPESTATUS[0] is
+//   read for timeout's exit code (124 = SIGTERM sent, 137 = SIGKILL).
+// - It still terminates the entire command with "true" so non-zero exits
+//   don't poison container lifecycle on transient hook issues. The TIMEOUT
+//   marker above is the diagnostic signal operators grep for.
 func wrapLifecycleHook(hook string, timeoutSeconds int64, cmd []string) []string {
 	wrapped := helmette.Join(" ", cmd)
-	return []string{"bash", "-c", fmt.Sprintf("timeout -v %d %s 2>&1 | sed \"s/^/lifecycle-hook %s $(date): /\" | tee /proc/1/fd/1; true", timeoutSeconds, wrapped, hook)}
+	script := fmt.Sprintf(
+		`timeout -v %d %s 2>&1 | sed "s/^/lifecycle-hook %s $(date): /" | tee /proc/1/fd/1`+"\n"+
+			`ec=${PIPESTATUS[0]}`+"\n"+
+			`if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then`+"\n"+
+			`  echo "lifecycle-hook %s $(date): TIMEOUT after %ds — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1`+"\n"+
+			`fi`+"\n"+
+			`true`,
+		timeoutSeconds, wrapped, hook, hook, timeoutSeconds,
+	)
+	return []string{"bash", "-c", script}
 }
 
 func statefulSetContainerRedpanda(state *RenderState, pool Pool) corev1.Container {

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -852,15 +852,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -2178,15 +2188,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -3358,15 +3378,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -4735,15 +4765,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -6029,15 +6069,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -7568,15 +7618,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -9093,15 +9153,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -10656,15 +10726,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -12096,15 +12176,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -13609,15 +13699,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -15101,15 +15201,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -16545,15 +16655,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -17807,15 +17927,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -19051,15 +19181,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -20521,15 +20661,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -21961,15 +22111,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -23404,15 +23564,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -24897,15 +25067,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -26406,15 +26586,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -27915,15 +28105,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -29376,15 +29576,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -30884,15 +31094,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -32411,15 +32631,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -33938,15 +34168,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -35418,15 +35658,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -36945,15 +37195,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -38472,15 +38732,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -39999,15 +40269,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -41479,15 +41759,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -42957,15 +43247,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -44398,15 +44698,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -45838,15 +46148,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -47358,15 +47678,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -48812,15 +49142,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -50306,15 +50646,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -51787,15 +52137,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -53234,15 +53594,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -54712,15 +55082,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -56178,15 +56558,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -57412,15 +57802,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -59009,15 +59409,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -60439,15 +60849,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -61982,15 +62402,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -63429,15 +63859,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -64901,15 +65341,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -66369,15 +66819,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -67709,15 +68169,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 60 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 60 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 60s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 60 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 60 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 60s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -69207,15 +69677,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -70715,15 +71195,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -72231,15 +72721,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -73720,15 +74220,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -75209,15 +75719,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -76664,15 +77184,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -78153,15 +78683,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -79642,15 +80182,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -81085,15 +81635,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -82574,15 +83134,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -84063,15 +84633,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -85506,15 +86086,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -86995,15 +87585,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -88484,15 +89084,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -89927,15 +90537,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -91416,15 +92036,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -92905,15 +93535,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -94348,15 +94988,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -95837,15 +96487,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -97326,15 +97986,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -98769,15 +99439,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -100023,15 +100703,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -101278,15 +101968,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -102816,15 +103516,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -104420,15 +105130,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -105962,15 +106682,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -107498,15 +108228,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -109006,15 +109746,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -110600,15 +111350,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -112040,15 +112800,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -113480,15 +114250,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -114947,15 +115727,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -116399,15 +117189,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -117949,15 +118749,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -119463,15 +120273,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -120952,15 +121772,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -122441,15 +123271,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -123884,15 +124724,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -125373,15 +126223,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -126862,15 +127722,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -128312,15 +129182,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -129907,15 +130787,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -131172,15 +132062,25 @@ spec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                post-start $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
           preStop:
             exec:
               command:
               - bash
               - -c
-              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+              - |-
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                ec=${PIPESTATUS[0]}
+                if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                fi
+                true
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 10

--- a/charts/redpanda/wrap_lifecycle_hook_test.go
+++ b/charts/redpanda/wrap_lifecycle_hook_test.go
@@ -11,7 +11,9 @@ package redpanda
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -34,6 +36,11 @@ import (
 // so that a future refactor (e.g. someone rewrites the wrapper but
 // silently drops the PIPESTATUS branch) gets caught.
 //
+// wrapLifecycleHook expects its cmd slice to be space-joinable into a
+// single valid shell command (e.g. ["bash", "-x", "/var/lifecycle/preStop.sh"]
+// in production). The tests follow that contract by writing the hook
+// body to a temp script and invoking it via `bash -x <path>`.
+//
 // Skipped when:
 //   - GOOS != linux  — the wrapper teas to /proc/1/fd/1 which is
 //     Linux-only. We test-substitute /dev/stdout but only on linux to
@@ -48,59 +55,79 @@ func TestWrapLifecycleHook_TimeoutSurfaced(t *testing.T) {
 		t.Skip("skipping: timeout(1) not on PATH")
 	}
 
-	t.Run("timeout fires emits TIMEOUT marker", func(t *testing.T) {
-		// 2s budget vs 8s sleep — timeout MUST fire.
-		cmd := wrapLifecycleHook("pre-stop", 2, []string{"bash", "-c", `echo hook-started; sleep 8; echo should-not-reach`})
+	// writeHook writes body to a tempfile and returns a cmd slice
+	// suitable for wrapLifecycleHook — argv-style, no shell quoting.
+	//
+	// The hook path is rendered into the wrapper *unquoted* (matching
+	// the production usage with /var/lifecycle/preStop.sh), so it must
+	// be free of shell-special characters. t.TempDir() bakes the
+	// subtest name into the path, and Go's testing harness can emit
+	// names containing parentheses (e.g. "non-zero_(not_timeout)") —
+	// so use a process-local temp directory and a deterministic
+	// filename instead.
+	hookDir, err := os.MkdirTemp("", "wraplifecyclehook")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(hookDir) })
 
-		// Substitute /proc/1/fd/1 → /dev/stdout so we observe the
-		// teed output here. The original path is meaningful only
-		// inside a pod; behavior under test (PIPESTATUS surfacing
-		// 124 via the TIMEOUT line) is unchanged by this swap.
-		script := strings.ReplaceAll(cmd[2], "/proc/1/fd/1", "/dev/stdout")
+	writeHook := func(t *testing.T, name, body string) []string {
+		t.Helper()
+		path := filepath.Join(hookDir, name+".sh")
+		require.NoError(t, os.WriteFile(path, []byte("#!/usr/bin/env bash\n"+body), 0o755))
+		return []string{"bash", "-x", path}
+	}
 
-		var stdout, stderr bytes.Buffer
+	// run renders the wrapper, substitutes /proc/1/fd/1 → /dev/stdout
+	// (so we observe the teed output here; behavior under test is
+	// unchanged), executes via bash and returns combined stdout.
+	run := func(t *testing.T, cmd []string, budget int64) (stdout string, exitErr error) {
+		t.Helper()
+		wrapped := wrapLifecycleHook("pre-stop", budget, cmd)
+		script := strings.ReplaceAll(wrapped[2], "/proc/1/fd/1", "/dev/stdout")
+
+		var out, errOut bytes.Buffer
 		c := exec.Command("bash", "-c", script)
-		c.Stdout = &stdout
-		c.Stderr = &stderr
+		c.Stdout = &out
+		c.Stderr = &errOut
 		err := c.Run()
+		if err != nil {
+			t.Logf("stderr:\n%s", errOut.String())
+		}
+		return out.String(), err
+	}
 
-		require.NoError(t, err, "wrapper must exit 0 (the trailing `true` preserves the safety property)\nstderr: %s", stderr.String())
-		assert.Contains(t, stdout.String(), "hook-started", "hook body should have started")
-		assert.NotContains(t, stdout.String(), "should-not-reach", "hook must have been killed before completion")
-		assert.Contains(t, stdout.String(), "TIMEOUT after 2s", "PR #1548 marker line must appear when timeout fires")
-		assert.Contains(t, stdout.String(), "exit 124", "marker must include the exit code from PIPESTATUS")
+	t.Run("timeout fires emits TIMEOUT marker", func(t *testing.T) {
+		// Hook sleeps 8s, budget is 2s → timeout MUST fire.
+		cmd := writeHook(t, "timeout", `echo hook-started
+sleep 8
+echo should-not-reach
+`)
+		stdout, err := run(t, cmd, 2)
+		require.NoError(t, err, "wrapper must exit 0 (the trailing `true` preserves the safety property)")
+		assert.Contains(t, stdout, "hook-started", "hook body should have started")
+		assert.NotContains(t, stdout, "should-not-reach", "hook must have been killed before completion")
+		assert.Contains(t, stdout, "TIMEOUT after 2s", "PR #1548 marker line must appear when timeout fires")
+		assert.Contains(t, stdout, "exit 124", "marker must include the exit code from PIPESTATUS")
 	})
 
 	t.Run("fast hook does not emit TIMEOUT marker", func(t *testing.T) {
-		cmd := wrapLifecycleHook("pre-stop", 5, []string{"bash", "-c", `echo fast-hook`})
-		script := strings.ReplaceAll(cmd[2], "/proc/1/fd/1", "/dev/stdout")
-
-		var stdout, stderr bytes.Buffer
-		c := exec.Command("bash", "-c", script)
-		c.Stdout = &stdout
-		c.Stderr = &stderr
-		err := c.Run()
-
-		require.NoError(t, err, "stderr: %s", stderr.String())
-		assert.Contains(t, stdout.String(), "fast-hook")
-		assert.NotContains(t, stdout.String(), "TIMEOUT", "no false-positive: marker must not appear when the hook completed within budget")
+		cmd := writeHook(t, "fast", `echo fast-hook
+`)
+		stdout, err := run(t, cmd, 5)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "fast-hook")
+		assert.NotContains(t, stdout, "TIMEOUT", "no false-positive: marker must not appear when the hook completed within budget")
 	})
 
 	t.Run("hook exits non-zero (not timeout) is still swallowed by trailing true", func(t *testing.T) {
-		// Hook that fails fast with exit 42 — should NOT trigger the
-		// TIMEOUT branch (exit code is neither 124 nor 137) and the
-		// trailing `true` should still mask the failure exit.
-		cmd := wrapLifecycleHook("pre-stop", 5, []string{"bash", "-c", `echo about-to-fail; exit 42`})
-		script := strings.ReplaceAll(cmd[2], "/proc/1/fd/1", "/dev/stdout")
-
-		var stdout, stderr bytes.Buffer
-		c := exec.Command("bash", "-c", script)
-		c.Stdout = &stdout
-		c.Stderr = &stderr
-		err := c.Run()
-
-		require.NoError(t, err, "trailing `true` must swallow non-timeout non-zero exits to avoid container-kill on transient hook bugs\nstderr: %s", stderr.String())
-		assert.Contains(t, stdout.String(), "about-to-fail")
-		assert.NotContains(t, stdout.String(), "TIMEOUT", "marker fires only on 124/137, not arbitrary non-zero")
+		// Hook fails fast with exit 42 — should NOT trigger the TIMEOUT
+		// branch (exit code is neither 124 nor 137) and the trailing
+		// `true` should still mask the failure exit.
+		cmd := writeHook(t, "fail", `echo about-to-fail
+exit 42
+`)
+		stdout, err := run(t, cmd, 5)
+		require.NoError(t, err, "trailing `true` must swallow non-timeout non-zero exits to avoid container-kill on transient hook bugs")
+		assert.Contains(t, stdout, "about-to-fail")
+		assert.NotContains(t, stdout, "TIMEOUT", "marker fires only on 124/137, not arbitrary non-zero")
 	})
 }

--- a/charts/redpanda/wrap_lifecycle_hook_test.go
+++ b/charts/redpanda/wrap_lifecycle_hook_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"bytes"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWrapLifecycleHook_TimeoutSurfaced executes the actual rendered
+// bash wrapper against:
+//
+//  1. a hook body that exceeds the time budget — the new PIPESTATUS
+//     check must surface a "TIMEOUT after Ns" marker line and
+//  2. a hook body that completes in time — no TIMEOUT line and no
+//     spurious diagnostics.
+//
+// This is the behavior the wrapper was changed to guarantee in
+// PR #1548. The chart template golden file pins the *shape* of the
+// rendered string; this test pins the *runtime behavior* of that string
+// so that a future refactor (e.g. someone rewrites the wrapper but
+// silently drops the PIPESTATUS branch) gets caught.
+//
+// Skipped when:
+//   - GOOS != linux  — the wrapper teas to /proc/1/fd/1 which is
+//     Linux-only. We test-substitute /dev/stdout but only on linux to
+//     stay close to the production execution path.
+//   - timeout(1) is not on PATH — GNU coreutils utility; CI's nix
+//     devshell provides it.
+func TestWrapLifecycleHook_TimeoutSurfaced(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("skipping: wrapper hardcodes /proc/1/fd/1; only meaningful on linux (got %s)", runtime.GOOS)
+	}
+	if _, err := exec.LookPath("timeout"); err != nil {
+		t.Skip("skipping: timeout(1) not on PATH")
+	}
+
+	t.Run("timeout fires emits TIMEOUT marker", func(t *testing.T) {
+		// 2s budget vs 8s sleep — timeout MUST fire.
+		cmd := wrapLifecycleHook("pre-stop", 2, []string{"bash", "-c", `echo hook-started; sleep 8; echo should-not-reach`})
+
+		// Substitute /proc/1/fd/1 → /dev/stdout so we observe the
+		// teed output here. The original path is meaningful only
+		// inside a pod; behavior under test (PIPESTATUS surfacing
+		// 124 via the TIMEOUT line) is unchanged by this swap.
+		script := strings.ReplaceAll(cmd[2], "/proc/1/fd/1", "/dev/stdout")
+
+		var stdout, stderr bytes.Buffer
+		c := exec.Command("bash", "-c", script)
+		c.Stdout = &stdout
+		c.Stderr = &stderr
+		err := c.Run()
+
+		require.NoError(t, err, "wrapper must exit 0 (the trailing `true` preserves the safety property)\nstderr: %s", stderr.String())
+		assert.Contains(t, stdout.String(), "hook-started", "hook body should have started")
+		assert.NotContains(t, stdout.String(), "should-not-reach", "hook must have been killed before completion")
+		assert.Contains(t, stdout.String(), "TIMEOUT after 2s", "PR #1548 marker line must appear when timeout fires")
+		assert.Contains(t, stdout.String(), "exit 124", "marker must include the exit code from PIPESTATUS")
+	})
+
+	t.Run("fast hook does not emit TIMEOUT marker", func(t *testing.T) {
+		cmd := wrapLifecycleHook("pre-stop", 5, []string{"bash", "-c", `echo fast-hook`})
+		script := strings.ReplaceAll(cmd[2], "/proc/1/fd/1", "/dev/stdout")
+
+		var stdout, stderr bytes.Buffer
+		c := exec.Command("bash", "-c", script)
+		c.Stdout = &stdout
+		c.Stderr = &stderr
+		err := c.Run()
+
+		require.NoError(t, err, "stderr: %s", stderr.String())
+		assert.Contains(t, stdout.String(), "fast-hook")
+		assert.NotContains(t, stdout.String(), "TIMEOUT", "no false-positive: marker must not appear when the hook completed within budget")
+	})
+
+	t.Run("hook exits non-zero (not timeout) is still swallowed by trailing true", func(t *testing.T) {
+		// Hook that fails fast with exit 42 — should NOT trigger the
+		// TIMEOUT branch (exit code is neither 124 nor 137) and the
+		// trailing `true` should still mask the failure exit.
+		cmd := wrapLifecycleHook("pre-stop", 5, []string{"bash", "-c", `echo about-to-fail; exit 42`})
+		script := strings.ReplaceAll(cmd[2], "/proc/1/fd/1", "/dev/stdout")
+
+		var stdout, stderr bytes.Buffer
+		c := exec.Command("bash", "-c", script)
+		c.Stdout = &stdout
+		c.Stderr = &stderr
+		err := c.Run()
+
+		require.NoError(t, err, "trailing `true` must swallow non-timeout non-zero exits to avoid container-kill on transient hook bugs\nstderr: %s", stderr.String())
+		assert.Contains(t, stdout.String(), "about-to-fail")
+		assert.NotContains(t, stdout.String(), "TIMEOUT", "marker fires only on 124/137, not arbitrary non-zero")
+	})
+}

--- a/operator/internal/lifecycle/testdata/redpanda-cases.pools.golden.txtar
+++ b/operator/internal/lifecycle/testdata/redpanda-cases.pools.golden.txtar
@@ -83,15 +83,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -459,15 +469,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -837,15 +857,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -1271,15 +1301,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -1647,15 +1687,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -2024,15 +2074,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -2400,15 +2460,25 @@
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
-                  post-start $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook post-start $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook post-start $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
             preStop:
               exec:
                 command:
                 - bash
                 - -c
-                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
-                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+                - |-
+                  timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
+                  ec=${PIPESTATUS[0]}
+                  if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
+                    echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
+                  fi
+                  true
           livenessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10


### PR DESCRIPTION
## Summary

The StatefulSet's lifecycle-hook wrapper (`wrapLifecycleHook` in
`charts/redpanda/statefulset.go`) previously ended every hook with `; true`:

```bash
bash -c 'timeout -v 45 /var/lifecycle/preStop.sh 2>&1 | sed ... | tee /proc/1/fd/1; true'
```

The trailing `true` is deliberate — it prevents the kubelet from re-terminating
the pod on a non-zero hook exit. The side-effect is that **timeouts get
silently masked**: when `timeout` sends SIGTERM (exit 124) or SIGKILL (exit
137) to the wrapped script because it ran past its budget, the overall pipeline
still exits 0 and there's no signal in pod logs or kubectl events that the hook
didn't actually complete.

This was the other half of the rolling-restart customer scenario we've been
chasing in #1547. From that thread:

> the preStop script enables maintenance mode and waits for leadership drain
> to finish. With heavy load + a peer broker that isn't ready to accept
> leadership transfer, the drain can hang past the 45-second budget
> (`terminationGracePeriodSeconds/2`, with default 90s grace). Today, the
> cluster looks like nothing happened — broker shut down ungracefully,
> controller leader was lost, `NOT_CONTROLLER` errors appear on the cluster,
> but the pod's own logs say `preStopHookFinished`.

## What this PR does

Captures `PIPESTATUS[0]` for `timeout`'s exit code and, on 124/137, emits a
distinct line before the trailing `true`:

```bash
timeout -v 45 cmd 2>&1 | sed "s/^/lifecycle-hook pre-stop $(date): /" | tee /proc/1/fd/1
ec=${PIPESTATUS[0]}
if [ "$ec" = "124" ] || [ "$ec" = "137" ]; then
  echo "lifecycle-hook pre-stop $(date): TIMEOUT after 45s — hook killed before completion; the broker will receive SIGTERM with work in-flight (exit $ec)" | tee /proc/1/fd/1
fi
true
```

Operators scanning pod logs after an ungraceful broker shutdown can immediately
see that the maintenance-mode drain (preStop) or maintenance-mode clear
(postStart) didn't complete in its budget.

## What this PR explicitly does NOT change

- **Pod lifecycle behavior.** `; true` still swallows the exit code, so
  non-zero on its own doesn't cause a pod-kill or container restart. The
  TIMEOUT line is purely diagnostic. (Why not propagate the timeout exit
  code? For `postStart`, a non-zero would cause the container to fail to
  start. Treating postStart and preStop differently here adds complexity
  for marginal benefit; the log line is enough for operators to act on.)
- **Default `terminationGracePeriodSeconds`.** Left at 90s. A wider default
  (e.g. 180s) would reduce timeout pressure but doubles teardown time on
  every restart; customers who routinely hit the timeout can bump it
  themselves via values. Worth a separate change if data shows it's
  pervasive.
- **`operator/multicluster/scripts.go`.** Has its own copy of
  `wrapLifecycleHook`. Per the standing rule on this work — no changes to
  multicluster code, since that subsystem is being removed — it's
  untouched here.

## Test plan

- [x] `task charts:generate:redpanda` — `_statefulset.go.tpl` regenerated
- [x] `go test ./charts/redpanda -run TestTemplate -update-golden` —
      `testdata/template-cases.golden.txtar` refreshed (+1260 / -360 lines:
      every `postStart` and `preStop` command across all chart cases now
      renders as the 7-line wrapper instead of the 1-line wrapper)
- [x] `go build ./charts/redpanda/...` — clean
- [x] `go vet ./charts/redpanda/...` — clean
- [x] `go test ./charts/redpanda -run TestTemplate` (no `-update-golden`) —
      passes against refreshed golden
- [ ] Manual: deploy a 3-broker cluster, force a preStop timeout (e.g. by
      making one broker unable to accept leadership transfers), confirm the
      surviving brokers' pod logs contain the `TIMEOUT after Ns` line for
      `pre-stop`.

## Stack

- #1547 — operator-side: per-broker pre-restart probe + roll-loop
  correctness (uses `PreRestartProbe` from common-go#170)
- **This PR** — chart-side: surface lifecycle-hook timeouts so the
  preStop drain failure mode becomes diagnosable

Both PRs are independent and can land in any order.
