### PR TITLE
operator: eliminate steady-state no-op writes and reconcile churn; ci: Docker Hub login to avoid pull rate limits

### DIFF
--- a/.buildkite/testsuite.yml
+++ b/.buildkite/testsuite.yml
@@ -41,6 +41,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
@@ -88,6 +89,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
@@ -138,6 +140,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
@@ -188,6 +191,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
@@ -238,6 +242,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
@@ -289,6 +294,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token
@@ -339,6 +345,7 @@ steps:
     plugins:
     - github.com/seek-oss/aws-sm-buildkite-plugin#v2.3.2:
         json-to-env:
+        - secret-id: sdlc/prod/buildkite/dockerhub
         - secret-id: sdlc/prod/buildkite/github_api_token
         - secret-id: sdlc/prod/buildkite/redpanda_sample_license
         - secret-id: sdlc/prod/buildkite/slack_vbot_token

--- a/.changes/unreleased/operator-Fixed-20260609-231549.yaml
+++ b/.changes/unreleased/operator-Fixed-20260609-231549.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: 'Topic controller no longer issues no-op `IncrementalAlterConfigs` on every reconcile: desired config values are now compared against the live broker config and only changed keys are written.'
+time: 2026-06-09T23:15:49.368018-07:00

--- a/.changes/unreleased/operator-Fixed-20260609-232046.yaml
+++ b/.changes/unreleased/operator-Fixed-20260609-232046.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Resource controllers (Topic, User, Group, Schema, Role, ShadowLink) no longer re-enqueue every CR on status-only updates of the referenced cluster CR. Cluster watches now filter to generation changes, so configured sync intervals (e.g. Topic `spec.interval`) take effect.
+time: 2026-06-09T23:20:46.850507-07:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -350,6 +350,15 @@ tasks:
       - redpandadata/redpanda:v26.1.5
 
     cmds:
+      # Authenticate to Docker Hub when credentials are available (CI) so
+      # pulls aren't subject to the anonymous rate limit (429 Too Many
+      # Requests), which otherwise causes silent pull failures here and
+      # ImagePullBackOff timeouts mid-test.
+      - cmd: |
+          if [ -n "${DOCKERHUB_USER:-}" ] && [ -n "${DOCKERHUB_TOKEN:-}" ]; then
+            echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USER" --password-stdin
+          fi
+        silent: true
       - |
         pids=""
         {{range .IMAGES}}
@@ -357,6 +366,17 @@ tasks:
         pids="$pids $!"
         {{end}}
         for pid in $pids; do wait "$pid" || true; done
+        # Pulls above are parallel and best-effort; verify afterwards so a
+        # missing image fails here with a clear message instead of as a k3d
+        # import error or an in-cluster ImagePullBackOff timeout mid-test.
+        missing=""
+        {{range .IMAGES}}
+        docker inspect "{{.}}" > /dev/null 2>&1 || missing="$missing {{.}}"
+        {{end}}
+        if [ -n "$missing" ]; then
+          echo "ERROR: failed to pull image(s):$missing" >&2
+          exit 1
+        fi
 
   pending-prs:
     desc: "Get all pending PRs for watched branches"

--- a/gen/pipeline/helpers.go
+++ b/gen/pipeline/helpers.go
@@ -117,6 +117,7 @@ func (suite *TestSuite) ToStep() pipeline.Step {
 				},
 				Plugins: pipeline.Plugins{
 					secretEnvVars(
+						DOCKERHUB,        // Authenticates docker pulls (test:pull-images) to avoid Docker Hub's anonymous rate limit.
 						GITHUB_API_TOKEN, // Required to clone private GH repos (Flux Shims, buildkite slack).
 						REDPANDA_SAMPLE_LICENSE,
 						SLACK_VBOT_TOKEN, // Used to notify us of build failures in slack.

--- a/gen/pipeline/pipeline.go
+++ b/gen/pipeline/pipeline.go
@@ -25,6 +25,7 @@ import (
 var (
 	// Known/Permitted environment variables pulled from AWS secret store.
 
+	DOCKERHUB               = secretEnvVar{SecretID: "sdlc/prod/buildkite/dockerhub"}
 	GITHUB_API_TOKEN        = secretEnvVar{SecretID: "sdlc/prod/buildkite/github_api_token"}
 	REDPANDA_SAMPLE_LICENSE = secretEnvVar{SecretID: "sdlc/prod/buildkite/redpanda_sample_license"}
 	SLACK_VBOT_TOKEN        = secretEnvVar{SecretID: "sdlc/prod/buildkite/slack_vbot_token"}

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -4858,7 +4858,20 @@ Examples: +
 `redpanda.remote.write=true` +
 `redpanda.remote.read=true` +
 `redpanda.remote.recovery=true` +
-`redpanda.remote.delete=true` + |  | 
+`redpanda.remote.delete=true` +
+
+The map is reconciled declaratively against the live topic configuration: +
+
+- A key with a string value is kept in sync on the topic: whenever the +
+live value differs from the desired one, the operator sets it back. +
+- A key absent from the map is not managed; if the topic carries a +
+non-default value for it, the operator resets it to the cluster +
+default. (Exceptions: `cleanup.policy` and `redpanda.storage.mode` +
+are never reset.) +
+- A key with a null value is exempt from both: the operator neither +
+updates it nor resets it to the cluster default. Use this for a +
+configuration that is managed outside the operator (e.g. set via +
+`rpk` or another client) and should be left untouched. + |  | 
 | *`cluster`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-clustersource[$$ClusterSource$$]__ | ClusterSource is a reference to the cluster where the user should be created. +
 It is used in constructing the client created to configure a cluster. + |  | 
 | *`kafkaApiSpec`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-kafkaapispec[$$KafkaAPISpec$$]__ | Defines client configuration for connecting to Redpanda brokers. +

--- a/operator/api/redpanda/v1alpha2/topic_types.go
+++ b/operator/api/redpanda/v1alpha2/topic_types.go
@@ -43,6 +43,19 @@ type TopicSpec struct {
 	// `redpanda.remote.read=true`
 	// `redpanda.remote.recovery=true`
 	// `redpanda.remote.delete=true`
+	//
+	// The map is reconciled declaratively against the live topic configuration:
+	//
+	// - A key with a string value is kept in sync on the topic: whenever the
+	//   live value differs from the desired one, the operator sets it back.
+	// - A key absent from the map is not managed; if the topic carries a
+	//   non-default value for it, the operator resets it to the cluster
+	//   default. (Exceptions: `cleanup.policy` and `redpanda.storage.mode`
+	//   are never reset.)
+	// - A key with a null value is exempt from both: the operator neither
+	//   updates it nor resets it to the cluster default. Use this for a
+	//   configuration that is managed outside the operator (e.g. set via
+	//   `rpk` or another client) and should be left untouched.
 	AdditionalConfig map[string]*string `json:"additionalConfig,omitempty"`
 
 	// ClusterSource is a reference to the cluster where the user should be created.

--- a/operator/config/crd/bases/cluster.redpanda.com_topics.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_topics.yaml
@@ -50,6 +50,19 @@ spec:
                   `redpanda.remote.read=true`
                   `redpanda.remote.recovery=true`
                   `redpanda.remote.delete=true`
+
+                  The map is reconciled declaratively against the live topic configuration:
+
+                  - A key with a string value is kept in sync on the topic: whenever the
+                    live value differs from the desired one, the operator sets it back.
+                  - A key absent from the map is not managed; if the topic carries a
+                    non-default value for it, the operator resets it to the cluster
+                    default. (Exceptions: `cleanup.policy` and `redpanda.storage.mode`
+                    are never reset.)
+                  - A key with a null value is exempt from both: the operator neither
+                    updates it nor resets it to the cluster default. Use this for a
+                    configuration that is managed outside the operator (e.g. set via
+                    `rpk` or another client) and should be left untouched.
                 type: object
               cluster:
                 description: |-
@@ -3579,6 +3592,19 @@ spec:
                   `redpanda.remote.read=true`
                   `redpanda.remote.recovery=true`
                   `redpanda.remote.delete=true`
+
+                  The map is reconciled declaratively against the live topic configuration:
+
+                  - A key with a string value is kept in sync on the topic: whenever the
+                    live value differs from the desired one, the operator sets it back.
+                  - A key absent from the map is not managed; if the topic carries a
+                    non-default value for it, the operator resets it to the cluster
+                    default. (Exceptions: `cleanup.policy` and `redpanda.storage.mode`
+                    are never reset.)
+                  - A key with a null value is exempt from both: the operator neither
+                    updates it nor resets it to the cluster default. Use this for a
+                    configuration that is managed outside the operator (e.g. set via
+                    `rpk` or another client) and should be left untouched.
                 type: object
               cluster:
                 description: |-

--- a/operator/internal/controller/redpanda/group_controller.go
+++ b/operator/internal/controller/redpanda/group_controller.go
@@ -131,7 +131,7 @@ func SetupGroupController(ctx context.Context, mgr multicluster.Manager, expande
 			if err != nil {
 				return err
 			}
-			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Group, controller.WatchOptions(clusterName)...)
+			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Group, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		if includeV2 {
@@ -139,7 +139,7 @@ func SetupGroupController(ctx context.Context, mgr multicluster.Manager, expande
 			if err != nil {
 				return err
 			}
-			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Group, controller.WatchOptions(clusterName)...)
+			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Group, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 	}
 
@@ -166,7 +166,7 @@ func SetupGroupControllerForMulticluster(ctx context.Context, mgr multicluster.M
 		if err != nil {
 			return err
 		}
-		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.ClusterSourceWatchOptions(clusterName)...)
 	}
 
 	ctl := NewResourceController(mgr, factory, &GroupReconciler{}, "GroupReconciler")

--- a/operator/internal/controller/redpanda/role_controller.go
+++ b/operator/internal/controller/redpanda/role_controller.go
@@ -295,7 +295,7 @@ func SetupRoleController(ctx context.Context, mgr multicluster.Manager, expander
 			if err != nil {
 				return err
 			}
-			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Role, controller.WatchOptions(clusterName)...)
+			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Role, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		if includeV2 {
@@ -303,7 +303,7 @@ func SetupRoleController(ctx context.Context, mgr multicluster.Manager, expander
 			if err != nil {
 				return err
 			}
-			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Role, controller.WatchOptions(clusterName)...)
+			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Role, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 	}
 
@@ -333,7 +333,7 @@ func SetupRoleControllerForMulticluster(ctx context.Context, mgr multicluster.Ma
 		if err != nil {
 			return err
 		}
-		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.ClusterSourceWatchOptions(clusterName)...)
 	}
 
 	ctl := NewResourceController(mgr, factory, &RoleReconciler{}, "RoleReconciler")

--- a/operator/internal/controller/redpanda/schema_controller.go
+++ b/operator/internal/controller/redpanda/schema_controller.go
@@ -100,7 +100,7 @@ func SetupSchemaController(ctx context.Context, mgr multicluster.Manager, expand
 			if err != nil {
 				return err
 			}
-			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Schema, controller.WatchOptions(clusterName)...)
+			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Schema, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		if includeV2 {
@@ -108,7 +108,7 @@ func SetupSchemaController(ctx context.Context, mgr multicluster.Manager, expand
 			if err != nil {
 				return err
 			}
-			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Schema, controller.WatchOptions(clusterName)...)
+			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Schema, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 	}
 
@@ -135,7 +135,7 @@ func SetupSchemaControllerForMulticluster(ctx context.Context, mgr multicluster.
 		if err != nil {
 			return err
 		}
-		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.ClusterSourceWatchOptions(clusterName)...)
 	}
 
 	ctl := NewResourceController(mgr, factory, &SchemaReconciler{}, "SchemaReconciler")

--- a/operator/internal/controller/redpanda/shadow_link_controller.go
+++ b/operator/internal/controller/redpanda/shadow_link_controller.go
@@ -118,7 +118,7 @@ func SetupShadowLinkController(ctx context.Context, mgr multicluster.Manager, ex
 			if err != nil {
 				return err
 			}
-			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1ShadowLink, controller.WatchOptions(clusterName)...)
+			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1ShadowLink, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		if includeV2 {
@@ -126,7 +126,7 @@ func SetupShadowLinkController(ctx context.Context, mgr multicluster.Manager, ex
 			if err != nil {
 				return err
 			}
-			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2ShadowLink, controller.WatchOptions(clusterName)...)
+			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2ShadowLink, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 	}
 
@@ -153,7 +153,7 @@ func SetupShadowLinkControllerForMulticluster(ctx context.Context, mgr multiclus
 		if err != nil {
 			return err
 		}
-		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.ClusterSourceWatchOptions(clusterName)...)
 	}
 
 	ctl := NewResourceController(mgr, factory, &ShadowLinkReconciler{}, "ShadowLinkReconciler")

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -607,7 +607,9 @@ func generateConf(
 	setConf = make(map[string]string)
 	specialSetConf = make(map[string]string)
 
+	liveValues := make(map[string]*string, len(describedConfig))
 	for _, conf := range describedConfig {
+		liveValues[conf.Name] = conf.Value
 		if conf.Source != kmsg.ConfigSourceDefaultConfig && conf.Value != nil && !slices.Contains(undeletableConfigs, conf.Name) {
 			deleteConf[conf.Name] = nil
 		}
@@ -628,12 +630,21 @@ func generateConf(
 			delete(deleteConf, k)
 		}
 		if v != nil {
+			// Only issue a SET when the broker's live value differs from the
+			// desired value; otherwise every reconcile of a converged topic
+			// emits a no-op IncrementalAlterConfigs that spams the broker's
+			// audit log.
+			if live, ok := liveValues[k]; ok && live != nil && *live == *v {
+				continue
+			}
 			setConf[k] = *v
 		}
 	}
 	if remoteWrite && remoteRead {
-		delete(setConf, "redpanda.remote.write")
-		specialSetConf["redpanda.remote.write"] = *topicSpecSingleValue["redpanda.remote.write"]
+		if _, ok := setConf["redpanda.remote.write"]; ok {
+			delete(setConf, "redpanda.remote.write")
+			specialSetConf["redpanda.remote.write"] = *topicSpecSingleValue["redpanda.remote.write"]
+		}
 	}
 
 	if desiredReplicationFactor != actualReplicationFactor {

--- a/operator/internal/controller/redpanda/topic_controller.go
+++ b/operator/internal/controller/redpanda/topic_controller.go
@@ -162,7 +162,7 @@ func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expande
 			if err != nil {
 				return err
 			}
-			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Schema, controller.WatchOptions(clusterName)...)
+			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1Schema, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		if includeV2 {
@@ -170,7 +170,7 @@ func SetupTopicController(ctx context.Context, mgr multicluster.Manager, expande
 			if err != nil {
 				return err
 			}
-			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Topic, controller.WatchOptions(clusterName)...)
+			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2Topic, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 	}
 
@@ -201,7 +201,7 @@ func SetupTopicControllerForMulticluster(ctx context.Context, mgr multicluster.M
 		if err != nil {
 			return err
 		}
-		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.ClusterSourceWatchOptions(clusterName)...)
 	}
 
 	return builder.Complete(controller.FilterNamespaceReconciler(namespace, r))

--- a/operator/internal/controller/redpanda/topic_controller_test.go
+++ b/operator/internal/controller/redpanda/topic_controller_test.go
@@ -1065,3 +1065,152 @@ func TestUnsetStorageMode(t *testing.T) {
 		return strings.Contains(string(logs), storageWarning)
 	}, 5*time.Second, 500*time.Millisecond, "operator should not attempt to remove redpanda.storage.mode; Redpanda logged a warning indicating a removal was attempted")
 }
+
+func describedConf(name, value string, source kmsg.ConfigSource) kmsg.DescribeConfigsResponseResourceConfig {
+	conf := kmsg.NewDescribeConfigsResponseResourceConfig()
+	conf.Name = name
+	conf.Value = ptr.To(value)
+	conf.Source = source
+	return conf
+}
+
+func TestGenerateConf(t *testing.T) {
+	for name, tc := range map[string]struct {
+		described          []kmsg.DescribeConfigsResponseResourceConfig
+		spec               map[string]*string
+		desiredReplicas    int16
+		actualReplicas     int16
+		expectedSet        map[string]string
+		expectedSpecialSet map[string]string
+		expectedDelete     map[string]any
+	}{
+		"converged topic issues no operations": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("retention.ms", "43200000", kmsg.ConfigSourceDynamicTopicConfig),
+				describedConf("cleanup.policy", "delete", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec: map[string]*string{
+				"retention.ms":   ptr.To("43200000"),
+				"cleanup.policy": ptr.To("delete"),
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+		"only the differing key is set": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("retention.ms", "43200000", kmsg.ConfigSourceDynamicTopicConfig),
+				describedConf("max.message.bytes", "1048576", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec: map[string]*string{
+				"retention.ms":      ptr.To("86400000"),
+				"max.message.bytes": ptr.To("1048576"),
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{"retention.ms": "86400000"},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+		"key matching the broker default is not re-set": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("retention.ms", "43200000", kmsg.ConfigSourceDefaultConfig),
+			},
+			spec: map[string]*string{
+				"retention.ms": ptr.To("43200000"),
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+		"key absent from the broker is set": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{},
+			spec: map[string]*string{
+				"retention.ms": ptr.To("43200000"),
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{"retention.ms": "43200000"},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+		"dynamic broker key removed from the spec is deleted": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("segment.bytes", "104857600", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec:               map[string]*string{},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{"segment.bytes": nil},
+		},
+		"nil spec value is neither set nor deleted": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("retention.ms", "43200000", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec: map[string]*string{
+				"retention.ms": nil,
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+		"changed remote.read and remote.write are split into a special set": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("redpanda.remote.read", "false", kmsg.ConfigSourceDynamicTopicConfig),
+				describedConf("redpanda.remote.write", "false", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec: map[string]*string{
+				"redpanda.remote.read":  ptr.To("true"),
+				"redpanda.remote.write": ptr.To("true"),
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{"redpanda.remote.read": "true"},
+			expectedSpecialSet: map[string]string{"redpanda.remote.write": "true"},
+			expectedDelete:     map[string]any{},
+		},
+		"converged remote.read and remote.write issue no operations": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("redpanda.remote.read", "true", kmsg.ConfigSourceDynamicTopicConfig),
+				describedConf("redpanda.remote.write", "true", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec: map[string]*string{
+				"redpanda.remote.read":  ptr.To("true"),
+				"redpanda.remote.write": ptr.To("true"),
+			},
+			desiredReplicas:    1,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+		"replication factor change is set even when configs are converged": {
+			described: []kmsg.DescribeConfigsResponseResourceConfig{
+				describedConf("retention.ms", "43200000", kmsg.ConfigSourceDynamicTopicConfig),
+			},
+			spec: map[string]*string{
+				"retention.ms": ptr.To("43200000"),
+			},
+			desiredReplicas:    3,
+			actualReplicas:     1,
+			expectedSet:        map[string]string{"replication.factor": "3"},
+			expectedSpecialSet: map[string]string{},
+			expectedDelete:     map[string]any{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			setConf, specialSetConf, deleteConf := generateConf(tc.described, tc.spec, tc.desiredReplicas, tc.actualReplicas)
+			assert.Equal(t, tc.expectedSet, setConf)
+			assert.Equal(t, tc.expectedSpecialSet, specialSetConf)
+			assert.Equal(t, tc.expectedDelete, deleteConf)
+		})
+	}
+}

--- a/operator/internal/controller/redpanda/user_controller.go
+++ b/operator/internal/controller/redpanda/user_controller.go
@@ -207,7 +207,7 @@ func SetupUserController(ctx context.Context, mgr multicluster.Manager, expander
 			if err != nil {
 				return err
 			}
-			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1User, controller.WatchOptions(clusterName)...)
+			builder.Watches(&vectorizedv1alpha1.Cluster{}, enqueueV1User, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		if includeV2 {
@@ -215,7 +215,7 @@ func SetupUserController(ctx context.Context, mgr multicluster.Manager, expander
 			if err != nil {
 				return err
 			}
-			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2User, controller.WatchOptions(clusterName)...)
+			builder.Watches(&redpandav1alpha2.Redpanda{}, enqueueV2User, controller.ClusterSourceWatchOptions(clusterName)...)
 		}
 
 		// Index Users by the password Secret they reference so we can
@@ -238,6 +238,9 @@ func SetupUserController(ctx context.Context, mgr multicluster.Manager, expander
 			return err
 		}
 
+		// Secrets never bump metadata.generation, so this watch must not use
+		// ClusterSourceWatchOptions — a generation predicate would filter out
+		// every Secret update.
 		builder.Watches(&corev1.Secret{}, enqueueUsersForSecret(mgr, clusterName), controller.WatchOptions(clusterName)...)
 	}
 
@@ -268,7 +271,7 @@ func SetupUserControllerForMulticluster(ctx context.Context, mgr multicluster.Ma
 		if err != nil {
 			return err
 		}
-		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.WatchOptions(clusterName)...)
+		builder.Watches(&redpandav1alpha2.StretchCluster{}, enqueueStretch, controller.ClusterSourceWatchOptions(clusterName)...)
 
 		cluster, err := mgr.GetCluster(ctx, clusterName)
 		if err != nil {
@@ -287,6 +290,9 @@ func SetupUserControllerForMulticluster(ctx context.Context, mgr multicluster.Ma
 			return err
 		}
 
+		// Secrets never bump metadata.generation, so this watch must not use
+		// ClusterSourceWatchOptions — a generation predicate would filter out
+		// every Secret update.
 		builder.Watches(&corev1.Secret{}, enqueueUsersForSecret(mgr, clusterName), controller.WatchOptions(clusterName)...)
 	}
 

--- a/operator/internal/controller/watches.go
+++ b/operator/internal/controller/watches.go
@@ -11,9 +11,27 @@ package controller
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 )
+
+// ClusterSourcePredicate filters the events of cluster CR watches down to
+// spec changes (and Create/Delete). Cluster CRs receive frequent status-only
+// updates from their own controllers; those bump resourceVersion but not
+// generation, and carry no information for resources connecting to the
+// cluster — connection details are derived from the cluster spec.
+var ClusterSourcePredicate predicate.Predicate = predicate.GenerationChangedPredicate{}
+
+// ClusterSourceWatchOptions returns WatchOptions extended with
+// ClusterSourcePredicate. It is meant for watches on cluster CRs (Redpanda,
+// V1 Cluster, StretchCluster) whose event handlers fan out to every resource
+// referencing the cluster: without the predicate each status-only update
+// re-enqueues every referencing resource, keeping the workqueue saturated
+// and overriding any configured sync interval.
+func ClusterSourceWatchOptions(clusterName string) []mcbuilder.WatchesOption {
+	return append(WatchOptions(clusterName), mcbuilder.WithPredicates(ClusterSourcePredicate))
+}
 
 func WatchOptions(clusterName string) []mcbuilder.WatchesOption {
 	if clusterName == mcmanager.LocalCluster {

--- a/operator/internal/controller/watches_test.go
+++ b/operator/internal/controller/watches_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// TestClusterSourcePredicate pins the event-filtering contract that
+// ClusterSourceWatchOptions relies on: status-only updates of a cluster CR
+// (resourceVersion bumped, generation unchanged) must not re-enqueue
+// referencing resources, while spec changes, creations, and deletions must.
+func TestClusterSourcePredicate(t *testing.T) {
+	cluster := func(generation int64, resourceVersion string) *redpandav1alpha2.Redpanda {
+		return &redpandav1alpha2.Redpanda{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "redpanda",
+				Namespace:       "redpanda",
+				Generation:      generation,
+				ResourceVersion: resourceVersion,
+			},
+		}
+	}
+
+	require.False(t, ClusterSourcePredicate.Update(event.UpdateEvent{
+		ObjectOld: cluster(1, "100"),
+		ObjectNew: cluster(1, "101"),
+	}), "status-only update (generation unchanged) should be filtered out")
+
+	require.True(t, ClusterSourcePredicate.Update(event.UpdateEvent{
+		ObjectOld: cluster(1, "100"),
+		ObjectNew: cluster(2, "101"),
+	}), "spec update (generation bumped) should pass")
+
+	require.True(t, ClusterSourcePredicate.Create(event.CreateEvent{
+		Object: cluster(1, "100"),
+	}), "create events should pass")
+
+	require.True(t, ClusterSourcePredicate.Delete(event.DeleteEvent{
+		Object: cluster(1, "100"),
+	}), "delete events should pass")
+}
+
+func TestClusterSourceWatchOptions(t *testing.T) {
+	for _, clusterName := range []string{mcmanager.LocalCluster, "remote"} {
+		require.Len(t, ClusterSourceWatchOptions(clusterName), len(WatchOptions(clusterName))+1,
+			"ClusterSourceWatchOptions should be WatchOptions plus the predicate")
+	}
+}

--- a/pkg/k3d/k3d.go
+++ b/pkg/k3d/k3d.go
@@ -376,6 +376,10 @@ Use testutils.SkipIfNotIntegration or testutils.SkipIfNotAcceptance to gate test
 	if registryConfig, err := dockerHubRegistryConfig(); err != nil {
 		return nil, err
 	} else if registryConfig != "" {
+		// `k3d cluster create` copies the config into the node containers,
+		// so the host copy is only needed while the command runs. Remove it
+		// on return so the credentials don't linger in the temp dir.
+		defer os.Remove(registryConfig) //nolint:errcheck
 		args = append(args, `--registry-config`, registryConfig)
 	}
 

--- a/pkg/k3d/k3d.go
+++ b/pkg/k3d/k3d.go
@@ -267,6 +267,42 @@ func lockFile(name string) (func(), error) {
 	}, nil
 }
 
+// dockerHubRegistryConfig writes a k3s registries.yaml granting containerd
+// authenticated access to Docker Hub, sourced from the DOCKERHUB_USER and
+// DOCKERHUB_TOKEN environment variables. It returns "" when the credentials
+// aren't set (e.g. local development), in which case pulls remain anonymous.
+func dockerHubRegistryConfig() (string, error) {
+	user := os.Getenv("DOCKERHUB_USER")
+	token := os.Getenv("DOCKERHUB_TOKEN")
+	if user == "" || token == "" {
+		return "", nil
+	}
+
+	auth := map[string]any{"auth": map[string]string{"username": user, "password": token}}
+	registries, err := yaml.Marshal(map[string]any{
+		// k3s normalizes docker.io to registry-1.docker.io; include both so
+		// the auth applies regardless of which endpoint containerd resolves.
+		"configs": map[string]any{
+			"docker.io":            auth,
+			"registry-1.docker.io": auth,
+		},
+	})
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	f, err := os.CreateTemp("", "k3d-registries-*.yaml")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(registries); err != nil {
+		return "", errors.WithStack(err)
+	}
+	return f.Name(), nil
+}
+
 func NewCluster(name string, opts ...ClusterOpt) (*Cluster, error) {
 	if !usagePermitted {
 		return nil, errors.New(`use of the k3d package is only permitted when using the integration or acceptance build tag.
@@ -331,6 +367,16 @@ Use testutils.SkipIfNotIntegration or testutils.SkipIfNotAcceptance to gate test
 			// hardware failures
 			`--k3s-arg`, `--node-taint=server=true:NoSchedule@server:*`,
 		}...)
+	}
+
+	// When Docker Hub credentials are available (CI), authenticate the
+	// cluster's containerd against docker.io so in-cluster image pulls
+	// (images not pre-imported, or re-pulled after kubelet image GC) aren't
+	// subject to the anonymous pull rate limit (429 Too Many Requests).
+	if registryConfig, err := dockerHubRegistryConfig(); err != nil {
+		return nil, err
+	} else if registryConfig != "" {
+		args = append(args, `--registry-config`, registryConfig)
 	}
 
 	out, err := exec.Command("k3d", args...).CombinedOutput()


### PR DESCRIPTION
## Summary

Fixes #1578 and #1579 (internal tracking: [K8S-871](https://redpandadata.atlassian.net/browse/K8S-871)).

Two bugs combine to produce a continuous flood of no-op `IncrementalAlterConfigs` writes from the Topic controller against the broker:

- **#1578 — no-op writes:** `generateConf` fetched the live topic config via `DescribeConfigs` but never compared it against the desired values from `spec.additionalConfig`, so every reconcile of a converged Topic issued a SET for every configured key. The broker logs `Successfully altered topic properties` each time even though nothing changed, polluting the audit trail (observed in the field: ~66,000 spurious lines per 24h for a single unchanged topic).
- **#1579 — unfiltered cluster watches:** the Topic controller (and the User, Group, Schema, Role, and ShadowLink controllers) watch their referenced cluster CRs with an event handler that fans out to every referencing resource — and no event predicate. Cluster CR status updates (~every 10–60s in a running cluster) re-enqueued every referencing CR, saturating the workqueue (`MaxConcurrentReconciles` defaults to 1) and starving the interval-based requeue, so `spec.interval` was effectively ignored.

\#1579 amplifies #1578: the missing predicate drives the reconcile rate, and the missing comparison turns each reconcile into a broker write. Fixed together here since #1579 also gates the sync-interval behavior shipped for #1536.

## Steady-state behavior: do Topic reconciles ever quiesce?

A question worth answering explicitly for reviewers, with numbers from the [live EKS validation](https://github.com/redpanda-data/redpanda-operator/pull/1585#issuecomment-4671752342):

**Without the fix: never.** A converged Topic's reconcile cadence is set by the *cluster CR's status-update rate*, not by `spec.interval` — and the cluster CR churns status even on a fully idle cluster (the Redpanda controller periodically rewrites health/license/condition state). Measured on a quiet single-broker cluster: 5 converged Topics with `interval: 10m` reconciled **30 times per 120s** (one per ~20s per topic — the interval was effectively decorative). Under genuine status activity it amplifies to ~1 reconcile/sec per topic (640 per 2-minute window under induced churn), bounded only by the single-threaded workqueue. And because of #1578, every one of those reconciles is also a broker **write** (a no-op `IncrementalAlterConfigs` re-SETting every configured key) — the ~66k audit-log lines/topic/day from the field report is this steady state.

**With the fix: reconciles tick at exactly the configured interval — by design, they never reach literal zero.** The interval-based requeue is the drift-detection contract (a third party editing topic config out-of-band is re-converged within one interval). What quiesces is everything between ticks: status churn no longer re-enqueues Topics (0 reconciles during 60 induced status-only updates), and each tick is now a read-only `DescribeConfigs` that short-circuits at `TopicAlreadySynced` with zero broker writes. Post-fix steady state observed: exactly 5 reconciles (one per Topic) every 10m00s, on the second, and nothing in between.

In short: the fix converts "constant write traffic at a cadence you don't control" into "a read-only heartbeat at exactly the cadence you configured."

## Changes

One commit per issue:

**`operator: skip no-op IncrementalAlterConfigs in Topic reconciliation`** (#1578)
- `generateConf` now builds a live-value lookup from `describedConfig` and skips the SET for any key whose broker value already equals the desired value. With this, the existing `len(configs) == 0` → `EventTopicAlreadySynced` short-circuit in `alterTopicConfiguration` fires for converged topics, as originally intended.
- The `redpanda.remote.read`/`redpanda.remote.write` split (workaround for redpanda-data/redpanda#9191) now only routes `remote.write` to the special first-request path when it actually needs changing. This also removes a latent nil-pointer dereference when `redpanda.remote.write` is declared with a nil value alongside `redpanda.remote.read`.
- Added a table-driven `TestGenerateConf` covering converged/diverged keys, broker defaults, delete-on-removal, nil spec values, the remote.read/write special case, and replication-factor changes.

**`operator: filter cluster CR watches to generation changes`** (#1579)
- New `controller.ClusterSourceWatchOptions` helper: `WatchOptions` plus a `GenerationChangedPredicate`, applied to the Redpanda, V1 Cluster, and StretchCluster watches in the Topic, User, Group, Schema, Role, and ShadowLink controllers. Status-only updates (resourceVersion bump, no generation change) no longer re-enqueue referencing resources; Create/Delete and spec changes still do.
- The Secret watches in the User controller intentionally keep unfiltered options — Secrets never bump `metadata.generation`, so a generation predicate would suppress all Secret updates (now noted in a comment).
- Added `TestClusterSourcePredicate` pinning the event-filtering contract.

## Reproducing the old behavior

Any Kubernetes cluster works (verified on EKS 1.34). With a **released operator** (any of v25.3.x–v26.1.x):

1. Install the operator and CRDs:
   ```bash
   helm repo add redpanda https://charts.redpanda.com
   helm install redpanda-operator redpanda/operator \
     --namespace topic-fix-e2e --create-namespace \
     --version 26.1.5 --set crds.enabled=true --wait
   ```
2. Create a small cluster and a Topic that declares config and a long interval:
   ```yaml
   apiVersion: cluster.redpanda.com/v1alpha2
   kind: Redpanda
   metadata: {name: redpanda-repro, namespace: topic-fix-e2e}
   spec:
     clusterSpec:
       statefulset: {replicas: 1}
       tls: {enabled: false}
       console: {enabled: false}
   ---
   apiVersion: cluster.redpanda.com/v1alpha2
   kind: Topic
   metadata: {name: repro-topic, namespace: topic-fix-e2e}
   spec:
     cluster: {clusterRef: {name: redpanda-repro}}
     partitions: 1
     replicationFactor: 1
     interval: 5m
     additionalConfig:
       retention.ms: "43200000"
       cleanup.policy: "delete"
   ```
3. Wait for the Topic to converge (`status.observedGeneration == 1`, condition Ready). **Make no further spec changes.**
4. **Observe Bug A** — the broker keeps logging config alterations for the unchanged topic:
   ```bash
   kubectl -n topic-fix-e2e logs redpanda-repro-0 --since=10m \
     | grep -c "Successfully altered topic properties"
   # non-zero, and grows every reconcile — should be 0 for a converged topic
   ```
5. **Observe Bug B** — the reconcile cadence ignores `spec.interval: 5m`:
   ```bash
   OPERATOR_POD=$(kubectl -n topic-fix-e2e get pods -l app.kubernetes.io/name=operator -o jsonpath='{.items[0].metadata.name}')
   kubectl -n topic-fix-e2e logs "$OPERATOR_POD" --since=10m | grep -c "reconciling topic"
   # far more than the <=2 per topic a 5m interval allows in 10 minutes
   ```
   and the trigger is visible as parent-CR status churn while the Topic is static:
   ```bash
   for i in 1 2 3; do
     kubectl -n topic-fix-e2e get redpanda redpanda-repro -o jsonpath='Redpanda RV={.metadata.resourceVersion}{"\n"}'
     kubectl -n topic-fix-e2e get topic repro-topic -o jsonpath='Topic    RV={.metadata.resourceVersion}{"\n"}'
     sleep 10
   done
   # Redpanda RV bumps (status-only updates); Topic RV constant
   ```

## Verifying the new behavior

Upgrade the same installation in-place to a build of this branch (chart from this branch so RBAC/CRDs match the image):

```bash
git switch k8s-871/topic-noop-alter-configs
task build:operator-image TAGS=<registry>/redpanda-operator-dev:k8s-871-fix PLATFORMS=linux/amd64 CLI_ARGS="--push"
helm upgrade redpanda-operator ./operator/chart \
  --namespace topic-fix-e2e --set crds.enabled=true \
  --set image.repository=<registry>/redpanda-operator-dev \
  --set image.tag=k8s-871-fix --wait
```

Wait ~10 minutes, then repeat the observations over a fresh window:

1. **Bug A fixed** — zero new alter-config lines for converged topics:
   ```bash
   kubectl -n topic-fix-e2e logs redpanda-repro-0 --since=10m \
     | grep -c "Successfully altered topic properties"   # → 0
   ```
2. **Bug B fixed** — reconcile cadence matches `spec.interval`:
   ```bash
   kubectl -n topic-fix-e2e logs "$OPERATOR_POD" --since=10m | grep -c "reconciling topic"
   # <=2 per topic per 10m at interval: 5m
   ```
   The Redpanda CR `resourceVersion` still churns (its own controller keeps updating status — that is normal and unchanged); those updates simply no longer re-enqueue Topics.
3. **No regression** — edit the topic's `retention.ms`, confirm exactly one alter-config line appears on the broker and the new value is live (`rpk topic describe`); the fix suppresses *no-op* writes only, real changes still propagate immediately.

## Safety of the predicate

Connection details for referencing resources (brokers, TLS, SASL) are derived from the cluster CR **spec** — via `RenderStateFromDot` for V2, cert Secrets + pod FQDNs for V1, and BrokerPool specs + Service endpoints for StretchCluster — never from the cluster CR's status. A resource created before its cluster is ready still converges via normal error backoff. The Redpanda↔NodePool and Console watches are left untouched, as those controllers may legitimately react to status transitions.

## CI: Docker Hub login to avoid pull rate limits

This PR's integration test builds exposed that CI agents hit Docker Hub's **anonymous pull rate limit** (429 Too Many Requests), failing test suites in two ways: `test:pull-images` swallows pull failures (`|| true`), so missing images surfaced as opaque k3d import errors (`TestIntegrationFactoryOperatorV1` failing on every shard), and **in-cluster** pulls by k3s containerd hit the same 429, leaving Redpanda pods in `ImagePullBackOff` until cluster tests timed out at their 600s deadlines.

CI now authenticates to Docker Hub using the existing `sdlc/prod/buildkite/dockerhub` secret (already used by the publish steps):

- **`gen/pipeline`**: every test-suite step receives `DOCKERHUB_USER`/`DOCKERHUB_TOKEN` (`testsuite.yml` regenerated).
- **`Taskfile.yml` `test:pull-images`**: runs `docker login` when the credentials are set, and verifies all images are present after the best-effort parallel pulls — failing loudly with the list of missing images instead of letting tests fail minutes later.
- **`pkg/k3d`**: passes k3s a `registries.yaml` with docker.io auth when the credentials are set, so in-cluster pulls (images not pre-imported, or re-pulled after kubelet image GC) are authenticated too.

Local development without the credentials is unchanged (anonymous pulls, as before).

## Testing

```
go test ./operator/internal/controller/ ./operator/internal/controller/redpanda/ -run "TestClusterSource|TestGenerateConf"
ok (11 tests)
golangci-lint run ./internal/controller/...  →  0 issues
```
End-to-end verification on EKS 1.34 (repro on v26.1.5, in-place upgrade to this branch's build): results to be posted in a PR comment.

## Notes for reviewers

- The config comparison is an exact string match. Keys whose spec formatting differs from the broker's canonical rendering (e.g. `"1e6"` vs `"1000000"`) keep the current always-write behavior — no worse than today.
- Happy to split this into two PRs (one per issue) if preferred for backporting.


[K8S-871]: https://redpandadata.atlassian.net/browse/K8S-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
