### PR TITLE
Bump Go toolchain to 1.26.4 to address Snyk findings

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cert-manager/cert-manager v1.19.3

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,3 +1,3 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.26.3
+go 1.26.4

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console/v3
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cloudhut/common v0.11.0

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda/v25
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cert-manager/cert-manager v1.19.3

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.26.3
+go 1.26.4
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 use (
 	./acceptance

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/goutils v1.1.1

--- a/gotohelm/testdata/src/example/go.mod
+++ b/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/redpanda-data/common-go/kube v0.0.0-20260408144400-efba9928bb27

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cockroachdb/errors v1.12.0

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260313213909-923579c57f1c.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.26.3
+go 1.26.4
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -8,7 +8,7 @@ changie version v1.24.0
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.26.3
+go version go1.26.4
 
 -- helm --
 # helm version


### PR DESCRIPTION
## What

Bumps the `go` directive to **1.26.4** across all workspace modules (and the `pkg/lint/testdata/tool-versions.txtar` golden file). Pure toolchain directive bump — no `go.sum` changes.

## Why

Clears two stdlib HIGH Snyk findings present across the operator's modules:

- **CVE-2026-27145** / GO-2026-5037 — Allocation of Resources Without Limits or Throttling in `crypto/x509` (inefficient candidate hostname parsing). Fixed in go1.26.4.
- **CVE-2026-42504** / GO-2026-5038 — Allocation of Resources Without Limits or Throttling in `net/mime`. Fixed in go1.26.4.

## Notes
- `go work sync` propagated the directive across the workspace (incl. `go.work` and the gotohelm testdata example module).
- No backport label — auto-backport bot fails on dep/toolchain bumps; I'll do manual backports (starting with release/v25.2.x) once this is green.

## References
- https://pkg.go.dev/vuln/GO-2026-5037
- https://pkg.go.dev/vuln/GO-2026-5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)