### PR TITLE
Make layered CRDs multicluster-aware

### DIFF
--- a/acceptance/features/stretch-cluster-crds.feature
+++ b/acceptance/features/stretch-cluster-crds.feature
@@ -2,8 +2,9 @@
 Feature: Stretch Cluster Layered CRDs
   # Happy-path coverage that Topic / RedpandaRole / Schema CRs whose
   # spec.cluster.clusterRef points at a StretchCluster reach a Synced
-  # status when the multicluster operator is running. This is the GA
-  # surface for layered CR support — see the Setup*ControllerForMulticluster
+  # status when the multicluster operator is running, and that the
+  # resulting object is observable from the brokers via rpk. This is the
+  # GA surface for layered CR support — see the Setup*ControllerForMulticluster
   # wiring in operator/cmd/multicluster.
   #
   # We deliberately apply the CRs to every vcluster (mirroring how the
@@ -11,6 +12,14 @@ Feature: Stretch Cluster Layered CRDs
   # exercises the per-peer `req.ClusterName` plumbing on the factory —
   # nothing in production requires the CR to exist on every cluster, but
   # checking against all three is the same wall-clock cost.
+  #
+  # Topic / RedpandaRole / Schema cover the three distinct client paths
+  # the factory's StretchCluster handling added (Kafka, Admin API, Schema
+  # Registry). User / Group / ShadowLink go through the same factory paths
+  # and would require either SASL bootstrapping or a remote source cluster
+  # to drive end-to-end, so they're intentionally left out of this smoke
+  # test — the unit-level CR wiring is covered by Setup*ControllerForMulticluster
+  # for those types alongside the three exercised here.
 
   @skip:gke @skip:aks @skip:eks
   Scenario: Layered CRs sync against a StretchCluster
@@ -70,6 +79,7 @@ Feature: Stretch Cluster Layered CRDs
       replicationFactor: 1
     """
     Then in "layered" the Kubernetes object "stretch-topic" in namespace "default" of type "Topic.v1alpha2.cluster.redpanda.com" should have condition "Ready" with status "True"
+    And I execute "rpk topic describe stretch-topic" command in the statefulset container in each cluster
 
     # RedpandaRole — generic resource controller, reports a Synced condition.
     When I apply a multicluster Kubernetes manifest to "layered":
@@ -88,6 +98,7 @@ Feature: Stretch Cluster Layered CRDs
           name: cluster
     """
     Then in "layered" the Kubernetes object "stretch-role" in namespace "default" of type "RedpandaRole.v1alpha2.cluster.redpanda.com" should have condition "Synced" with status "True"
+    And I execute "rpk security role describe stretch-role" command in the statefulset container in each cluster
 
     # Schema — exercises the Schema Registry endpoint discovery added to the
     # factory's StretchCluster path.
@@ -116,3 +127,4 @@ Feature: Stretch Cluster Layered CRDs
         }
     """
     Then in "layered" the Kubernetes object "stretch-schema" in namespace "default" of type "Schema.v1alpha2.cluster.redpanda.com" should have condition "Synced" with status "True"
+    And I execute "rpk registry schema get stretch-schema" command in the statefulset container in each cluster

--- a/acceptance/features/stretch-cluster-crds.feature
+++ b/acceptance/features/stretch-cluster-crds.feature
@@ -127,4 +127,4 @@ Feature: Stretch Cluster Layered CRDs
         }
     """
     Then in "layered" the Kubernetes object "stretch-schema" in namespace "default" of type "Schema.v1alpha2.cluster.redpanda.com" should have condition "Synced" with status "True"
-    And I execute "rpk registry schema get stretch-schema" command in the statefulset container in each cluster
+    And I execute "rpk registry schema get stretch-schema --schema-version latest" command in the statefulset container in each cluster

--- a/acceptance/features/stretch-cluster-crds.feature
+++ b/acceptance/features/stretch-cluster-crds.feature
@@ -1,0 +1,118 @@
+@multicluster
+Feature: Stretch Cluster Layered CRDs
+  # Happy-path coverage that Topic / RedpandaRole / Schema CRs whose
+  # spec.cluster.clusterRef points at a StretchCluster reach a Synced
+  # status when the multicluster operator is running. This is the GA
+  # surface for layered CR support — see the Setup*ControllerForMulticluster
+  # wiring in operator/cmd/multicluster.
+  #
+  # We deliberately apply the CRs to every vcluster (mirroring how the
+  # StretchCluster itself is replicated) so the same scenario also
+  # exercises the per-peer `req.ClusterName` plumbing on the factory —
+  # nothing in production requires the CR to exist on every cluster, but
+  # checking against all three is the same wall-clock cost.
+
+  @skip:gke @skip:aks @skip:eks
+  Scenario: Layered CRs sync against a StretchCluster
+    Given I create a multicluster operator named "layered" with 3 nodes
+    And I apply a multicluster Kubernetes manifest to "layered":
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: StretchCluster
+    metadata:
+      name: cluster
+      namespace: default
+    spec:
+      external:
+        enabled: false
+      rbac:
+        enabled: true
+    """
+    And I apply a RedpandaBrokerPool Kubernetes manifest to "layered":
+    """
+    spec:
+      clusterRef:
+        group: cluster.redpanda.com
+        kind: StretchCluster
+        name: cluster
+      replicas: 1
+      image:
+        repository: redpandadata/redpanda
+        tag: v25.2.1
+      sidecarImage:
+        repository: localhost/redpanda-operator
+        tag: dev
+      services:
+        perPod:
+          remote:
+            enabled: false
+    """
+    And I expect 3 statefulsets in 3 kubernetes cluster to be created and eventually ready
+    And I expect all 3 RedpandaBrokerPools in "layered" to be eventually bound and deployed
+
+    # Topic — Topic uses its own ReadyCondition (status True / reason Succeeded).
+    When I apply a multicluster Kubernetes manifest to "layered":
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Topic
+    metadata:
+      name: stretch-topic
+      namespace: default
+    spec:
+      cluster:
+        clusterRef:
+          group: cluster.redpanda.com
+          kind: StretchCluster
+          name: cluster
+      partitions: 1
+      replicationFactor: 1
+    """
+    Then in "layered" the Kubernetes object "stretch-topic" in namespace "default" of type "Topic.v1alpha2.cluster.redpanda.com" should have condition "Ready" with status "True"
+
+    # RedpandaRole — generic resource controller, reports a Synced condition.
+    When I apply a multicluster Kubernetes manifest to "layered":
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: RedpandaRole
+    metadata:
+      name: stretch-role
+      namespace: default
+    spec:
+      cluster:
+        clusterRef:
+          group: cluster.redpanda.com
+          kind: StretchCluster
+          name: cluster
+    """
+    Then in "layered" the Kubernetes object "stretch-role" in namespace "default" of type "RedpandaRole.v1alpha2.cluster.redpanda.com" should have condition "Synced" with status "True"
+
+    # Schema — exercises the Schema Registry endpoint discovery added to the
+    # factory's StretchCluster path.
+    When I apply a multicluster Kubernetes manifest to "layered":
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: Schema
+    metadata:
+      name: stretch-schema
+      namespace: default
+    spec:
+      cluster:
+        clusterRef:
+          group: cluster.redpanda.com
+          kind: StretchCluster
+          name: cluster
+      schemaType: avro
+      text: |
+        {
+          "type": "record",
+          "name": "Event",
+          "fields": [
+            { "type": "string", "name": "id" }
+          ]
+        }
+    """
+    Then in "layered" the Kubernetes object "stretch-schema" in namespace "default" of type "Schema.v1alpha2.cluster.redpanda.com" should have condition "Synced" with status "True"

--- a/acceptance/steps/register.go
+++ b/acceptance/steps/register.go
@@ -113,6 +113,7 @@ func init() {
 	framework.RegisterStep(`^I create a multicluster operator named "([^"]*)" with (\d+) nodes$`, createNetworkedVClusterOperators)
 	framework.RegisterStep(`^I apply a multicluster Kubernetes manifest to "([^"]*)":$`, iApplyKuberneteMulticlusterManifest)
 	framework.RegisterStep(`^in "([^"]*)" the Kubernetes object "([^"]*)" in namespace "([^"]*)" of type "([^"]*)" should have finalizer "([^"]*)"$`, checkMulticlusterFinalizers)
+	framework.RegisterStep(`^in "([^"]*)" the Kubernetes object "([^"]*)" in namespace "([^"]*)" of type "([^"]*)" should have condition "([^"]*)" with status "([^"]*)"$`, checkMulticlusterCondition)
 	framework.RegisterStep(`^I apply a RedpandaBrokerPool Kubernetes manifest to "([^"]*)":$`, applyBrokerPoolWithStretchCluster)
 	framework.RegisterStep(`^I expect (\d+) statefulsets in (\d+) kubernetes cluster to be created and eventually ready$`, expectStatefulsetsReady)
 	framework.RegisterStep(`^I expect all (\d+) RedpandaBrokerPools in "([^"]*)" to be eventually bound and deployed$`, expectBrokerPoolsBoundAndDeployed)

--- a/acceptance/steps/stretch.go
+++ b/acceptance/steps/stretch.go
@@ -152,6 +152,13 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 			}
 		}
 
+		// Dump layered CR objects (Topic, User, RedpandaRole, Schema, Group,
+		// ShadowLink) with their full conditions. The TopicFailed/Synced=False
+		// condition message in the CR is a generic "Topic reconciliation failed"
+		// or similar — combined with the operator-log filter below this gives
+		// the actual underlying error.
+		dumpLayeredCRs(diagCtx, t, node)
+
 		// Dump ClusterRoles.
 		var crList rbacv1.ClusterRoleList
 		if err := node.List(diagCtx, &crList); err != nil {
@@ -179,7 +186,13 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 			}
 		}
 
-		// Dump operator pod logs (last 100 lines).
+		// Dump operator pod logs. We grab a long tail (4000 lines) because the
+		// StretchCluster reconciler runs roughly once per second and quickly
+		// flushes more interesting controller logs out of any shorter window —
+		// in the worst case (a 10-minute Eventually timeout) that's ~600
+		// reconciles before we even get to anything else. We also surface the
+		// subset filtered by layered-CR controller names so the actual error
+		// the Topic/User/Role/etc. reconciler hit is easy to find.
 		k8sClient, err := kubernetes.NewForConfig(node.RESTConfig())
 		if err != nil {
 			t.Logf("[multicluster-diagnostics] failed to create k8s client for logs: %v", err)
@@ -189,7 +202,7 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 			if !strings.Contains(pod.Name, "operator") {
 				continue
 			}
-			tailLines := int64(100)
+			tailLines := int64(4000)
 			req := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{TailLines: &tailLines})
 			logStream, err := req.Stream(diagCtx)
 			if err != nil {
@@ -198,9 +211,120 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 			}
 			logBytes, _ := io.ReadAll(logStream)
 			_ = logStream.Close()
-			t.Logf("[multicluster-diagnostics] === operator logs %s (last 100 lines) ===\n%s", pod.Name, string(logBytes))
+
+			logStr := string(logBytes)
+			dumpLayeredControllerLogs(t, pod.Name, logStr)
+			t.Logf("[multicluster-diagnostics] === operator logs %s (last 4000 lines) ===\n%s", pod.Name, logStr)
 		}
 	}
+}
+
+// dumpLayeredCRs lists each layered CR kind and emits its conditions. The
+// generic "Topic reconciliation failed" / "Synced=False" status condition
+// messages are the same regardless of root cause, but having every CR's
+// observedGeneration plus all conditions in one place narrows the search
+// space.
+func dumpLayeredCRs(ctx context.Context, t framework.TestingT, node *vclusterNode) {
+	tag := "[multicluster-diagnostics]"
+
+	var topics redpandav1alpha2.TopicList
+	if err := node.List(ctx, &topics); err != nil {
+		t.Logf("%s failed to list Topics: %v", tag, err)
+	} else {
+		for _, o := range topics.Items {
+			t.Logf("%s Topic %s/%s: generation=%d observed=%d conditions=%d",
+				tag, o.Namespace, o.Name, o.Generation, o.Status.ObservedGeneration, len(o.Status.Conditions))
+			for _, c := range o.Status.Conditions {
+				t.Logf("%s   condition %s=%s reason=%s: %s", tag, c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+	}
+
+	var users redpandav1alpha2.UserList
+	if err := node.List(ctx, &users); err == nil {
+		for _, o := range users.Items {
+			t.Logf("%s User %s/%s: conditions=%d", tag, o.Namespace, o.Name, len(o.Status.Conditions))
+			for _, c := range o.Status.Conditions {
+				t.Logf("%s   condition %s=%s reason=%s: %s", tag, c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+	}
+
+	var roles redpandav1alpha2.RedpandaRoleList
+	if err := node.List(ctx, &roles); err == nil {
+		for _, o := range roles.Items {
+			t.Logf("%s RedpandaRole %s/%s: conditions=%d", tag, o.Namespace, o.Name, len(o.Status.Conditions))
+			for _, c := range o.Status.Conditions {
+				t.Logf("%s   condition %s=%s reason=%s: %s", tag, c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+	}
+
+	var schemas redpandav1alpha2.SchemaList
+	if err := node.List(ctx, &schemas); err == nil {
+		for _, o := range schemas.Items {
+			t.Logf("%s Schema %s/%s: conditions=%d", tag, o.Namespace, o.Name, len(o.Status.Conditions))
+			for _, c := range o.Status.Conditions {
+				t.Logf("%s   condition %s=%s reason=%s: %s", tag, c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+	}
+
+	var groups redpandav1alpha2.GroupList
+	if err := node.List(ctx, &groups); err == nil {
+		for _, o := range groups.Items {
+			t.Logf("%s Group %s/%s: conditions=%d", tag, o.Namespace, o.Name, len(o.Status.Conditions))
+			for _, c := range o.Status.Conditions {
+				t.Logf("%s   condition %s=%s reason=%s: %s", tag, c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+	}
+
+	var shadowLinks redpandav1alpha2.ShadowLinkList
+	if err := node.List(ctx, &shadowLinks); err == nil {
+		for _, o := range shadowLinks.Items {
+			t.Logf("%s ShadowLink %s/%s: conditions=%d", tag, o.Namespace, o.Name, len(o.Status.Conditions))
+			for _, c := range o.Status.Conditions {
+				t.Logf("%s   condition %s=%s reason=%s: %s", tag, c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+	}
+}
+
+// dumpLayeredControllerLogs extracts lines from the operator log that are
+// tagged with one of the layered-CR controllers, so the actual reconcile
+// errors aren't drowned out by the per-second StretchCluster reconcile churn
+// in the main log dump.
+func dumpLayeredControllerLogs(t framework.TestingT, podName, logs string) {
+	wanted := []string{
+		`"controller":"topic"`,
+		`"controller":"user"`,
+		`"controller":"redpandarole"`,
+		`"controller":"schema"`,
+		`"controller":"group"`,
+		`"controller":"shadowlink"`,
+		`TopicReconciler`,
+		`UserReconciler`,
+		`RoleReconciler`,
+		`SchemaReconciler`,
+		`GroupReconciler`,
+		`ShadowLinkReconciler`,
+	}
+
+	var matched []string
+	for _, line := range strings.Split(logs, "\n") {
+		for _, w := range wanted {
+			if strings.Contains(line, w) {
+				matched = append(matched, line)
+				break
+			}
+		}
+	}
+	if len(matched) == 0 {
+		return
+	}
+	t.Logf("[multicluster-diagnostics] === %s layered-CR controller log lines (%d) ===\n%s",
+		podName, len(matched), strings.Join(matched, "\n"))
 }
 
 var nameMap = map[string]string{

--- a/acceptance/steps/stretch.go
+++ b/acceptance/steps/stretch.go
@@ -404,6 +404,58 @@ func checkMulticlusterFinalizers(ctx context.Context, t framework.TestingT, clus
 	}
 }
 
+// checkMulticlusterCondition asserts that the given object eventually has the
+// requested status condition with the requested status across every node in the
+// multicluster. Used by happy-path layered-CR scenarios (Topic, User, …) where
+// each CR type carries its own ready condition (`Ready`, `Synced`, …).
+func checkMulticlusterCondition(ctx context.Context, t framework.TestingT, clusterName, name, namespace, groupVersionKind, conditionType, conditionStatusStr string) {
+	nn := types.NamespacedName{Namespace: namespace, Name: name}
+	nodes := getNodes(ctx, clusterName)
+
+	want := metav1.ConditionStatus(conditionStatusStr)
+
+	nodes.CheckAll(ctx, nn, groupVersionKind, func(o client.Object) bool {
+		conds := extractConditions(o)
+		cond := apimeta.FindStatusCondition(conds, conditionType)
+		if cond == nil {
+			t.Logf("condition %q not yet present on %s/%s", conditionType, o.GetNamespace(), o.GetName())
+			return false
+		}
+		if cond.Status != want {
+			t.Logf("condition %q on %s/%s has status %q (want %q): %s",
+				conditionType, o.GetNamespace(), o.GetName(), cond.Status, want, cond.Message)
+			return false
+		}
+		return true
+	})
+}
+
+// extractConditions pulls the .status.conditions slice out of any of our CRs
+// without reflecting per-type. Each layered CR exposes its conditions via the
+// same generated struct path; we type-switch over the kinds the feature file
+// touches and fall back to reflection for anything else.
+func extractConditions(o client.Object) []metav1.Condition {
+	switch v := o.(type) {
+	case *redpandav1alpha2.Topic:
+		return v.Status.Conditions
+	case *redpandav1alpha2.User:
+		return v.Status.Conditions
+	case *redpandav1alpha2.RedpandaRole:
+		return v.Status.Conditions
+	case *redpandav1alpha2.Group:
+		return v.Status.Conditions
+	case *redpandav1alpha2.Schema:
+		return v.Status.Conditions
+	case *redpandav1alpha2.ShadowLink:
+		return v.Status.Conditions
+	case *redpandav1alpha2.StretchCluster:
+		return v.Status.Conditions
+	case *redpandav1alpha2.NodePool:
+		return v.Status.Conditions
+	}
+	return nil
+}
+
 func createNetworkedVClusterOperators(ctx context.Context, t framework.TestingT, clusterName string, clusters int32) context.Context {
 	namespace := metav1.NamespaceDefault
 	redpandaLicense := os.Getenv(LicenseEnvVar)

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -381,6 +381,37 @@ func Run(
 		return err
 	}
 
+	// Register the layered Redpanda CR controllers (Topic, User, RedpandaRole,
+	// Group, Schema, ShadowLink). These reconcile resources whose
+	// spec.cluster.clusterRef points at a StretchCluster — the cluster ref
+	// kind the multicluster operator manages — by talking to the underlying
+	// Redpanda data plane via the shared client factory.
+	namespace := ""
+	if err := redpandacontrollers.SetupTopicControllerForMulticluster(ctx, manager, factory, namespace); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Topic")
+		return err
+	}
+	if err := redpandacontrollers.SetupUserControllerForMulticluster(ctx, manager, factory, namespace); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "User")
+		return err
+	}
+	if err := redpandacontrollers.SetupRoleControllerForMulticluster(ctx, manager, factory, namespace); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "RedpandaRole")
+		return err
+	}
+	if err := redpandacontrollers.SetupGroupControllerForMulticluster(ctx, manager, factory, namespace); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Group")
+		return err
+	}
+	if err := redpandacontrollers.SetupSchemaControllerForMulticluster(ctx, manager, factory, namespace); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Schema")
+		return err
+	}
+	if err := redpandacontrollers.SetupShadowLinkControllerForMulticluster(ctx, manager, factory, namespace); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ShadowLink")
+		return err
+	}
+
 	if opts.EnableConsoleController {
 		localMgr := manager.GetLocalManager()
 		ctl, err := kube.FromRESTConfig(localMgr.GetConfig(), kube.Options{

--- a/operator/internal/controller/redpanda/group_controller.go
+++ b/operator/internal/controller/redpanda/group_controller.go
@@ -17,8 +17,11 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
@@ -113,7 +116,7 @@ func (r *GroupReconciler) DeleteResource(ctx context.Context, request ResourceRe
 }
 
 func (r *GroupReconciler) aclClient(ctx context.Context, request ResourceRequest[*redpandav1alpha2.Group]) (*acls.Syncer, error) {
-	return request.factory.ACLs(ctx, request.object, r.extraOptions...)
+	return request.factory.ACLsForCluster(ctx, request.object, request.clusterName, r.extraOptions...)
 }
 
 func SetupGroupController(ctx context.Context, mgr multicluster.Manager, expander *secrets.CloudExpander, includeV1, includeV2 bool, namespace string) error {
@@ -146,4 +149,26 @@ func SetupGroupController(ctx context.Context, mgr multicluster.Manager, expande
 	// happened on the resource synced to the cluster and attempt to correct
 	// any drift.
 	return builder.Complete(controller.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
+}
+
+// SetupGroupControllerForMulticluster registers the Group reconciler against a
+// multicluster manager and watches StretchCluster CRs.
+func SetupGroupControllerForMulticluster(ctx context.Context, mgr multicluster.Manager, factory internalclient.ClientFactory, namespace string) error {
+	builder := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.Group{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+
+	for _, clusterName := range mgr.GetClusterNames() {
+		enqueueStretch, err := controller.RegisterStretchClusterSourceIndex(ctx, mgr, "group_stretch", clusterName, &redpandav1alpha2.Group{}, &redpandav1alpha2.GroupList{})
+		if err != nil {
+			return err
+		}
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+	}
+
+	ctl := NewResourceController(mgr, factory, &GroupReconciler{}, "GroupReconciler")
+
+	return builder.Complete(ctl.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
 }

--- a/operator/internal/controller/redpanda/resource_controller.go
+++ b/operator/internal/controller/redpanda/resource_controller.go
@@ -41,6 +41,12 @@ type ResourceRequest[T client.Object] struct {
 	factory internalclient.ClientFactory
 	logger  logr.Logger
 	object  T
+	// clusterName identifies which peer Kubernetes API the object lives on.
+	// Layered-CR reconcilers must pass this to factory.*ForCluster methods
+	// so the underlying clusterRef lookup targets the right cluster;
+	// otherwise multicluster reconciliation falls back to the local cluster
+	// and misses peer-resident Redpanda/StretchCluster CRs.
+	clusterName string
 }
 
 type ResourceReconciler[T client.Object] interface {
@@ -105,9 +111,10 @@ func (r *ResourceController[T, U]) Reconcile(ctx context.Context, req mcreconcil
 	}
 
 	request := ResourceRequest[U]{
-		factory: r.ClientFactory,
-		logger:  l,
-		object:  object,
+		factory:     r.ClientFactory,
+		logger:      l,
+		object:      object,
+		clusterName: req.ClusterName,
 	}
 
 	if !object.GetDeletionTimestamp().IsZero() {

--- a/operator/internal/controller/redpanda/role_controller.go
+++ b/operator/internal/controller/redpanda/role_controller.go
@@ -18,8 +18,11 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
@@ -261,12 +264,12 @@ func (r *RoleReconciler) DeleteResource(ctx context.Context, request ResourceReq
 
 func (r *RoleReconciler) roleAndACLClients(ctx context.Context, request ResourceRequest[*redpandav1alpha2.RedpandaRole]) (*roles.Client, *acls.Syncer, bool, error) {
 	role := request.object
-	rolesClient, err := request.factory.Roles(ctx, role, r.rolesOptions...)
+	rolesClient, err := request.factory.RolesForCluster(ctx, role, request.clusterName, r.rolesOptions...)
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	syncer, err := request.factory.ACLs(ctx, role, r.extraOptions...)
+	syncer, err := request.factory.ACLsForCluster(ctx, role, request.clusterName, r.extraOptions...)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -310,4 +313,29 @@ func SetupRoleController(ctx context.Context, mgr multicluster.Manager, expander
 	// happened on the resource synced to the cluster and attempt to correct
 	// any drift.
 	return builder.Complete(controller.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
+}
+
+// SetupRoleControllerForMulticluster registers the RedpandaRole reconciler
+// against a multicluster manager and watches StretchCluster CRs. See
+// [SetupTopicControllerForMulticluster] for the rationale on why this is
+// a separate entry point.
+func SetupRoleControllerForMulticluster(ctx context.Context, mgr multicluster.Manager, factory internalclient.ClientFactory, namespace string) error {
+	builder := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.RedpandaRole{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true)).
+		Owns(&corev1.Secret{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+
+	for _, clusterName := range mgr.GetClusterNames() {
+		enqueueStretch, err := controller.RegisterStretchClusterSourceIndex(ctx, mgr, "role_stretch", clusterName, &redpandav1alpha2.RedpandaRole{}, &redpandav1alpha2.RedpandaRoleList{})
+		if err != nil {
+			return err
+		}
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+	}
+
+	ctl := NewResourceController(mgr, factory, &RoleReconciler{}, "RoleReconciler")
+
+	return builder.Complete(ctl.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
 }

--- a/operator/internal/controller/redpanda/schema_controller.go
+++ b/operator/internal/controller/redpanda/schema_controller.go
@@ -15,8 +15,11 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
@@ -65,7 +68,7 @@ func (r *SchemaReconciler) SyncResource(ctx context.Context, request ResourceReq
 
 	hash := schema.Status.SchemaHash
 	versions := schema.Status.Versions
-	syncer, err := request.factory.Schemas(ctx, schema)
+	syncer, err := request.factory.SchemasForCluster(ctx, schema, request.clusterName)
 	if err != nil {
 		return createPatch(err, hash, versions)
 	}
@@ -75,7 +78,7 @@ func (r *SchemaReconciler) SyncResource(ctx context.Context, request ResourceReq
 }
 
 func (r *SchemaReconciler) DeleteResource(ctx context.Context, request ResourceRequest[*redpandav1alpha2.Schema]) error {
-	syncer, err := request.factory.Schemas(ctx, request.object)
+	syncer, err := request.factory.SchemasForCluster(ctx, request.object, request.clusterName)
 	if err != nil {
 		return ignoreAllConnectionErrors(request.logger, err)
 	}
@@ -115,4 +118,26 @@ func SetupSchemaController(ctx context.Context, mgr multicluster.Manager, expand
 	// happened on the resource synced to the cluster and attempt to correct
 	// any drift.
 	return builder.Complete(controller.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
+}
+
+// SetupSchemaControllerForMulticluster registers the Schema reconciler against
+// a multicluster manager and watches StretchCluster CRs.
+func SetupSchemaControllerForMulticluster(ctx context.Context, mgr multicluster.Manager, factory internalclient.ClientFactory, namespace string) error {
+	builder := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.Schema{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+
+	for _, clusterName := range mgr.GetClusterNames() {
+		enqueueStretch, err := controller.RegisterStretchClusterSourceIndex(ctx, mgr, "schema_stretch", clusterName, &redpandav1alpha2.Schema{}, &redpandav1alpha2.SchemaList{})
+		if err != nil {
+			return err
+		}
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+	}
+
+	ctl := NewResourceController(mgr, factory, &SchemaReconciler{}, "SchemaReconciler")
+
+	return builder.Complete(ctl.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
 }

--- a/operator/internal/controller/redpanda/shadow_link_controller.go
+++ b/operator/internal/controller/redpanda/shadow_link_controller.go
@@ -14,9 +14,12 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
@@ -72,12 +75,12 @@ func (r *ShadowLinkReconciler) SyncResource(ctx context.Context, request Resourc
 	state := shadowLink.Status.State
 	tasks := shadowLink.Status.TaskStatuses
 	topics := shadowLink.Status.ShadowTopicStatuses
-	syncer, err := request.factory.ShadowLinks(ctx, shadowLink)
+	syncer, err := request.factory.ShadowLinksForCluster(ctx, shadowLink, request.clusterName)
 	if err != nil {
 		return createPatch(err, state, tasks, topics)
 	}
 
-	remoteCluster, err := request.factory.RemoteClusterSettings(ctx, shadowLink)
+	remoteCluster, err := request.factory.RemoteClusterSettingsForCluster(ctx, shadowLink, request.clusterName)
 	if err != nil {
 		return createPatch(err, state, tasks, topics)
 	}
@@ -90,7 +93,7 @@ func (r *ShadowLinkReconciler) SyncResource(ctx context.Context, request Resourc
 }
 
 func (r *ShadowLinkReconciler) DeleteResource(ctx context.Context, request ResourceRequest[*redpandav1alpha2.ShadowLink]) error {
-	syncer, err := request.factory.ShadowLinks(ctx, request.object)
+	syncer, err := request.factory.ShadowLinksForCluster(ctx, request.object, request.clusterName)
 	if err != nil {
 		return ignoreAllConnectionErrors(request.logger, err)
 	}
@@ -133,6 +136,28 @@ func SetupShadowLinkController(ctx context.Context, mgr multicluster.Manager, ex
 	// happened on the resource synced to the cluster and attempt to correct
 	// any drift.
 	return builder.Complete(controller.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
+}
+
+// SetupShadowLinkControllerForMulticluster registers the ShadowLink reconciler
+// against a multicluster manager and watches StretchCluster CRs.
+func SetupShadowLinkControllerForMulticluster(ctx context.Context, mgr multicluster.Manager, factory internalclient.ClientFactory, namespace string) error {
+	builder := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.ShadowLink{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true), mcbuilder.WithPredicates(predicate.GenerationChangedPredicate{}))
+
+	for _, clusterName := range mgr.GetClusterNames() {
+		enqueueStretch, err := controller.RegisterStretchClusterSourceIndex(ctx, mgr, "shadow_link_stretch", clusterName, &redpandav1alpha2.ShadowLink{}, &redpandav1alpha2.ShadowLinkList{})
+		if err != nil {
+			return err
+		}
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+	}
+
+	ctl := NewResourceController(mgr, factory, &ShadowLinkReconciler{}, "ShadowLinkReconciler")
+
+	return builder.Complete(ctl.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
 }
 
 func ShadowLinkTaskStatusesToConfigs(existing, updated []redpandav1alpha2.ShadowLinkTaskStatus) []*redpandav1alpha2ac.ShadowLinkTaskStatusApplyConfiguration {

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -27,9 +27,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	v2 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
@@ -102,7 +104,7 @@ func (r *TopicReconciler) Reconcile(ctx context.Context, req mcreconcile.Request
 	}
 
 	l.Info("reconciling topic")
-	topic, result, err := r.reconcile(ctx, r.getRecorder(cluster), topic, l)
+	topic, result, err := r.reconcile(ctx, r.getRecorder(cluster), topic, req.ClusterName, l)
 
 	l.Info("updating topic status")
 	// Update status after reconciliation.
@@ -170,7 +172,36 @@ func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expande
 	return builder.Complete(controller.FilterNamespaceReconciler(namespace, r))
 }
 
-func (r *TopicReconciler) reconcile(ctx context.Context, recorder record.EventRecorder, topic *redpandav1alpha2.Topic, l logr.Logger) (*redpandav1alpha2.Topic, ctrl.Result, error) {
+// SetupTopicControllerForMulticluster registers the Topic reconciler against a
+// multicluster manager and configures it to re-enqueue Topic CRs whose
+// spec.cluster.clusterRef points at a StretchCluster. Mirrors the
+// SetupWithMulticlusterManager pattern used by the Console controller —
+// Redpanda CRs are not deployed in multicluster mode, so the only cluster ref
+// kind worth watching here is StretchCluster.
+func SetupTopicControllerForMulticluster(ctx context.Context, mgr multicluster.Manager, factory internalclient.ClientFactory, namespace string) error {
+	r := &TopicReconciler{
+		Manager: mgr,
+		Factory: factory,
+	}
+
+	builder := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.Topic{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+
+	for _, clusterName := range mgr.GetClusterNames() {
+		enqueueStretch, err := controller.RegisterStretchClusterSourceIndex(ctx, mgr, "topic_stretch", clusterName, &redpandav1alpha2.Topic{}, &redpandav1alpha2.TopicList{})
+		if err != nil {
+			return err
+		}
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+	}
+
+	return builder.Complete(controller.FilterNamespaceReconciler(namespace, r))
+}
+
+func (r *TopicReconciler) reconcile(ctx context.Context, recorder record.EventRecorder, topic *redpandav1alpha2.Topic, clusterName string, l logr.Logger) (*redpandav1alpha2.Topic, ctrl.Result, error) {
 	l = l.WithName("reconcile")
 
 	interval := metav1.Duration{Duration: time.Second * 3}
@@ -184,7 +215,7 @@ func (r *TopicReconciler) reconcile(ctx context.Context, recorder record.EventRe
 		l.V(log.TraceLevel).Info("bump observed generation", "observed generation", topic.Generation)
 	}
 
-	kafkaClient, err := r.createKafkaClient(ctx, topic, l)
+	kafkaClient, err := r.createKafkaClient(ctx, topic, clusterName, l)
 	if err != nil {
 		// If topic is being deleted, allow finalizer removal when we can't
 		// establish a connection. This prevents namespaces from getting stuck
@@ -603,8 +634,8 @@ func generateConf(
 	return setConf, specialSetConf, deleteConf
 }
 
-func (r *TopicReconciler) createKafkaClient(ctx context.Context, topic *redpandav1alpha2.Topic, l logr.Logger) (*kgo.Client, error) {
-	kafkaClient, err := r.Factory.KafkaClient(log.IntoContext(ctx, l.WithName("kafkaClient")), topic)
+func (r *TopicReconciler) createKafkaClient(ctx context.Context, topic *redpandav1alpha2.Topic, clusterName string, l logr.Logger) (*kgo.Client, error) {
+	kafkaClient, err := r.Factory.KafkaClientForCluster(log.IntoContext(ctx, l.WithName("kafkaClient")), topic, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("creating franz-go kafka client: %w", err)
 	}

--- a/operator/internal/controller/redpanda/user_controller.go
+++ b/operator/internal/controller/redpanda/user_controller.go
@@ -20,10 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2ac "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration/redpanda/v1alpha2"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
@@ -171,12 +174,12 @@ func (r *UserReconciler) DeleteResource(ctx context.Context, request ResourceReq
 
 func (r *UserReconciler) userAndACLClients(ctx context.Context, request ResourceRequest[*redpandav1alpha2.User]) (*users.Client, *acls.Syncer, bool, error) {
 	user := request.object
-	usersClient, err := request.factory.Users(ctx, user, r.extraOptions...)
+	usersClient, err := request.factory.UsersForCluster(ctx, user, request.clusterName, r.extraOptions...)
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	syncer, err := request.factory.ACLs(ctx, user, r.extraOptions...)
+	syncer, err := request.factory.ACLsForCluster(ctx, user, request.clusterName, r.extraOptions...)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -243,6 +246,51 @@ func SetupUserController(ctx context.Context, mgr multicluster.Manager, expander
 	// Every 5 minutes try and check to make sure no manual modifications
 	// happened on the resource synced to the cluster and attempt to correct
 	// any drift.
+	return builder.Complete(ctrl.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
+}
+
+// SetupUserControllerForMulticluster registers the User reconciler against a
+// multicluster manager wired up by the multicluster operator subcommand. It
+// only watches StretchCluster cluster refs — Redpanda CRs are not deployed in
+// multicluster mode. Per-cluster password-secret indexes are still installed
+// so external Secret rotations (e.g. ESO) trigger immediate reconciliation.
+func SetupUserControllerForMulticluster(ctx context.Context, mgr multicluster.Manager, factory internalclient.ClientFactory, namespace string) error {
+	builder := mcbuilder.ControllerManagedBy(mgr).
+		WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+			SkipNameValidation: ptr.To(true),
+		}).
+		For(&redpandav1alpha2.User{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true)).
+		Owns(&corev1.Secret{}, mcbuilder.WithEngageWithLocalCluster(true), mcbuilder.WithEngageWithProviderClusters(true))
+
+	for _, clusterName := range mgr.GetClusterNames() {
+		enqueueStretch, err := controller.RegisterStretchClusterSourceIndex(ctx, mgr, "user_stretch", clusterName, &redpandav1alpha2.User{}, &redpandav1alpha2.UserList{})
+		if err != nil {
+			return err
+		}
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+
+		cluster, err := mgr.GetCluster(ctx, clusterName)
+		if err != nil {
+			return err
+		}
+		if err := cluster.GetFieldIndexer().IndexField(ctx, &redpandav1alpha2.User{}, userPasswordSecretIndex, func(o client.Object) []string {
+			user, ok := o.(*redpandav1alpha2.User)
+			if !ok {
+				return nil
+			}
+			if name := user.GetPasswordSecretName(); user.ShouldSyncCredentials() && name != "" {
+				return []string{types.NamespacedName{Namespace: user.Namespace, Name: name}.String()}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		builder.Watches(&corev1.Secret{}, enqueueUsersForSecret(mgr, clusterName), controller.WatchOptions(clusterName)...)
+	}
+
+	ctrl := NewResourceController(mgr, factory, &UserReconciler{}, "UserReconciler")
+
 	return builder.Complete(ctrl.PeriodicallyReconcile(5 * time.Minute).FilterNamespace(namespace))
 }
 

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -244,6 +244,15 @@ func (c *Factory) KafkaClientForCluster(ctx context.Context, obj any, clusterNam
 		return c.kafkaForCluster(ctx, cluster, clusterName, opts...)
 	}
 
+	stretchCluster, err := c.getStretchCluster(ctx, o, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if stretchCluster != nil {
+		return c.kafkaForStretchCluster(ctx, stretchCluster, clusterName, opts...)
+	}
+
 	v1Cluster, err := c.getV1Cluster(ctx, o, clusterName)
 	if err != nil {
 		return nil, err
@@ -295,6 +304,15 @@ func (c *Factory) RedpandaAdminClientForCluster(ctx context.Context, obj any, cl
 
 	if cluster != nil {
 		return c.redpandaAdminForCluster(ctx, cluster, clusterName)
+	}
+
+	stretchCluster, err := c.getStretchCluster(ctx, o, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if stretchCluster != nil {
+		return c.redpandaAdminForStretchCluster(ctx, stretchCluster, clusterName)
 	}
 
 	v1Cluster, err := c.getV1Cluster(ctx, o, clusterName)
@@ -354,6 +372,15 @@ func (c *Factory) SchemaRegistryClientForCluster(ctx context.Context, obj any, c
 		return c.schemaRegistryForCluster(ctx, cluster, clusterName)
 	}
 
+	stretchCluster, err := c.getStretchCluster(ctx, o, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	if stretchCluster != nil {
+		return c.schemaRegistryForStretchCluster(ctx, stretchCluster, clusterName)
+	}
+
 	v1Cluster, err := c.getV1Cluster(ctx, o, clusterName)
 	if err != nil {
 		return nil, err
@@ -375,7 +402,7 @@ func (c *Factory) SchemaRegistryClient(ctx context.Context, obj any) (*sr.Client
 }
 
 func (c *Factory) SchemasForCluster(ctx context.Context, obj redpandav1alpha2.ClusterReferencingObject, clusterName string) (*schemas.Syncer, error) {
-	schemaRegistryClient, err := c.SchemaRegistryClient(ctx, obj)
+	schemaRegistryClient, err := c.SchemaRegistryClientForCluster(ctx, obj, clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +415,7 @@ func (c *Factory) Schemas(ctx context.Context, obj redpandav1alpha2.ClusterRefer
 }
 
 func (c *Factory) ShadowLinksForCluster(ctx context.Context, obj redpandav1alpha2.RemoteClusterReferencingObject, clusterName string) (*shadow.Syncer, error) {
-	adminClient, err := c.RedpandaAdminClient(ctx, obj)
+	adminClient, err := c.RedpandaAdminClientForCluster(ctx, obj, clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +428,7 @@ func (c *Factory) ShadowLinks(ctx context.Context, obj redpandav1alpha2.RemoteCl
 }
 
 func (c *Factory) ACLsForCluster(ctx context.Context, obj redpandav1alpha2.ClusterReferencingObject, clusterName string, opts ...kgo.Opt) (*acls.Syncer, error) {
-	kafkaClient, err := c.KafkaClient(ctx, obj, opts...)
+	kafkaClient, err := c.KafkaClientForCluster(ctx, obj, clusterName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -448,12 +475,12 @@ func (c *Factory) UsersForCluster(ctx context.Context, obj redpandav1alpha2.Clus
 		return nil, err
 	}
 
-	kafkaClient, err := c.KafkaClient(ctx, obj, opts...)
+	kafkaClient, err := c.KafkaClientForCluster(ctx, obj, clusterName, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	adminClient, err := c.RedpandaAdminClient(ctx, obj)
+	adminClient, err := c.RedpandaAdminClientForCluster(ctx, obj, clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +493,7 @@ func (c *Factory) Users(ctx context.Context, obj redpandav1alpha2.ClusterReferen
 }
 
 func (c *Factory) RolesForCluster(ctx context.Context, obj redpandav1alpha2.ClusterReferencingObject, clusterName string, opts ...roles.Option) (*roles.Client, error) {
-	adminClient, err := c.RedpandaAdminClient(ctx, obj)
+	adminClient, err := c.RedpandaAdminClientForCluster(ctx, obj, clusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -581,6 +608,41 @@ func (c *Factory) getV2Cluster(ctx context.Context, obj client.Object, clusterNa
 	if source := o.GetClusterSource(); source != nil { //nolint:nestif // ignore
 		if ref := source.GetClusterRef(); ref != nil && ref.IsV2() {
 			var cluster redpandav1alpha2.Redpanda
+
+			client, err := c.GetClient(ctx, clusterName)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := client.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: ref.Name}, &cluster); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil, ErrInvalidClusterRef
+				}
+				return nil, err
+			}
+
+			return &cluster, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// getStretchCluster resolves a StretchCluster CR referenced by obj's
+// spec.cluster.clusterRef. Used by the layered-CR (Topic/User/Role/Schema/
+// Group/ShadowLink) reconcilers running in multicluster mode, where the
+// referenced cluster CR is a StretchCluster rather than a Redpanda CR.
+// clusterName must be the cluster on which obj itself lives so the lookup
+// targets the right peer Kubernetes API.
+func (c *Factory) getStretchCluster(ctx context.Context, obj client.Object, clusterName string) (*redpandav1alpha2.StretchCluster, error) {
+	o, ok := obj.(redpandav1alpha2.ClusterReferencingObject)
+	if !ok {
+		return nil, nil
+	}
+
+	if source := o.GetClusterSource(); source != nil { //nolint:nestif // ignore
+		if ref := source.GetClusterRef(); ref != nil && ref.IsStretchCluster() {
+			var cluster redpandav1alpha2.StretchCluster
 
 			client, err := c.GetClient(ctx, clusterName)
 			if err != nil {


### PR DESCRIPTION
This adds multicluster support for Topics, Users, RedpandaRoles, Groups, Schemas, and ShadowLinks. It also adds a general acceptance test that just ensures the CRDs propagate to the cluster properly. No variants are added due to the complexity of making this snappy and work properly with a different, default multicluster-deployed operator since the current acceptance tests leverage the default-deployed operator that runs without multicluster support. Most of the wiring is just plumbing through the proper clusterRef resolution through our factory methods and handing off the reconciled cluster to our generic resource controller implementation.