### PR TITLE
Bump Go toolchain to 1.25.11 to address Snyk findings (release/v25.2.x)

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,3 +1,3 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.25.10
+go 1.25.11

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console/v3
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/cloudhut/common v0.11.0

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda/v25
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.25.10
+go 1.25.11
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.10
+go 1.25.11
 
 use (
 	./acceptance

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/Masterminds/goutils v1.1.1

--- a/gotohelm/testdata/src/example/go.mod
+++ b/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/redpanda-data/redpanda-operator/gotohelm v0.0.0-00010101000000-000000000000

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/licensereport/go.mod
+++ b/licensereport/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licensereport
 
-go 1.25.0
+go 1.25.11
 
 require github.com/google/licenseclassifier/v2 v2.0.0
 

--- a/licenseupdater/go.mod
+++ b/licenseupdater/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licenseupdater
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.25.10
+go 1.25.11
 
 require (
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251111205446-9c61b5cb371f.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.25.10
+go 1.25.11
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -8,7 +8,7 @@ changie version v1.24.0
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.25.10
+go version go1.25.11
 
 -- helm --
 # helm version


### PR DESCRIPTION
## What

Backport of #1581 to `release/v25.2.x`. Bumps the `go` directive to **1.25.11** across all workspace modules (and the `pkg/lint/testdata/tool-versions.txtar` golden file). Pure toolchain directive bump — no `go.sum` changes.

This release branch is on the Go **1.25** line, so this is a patch bump (`1.25.10` → `1.25.11`, and `licensereport` `1.25.0` → `1.25.11`) rather than a move to the 1.26.x toolchain used on `main` in #1581.

## Why

Clears two stdlib HIGH Snyk findings:

- **CVE-2026-27145** / GO-2026-5037 — Allocation of Resources Without Limits or Throttling in `crypto/x509` (inefficient candidate hostname parsing). Fixed in go1.25.11.
- **CVE-2026-42504** / GO-2026-5038 — Allocation of Resources Without Limits or Throttling in `net/mime`. Fixed in go1.25.11.

## Notes
- Verified with `govulncheck ./...` against the `operator` module: both findings are reported at go1.25.10 and absent at go1.25.11.

## References
- https://pkg.go.dev/vuln/GO-2026-5037
- https://pkg.go.dev/vuln/GO-2026-5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)