### PR TITLE
operator: fix decommission broker Admin API DNS when fullnameOverride is set

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260601-170000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260601-170000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: "Fixed the operator-wide broker decommissioner (`--additional-controllers=decommission`) constructing the wrong broker Admin API hostname when `fullnameOverride` is set. It used the Helm release name for the Pod segment (`<release>-N.<fullname>...`) while the actual broker Pod is named from the chart fullname (`<fullname>-N.<fullname>...`), so the cluster-health check failed with `no such host` and decommission/PVC cleanup never completed. The Pod hostname now uses the fullname (honoring `fullnameOverride`); behavior is unchanged when `fullnameOverride` is unset."
+time: 2026-06-01T17:00:00.000000-07:00

--- a/operator/internal/controller/olddecommission/broker_urls_test.go
+++ b/operator/internal/controller/olddecommission/broker_urls_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package olddecommission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestCreateBrokerURLs(t *testing.T) {
+	values := func(fullnameOverride string) map[string]interface{} {
+		return map[string]interface{}{
+			"fullnameOverride": fullnameOverride,
+			"clusterDomain":    "cluster.local",
+			"listeners": map[string]interface{}{
+				"admin": map[string]interface{}{
+					"port": float64(9644),
+				},
+			},
+		}
+	}
+
+	t.Run("fullnameOverride differs from release: pod host uses the fullname", func(t *testing.T) {
+		// Regression for the fullnameOverride decommission bug: with release
+		// "redpanda-helm" and fullnameOverride "redpanda" the broker Pod is
+		// redpanda-N (StatefulSet/fullname), not redpanda-helm-N.
+		urls, err := createBrokerURLs("redpanda-helm", "dev-redpanda", 3, nil, values("redpanda"))
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"redpanda-0.redpanda.dev-redpanda.svc.cluster.local:9644",
+			"redpanda-1.redpanda.dev-redpanda.svc.cluster.local:9644",
+			"redpanda-2.redpanda.dev-redpanda.svc.cluster.local:9644",
+		}, urls)
+	})
+
+	t.Run("single ordinal uses the fullname", func(t *testing.T) {
+		urls, err := createBrokerURLs("redpanda-helm", "dev-redpanda", 3, ptr.To(2), values("redpanda"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"redpanda-2.redpanda.dev-redpanda.svc.cluster.local:9644"}, urls)
+	})
+
+	t.Run("no fullnameOverride: pod host falls back to the release name", func(t *testing.T) {
+		urls, err := createBrokerURLs("redpanda", "ns", 1, nil, values(""))
+		require.NoError(t, err)
+		require.Equal(t, []string{"redpanda-0.redpanda.ns.svc.cluster.local:9644"}, urls)
+	})
+}

--- a/operator/internal/controller/olddecommission/redpanda_decommission_controller.go
+++ b/operator/internal/controller/olddecommission/redpanda_decommission_controller.go
@@ -643,12 +643,20 @@ func createBrokerURLs(release, namespace string, replicas int32, ordinal *int, v
 		return brokerList, fmt.Errorf("could not retrieve clusterDomain: %s; error: %w", domain, err)
 	}
 
+	// The broker Pod hostname is derived from the chart's fullname (the
+	// StatefulSet name), not the Helm release name. These differ when
+	// `fullnameOverride` is set, so the pod segment must use serviceName (which
+	// already accounts for fullnameOverride) rather than release — otherwise the
+	// admin-api health check targets a nonexistent host
+	// (e.g. `<release>-0.<fullname>...` instead of `<fullname>-0.<fullname>...`)
+	// and decommission/PVC cleanup never completes. When fullnameOverride is
+	// unset, serviceName == release, so this is a no-op for the common case.
 	if ordinal == nil {
 		for i := 0; i < int(replicas); i++ {
-			brokerList = append(brokerList, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", release, i, serviceName, namespace, domain, port))
+			brokerList = append(brokerList, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", serviceName, i, serviceName, namespace, domain, port))
 		}
 	} else {
-		brokerList = append(brokerList, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", release, *ordinal, serviceName, namespace, domain, port))
+		brokerList = append(brokerList, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", serviceName, *ordinal, serviceName, namespace, domain, port))
 	}
 
 	return brokerList, nil


### PR DESCRIPTION
## Problem

The operator-wide broker decommissioner (`olddecommission.DecommissionReconciler`, enabled via `--additional-controllers=decommission`) builds the broker Admin API URL in `createBrokerURLs` using the Helm **release** name for the Pod hostname segment:

```go
fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", release, ordinal, serviceName, namespace, domain, port)
//                                    ^^^^^^^          ^^^^^^^^^^^
//                                    Pod host         service (honors fullnameOverride)
```

Broker Pods are named from the chart **fullname** (the StatefulSet name), which differs from the release name when **`fullnameOverride`** is set. The service segment already used `serviceName` (which honors `fullnameOverride`), but the Pod segment used `release`, so the health-overview request targeted a nonexistent host:

```
Get "http://redpanda-helm-0.redpanda.dev-redpanda.svc.cluster.local.:9644/v1/cluster/health_overview":
dial tcp: lookup redpanda-helm-0.redpanda.dev-redpanda.svc.cluster.local … no such host
```

(actual broker is `redpanda-0.redpanda…`). The check fails, so decommission — and the PVC cleanup that follows it — never completes. Reported by a customer running an operator-managed cluster with `fullnameOverride`.

## Fix

Use `serviceName` (which already accounts for `fullnameOverride`) for the Pod hostname segment as well. When `fullnameOverride` is unset, `serviceName == release`, so this is a no-op for the common case.

```go
fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", serviceName, ordinal, serviceName, namespace, domain, port)
```

## Scope

- **PVCUnbinder is not affected.** It operates on Pods/PVCs/PVs via owner references and labels and never constructs broker DNS, so there's nothing analogous to fix there. (Confirmed by inspection.)
- This is the operator-wide (`olddecommission`) controller only. The per-broker sidecar decommissioner (`--run-decommissioner`) already resolves brokers via the chart-rendered DNS and was never affected; enabling the sidecar (see #1563) also sidesteps this bug.
- Out of scope: `createBrokerURLs` also ignores a separately-overridden `service.name` (the chart's `ServiceName` can differ from `Fullname`). That's a narrower pre-existing gap, not this bug.

## Tests

- New `TestCreateBrokerURLs`: asserts the Pod host uses the fullname when `fullnameOverride` differs from the release (all-replicas and single-ordinal), and falls back to the release name when `fullnameOverride` is unset.
- `golangci-lint` clean.

---

## E2E validation on EKS 1.34

Validated on a fresh **EKS 1.34.8** cluster reproducing the customer's operator-managed + `fullnameOverride` setup, swapping **only** the operator image between runs to isolate the fix.

**Setup**
- EKS **1.34.8**, operator run with `--additional-controllers=decommission --unbind-pvcs-after=60s --allow-pv-rebinding`.
- Redpanda CR/release name `redpanda-helm`, namespace `dev-redpanda`, **`fullnameOverride: redpanda`** → broker Pods/StatefulSet are `redpanda-N` / `redpanda`, but the Helm **release** is `redpanda-helm` (**release ≠ fullname** = the trigger). No CR sidecars (the operator-wide `olddecommission` path).
- BEFORE = operator build *without* this fix (release-name host); AFTER = this PR's build. Only the operator Deployment image changed.

Brokers advertise on the fullname (`redpanda-0.redpanda.dev-redpanda.svc.cluster.local.`), confirming Pods are `redpanda-N`, not `redpanda-helm-N`.

### BEFORE (without the fix) — `olddecommission` stuck on the wrong DNS
On scale-down the StatefulSet `DecommissionReconciler` errored every ~60s and requeued indefinitely:
```
could not make request to admin-api: Get
"http://redpanda-helm-0.redpanda.dev-redpanda.svc.cluster.local.:9644/v1/cluster/health_overview":
dial tcp: lookup redpanda-helm-0.redpanda.dev-redpanda.svc.cluster.local. … no such host
…
"msg":"found error, we will requeue"
```
The Pod-host segment used the **release** name `redpanda-helm-0` (the actual broker is `redpanda-0`).

### AFTER (this PR) — DNS resolves, reconcile completes
Same cluster, only the operator image swapped to the PR build. The `no such host` errors **stop (0 occurrences)**, the health check succeeds against the correct **fullname** host, and the reconcile finishes cleanly:
```
"msg":"cluster health","health":{"is_healthy":true,"all_nodes":[0,1],"nodes_down":[]…}
"msg":"succesfull reconciliation finished …"
```

✅ **The reported `fullnameOverride` bug is fixed** — the broker Admin API health-overview URL now uses the chart fullname (`redpanda-0…`) instead of the Helm release name (`redpanda-helm-0…`), so the request resolves and the decommission reconciler is no longer stuck in an error loop.

### Scope note
The test cluster is **operator-managed (v2)**, where broker-membership decommission is driven by the v2 controller — it removed the scaled-down broker from membership on its own (even while the un-fixed `olddecommission` controller was stuck). So in this topology the bug's observable impact is the continuous DNS-resolution failure + stuck `olddecommission` reconcile, which this PR eliminates. The full decommission-and-PVC-cleanup *via `olddecommission`* applies to Helm-managed clusters where that controller is the sole decommissioner.

_Validated end-to-end on EKS 1.34, 2026-06-02._
