### PR TITLE
operator: honor clusterRef.namespace in Console cluster resolution

### DIFF
--- a/.changes/unreleased/operator-Changed-20260603-154709.yaml
+++ b/.changes/unreleased/operator-Changed-20260603-154709.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Changed
+body: "The Console controller now honors the `namespace` field of its `clusterSource.clusterRef`. Previously the renderer always resolved the referenced cluster in the Console's own namespace, so the `clusterRef.namespace` field exposed by the CRD was silently inert: a Console could fail to find the intended cluster, or — if a same-named cluster existed in its own namespace — silently bind to the wrong Redpanda and deploy against it. The lookup now uses `clusterRef.namespace` when set and falls back to the Console's namespace otherwise (no behavior change for same-namespace references). This covers `Redpanda`, `StretchCluster`, and v1 `Cluster` lookups."
+time: 2026-06-03T15:47:09.000000+02:00

--- a/operator/internal/controller/console/controller.go
+++ b/operator/internal/controller/console/controller.go
@@ -520,7 +520,7 @@ func (r *render) clusterFragment(ctx context.Context) (console.PartialRenderValu
 	if ref := r.console.Spec.ClusterSource.ClusterRef; ref != nil {
 		key := kube.ObjectKey{
 			Name:      ref.Name,
-			Namespace: r.console.Namespace,
+			Namespace: ref.GetNamespace(r.console.Namespace),
 		}
 
 		if ref.IsStretchCluster() {


### PR DESCRIPTION
The Console CRD already exposes spec.clusterSource.clusterRef.namespace (the shared ClusterRef field added for cross-namespace ShadowLinks), but the Console renderer ignored it: clusterFragment built the lookup key with the Console's own namespace, so the field was silently inert.

A Console in namespace `b` setting clusterRef.namespace=`a` would either fail to find the cluster, or — if a same-named cluster happened to exist in `b` — silently bind to the wrong Redpanda (b/<name>) and deploy against it.

Resolve the key via ref.GetNamespace(r.console.Namespace) so an explicit clusterRef.namespace is honored and an unset namespace still falls back to the Console's own namespace (no behavior change for same-namespace refs). This covers Redpanda, StretchCluster, and v1 Cluster lookups in clusterFragment.