### PR TITLE
operator: emit anonymous Kubernetes telemetry

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,6 +61,7 @@ steps:
             - secret-id: sdlc/prod/buildkite/github_api_token
             - secret-id: sdlc/prod/buildkite/redpanda_sample_license
             - secret-id: sdlc/prod/buildkite/slack_vbot_token
+            - secret-id: sdlc/prod/buildkite/telemetry_private_key
       - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
           message: "Nightly releases failed"
           channel_name: "kubernetes-tests"
@@ -111,6 +112,7 @@ steps:
             - secret-id: sdlc/prod/buildkite/slack_vbot_token
             - secret-id: sdlc/prod/buildkite/teleport_bot_token
             - secret-id: sdlc/prod/buildkite/test_result_dsn
+            - secret-id: sdlc/prod/buildkite/telemetry_private_key
       - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
           message: ":cloud: Operator Release Job Failed"
           channel_name: "kubernetes-tests"

--- a/.changes/unreleased/operator-Added-20260610-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260610-120000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: "Added optional anonymous cluster-shape telemetry: NodePools, stretch clusters, managed Connectors, Redpanda/vectorized cluster and broker counts, broker CPU/memory sizing, Redpanda versions in use, per-cluster TLS/SASL/tiered-storage/console adoption, storage CSI drivers, PVC Unbinder, CRD and supporting-CR counts, and operator feature flags. Licensed clusters additionally report the enterprise license checksum (id_hash) for account correlation. Disabled in builds without an embedded key and via the telemetry.enabled chart value / --disable-telemetry."
+time: 2026-06-10T12:00:00.000000-07:00

--- a/acceptance/go.sum
+++ b/acceptance/go.sum
@@ -250,6 +250,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -293,6 +295,8 @@ github.com/go-openapi/testify/enable/yaml/v2 v2.0.2 h1:0+Y41Pz1NkbTHz8NngxTuAXxE
 github.com/go-openapi/testify/enable/yaml/v2 v2.0.2/go.mod h1:kme83333GCtJQHXQ8UKX3IBZu6z8T5Dvy5+CW3NLUUg=
 github.com/go-openapi/testify/v2 v2.0.2 h1:X999g3jeLcoY8qctY/c/Z8iBHTbwLz7R2WXd6Ub6wls=
 github.com/go-openapi/testify/v2 v2.0.2/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
+github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
+github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
@@ -606,6 +610,8 @@ github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1
 github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1/go.mod h1:V3OBV2kcF/BDDytUZuKvIygbaXoGPT5VO3KmMAz+mBM=
 github.com/redpanda-data/common-go/kube v0.0.0-20260408144400-efba9928bb27 h1:735zfoMDegKzXO+mipLeEJhjvoboMiOwlZiEfWTs9IY=
 github.com/redpanda-data/common-go/kube v0.0.0-20260408144400-efba9928bb27/go.mod h1:87/jKBvBse9m7PBwCxzISdxOpHblNKTqxZZNa1U1utM=
+github.com/redpanda-data/common-go/license v0.0.0-20260120073450-935d3dd3d6c1 h1:6aPxMthcrAljux5bgqU78yHxM8BK1ITqh9G9H+s707U=
+github.com/redpanda-data/common-go/license v0.0.0-20260120073450-935d3dd3d6c1/go.mod h1:F1fp8xVNS2UwWFosOjJ9+5jaEZnXSjB9AdHk2R9XlpI=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7 h1:MXLdjFdFjOtyuUR4TdVVsqFP8xnru2YDwzH9bJTUr1M=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7/go.mod h1:UJIi/yUxGOBYXUrfUsOkxfYxcb/ll7mZrwae/i+U2kc=
 github.com/redpanda-data/common-go/otelutil v0.0.0-20260413160920-df1679f86269 h1:tEFqrnhUNN08Ye6n1FxtFHqkrFRhA0PGs2917v4JAOk=
@@ -618,6 +624,8 @@ github.com/redpanda-data/common-go/rpsr v0.1.4 h1:d9lu5q5wyhZWBYR1GnZkq+eZGKU0qo
 github.com/redpanda-data/common-go/rpsr v0.1.4/go.mod h1:qVa7b0yaCRdZDn5dcZ9CazqVr4jYbgtOJUywI2X3G3I=
 github.com/redpanda-data/common-go/secrets v0.1.4 h1:CGp3KolGnjcJvIafTwf7Hlj5ztLOJCjgkegRu7IAkSw=
 github.com/redpanda-data/common-go/secrets v0.1.4/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
+github.com/redpanda-data/common-go/telemetry v0.1.0 h1:j+2mIuSXW/1ouIloaKModskNjFQVZnBQTXdrmKhVRi0=
+github.com/redpanda-data/common-go/telemetry v0.1.0/go.mod h1:jl4UZ/9/kX3XKPBYLWeog7y/lDNjNE0ptgGyROYOiIU=
 github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4 h1:pIykUyZu5OEd3XYUrpft62pE2nKtlzEQzUKAUt8oyGY=
 github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4/go.mod h1:POzpjZ7Fm4W7zr1mNLV/V48hHR70NWm1GWdWz6IUYOU=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 h1:SbcvWTYFEbH5+NQOl1To5jppEa8RCK1HAkRNfhdUGLg=

--- a/gen/go.sum
+++ b/gen/go.sum
@@ -244,6 +244,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -289,6 +291,8 @@ github.com/go-openapi/testify/v2 v2.0.2 h1:X999g3jeLcoY8qctY/c/Z8iBHTbwLz7R2WXd6
 github.com/go-openapi/testify/v2 v2.0.2/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
+github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
@@ -584,6 +588,8 @@ github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1
 github.com/redpanda-data/common-go/goldenfile v0.0.0-20260109170727-1dd9f5d22ee1/go.mod h1:V3OBV2kcF/BDDytUZuKvIygbaXoGPT5VO3KmMAz+mBM=
 github.com/redpanda-data/common-go/kube v0.0.0-20260408144400-efba9928bb27 h1:735zfoMDegKzXO+mipLeEJhjvoboMiOwlZiEfWTs9IY=
 github.com/redpanda-data/common-go/kube v0.0.0-20260408144400-efba9928bb27/go.mod h1:87/jKBvBse9m7PBwCxzISdxOpHblNKTqxZZNa1U1utM=
+github.com/redpanda-data/common-go/license v0.0.0-20260120073450-935d3dd3d6c1 h1:6aPxMthcrAljux5bgqU78yHxM8BK1ITqh9G9H+s707U=
+github.com/redpanda-data/common-go/license v0.0.0-20260120073450-935d3dd3d6c1/go.mod h1:F1fp8xVNS2UwWFosOjJ9+5jaEZnXSjB9AdHk2R9XlpI=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7 h1:MXLdjFdFjOtyuUR4TdVVsqFP8xnru2YDwzH9bJTUr1M=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7/go.mod h1:UJIi/yUxGOBYXUrfUsOkxfYxcb/ll7mZrwae/i+U2kc=
 github.com/redpanda-data/common-go/otelutil v0.0.0-20260413160920-df1679f86269 h1:tEFqrnhUNN08Ye6n1FxtFHqkrFRhA0PGs2917v4JAOk=
@@ -596,6 +602,8 @@ github.com/redpanda-data/common-go/rpsr v0.1.4 h1:d9lu5q5wyhZWBYR1GnZkq+eZGKU0qo
 github.com/redpanda-data/common-go/rpsr v0.1.4/go.mod h1:qVa7b0yaCRdZDn5dcZ9CazqVr4jYbgtOJUywI2X3G3I=
 github.com/redpanda-data/common-go/secrets v0.1.4 h1:CGp3KolGnjcJvIafTwf7Hlj5ztLOJCjgkegRu7IAkSw=
 github.com/redpanda-data/common-go/secrets v0.1.4/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
+github.com/redpanda-data/common-go/telemetry v0.1.0 h1:j+2mIuSXW/1ouIloaKModskNjFQVZnBQTXdrmKhVRi0=
+github.com/redpanda-data/common-go/telemetry v0.1.0/go.mod h1:jl4UZ/9/kX3XKPBYLWeog7y/lDNjNE0ptgGyROYOiIU=
 github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4 h1:pIykUyZu5OEd3XYUrpft62pE2nKtlzEQzUKAUt8oyGY=
 github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4/go.mod h1:POzpjZ7Fm4W7zr1mNLV/V48hHR70NWm1GWdWz6IUYOU=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 h1:SbcvWTYFEbH5+NQOl1To5jppEa8RCK1HAkRNfhdUGLg=

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -90,6 +90,8 @@ Run `task generate:third-party-licenses-list`.
 | github.com/go-chi/chi/v5 | [MIT](https://github.com/go-chi/chi/blob/v5.2.5/LICENSE) |
 | github.com/go-errors/errors | [MIT](https://github.com/go-errors/errors/blob/v1.5.1/LICENSE.MIT) |
 | github.com/go-gorp/gorp/v3 | [MIT](https://github.com/go-gorp/gorp/blob/v3.1.0/LICENSE) |
+| github.com/go-jose/go-jose/v4 | [Apache-2.0](https://github.com/go-jose/go-jose/blob/v4.1.4/LICENSE) |
+| github.com/go-jose/go-jose/v4/json | [BSD-3-Clause](https://github.com/go-jose/go-jose/blob/v4.1.4/json/LICENSE) |
 | github.com/go-logr/logr | [Apache-2.0](https://github.com/go-logr/logr/blob/v1.4.3/LICENSE) |
 | github.com/go-logr/stdr | [Apache-2.0](https://github.com/go-logr/stdr/blob/v1.2.2/LICENSE) |
 | github.com/go-logr/zapr | [Apache-2.0](https://github.com/go-logr/zapr/blob/v1.3.0/LICENSE) |
@@ -107,6 +109,7 @@ Run `task generate:third-party-licenses-list`.
 | github.com/go-openapi/swag/stringutils | [Apache-2.0](https://github.com/go-openapi/swag/blob/stringutils/v0.25.4/LICENSE) |
 | github.com/go-openapi/swag/typeutils | [Apache-2.0](https://github.com/go-openapi/swag/blob/typeutils/v0.25.4/LICENSE) |
 | github.com/go-openapi/swag/yamlutils | [Apache-2.0](https://github.com/go-openapi/swag/blob/yamlutils/v0.25.4/LICENSE) |
+| github.com/go-resty/resty/v2 | [MIT](https://github.com/go-resty/resty/blob/v2.17.2/LICENSE) |
 | github.com/go-viper/mapstructure/v2 | [MIT](https://github.com/go-viper/mapstructure/blob/v2.5.0/LICENSE) |
 | github.com/gobwas/glob | [MIT](https://github.com/gobwas/glob/blob/v0.2.3/LICENSE) |
 | github.com/gogo/protobuf | [BSD-3-Clause](https://github.com/gogo/protobuf/blob/v1.3.2/LICENSE) |

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -386,6 +386,10 @@ Sets deployment strategy. For details, see the [Kubernetes documentation](https:
 
 **Default:** `{"type":"RollingUpdate"}`
 
+### [telemetry.enabled](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=telemetry.enabled)
+
+**Default:** `true`
+
 ### [tolerations](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=tolerations)
 
 Taints to be tolerated by Pods. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).

--- a/operator/chart/deployment.go
+++ b/operator/chart/deployment.go
@@ -119,6 +119,24 @@ func operatorContainers(dot *helmette.Dot, podTerminationGracePeriodSeconds *int
 			ImagePullPolicy: values.Image.PullPolicy,
 			Command:         []string{"/manager"},
 			Args:            operatorArguments(dot),
+			Env: []corev1.EnvVar{
+				{
+					Name: "POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "POD_NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
+				},
+			},
 			SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)},
 			Ports: []corev1.ContainerPort{
 				{
@@ -363,6 +381,10 @@ func operatorArguments(dot *helmette.Dot) []string {
 		} else {
 			flags = append(flags, fmt.Sprintf("%s=%s", key, value))
 		}
+	}
+
+	if !values.Telemetry.Enabled {
+		flags = append(flags, "--disable-telemetry")
 	}
 
 	return flags

--- a/operator/chart/files/rbac/leader-election.ClusterRole.yaml
+++ b/operator/chart/files/rbac/leader-election.ClusterRole.yaml
@@ -5,6 +5,12 @@ metadata:
   name: leader-election
 rules:
   - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+  - apiGroups:
       - authentication.k8s.io
     resources:
       - tokenreviews

--- a/operator/chart/files/rbac/leader-election.Role.yaml
+++ b/operator/chart/files/rbac/leader-election.Role.yaml
@@ -25,6 +25,12 @@ rules:
       - create
       - patch
   - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases

--- a/operator/chart/files/rbac/multicluster-manager.ClusterRole.yaml
+++ b/operator/chart/files/rbac/multicluster-manager.ClusterRole.yaml
@@ -14,3 +14,9 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list

--- a/operator/chart/files/rbac/multicluster-manager.Role.yaml
+++ b/operator/chart/files/rbac/multicluster-manager.Role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: multicluster-manager
+  namespace: default
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get

--- a/operator/chart/multicluster_deployment.go
+++ b/operator/chart/multicluster_deployment.go
@@ -98,6 +98,24 @@ func multiclusterOperatorContainers(dot *helmette.Dot, podTerminationGracePeriod
 			ImagePullPolicy: values.Image.PullPolicy,
 			Command:         []string{"/redpanda-operator"},
 			Args:            multiclusterOperatorArguments(dot),
+			Env: []corev1.EnvVar{
+				{
+					Name: "POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "POD_NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
+				},
+			},
 			SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)},
 			Ports: []corev1.ContainerPort{
 				{
@@ -217,6 +235,10 @@ func multiclusterOperatorArguments(dot *helmette.Dot) []string {
 
 	for _, peer := range values.Multicluster.Peers {
 		flags = append(flags, fmt.Sprintf("--peer=%s://%s:9443", peer.Name, peer.Address))
+	}
+
+	if !values.Telemetry.Enabled {
+		flags = append(flags, "--disable-telemetry")
 	}
 
 	return flags

--- a/operator/chart/templates/_deployment.go.tpl
+++ b/operator/chart/templates/_deployment.go.tpl
@@ -39,7 +39,7 @@
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "manager" "image" (get (fromJson (include "operator.containerImage" (dict "a" (list $dot)))) "r") "imagePullPolicy" $values.image.pullPolicy "command" (list "/manager") "args" (get (fromJson (include "operator.operatorArguments" (dict "a" (list $dot)))) "r") "securityContext" (mustMergeOverwrite (dict) (dict "allowPrivilegeEscalation" false)) "ports" (list (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "webhook-server" "containerPort" (9443 | int) "protocol" "TCP")) (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "https" "containerPort" (8443 | int) "protocol" "TCP"))) "volumeMounts" (get (fromJson (include "operator.operatorPodVolumesMounts" (dict "a" (list $dot)))) "r") "livenessProbe" (get (fromJson (include "operator.livenessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "readinessProbe" (get (fromJson (include "operator.readinessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "resources" $values.resources)))) | toJson -}}
+{{- (dict "r" (list (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "manager" "image" (get (fromJson (include "operator.containerImage" (dict "a" (list $dot)))) "r") "imagePullPolicy" $values.image.pullPolicy "command" (list "/manager") "args" (get (fromJson (include "operator.operatorArguments" (dict "a" (list $dot)))) "r") "env" (list (mustMergeOverwrite (dict "name" "") (dict "name" "POD_NAME" "valueFrom" (mustMergeOverwrite (dict) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "") (dict "fieldPath" "metadata.name")))))) (mustMergeOverwrite (dict "name" "") (dict "name" "POD_NAMESPACE" "valueFrom" (mustMergeOverwrite (dict) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "") (dict "fieldPath" "metadata.namespace"))))))) "securityContext" (mustMergeOverwrite (dict) (dict "allowPrivilegeEscalation" false)) "ports" (list (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "webhook-server" "containerPort" (9443 | int) "protocol" "TCP")) (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "https" "containerPort" (8443 | int) "protocol" "TCP"))) "volumeMounts" (get (fromJson (include "operator.operatorPodVolumesMounts" (dict "a" (list $dot)))) "r") "livenessProbe" (get (fromJson (include "operator.livenessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "readinessProbe" (get (fromJson (include "operator.readinessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "resources" $values.resources)))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -190,6 +190,9 @@
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}
+{{- end -}}
+{{- if (not $values.telemetry.enabled) -}}
+{{- $flags = (concat (default (list) $flags) (list "--disable-telemetry")) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $flags) | toJson -}}

--- a/operator/chart/templates/_multicluster_deployment.go.tpl
+++ b/operator/chart/templates/_multicluster_deployment.go.tpl
@@ -32,7 +32,7 @@
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "manager" "image" (get (fromJson (include "operator.containerImage" (dict "a" (list $dot)))) "r") "imagePullPolicy" $values.image.pullPolicy "command" (list "/redpanda-operator") "args" (get (fromJson (include "operator.multiclusterOperatorArguments" (dict "a" (list $dot)))) "r") "securityContext" (mustMergeOverwrite (dict) (dict "allowPrivilegeEscalation" false)) "ports" (list (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "webhook-server" "containerPort" (9443 | int) "protocol" "TCP")) (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "https" "containerPort" (8443 | int) "protocol" "TCP"))) "volumeMounts" (get (fromJson (include "operator.multiclusterOperatorPodVolumesMounts" (dict "a" (list $dot)))) "r") "livenessProbe" (get (fromJson (include "operator.livenessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "readinessProbe" (get (fromJson (include "operator.readinessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "resources" $values.resources)))) | toJson -}}
+{{- (dict "r" (list (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "manager" "image" (get (fromJson (include "operator.containerImage" (dict "a" (list $dot)))) "r") "imagePullPolicy" $values.image.pullPolicy "command" (list "/redpanda-operator") "args" (get (fromJson (include "operator.multiclusterOperatorArguments" (dict "a" (list $dot)))) "r") "env" (list (mustMergeOverwrite (dict "name" "") (dict "name" "POD_NAME" "valueFrom" (mustMergeOverwrite (dict) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "") (dict "fieldPath" "metadata.name")))))) (mustMergeOverwrite (dict "name" "") (dict "name" "POD_NAMESPACE" "valueFrom" (mustMergeOverwrite (dict) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "") (dict "fieldPath" "metadata.namespace"))))))) "securityContext" (mustMergeOverwrite (dict) (dict "allowPrivilegeEscalation" false)) "ports" (list (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "webhook-server" "containerPort" (9443 | int) "protocol" "TCP")) (mustMergeOverwrite (dict "containerPort" 0) (dict "name" "https" "containerPort" (8443 | int) "protocol" "TCP"))) "volumeMounts" (get (fromJson (include "operator.multiclusterOperatorPodVolumesMounts" (dict "a" (list $dot)))) "r") "livenessProbe" (get (fromJson (include "operator.livenessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "readinessProbe" (get (fromJson (include "operator.readinessProbe" (dict "a" (list $dot $podTerminationGracePeriodSeconds)))) "r") "resources" $values.resources)))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -110,6 +110,9 @@
 {{- end -}}
 {{- if $_is_returning -}}
 {{- break -}}
+{{- end -}}
+{{- if (not $values.telemetry.enabled) -}}
+{{- $flags = (concat (default (list) $flags) (list "--disable-telemetry")) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $flags) | toJson -}}

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -165,6 +165,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -195,6 +201,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -824,7 +836,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1009,6 +1029,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -1039,6 +1065,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -1641,6 +1673,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -1671,6 +1709,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -2300,7 +2344,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 82:UkFHNyv
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -2512,6 +2564,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -2542,6 +2600,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -3164,6 +3228,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -3194,6 +3264,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -3822,7 +3898,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4021,6 +4105,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -4051,6 +4141,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -4659,6 +4755,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -4689,6 +4791,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -5475,7 +5583,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -5719,6 +5835,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -5749,6 +5871,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -6614,6 +6742,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -6644,6 +6778,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -7275,7 +7415,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -7472,6 +7620,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -7502,6 +7656,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -8108,6 +8268,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -8138,6 +8304,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -8766,7 +8938,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -9004,6 +9184,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -9034,6 +9220,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -9728,6 +9920,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -9758,6 +9956,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -10387,7 +10591,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: Fd0:cOgp6ac
         imagePullPolicy: Always
         livenessProbe:
@@ -10670,6 +10882,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -10700,6 +10918,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -11427,6 +11651,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -11457,6 +11687,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -12100,7 +12336,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 1F5:82lZfTf2
         imagePullPolicy: Never
         livenessProbe:
@@ -12302,6 +12546,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -12332,6 +12582,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -12941,6 +13197,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -12971,6 +13233,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -13602,7 +13870,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: Hol:8ePENyCLz
         imagePullPolicy: Never
         livenessProbe:
@@ -13804,6 +14080,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -13834,6 +14116,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -14445,6 +14733,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -14475,6 +14769,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -15105,7 +15405,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: j:efh5i
         imagePullPolicy: Never
         livenessProbe:
@@ -15341,6 +15649,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -15371,6 +15685,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -15980,6 +16300,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -16010,6 +16336,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -16475,7 +16807,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -16683,6 +17023,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -16713,6 +17059,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -17336,6 +17688,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -17366,6 +17724,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -18002,7 +18366,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -18206,6 +18578,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -18236,6 +18614,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -18863,6 +19247,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -18893,6 +19283,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -19731,7 +20127,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -19940,6 +20344,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -19970,6 +20380,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -20746,6 +21162,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -20776,6 +21198,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -21295,7 +21723,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -21495,6 +21931,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -21525,6 +21967,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -22122,6 +22570,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -22152,6 +22606,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -22786,7 +23246,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -22994,6 +23462,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -23024,6 +23498,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -23641,6 +24121,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -23671,6 +24157,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -24301,7 +24793,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: YVfoVe:wqmCFiuJSq
         imagePullPolicy: Never
         livenessProbe:
@@ -24505,6 +25005,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -24535,6 +25041,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -25145,7 +25657,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 5ZJUE:25V2E90p
         imagePullPolicy: Always
         livenessProbe:
@@ -25511,6 +26031,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -25541,6 +26067,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -26215,7 +26747,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: hchsZ8:9lUTX
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -26593,6 +27133,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -26623,6 +27169,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -27241,6 +27793,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -27271,6 +27829,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -27949,7 +28513,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -28144,6 +28716,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -28174,6 +28752,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -28783,6 +29367,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -28813,6 +29403,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -29608,7 +30204,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -29803,6 +30407,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -29833,6 +30443,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -30600,7 +31216,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -30970,6 +31594,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -31000,6 +31630,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -31774,7 +32410,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: T1Xvq:JedSySWkwU
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -31989,6 +32633,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -32019,6 +32669,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -32630,6 +33286,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -32660,6 +33322,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -33531,7 +34199,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -33890,6 +34566,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -33920,6 +34602,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -34695,6 +35383,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -34725,6 +35419,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -35362,7 +36062,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: cWng:afUH16iMvi
         imagePullPolicy: Never
         livenessProbe:
@@ -35571,6 +36279,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -35601,6 +36315,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -36227,6 +36947,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -36257,6 +36983,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -36994,7 +37726,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 8ta:N5m1k
         imagePullPolicy: Always
         livenessProbe:
@@ -37413,6 +38153,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -37443,6 +38189,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -38226,7 +38978,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: OLVAhRBe:iR9tH
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -38562,6 +39322,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -38592,6 +39358,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -39166,7 +39938,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: Jy:QK8rajxXu7
         imagePullPolicy: Always
         livenessProbe:
@@ -39630,6 +40410,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -39660,6 +40446,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -40345,7 +41137,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: :yLRNE5
         imagePullPolicy: Never
         livenessProbe:
@@ -40688,6 +41488,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -40718,6 +41524,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -41520,7 +42332,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: O:F0pU
         imagePullPolicy: Never
         livenessProbe:
@@ -41780,6 +42600,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -41810,6 +42636,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -42438,6 +43270,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -42468,6 +43306,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -43234,7 +44078,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -43516,6 +44368,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -43546,6 +44404,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -44165,6 +45029,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -44195,6 +45065,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -44911,7 +45787,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -45271,6 +46155,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -45301,6 +46191,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -46204,7 +47100,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: h6rx:yXNMX
         imagePullPolicy: Always
         livenessProbe:
@@ -46758,6 +47662,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -46788,6 +47698,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -47665,7 +48581,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: :vO
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -48020,6 +48944,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -48050,6 +48980,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -48778,6 +49714,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -48808,6 +49750,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -49324,7 +50272,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: HJ:0ORIQruw
         imagePullPolicy: Always
         livenessProbe:
@@ -49677,6 +50633,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -49707,6 +50669,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -50478,6 +51446,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -50508,6 +51482,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -51391,7 +52371,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: JoEOn0Quud0uJ:Jzj6fJDqK
         imagePullPolicy: Always
         livenessProbe:
@@ -51808,6 +52796,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -51838,6 +52832,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -52642,7 +53642,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: bR:TxCthY7Ie
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -53273,7 +54281,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: :9dFbDt
         imagePullPolicy: Always
         livenessProbe:
@@ -54011,6 +55027,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -54041,6 +55063,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -54978,7 +56006,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: HOES5h7c:blks9
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -55446,6 +56482,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -55476,6 +56518,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -56618,7 +57666,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: cbG:0q7KunZ1RCP
         imagePullPolicy: Never
         livenessProbe:
@@ -57207,6 +58263,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -57237,6 +58299,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -57926,7 +58994,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: RF7Jmqe27:bC
         imagePullPolicy: Never
         livenessProbe:
@@ -58378,6 +59454,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -58408,6 +59490,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -59197,7 +60285,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: UqP:XrgP
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -60019,7 +61115,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 0HXtC:xSn6
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -60707,6 +61811,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -60737,6 +61847,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -61651,7 +62767,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 95JHcsXy:YVZ
         imagePullPolicy: Always
         livenessProbe:
@@ -62116,6 +63240,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -62146,6 +63276,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -62873,6 +64009,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -62903,6 +64045,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -63903,7 +65051,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: gkRs29P:kgK
         imagePullPolicy: Always
         livenessProbe:
@@ -64319,6 +65475,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -64349,6 +65511,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -65245,7 +66413,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: UG:zsECOIlUnlWTDC
         imagePullPolicy: Always
         livenessProbe:
@@ -65740,6 +66916,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -65770,6 +66952,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -66483,7 +67671,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: 929tqf:VZB
         imagePullPolicy: Never
         livenessProbe:
@@ -66905,6 +68101,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -66935,6 +68137,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -67683,7 +68891,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: FlBYj:fS
         imagePullPolicy: Always
         livenessProbe:
@@ -68252,6 +69468,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -68282,6 +69504,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -69149,7 +70377,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: Iedc3BYXQ:UoBs
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -69654,6 +70890,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -69684,6 +70926,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -70590,6 +71838,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -70620,6 +71874,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -71274,7 +72534,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: zg2YXP:Cp
         imagePullPolicy: Never
         livenessProbe:
@@ -71806,6 +73074,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -71836,6 +73110,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -72594,6 +73874,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -72624,6 +73910,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -73627,7 +74919,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: mLw:5QaeLH
         imagePullPolicy: Never
         livenessProbe:
@@ -74050,6 +75350,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -74080,6 +75386,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -74965,6 +76277,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -74995,6 +76313,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -75848,7 +77172,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: ZuVTlT:J
         imagePullPolicy: Never
         livenessProbe:
@@ -76323,6 +77655,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -76353,6 +77691,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -77083,6 +78427,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -77113,6 +78463,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -77743,7 +79099,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -77928,6 +79292,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -77958,6 +79328,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -78560,6 +79936,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -78590,6 +79972,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -79218,7 +80606,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -79447,6 +80843,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -79477,6 +80879,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -80170,6 +81578,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -80200,6 +81614,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -80828,7 +82248,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -81057,6 +82485,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -81087,6 +82521,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -81779,6 +83219,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -81809,6 +83255,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -82437,7 +83889,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -82622,6 +84082,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -82652,6 +84118,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -83254,6 +84726,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -83284,6 +84762,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -83912,7 +85396,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -84114,6 +85606,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -84144,6 +85642,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -84746,6 +86250,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -84776,6 +86286,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -85404,7 +86920,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -85589,6 +87113,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -85619,6 +87149,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -86221,6 +87757,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -86251,6 +87793,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -86879,7 +88427,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -87064,6 +88620,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -87094,6 +88656,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -87696,6 +89264,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -87726,6 +89300,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -88355,7 +89935,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -88547,6 +90135,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -88577,6 +90171,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -89179,6 +90779,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -89209,6 +90815,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -89838,7 +91450,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -90030,6 +91650,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -90060,6 +91686,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -90662,6 +92294,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -90692,6 +92330,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -91320,7 +92964,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -91539,6 +93191,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -91569,6 +93227,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -92171,6 +93835,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -92201,6 +93871,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -92829,7 +94505,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -93138,6 +94822,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -93168,6 +94858,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -93770,6 +95466,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -93800,6 +95502,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -94428,7 +96136,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -94649,6 +96365,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -94679,6 +96401,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -95281,6 +97009,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -95311,6 +97045,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -95939,7 +97679,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -96160,6 +97908,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -96190,6 +97944,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -96792,6 +98552,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -96822,6 +98588,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -97450,7 +99222,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -97670,6 +99450,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -97700,6 +99486,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -98302,6 +100094,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -98333,6 +100131,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -98354,6 +100158,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -99003,7 +100813,15 @@ spec:
         - --peer=west://west.example.com:9443
         command:
         - /redpanda-operator
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -99245,6 +101063,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -99276,6 +101100,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -99297,6 +101127,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -99978,6 +101814,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -100009,6 +101851,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -100030,6 +101878,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -100679,7 +102533,15 @@ spec:
         - --peer=east://east.example.com:9443
         command:
         - /redpanda-operator
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -100976,6 +102838,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -101007,6 +102875,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -101028,6 +102902,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -101709,6 +103589,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -101740,6 +103626,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -101761,6 +103653,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -102459,7 +104357,15 @@ spec:
         - --peer=east://east.example.com:9443
         command:
         - /redpanda-operator
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -102701,6 +104607,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -102732,6 +104644,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -102753,6 +104671,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -103434,6 +105358,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -103465,6 +105395,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -103486,6 +105422,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -104110,7 +106052,15 @@ spec:
         - --peer=east://some.other.dns.label:9443
         command:
         - /redpanda-operator
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -104359,6 +106309,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -104390,6 +106346,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -104411,6 +106373,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -105092,6 +107060,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -105123,6 +107097,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -105144,6 +107124,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -105767,7 +107753,15 @@ spec:
         - --peer=east://some.other.dns.label:9443
         command:
         - /redpanda-operator
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -106009,6 +108003,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -106040,6 +108040,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -106061,6 +108067,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:
@@ -106742,6 +108754,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -106772,6 +108790,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -107422,7 +109446,15 @@ spec:
         - --webhook-enabled=true
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -107716,6 +109748,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -107746,6 +109784,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -108348,6 +110392,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -108378,6 +110428,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -109006,7 +111062,15 @@ spec:
         - --webhook-enabled=false
         command:
         - /manager
-        env: []
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -109198,6 +111262,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -109228,6 +111298,1520 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-migration-job-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-migration-job-default
+subjects:
+- kind: ServiceAccount
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-4"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-migration
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - migration
+        command:
+        - /redpanda-operator
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
+        imagePullPolicy: IfNotPresent
+        name: migration
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: OnFailure
+      serviceAccountName: operator-migration-job
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+-- testdata/telemetry-disabled.yaml.golden --
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |-
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: :8081
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: aa9fc693.vectorized.io
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-config
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-default-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-additional-controllers-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-default-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-additional-controllers-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/name: operator
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/name: operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
+        - --configurator-tag=v26.2.1-beta.2
+        - --enable-console=true
+        - --enable-vectorized-controllers=false
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        - --log-level=info
+        - --metrics-bind-address=:8443
+        - --webhook-enabled=false
+        - --disable-telemetry
+        command:
+        - /manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1-beta.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      ephemeralContainers: null
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1-beta.2
+    helm.sh/chart: operator-26.2.1-beta.2
+  name: operator-migration-job-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/operator/chart/testdata/template-cases.txtar
+++ b/operator/chart/testdata/template-cases.txtar
@@ -231,3 +231,9 @@ controllers:
     interval: 45s
   user:
     interval: 20s
+
+-- telemetry-disabled --
+# Asserts the opt-out renders the flag the operator binary actually registers
+# (--disable-telemetry), so the chart and binary can't drift apart again.
+telemetry:
+  enabled: false

--- a/operator/chart/values.go
+++ b/operator/chart/values.go
@@ -96,6 +96,10 @@ type Multicluster struct {
 	Peers                        []Peer              `json:"peers"`
 }
 
+type Telemetry struct {
+	Enabled bool `json:"enabled"`
+}
+
 type Enterprise struct {
 	LicenseSecretRef *corev1.SecretKeySelector `json:"licenseSecretRef,omitempty"`
 }
@@ -132,6 +136,7 @@ type Values struct {
 	VectorizedControllers VectorizedControllers         `json:"vectorizedControllers"`
 	Controllers           Controllers                   `json:"controllers"`
 	Multicluster          Multicluster                  `json:"multicluster"`
+	Telemetry             Telemetry                     `json:"telemetry"`
 }
 
 type VectorizedControllers struct {

--- a/operator/chart/values.schema.json
+++ b/operator/chart/values.schema.json
@@ -6568,6 +6568,15 @@
       },
       "type": "object"
     },
+    "telemetry": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "tolerations": {
       "oneOf": [
         {

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -282,3 +282,6 @@ multicluster:
     # controller (Submariner Lighthouse, GKE MCS, …). Mutually
     # exclusive with mesh.
     mcs: false
+
+telemetry:
+  enabled: true

--- a/operator/chart/values_partial.gen.go
+++ b/operator/chart/values_partial.gen.go
@@ -50,6 +50,7 @@ type PartialValues struct {
 	VectorizedControllers *PartialVectorizedControllers "json:\"vectorizedControllers,omitempty\""
 	Controllers           *PartialControllers           "json:\"controllers,omitempty\""
 	Multicluster          *PartialMulticluster          "json:\"multicluster,omitempty\""
+	Telemetry             *PartialTelemetry             "json:\"telemetry,omitempty\""
 }
 
 type PartialImage struct {
@@ -114,6 +115,10 @@ type PartialMulticluster struct {
 	Name                         *string                     "json:\"name,omitempty\""
 	KubernetesAPIExternalAddress *string                     "json:\"apiServerExternalAddress,omitempty\""
 	Peers                        []PartialPeer               "json:\"peers,omitempty\""
+}
+
+type PartialTelemetry struct {
+	Enabled *bool "json:\"enabled,omitempty\""
 }
 
 type PartialEnterprise struct {

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/redpanda-data/common-go/license"
 	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/discovery"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -30,11 +31,13 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/redpanda-data/redpanda-operator/operator/cmd/version"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	consolecontroller "github.com/redpanda-data/redpanda-operator/operator/internal/controller/console"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller/pvcunbinder"
 	redpandacontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/telemetry"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster/watcher"
@@ -46,6 +49,13 @@ import (
 
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create;update;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;patch
+
+// Telemetry permissions: the telemetry collector lists CRDs cluster-wide to
+// count Redpanda CRDs, and the source-identifier resolver reads the operator's
+// own ReplicaSet to walk up to the owning Deployment. The collector uses the
+// uncached API reader, so only "list" (not "watch") is required.
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
+// +kubebuilder:rbac:groups=apps,namespace=default,resources=replicasets,verbs=get
 
 type RaftCluster struct {
 	Name    string
@@ -101,6 +111,12 @@ type MulticlusterOptions struct {
 	ShadowLinkSyncInterval time.Duration
 
 	EnableConsoleController bool
+
+	disableTelemetry          bool
+	telemetrySourceIdentifier string
+	telemetryEndpoint         string
+	telemetryPeriod           time.Duration
+	telemetryFeatures         map[string]string
 }
 
 func (o *MulticlusterOptions) validate() error {
@@ -205,6 +221,12 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&o.SchemaSyncInterval, "schema-sync-interval", redpandacontrollers.DefaultSchemaSyncInterval, "Default Schema reconcile interval. A per-CR spec.interval takes precedence.")
 	cmd.Flags().DurationVar(&o.RoleSyncInterval, "role-sync-interval", redpandacontrollers.DefaultRoleSyncInterval, "Default Role reconcile interval. A per-CR spec.interval takes precedence.")
 	cmd.Flags().DurationVar(&o.ShadowLinkSyncInterval, "shadowlink-sync-interval", redpandacontrollers.DefaultShadowLinkSyncInterval, "Default ShadowLink reconcile interval.")
+	// Telemetry related flags.
+	cmd.Flags().BoolVar(&o.disableTelemetry, "disable-telemetry", false, "Disable anonymous cluster-shape telemetry.")
+	cmd.Flags().StringVar(&o.telemetrySourceIdentifier, "telemetry-source-identifier", "", "Override the auto-detected Deployment UID used to identify this operator installation in telemetry.")
+	cmd.Flags().StringVar(&o.telemetryEndpoint, "telemetry-endpoint", "", "Override the telemetry ingestion endpoint (testing).")
+	cmd.Flags().DurationVar(&o.telemetryPeriod, "telemetry-period", 0, "Interval between telemetry reports. 0 uses the library default (24h).")
+	cmd.Flags().StringToStringVar(&o.telemetryFeatures, "telemetry-features", nil, "Additional ad-hoc feature flags to include in every telemetry report, as name=bool pairs (e.g. redpanda-cloud=true). Repeatable or comma-separated; entries override the built-in feature flags.")
 }
 
 func Command() *cobra.Command {
@@ -464,6 +486,60 @@ func Run(
 			AllowRebinding: opts.AllowPVRebinding,
 		}).SetupWithMultiClusterManager(); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PVCUnbinder")
+			return err
+		}
+	}
+
+	if !opts.disableTelemetry && telemetry.Enabled() {
+		id := opts.telemetrySourceIdentifier
+		if id == "" {
+			// Use the uncached API reader: this runs before mgr.Start(), so the
+			// cached client would return ErrCacheNotStarted (and would need
+			// list+watch RBAC for its informers). A direct GET works pre-start
+			// and matches the "get"-only RBAC on pods/replicasets.
+			id = telemetry.ResolveSourceID(ctx, manager.GetLocalManager().GetAPIReader())
+		}
+
+		// Build a discovery client so the collector can resolve the Kubernetes
+		// server version each cycle. Best-effort: on failure pass nil and the
+		// collector omits kubeVersion.
+		var disco discovery.ServerVersionInterface
+		if dc, err := discovery.NewDiscoveryClientForConfig(manager.GetLocalManager().GetConfig()); err != nil {
+			setupLog.Error(err, "unable to build discovery client for telemetry; kube version will be omitted")
+		} else {
+			disco = dc
+		}
+
+		// Deployer-supplied ad-hoc features (e.g. redpanda-cloud=true) ride along
+		// in every report.
+		features, err := telemetry.MergeAdHocFeatures(map[string]bool{
+			"multicluster":      true,
+			"pvcUnbinder":       opts.UnbindPVCsAfter > 0,
+			"allowPVRebinding":  opts.AllowPVRebinding,
+			"consoleController": opts.EnableConsoleController,
+		}, opts.telemetryFeatures)
+		if err != nil {
+			setupLog.Error(err, "invalid --telemetry-features")
+			return err
+		}
+
+		tele, err := telemetry.NewRunnable(manager.GetLocalManager().GetAPIReader(), disco, setupLog, telemetry.Options{
+			Endpoint:        opts.telemetryEndpoint,
+			ID:              id,
+			OperatorVersion: version.Version,
+			// The multicluster operator requires a valid enterprise license
+			// (validated above), so its checksum is always reported as id_hash.
+			IDHash:   telemetry.LicenseChecksum(l),
+			Features: features,
+			Period:   opts.telemetryPeriod,
+		})
+		if err != nil {
+			setupLog.Error(err, "unable to build telemetry runnable")
+			return err
+		}
+
+		if err := manager.Add(tele); err != nil {
+			setupLog.Error(err, "unable to add telemetry runnable")
 			return err
 		}
 	}

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/redpanda-data/common-go/kube"
+	"github.com/redpanda-data/common-go/license"
 	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -44,6 +46,7 @@ import (
 	redpandacontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/redpanda"
 	vectorizedcontrollers "github.com/redpanda-data/redpanda-operator/operator/internal/controller/vectorized"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/telemetry"
 	adminutils "github.com/redpanda-data/redpanda-operator/operator/pkg/admin"
 	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
@@ -135,6 +138,13 @@ type RunOptions struct {
 	cloudSecretsEnabled                 bool
 	cloudSecretsPrefix                  string
 	cloudSecretsConfig                  pkgsecrets.ExpanderCloudConfiguration
+
+	disableTelemetry          bool
+	telemetrySourceIdentifier string
+	telemetryEndpoint         string
+	telemetryPeriod           time.Duration
+	telemetryFeatures         map[string]string
+	licenseFilePath           string
 }
 
 func (o *RunOptions) BindFlags(cmd *cobra.Command) {
@@ -195,6 +205,14 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.enableGhostBrokerDecommissioner, "enable-ghost-broker-decommissioner", false, "Enable ghost broker decommissioner.")
 	cmd.Flags().DurationVar(&o.ghostBrokerDecommissionerSyncPeriod, "ghost-broker-decommissioner-sync-period", time.Minute*5, "Ghost broker sync period. The Ghost Broker Decommissioner is guaranteed to be called after this period.")
 
+	// Telemetry related flags.
+	cmd.Flags().BoolVar(&o.disableTelemetry, "disable-telemetry", false, "Disable anonymous cluster-shape telemetry.")
+	cmd.Flags().StringVar(&o.telemetrySourceIdentifier, "telemetry-source-identifier", "", "Override the auto-detected Deployment UID used to identify this operator installation in telemetry.")
+	cmd.Flags().StringVar(&o.telemetryEndpoint, "telemetry-endpoint", "", "Override the telemetry ingestion endpoint (testing).")
+	cmd.Flags().DurationVar(&o.telemetryPeriod, "telemetry-period", 0, "Interval between telemetry reports. 0 uses the library default (24h).")
+	cmd.Flags().StringToStringVar(&o.telemetryFeatures, "telemetry-features", nil, "Additional ad-hoc feature flags to include in every telemetry report, as name=bool pairs (e.g. redpanda-cloud=true). Repeatable or comma-separated; entries override the built-in feature flags.")
+	cmd.Flags().StringVar(&o.licenseFilePath, "license-file-path", "", "The path to the Redpanda enterprise license file. When set and valid, its checksum (id_hash) is included in telemetry to correlate licensed clusters to an account.")
+
 	// Secret store related flags.
 	cmd.Flags().BoolVar(&o.cloudSecretsEnabled, "enable-cloud-secrets", false, "Set to true if config values can reference secrets from cloud secret store")
 	cmd.Flags().StringVar(&o.cloudSecretsPrefix, "cloud-secrets-prefix", "", "Prefix for all names of cloud secrets")
@@ -249,6 +267,13 @@ func (o *RunOptions) ControllerEnabled(controller Controller) bool {
 // +kubebuilder:rbac:groups=coordination.k8s.io,namespace=default,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace=default,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace=default,resources=events,verbs=create;patch
+
+// Telemetry permissions: the telemetry collector lists CRDs cluster-wide to
+// count Redpanda CRDs, and the source-identifier resolver reads the operator's
+// own ReplicaSet to walk up to the owning Deployment. The collector uses the
+// uncached API reader, so only "list" (not "watch") is required.
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
+// +kubebuilder:rbac:groups=apps,namespace=default,resources=replicasets,verbs=get
 
 func Command() *cobra.Command {
 	var options RunOptions
@@ -627,6 +652,89 @@ func Run(
 
 		if err := mgr.AddHealthzCheck("webhook", hookServer.StartedChecker()); err != nil {
 			setupLog.Error(err, "unable to create health check")
+			return err
+		}
+	}
+
+	if !opts.disableTelemetry && telemetry.Enabled() {
+		id := opts.telemetrySourceIdentifier
+		if id == "" {
+			// Use the uncached API reader: this runs before mgr.Start(), so the
+			// cached client would return ErrCacheNotStarted (and would need
+			// list+watch RBAC for its informers). A direct GET works pre-start
+			// and matches the "get"-only RBAC on pods/replicasets.
+			id = telemetry.ResolveSourceID(ctx, mgr.GetAPIReader())
+		}
+
+		// Build a discovery client so the collector can resolve the Kubernetes
+		// server version each cycle. Best-effort: on failure pass nil and the
+		// collector omits kubeVersion.
+		var disco discovery.ServerVersionInterface
+		if dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig()); err != nil {
+			setupLog.Error(err, "unable to build discovery client for telemetry; kube version will be omitted")
+		} else {
+			disco = dc
+		}
+
+		// Resolve the enterprise license checksum (id_hash) from the mounted
+		// license file, but only for a valid enterprise license — OSS/unlicensed
+		// installs send no id_hash and stay anonymous. Best-effort: a missing or
+		// unreadable license simply omits the field.
+		idHash := ""
+		if opts.licenseFilePath != "" {
+			if l, err := license.ReadLicense(opts.licenseFilePath); err != nil {
+				setupLog.V(1).Info("telemetry: license not readable, omitting id_hash", "error", err)
+			} else if l.AllowsEnterpriseFeatures() {
+				idHash = telemetry.LicenseChecksum(l)
+			}
+		}
+
+		features := map[string]bool{
+			// Controllers.
+			"vectorizedControllers":   opts.enableVectorizedControllers,
+			"redpandaControllers":     opts.enableRedpandaControllers,
+			"v2NodepoolController":    opts.enableV2NodepoolController,
+			"consoleController":       opts.enableConsoleController,
+			"decommission":            opts.ControllerEnabled(DecommissionController),
+			"legacyDecommission":      opts.ControllerEnabled(LegacyDecommissionController),
+			"ghostBrokerDecommission": opts.enableGhostBrokerDecommissioner,
+			"ghostbuster":             opts.ghostbuster,
+			// Operator-shape configuration (no extra API calls).
+			"pvcUnbinder":      opts.unbindPVCsAfter > 0,
+			"autoDeletePVCs":   opts.autoDeletePVCs,
+			"allowPVRebinding": opts.allowPVRebinding,
+			"webhook":          opts.webhookEnabled,
+			"namespaceScoped":  opts.namespace != "",
+			"leaderElection":   opts.managerOptions.LeaderElection,
+			// Cloud-secrets backend (provider only, never the secret values).
+			"cloudSecrets":      opts.cloudSecretsEnabled,
+			"cloudSecretsAWS":   opts.cloudSecretsEnabled && (opts.cloudSecretsConfig.AWSRegion != "" || opts.cloudSecretsConfig.AWSRoleARN != ""),
+			"cloudSecretsGCP":   opts.cloudSecretsEnabled && opts.cloudSecretsConfig.GCPProjectID != "",
+			"cloudSecretsAzure": opts.cloudSecretsEnabled && opts.cloudSecretsConfig.AzureKeyVaultURI != "",
+		}
+		// Deployer-supplied ad-hoc features (e.g. redpanda-cloud=true) ride along
+		// in every report.
+		features, err := telemetry.MergeAdHocFeatures(features, opts.telemetryFeatures)
+		if err != nil {
+			setupLog.Error(err, "invalid --telemetry-features")
+			return err
+		}
+
+		tele, err := telemetry.NewRunnable(mgr.GetAPIReader(), disco, setupLog, telemetry.Options{
+			Endpoint:        opts.telemetryEndpoint,
+			ID:              id,
+			OperatorVersion: version.Version,
+			IDHash:          idHash,
+			Features:        features,
+			Period:          opts.telemetryPeriod,
+		})
+		if err != nil {
+			setupLog.Error(err, "unable to build telemetry runnable")
+			return err
+		}
+
+		if err := mgr.Add(tele); err != nil {
+			setupLog.Error(err, "unable to add telemetry runnable")
 			return err
 		}
 	}

--- a/operator/config/rbac/bases/operator/role.yaml
+++ b/operator/config/rbac/bases/operator/role.yaml
@@ -74,6 +74,7 @@ rules:
   verbs:
   - create
   - get
+  - list
   - patch
   - update
 - apiGroups:
@@ -401,6 +402,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:

--- a/operator/config/rbac/itemized/leader-election.yaml
+++ b/operator/config/rbac/itemized/leader-election.yaml
@@ -5,6 +5,12 @@ metadata:
   name: leader-election
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -42,6 +48,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/operator/config/rbac/itemized/multicluster-manager.yaml
+++ b/operator/config/rbac/itemized/multicluster-manager.yaml
@@ -14,3 +14,22 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: multicluster-manager
+  namespace: default
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/redpanda-data/common-go/rp-controller-utils v0.0.0-20260109170727-1dd9f5d22ee1
 	github.com/redpanda-data/common-go/rpadmin v0.2.4
 	github.com/redpanda-data/common-go/rpsr v0.1.4
+	github.com/redpanda-data/common-go/telemetry v0.1.0
 	github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4
 	github.com/redpanda-data/redpanda-operator/charts/console/v3 v3.7.0
 	github.com/redpanda-data/redpanda-operator/charts/redpanda/v25 v25.3.1
@@ -162,6 +163,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.5 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
@@ -179,6 +181,7 @@ require (
 	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
 	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
+	github.com/go-resty/resty/v2 v2.17.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -250,6 +250,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -294,6 +296,8 @@ github.com/go-openapi/testify/enable/yaml/v2 v2.0.2 h1:0+Y41Pz1NkbTHz8NngxTuAXxE
 github.com/go-openapi/testify/enable/yaml/v2 v2.0.2/go.mod h1:kme83333GCtJQHXQ8UKX3IBZu6z8T5Dvy5+CW3NLUUg=
 github.com/go-openapi/testify/v2 v2.0.2 h1:X999g3jeLcoY8qctY/c/Z8iBHTbwLz7R2WXd6Ub6wls=
 github.com/go-openapi/testify/v2 v2.0.2/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
+github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
+github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
@@ -618,6 +622,8 @@ github.com/redpanda-data/common-go/rpsr v0.1.4 h1:d9lu5q5wyhZWBYR1GnZkq+eZGKU0qo
 github.com/redpanda-data/common-go/rpsr v0.1.4/go.mod h1:qVa7b0yaCRdZDn5dcZ9CazqVr4jYbgtOJUywI2X3G3I=
 github.com/redpanda-data/common-go/secrets v0.1.4 h1:CGp3KolGnjcJvIafTwf7Hlj5ztLOJCjgkegRu7IAkSw=
 github.com/redpanda-data/common-go/secrets v0.1.4/go.mod h1:WjUU/5saSXwItZx6veFOGbQZUgPQz4MQ65z22y0Ky84=
+github.com/redpanda-data/common-go/telemetry v0.1.0 h1:j+2mIuSXW/1ouIloaKModskNjFQVZnBQTXdrmKhVRi0=
+github.com/redpanda-data/common-go/telemetry v0.1.0/go.mod h1:jl4UZ/9/kX3XKPBYLWeog7y/lDNjNE0ptgGyROYOiIU=
 github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4 h1:pIykUyZu5OEd3XYUrpft62pE2nKtlzEQzUKAUt8oyGY=
 github.com/redpanda-data/console/backend v0.0.0-20260330203659-9db13eb40ef4/go.mod h1:POzpjZ7Fm4W7zr1mNLV/V48hHR70NWm1GWdWz6IUYOU=
 github.com/redpanda-data/redpanda/src/go/rpk v0.0.0-20250716004441-6e1647296ad6 h1:SbcvWTYFEbH5+NQOl1To5jppEa8RCK1HAkRNfhdUGLg=

--- a/operator/internal/controller/decommissioning/testdata/role.yaml
+++ b/operator/internal/controller/decommissioning/testdata/role.yaml
@@ -11,6 +11,12 @@ rules:
   verbs:
   - patch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -66,6 +72,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:

--- a/operator/internal/controller/redpanda/testdata/role.yaml
+++ b/operator/internal/controller/redpanda/testdata/role.yaml
@@ -64,6 +64,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
   - apps
   resources:
   - controllerrevisions
@@ -335,6 +341,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+)
+
+const (
+	// redpandaCRDGroup is the API group for the Redpanda operator's
+	// CustomResourceDefinitions.
+	redpandaCRDGroup = "cluster.redpanda.com"
+	// pvcNameLabel selects PersistentVolumeClaims owned by Redpanda clusters.
+	pvcNameLabel = "app.kubernetes.io/name"
+	// storageProvisionerAnnotation records the CSI driver that provisioned a
+	// PersistentVolumeClaim.
+	storageProvisionerAnnotation = "volume.kubernetes.io/storage-provisioner"
+	// collectTimeout bounds a single collection cycle so a slow or unresponsive
+	// API server cannot stall the reporter loop indefinitely.
+	collectTimeout = 30 * time.Second
+)
+
+// Collector gathers anonymous cluster-shape telemetry about a Redpanda
+// operator installation by listing the relevant Kubernetes resources.
+type Collector struct {
+	// Reader should be the manager's uncached API reader (mgr.GetAPIReader()),
+	// not its cached client: this is a once-per-cycle read, so an informer cache
+	// would be pure overhead (it would watch+cache every PVC and CRD in the
+	// cluster for the process lifetime) and a forbidden read on the cached
+	// client retries forever instead of failing fast.
+	Reader          client.Reader
+	ID              string
+	OperatorVersion string
+	// IDHash is the enterprise license checksum, included in the payload as
+	// id_hash. Empty for OSS/unlicensed installs (then omitted).
+	IDHash   string
+	Features map[string]bool
+	// Discovery resolves the Kubernetes server version each collection cycle so
+	// the reported version tracks in-place cluster upgrades. Optional: when nil,
+	// kubeVersion is omitted from the payload.
+	Discovery discovery.ServerVersionInterface
+}
+
+// Collect builds a Payload describing the current shape of the cluster.
+//
+// Collection degrades per field rather than all-or-nothing: a missing CRD
+// (NoMatch) or missing RBAC (Forbidden) for one resource leaves that field at
+// its zero value and collection continues, so installs that haven't yet applied
+// a new CRD or its role rules still report everything else (operator version,
+// the resources they do have) instead of vanishing from the dataset. Any other
+// error (e.g. a transient API outage) is returned so the Reporter drops the
+// cycle rather than sending a misleading all-zero payload.
+func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
+	ctx, cancel := context.WithTimeout(ctx, collectTimeout)
+	defer cancel()
+
+	payload := &Payload{
+		ID:              c.ID,
+		OperatorVersion: c.OperatorVersion,
+		GoVersion:       runtime.Version(),
+		IDHash:          c.IDHash,
+		Features:        c.Features,
+	}
+
+	// KubeVersion is best-effort: a discovery failure must not drop the whole
+	// telemetry document, so on error the field is left empty (omitempty).
+	if c.Discovery != nil {
+		if info, err := c.Discovery.ServerVersion(); err == nil {
+			payload.KubeVersion = info.GitVersion
+		}
+	}
+
+	// Redpanda fleet. Process before NodePools so per-broker resources are known
+	// for the NodePool correlation below.
+	var rpSizing sizing
+	// perBroker maps "namespace/name" -> a Redpanda's rendered per-broker
+	// requirements, so NodePool CRs (which carry replicas but no resources of
+	// their own) can be sized against their parent cluster.
+	perBroker := map[string]corev1.ResourceRequirements{}
+	var redpandas redpandav1alpha2.RedpandaList
+	if ok, err := c.list(ctx, &redpandas); err != nil {
+		return nil, err
+	} else if ok {
+		c.aggregateRedpandas(payload, redpandas.Items, &rpSizing, perBroker)
+	}
+
+	var nodePools redpandav1alpha2.NodePoolList
+	if ok, err := c.list(ctx, &nodePools); err != nil {
+		return nil, err
+	} else if ok {
+		payload.NodePools.Count = len(nodePools.Items)
+		payload.NodePools.Enabled = payload.NodePools.Count > 0
+		for i := range nodePools.Items {
+			np := &nodePools.Items[i]
+			replicas := derefInt32(np.Spec.Replicas)
+			payload.Redpanda.BrokerCount += replicas
+			// NodePool brokers inherit the parent Redpanda's per-broker resources.
+			if reqs, found := perBroker[np.Namespace+"/"+np.Spec.ClusterRef.Name]; found {
+				rpSizing.add(reqs, replicas)
+			}
+		}
+	}
+	rpSizing.into(&payload.Redpanda.TotalCPUCores, &payload.Redpanda.TotalMemoryGiB, &payload.Redpanda.BrokerSizes)
+
+	var stretchClusters redpandav1alpha2.StretchClusterList
+	if ok, err := c.list(ctx, &stretchClusters); err != nil {
+		return nil, err
+	} else if ok {
+		payload.StretchCluster.Count = len(stretchClusters.Items)
+		payload.StretchCluster.Enabled = payload.StretchCluster.Count > 0
+	}
+
+	// Stretch/multicluster broker sizing lives on RedpandaBrokerPool CRs.
+	var brokerPools redpandav1alpha2.RedpandaBrokerPoolList
+	if ok, err := c.list(ctx, &brokerPools); err != nil {
+		return nil, err
+	} else if ok {
+		var sc sizing
+		for i := range brokerPools.Items {
+			pool := &brokerPools.Items[i]
+			replicas := int(pool.GetReplicas())
+			payload.StretchCluster.BrokerCount += replicas
+			sc.add(pool.Spec.GetResourceRequirements(), replicas)
+		}
+		sc.into(&payload.StretchCluster.TotalCPUCores, &payload.StretchCluster.TotalMemoryGiB, &payload.StretchCluster.BrokerSizes)
+	}
+
+	var vectorized vectorizedv1alpha1.ClusterList
+	if ok, err := c.list(ctx, &vectorized); err != nil {
+		return nil, err
+	} else if ok {
+		payload.VectorizedClusters.Count = len(vectorized.Items)
+		var vec sizing
+		for i := range vectorized.Items {
+			spec := vectorized.Items[i].Spec
+			// Either the legacy single pool (spec.replicas) or explicit nodePools,
+			// not both — avoid double counting.
+			if len(spec.NodePools) == 0 {
+				replicas := derefInt32(spec.Replicas)
+				payload.VectorizedClusters.BrokerCount += replicas
+				vec.add(spec.Resources.ResourceRequirements, replicas)
+			} else {
+				for _, np := range spec.NodePools {
+					replicas := derefInt32(np.Replicas)
+					payload.VectorizedClusters.BrokerCount += replicas
+					vec.add(np.Resources.ResourceRequirements, replicas)
+				}
+			}
+		}
+		vec.into(&payload.VectorizedClusters.TotalCPUCores, &payload.VectorizedClusters.TotalMemoryGiB, &payload.VectorizedClusters.BrokerSizes)
+	}
+
+	// Supporting CR-type counts. Metadata-only lists: we only need len(), so
+	// avoid loading full objects into memory.
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("TopicList"), &payload.Resources.Topics); err != nil {
+		return nil, err
+	}
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("UserList"), &payload.Resources.Users); err != nil {
+		return nil, err
+	}
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("SchemaList"), &payload.Resources.Schemas); err != nil {
+		return nil, err
+	}
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("RedpandaRoleList"), &payload.Resources.Roles); err != nil {
+		return nil, err
+	}
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("ShadowLinkList"), &payload.Resources.ShadowLinks); err != nil {
+		return nil, err
+	}
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("ConsoleList"), &payload.Resources.Consoles); err != nil {
+		return nil, err
+	}
+
+	// CSI drivers come from a PVC *annotation*, so a metadata-only list
+	// suffices — no need to load every Redpanda PVC's spec/status.
+	var pvcs metav1.PartialObjectMetadataList
+	pvcs.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaimList"))
+	if ok, err := c.list(ctx, &pvcs, client.MatchingLabels{pvcNameLabel: "redpanda"}); err != nil {
+		return nil, err
+	} else if ok {
+		drivers := map[string]struct{}{}
+		for i := range pvcs.Items {
+			if driver := pvcs.Items[i].Annotations[storageProvisionerAnnotation]; driver != "" {
+				drivers[driver] = struct{}{}
+			}
+		}
+		for driver := range drivers {
+			payload.Storage.CSIDrivers = append(payload.Storage.CSIDrivers, driver)
+		}
+		sort.Strings(payload.Storage.CSIDrivers)
+	}
+
+	// CRD definitions are large; a metadata-only list keeps this cheap. A CRD's
+	// name is always "<plural>.<group>", so the name suffix identifies the
+	// group without loading specs.
+	var crds metav1.PartialObjectMetadataList
+	crds.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinitionList"))
+	if ok, err := c.list(ctx, &crds); err != nil {
+		return nil, err
+	} else if ok {
+		for i := range crds.Items {
+			if strings.HasSuffix(crds.Items[i].Name, "."+redpandaCRDGroup) {
+				payload.CRDCount++
+			}
+		}
+	}
+
+	return payload, nil
+}
+
+// aggregateRedpandas folds the Redpanda fleet into the payload: count, broker
+// count, distinct versions, per-cluster feature adoption, and the default-pool
+// sizing. Feature adoption and versions are read from the raw spec (explicit
+// opt-ins), while broker count and resource sizing are derived from the
+// chart-rendered values (cluster.GetValues()) so installs relying on chart
+// defaults are not undercounted. perBroker is populated with each cluster's
+// rendered per-broker requirements for NodePool correlation by the caller.
+func (c *Collector) aggregateRedpandas(payload *Payload, items []redpandav1alpha2.Redpanda, rp *sizing, perBroker map[string]corev1.ResourceRequirements) {
+	payload.Redpanda.Count = len(items)
+	versions := map[string]struct{}{}
+	for i := range items {
+		rpCR := &items[i]
+		spec := rpCR.Spec.ClusterSpec
+		if spec == nil {
+			continue
+		}
+
+		// Feature adoption + version: raw spec.
+		if spec.Image != nil && spec.Image.Tag != nil && *spec.Image.Tag != "" {
+			versions[*spec.Image.Tag] = struct{}{}
+		}
+		if spec.TLS != nil && ptrBool(spec.TLS.Enabled) {
+			payload.Redpanda.TLS++
+		}
+		if spec.Auth != nil && spec.Auth.SASL != nil && ptrBool(spec.Auth.SASL.Enabled) {
+			payload.Redpanda.SASL++
+		}
+		if spec.Storage != nil && spec.Storage.Tiered != nil && spec.Storage.Tiered.Config != nil &&
+			jsonBoolTrue(spec.Storage.Tiered.Config.CloudStorageEnabled) {
+			payload.Redpanda.TieredStorage++
+		}
+		if spec.Console != nil && ptrBool(spec.Console.Enabled) {
+			payload.Redpanda.Console++
+		}
+		if spec.Connectors != nil && ptrBool(spec.Connectors.Enabled) {
+			payload.Redpanda.ManagedConnectors++
+		}
+
+		// Broker count + sizing: chart-rendered. Fall back to raw replicas for the
+		// count if rendering fails (sizing is simply skipped for that cluster).
+		values, err := rpCR.GetValues()
+		if err != nil {
+			if spec.Statefulset != nil && spec.Statefulset.Replicas != nil {
+				payload.Redpanda.BrokerCount += *spec.Statefulset.Replicas
+			}
+			continue
+		}
+		replicas := int(values.Statefulset.Replicas)
+		payload.Redpanda.BrokerCount += replicas
+		reqs := values.Resources.GetResourceRequirements()
+		rp.add(reqs, replicas)
+		perBroker[rpCR.Namespace+"/"+rpCR.Name] = reqs
+	}
+	for v := range versions {
+		payload.Redpanda.Versions = append(payload.Redpanda.Versions, v)
+	}
+	sort.Strings(payload.Redpanda.Versions)
+}
+
+// sizing accumulates aggregate provisioned capacity (Σ per-broker × replicas)
+// and the set of distinct per-broker sizes across a group of pools.
+type sizing struct {
+	milliCPU int64
+	memBytes int64
+	sizes    map[string]struct{}
+}
+
+// add folds one pool's per-broker requirements × replicas into the totals.
+// Limits are preferred over Requests; a pool with neither CPU nor memory set is
+// skipped (per-field degradation — unset resources contribute nothing).
+func (s *sizing) add(reqs corev1.ResourceRequirements, replicas int) {
+	if replicas <= 0 {
+		return
+	}
+	list := reqs.Limits
+	if len(list) == 0 {
+		list = reqs.Requests
+	}
+	cpu := list[corev1.ResourceCPU]
+	mem := list[corev1.ResourceMemory]
+	milliCPU := cpu.MilliValue()
+	memBytes := mem.Value()
+	if milliCPU == 0 && memBytes == 0 {
+		return
+	}
+	s.milliCPU += milliCPU * int64(replicas)
+	s.memBytes += memBytes * int64(replicas)
+	if s.sizes == nil {
+		s.sizes = map[string]struct{}{}
+	}
+	s.sizes[brokerSizeLabel(milliCPU, memBytes)] = struct{}{}
+}
+
+// into writes the accumulated totals (rounded to integer cores/GiB) and the
+// sorted distinct sizes into the payload fields.
+func (s *sizing) into(cores, gib *int, sizes *[]string) {
+	*cores = roundDiv(s.milliCPU, 1000)
+	*gib = roundDiv(s.memBytes, 1<<30)
+	if len(s.sizes) == 0 {
+		return
+	}
+	out := make([]string, 0, len(s.sizes))
+	for sz := range s.sizes {
+		out = append(out, sz)
+	}
+	sort.Strings(out)
+	*sizes = out
+}
+
+// brokerSizeLabel renders a per-broker size like "4c/16Gi" from raw millicores
+// and bytes, rounded to integers.
+func brokerSizeLabel(milliCPU, memBytes int64) string {
+	return fmt.Sprintf("%dc/%dGi", roundDiv(milliCPU, 1000), roundDiv(memBytes, 1<<30))
+}
+
+func roundDiv(n, d int64) int { return int(math.Round(float64(n) / float64(d))) }
+
+func derefInt32(p *int32) int {
+	if p == nil {
+		return 0
+	}
+	return int(*p)
+}
+
+// count lists the given object list (tolerating missing CRD/RBAC) and writes
+// the item count into dst. It lists metadata only (PartialObjectMetadataList)
+// so counting never loads full objects into memory.
+func (c *Collector) count(ctx context.Context, listGVK schema.GroupVersionKind, dst *int) error {
+	var list metav1.PartialObjectMetadataList
+	list.SetGroupVersionKind(listGVK)
+	ok, err := c.list(ctx, &list)
+	if err != nil {
+		return err
+	}
+	if ok {
+		*dst = len(list.Items)
+	}
+	return nil
+}
+
+// list reads a resource list, tolerating the two permanent, install-specific
+// conditions that would otherwise discard the whole telemetry document: a
+// missing CRD (NoMatch) and missing RBAC (Forbidden). It returns ok=false (with
+// a nil error) in those cases so the caller leaves the field at its zero value
+// and continues; any other error is returned for the caller to propagate.
+func (c *Collector) list(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (bool, error) {
+	if err := c.Reader.List(ctx, list, opts...); err != nil {
+		if meta.IsNoMatchError(err) || apierrors.IsForbidden(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func ptrBool(b *bool) bool { return b != nil && *b }
+
+// jsonBoolTrue reports whether a spec JSONBoolean is set to a truthy value.
+// Truthiness matches JSONBoolean.MarshalJSON: the raw JSON is `true` or "true".
+func jsonBoolTrue(b *apiutil.JSONBoolean) bool {
+	if b == nil {
+		return false
+	}
+	switch string(b.Raw) {
+	case `true`, `"true"`:
+		return true
+	default:
+		return false
+	}
+}

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -1,0 +1,420 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+)
+
+// fakeServerVersion is a discovery.ServerVersionInterface stub for tests.
+type fakeServerVersion struct {
+	info *version.Info
+	err  error
+}
+
+func (f fakeServerVersion) ServerVersion() (*version.Info, error) { return f.info, f.err }
+
+func testScheme(t *testing.T) *apimachineryruntime.Scheme {
+	t.Helper()
+	scheme := apimachineryruntime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+	require.NoError(t, vectorizedv1alpha1.Install(scheme))
+	return scheme
+}
+
+func TestCollect_PopulatedCluster(t *testing.T) {
+	scheme := testScheme(t)
+
+	objs := []client.Object{
+		&redpandav1alpha2.NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: "np-1", Namespace: "default"},
+			Spec: redpandav1alpha2.NodePoolSpec{
+				// ClusterRef ties this pool to rp-1 so it inherits rp-1's
+				// per-broker resources for sizing.
+				ClusterRef:           redpandav1alpha2.ClusterRef{Name: "rp-1"},
+				EmbeddedNodePoolSpec: redpandav1alpha2.EmbeddedNodePoolSpec{Replicas: ptr.To(int32(2))},
+			},
+		},
+		&redpandav1alpha2.StretchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "sc-1", Namespace: "default"},
+		},
+		&redpandav1alpha2.RedpandaBrokerPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp-1", Namespace: "default"},
+			Spec: redpandav1alpha2.BrokerPoolSpec{
+				EmbeddedBrokerPoolSpec: redpandav1alpha2.EmbeddedBrokerPoolSpec{
+					Replicas: ptr.To(int32(3)),
+					Resources: &redpandav1alpha2.StretchResources{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("32Gi"),
+						},
+					},
+				},
+			},
+		},
+		&redpandav1alpha2.Topic{
+			ObjectMeta: metav1.ObjectMeta{Name: "topic-1", Namespace: "default"},
+		},
+		&redpandav1alpha2.User{ObjectMeta: metav1.ObjectMeta{Name: "user-1", Namespace: "default"}},
+		&redpandav1alpha2.Schema{ObjectMeta: metav1.ObjectMeta{Name: "schema-1", Namespace: "default"}},
+		&redpandav1alpha2.RedpandaRole{ObjectMeta: metav1.ObjectMeta{Name: "role-1", Namespace: "default"}},
+		&redpandav1alpha2.ShadowLink{ObjectMeta: metav1.ObjectMeta{Name: "sl-1", Namespace: "default"}},
+		&redpandav1alpha2.Console{ObjectMeta: metav1.ObjectMeta{Name: "console-1", Namespace: "default"}},
+		&vectorizedv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "v1-1", Namespace: "default"},
+			Spec: vectorizedv1alpha1.ClusterSpec{
+				Replicas: ptr.To(int32(1)),
+				Resources: vectorizedv1alpha1.RedpandaResourceRequirements{
+					ResourceRequirements: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+		},
+		&redpandav1alpha2.Redpanda{
+			ObjectMeta: metav1.ObjectMeta{Name: "rp-1", Namespace: "default"},
+			Spec: redpandav1alpha2.RedpandaSpec{
+				ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+					Image:       &redpandav1alpha2.RedpandaImage{Tag: ptr.To("v25.2.1")},
+					Statefulset: &redpandav1alpha2.Statefulset{Replicas: ptr.To(3)},
+					Resources: &redpandav1alpha2.Resources{
+						CPU:    &redpandav1alpha2.CPU{Cores: ptr.To(resource.MustParse("4"))},
+						Memory: &redpandav1alpha2.Memory{Container: &redpandav1alpha2.ContainerResources{Max: ptr.To(resource.MustParse("16Gi"))}},
+					},
+					TLS:        &redpandav1alpha2.TLS{Enabled: ptr.To(true)},
+					Auth:       &redpandav1alpha2.Auth{SASL: &redpandav1alpha2.SASL{Enabled: ptr.To(true)}},
+					Console:    &redpandav1alpha2.RedpandaConsole{Enabled: ptr.To(true)},
+					Connectors: &redpandav1alpha2.RedpandaConnectors{Enabled: ptr.To(true)},
+					Storage: &redpandav1alpha2.Storage{
+						Tiered: &redpandav1alpha2.Tiered{
+							Config: &redpandav1alpha2.TieredConfig{
+								CloudStorageEnabled: &apiutil.JSONBoolean{Raw: []byte("true")},
+							},
+						},
+					},
+				},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-1",
+				Namespace: "default",
+				Labels:    map[string]string{"app.kubernetes.io/name": "redpanda"},
+				Annotations: map[string]string{
+					"volume.kubernetes.io/storage-provisioner": "ebs.csi.aws.com",
+				},
+			},
+		},
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "redpandas.cluster.redpanda.com"},
+			Spec:       apiextensionsv1.CustomResourceDefinitionSpec{Group: "cluster.redpanda.com"},
+		},
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "certificates.cert-manager.io"},
+			Spec:       apiextensionsv1.CustomResourceDefinitionSpec{Group: "cert-manager.io"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	collector := &Collector{
+		Reader:          c,
+		ID:              "source-id",
+		OperatorVersion: "v26.2.0",
+		IDHash:          "deadbeefcafe",
+		Features:        map[string]bool{"pvcUnbinder": true},
+		Discovery:       fakeServerVersion{info: &version.Info{GitVersion: "v1.32.0"}},
+	}
+
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	payload := raw
+
+	require.Equal(t, "source-id", payload.ID)
+	require.Equal(t, "v26.2.0", payload.OperatorVersion)
+	require.Equal(t, runtime.Version(), payload.GoVersion)
+	require.Equal(t, "v1.32.0", payload.KubeVersion)
+	require.Equal(t, "deadbeefcafe", payload.IDHash)
+
+	require.True(t, payload.NodePools.Enabled)
+	require.Equal(t, 1, payload.NodePools.Count)
+
+	require.True(t, payload.StretchCluster.Enabled)
+	require.Equal(t, 1, payload.StretchCluster.Count)
+
+	// Redpanda fleet aggregates.
+	require.Equal(t, 1, payload.Redpanda.Count)
+	require.Equal(t, 5, payload.Redpanda.BrokerCount) // 3 rendered statefulset + 2 nodepool
+	require.Equal(t, []string{"v25.2.1"}, payload.Redpanda.Versions)
+	require.Equal(t, 1, payload.Redpanda.TLS)
+	require.Equal(t, 1, payload.Redpanda.SASL)
+	require.Equal(t, 1, payload.Redpanda.TieredStorage)
+	require.Equal(t, 1, payload.Redpanda.Console)
+	require.Equal(t, 1, payload.Redpanda.ManagedConnectors)
+	// Sizing: 4c/16Gi per broker × 5 brokers (rp-1 default pool + correlated np-1).
+	require.Equal(t, 20, payload.Redpanda.TotalCPUCores)
+	require.Equal(t, 80, payload.Redpanda.TotalMemoryGiB)
+	require.Equal(t, []string{"4c/16Gi"}, payload.Redpanda.BrokerSizes)
+
+	// Stretch sizing from the RedpandaBrokerPool: 8c/32Gi × 3.
+	require.Equal(t, 3, payload.StretchCluster.BrokerCount)
+	require.Equal(t, 24, payload.StretchCluster.TotalCPUCores)
+	require.Equal(t, 96, payload.StretchCluster.TotalMemoryGiB)
+	require.Equal(t, []string{"8c/32Gi"}, payload.StretchCluster.BrokerSizes)
+
+	// Vectorized sizing: 2c/8Gi × 1.
+	require.Equal(t, 1, payload.VectorizedClusters.Count)
+	require.Equal(t, 1, payload.VectorizedClusters.BrokerCount)
+	require.Equal(t, 2, payload.VectorizedClusters.TotalCPUCores)
+	require.Equal(t, 8, payload.VectorizedClusters.TotalMemoryGiB)
+	require.Equal(t, []string{"2c/8Gi"}, payload.VectorizedClusters.BrokerSizes)
+
+	require.Equal(t, []string{"ebs.csi.aws.com"}, payload.Storage.CSIDrivers)
+
+	// Supporting CR-type counts.
+	require.Equal(t, 1, payload.Resources.Topics)
+	require.Equal(t, 1, payload.Resources.Users)
+	require.Equal(t, 1, payload.Resources.Schemas)
+	require.Equal(t, 1, payload.Resources.Roles)
+	require.Equal(t, 1, payload.Resources.ShadowLinks)
+	require.Equal(t, 1, payload.Resources.Consoles)
+
+	require.Equal(t, 1, payload.CRDCount)
+	// PVC Unbinder usage is reported via the features map, not a dedicated field.
+	require.True(t, payload.Features["pvcUnbinder"])
+	require.Equal(t, map[string]bool{"pvcUnbinder": true}, payload.Features)
+}
+
+func TestCollect_KubeVersionBestEffort(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// A discovery failure must not fail collection; kubeVersion is left empty.
+	collector := &Collector{
+		Reader:    c,
+		Discovery: fakeServerVersion{err: errors.New("api server unreachable")},
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, raw.KubeVersion)
+
+	// A nil discovery client also yields an empty version, no panic.
+	collector = &Collector{Reader: c}
+	raw, err = collector.Collect(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, raw.KubeVersion)
+}
+
+func TestCollect_EmptyCluster(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	collector := &Collector{
+		Reader:          c,
+		ID:              "source-id",
+		OperatorVersion: "v26.2.0",
+	}
+
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	payload := raw
+
+	require.False(t, payload.NodePools.Enabled)
+	require.Equal(t, 0, payload.NodePools.Count)
+	require.False(t, payload.StretchCluster.Enabled)
+	require.Equal(t, 0, payload.StretchCluster.Count)
+	require.Equal(t, 0, payload.Redpanda.Count)
+	require.Equal(t, 0, payload.Redpanda.BrokerCount)
+	require.Empty(t, payload.Redpanda.Versions)
+	require.Equal(t, 0, payload.Redpanda.ManagedConnectors)
+	require.Equal(t, 0, payload.VectorizedClusters.Count)
+	require.Empty(t, payload.Storage.CSIDrivers)
+	require.Equal(t, 0, payload.Resources.Topics)
+	require.Equal(t, 0, payload.CRDCount)
+}
+
+func TestCollect_CSIDriversSortedAndDistinct(t *testing.T) {
+	scheme := testScheme(t)
+
+	pvc := func(name, provisioner string) client.Object {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    map[string]string{"app.kubernetes.io/name": "redpanda"},
+				Annotations: map[string]string{
+					"volume.kubernetes.io/storage-provisioner": provisioner,
+				},
+			},
+		}
+	}
+
+	objs := []client.Object{
+		pvc("pvc-1", "pd.csi.storage.gke.io"),
+		pvc("pvc-2", "ebs.csi.aws.com"),
+		pvc("pvc-3", "ebs.csi.aws.com"),
+		// Unlabeled PVC must be ignored.
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-other",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"volume.kubernetes.io/storage-provisioner": "other.csi.driver",
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	collector := &Collector{Reader: c}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"ebs.csi.aws.com", "pd.csi.storage.gke.io"}, raw.Storage.CSIDrivers)
+}
+
+// stubReader wraps a client.Reader and lets a test force specific List calls to
+// fail, to exercise the collector's per-field degradation.
+type stubReader struct {
+	client.Reader
+	listErr func(client.ObjectList) error
+}
+
+func (s stubReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if s.listErr != nil {
+		if err := s.listErr(list); err != nil {
+			return err
+		}
+	}
+	return s.Reader.List(ctx, list, opts...)
+}
+
+func TestCollect_DegradesOnMissingCRDAndForbidden(t *testing.T) {
+	scheme := testScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&redpandav1alpha2.NodePool{ObjectMeta: metav1.ObjectMeta{Name: "np-1", Namespace: "default"}},
+		&redpandav1alpha2.Topic{ObjectMeta: metav1.ObjectMeta{Name: "t-1", Namespace: "default"}},
+	).Build()
+
+	reader := stubReader{
+		Reader: base,
+		listErr: func(list client.ObjectList) error {
+			switch l := list.(type) {
+			case *redpandav1alpha2.StretchClusterList:
+				// CRD not installed -> RESTMapper no-match.
+				return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: redpandaCRDGroup, Kind: "StretchCluster"}}
+			case *metav1.PartialObjectMetadataList:
+				// Counts use metadata-only lists; match the User count by GVK.
+				if l.GroupVersionKind().Kind == "UserList" {
+					// RBAC not granted -> Forbidden.
+					return apierrors.NewForbidden(schema.GroupResource{Group: redpandaCRDGroup, Resource: "users"}, "", errors.New("forbidden"))
+				}
+			}
+			return nil
+		},
+	}
+
+	collector := &Collector{Reader: reader, ID: "id", OperatorVersion: "v26.2.0"}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err) // tolerated, document still sent
+
+	// Base fields and the resources that ARE available are still reported.
+	require.Equal(t, "id", raw.ID)
+	require.Equal(t, "v26.2.0", raw.OperatorVersion)
+	require.True(t, raw.NodePools.Enabled)
+	require.Equal(t, 1, raw.NodePools.Count)
+	require.Equal(t, 1, raw.Resources.Topics)
+	// Missing CRD (NoMatch) and missing RBAC (Forbidden) degrade to zero values.
+	require.False(t, raw.StretchCluster.Enabled)
+	require.Equal(t, 0, raw.StretchCluster.Count)
+	require.Equal(t, 0, raw.Resources.Users)
+}
+
+func TestCollect_PropagatesUnexpectedError(t *testing.T) {
+	scheme := testScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reader := stubReader{
+		Reader: base,
+		listErr: func(list client.ObjectList) error {
+			if _, ok := list.(*redpandav1alpha2.NodePoolList); ok {
+				return errors.New("api server unavailable")
+			}
+			return nil
+		},
+	}
+
+	collector := &Collector{Reader: reader}
+	_, err := collector.Collect(t.Context())
+	// A non-tolerated error drops the cycle rather than sending a partial payload.
+	require.Error(t, err)
+}
+
+func TestSizing(t *testing.T) {
+	var s sizing
+	// Limits used directly.
+	s.add(corev1.ResourceRequirements{Limits: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("4"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+	}}, 3)
+	// Requests used as fallback when Limits is empty.
+	s.add(corev1.ResourceRequirements{Requests: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
+	}}, 2)
+	// Unset resources contribute nothing (per-field degradation).
+	s.add(corev1.ResourceRequirements{}, 5)
+	// Zero replicas contribute nothing.
+	s.add(corev1.ResourceRequirements{Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("99")}}, 0)
+	// Fractional CPU rounds to the nearest integer core in the label.
+	s.add(corev1.ResourceRequirements{Limits: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("3500m"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+	}}, 1)
+
+	var cores, gib int
+	var sizes []string
+	s.into(&cores, &gib, &sizes)
+
+	// Σ cores: 4*3 + 2*2 + round(3.5)*1 = 12 + 4 + 4 = 20.
+	require.Equal(t, 20, cores)
+	// Σ GiB: 16*3 + 8*2 + 16*1 = 48 + 16 + 16 = 80.
+	require.Equal(t, 80, gib)
+	require.Equal(t, []string{"2c/8Gi", "4c/16Gi"}, sizes)
+}

--- a/operator/internal/telemetry/features.go
+++ b/operator/internal/telemetry/features.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// MergeAdHocFeatures folds operator-provided ad-hoc feature flags (from the
+// --telemetry-features key=bool flag) into the built-in features map and
+// returns the result. Ad-hoc entries take precedence over built-ins, so a
+// deployer can both add new signals (e.g. "redpanda-cloud": true for
+// cloud-managed installs) and explicitly override a derived one. Values must
+// parse as booleans; anything else is a deployment configuration error and is
+// returned as such so the operator fails fast at startup instead of silently
+// reporting skewed data.
+func MergeAdHocFeatures(features map[string]bool, adHoc map[string]string) (map[string]bool, error) {
+	if features == nil {
+		features = map[string]bool{}
+	}
+	for name, raw := range adHoc {
+		if name == "" {
+			return nil, fmt.Errorf("telemetry feature with value %q has an empty name", raw)
+		}
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("telemetry feature %q: value %q is not a boolean: %w", name, raw, err)
+		}
+		features[name] = value
+	}
+	return features, nil
+}

--- a/operator/internal/telemetry/features_test.go
+++ b/operator/internal/telemetry/features_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeAdHocFeatures(t *testing.T) {
+	// Ad-hoc entries are added and override built-ins.
+	merged, err := MergeAdHocFeatures(
+		map[string]bool{"pvcUnbinder": true, "webhook": false},
+		map[string]string{"redpanda-cloud": "true", "webhook": "true"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]bool{
+		"pvcUnbinder":    true,
+		"webhook":        true, // overridden by the ad-hoc entry
+		"redpanda-cloud": true,
+	}, merged)
+
+	// Nil inputs are fine.
+	merged, err = MergeAdHocFeatures(nil, map[string]string{"redpanda-cloud": "false"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]bool{"redpanda-cloud": false}, merged)
+
+	merged, err = MergeAdHocFeatures(map[string]bool{"a": true}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]bool{"a": true}, merged)
+
+	// Non-boolean values and empty names fail fast.
+	_, err = MergeAdHocFeatures(nil, map[string]string{"redpanda-cloud": "yes-please"})
+	require.ErrorContains(t, err, `"redpanda-cloud"`)
+
+	_, err = MergeAdHocFeatures(nil, map[string]string{"": "true"})
+	require.ErrorContains(t, err, "empty name")
+}

--- a/operator/internal/telemetry/identity.go
+++ b/operator/internal/telemetry/identity.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"context"
+	"os"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ResolveSourceID returns the operator Deployment's UID by walking
+// Pod -> ReplicaSet -> Deployment owner references. Best effort: falls back
+// to the pod UID, then "".
+//
+// It takes a client.Reader (not the manager's cached client) and is meant to be
+// called with mgr.GetAPIReader() at startup, before mgr.Start(): the cached
+// client returns ErrCacheNotStarted for pre-start reads, and its lazily-started
+// informers would also require list+watch RBAC. An uncached APIReader reads
+// directly from the API server, works pre-start, and needs only "get".
+func ResolveSourceID(ctx context.Context, reader client.Reader) string {
+	namespace := os.Getenv("POD_NAMESPACE")
+	name := os.Getenv("POD_NAME")
+	if namespace == "" || name == "" {
+		return ""
+	}
+
+	var pod corev1.Pod
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &pod); err != nil {
+		return ""
+	}
+
+	rsRef := controllerOwnerOfKind(pod.OwnerReferences, "ReplicaSet")
+	if rsRef == nil {
+		return string(pod.UID)
+	}
+
+	var rs appsv1.ReplicaSet
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: rsRef.Name}, &rs); err != nil {
+		return string(pod.UID)
+	}
+
+	if deployRef := controllerOwnerOfKind(rs.OwnerReferences, "Deployment"); deployRef != nil {
+		return string(deployRef.UID)
+	}
+
+	return string(pod.UID)
+}
+
+func controllerOwnerOfKind(refs []metav1.OwnerReference, kind string) *metav1.OwnerReference {
+	for i := range refs {
+		if refs[i].Kind == kind && refs[i].Controller != nil && *refs[i].Controller {
+			return &refs[i]
+		}
+	}
+	return nil
+}

--- a/operator/internal/telemetry/identity_test.go
+++ b/operator/internal/telemetry/identity_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func identityScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestResolveSourceID_WalksToDeployment(t *testing.T) {
+	scheme := identityScheme(t)
+
+	deploymentUID := types.UID("deployment-uid")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-pod",
+			Namespace: "redpanda",
+			UID:       types.UID("pod-uid"),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       "operator-rs",
+				UID:        types.UID("rs-uid"),
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-rs",
+			Namespace: "redpanda",
+			UID:       types.UID("rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "operator",
+				UID:        deploymentUID,
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, rs).Build()
+
+	t.Setenv("POD_NAMESPACE", "redpanda")
+	t.Setenv("POD_NAME", "operator-pod")
+
+	require.Equal(t, string(deploymentUID), ResolveSourceID(t.Context(), c))
+}
+
+func TestResolveSourceID_FallsBackToPodUID(t *testing.T) {
+	scheme := identityScheme(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-pod",
+			Namespace: "redpanda",
+			UID:       types.UID("pod-uid"),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	t.Setenv("POD_NAMESPACE", "redpanda")
+	t.Setenv("POD_NAME", "operator-pod")
+
+	require.Equal(t, "pod-uid", ResolveSourceID(t.Context(), c))
+}
+
+func TestResolveSourceID_MissingEnv(t *testing.T) {
+	scheme := identityScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	t.Setenv("POD_NAMESPACE", "")
+	t.Setenv("POD_NAME", "")
+
+	require.Equal(t, "", ResolveSourceID(t.Context(), c))
+}

--- a/operator/internal/telemetry/license.go
+++ b/operator/internal/telemetry/license.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import "github.com/redpanda-data/common-go/license"
+
+// LicenseChecksum returns the hex SHA-256 checksum of a parsed enterprise
+// license — the same value Redpanda core reports as id_hash. The
+// license.RedpandaLicense interface doesn't expose the checksum, so we type
+// switch to the concrete versions. Returns "" for an unrecognized type.
+//
+// Callers must gate on license.AllowsEnterpriseFeatures() first: the checksum
+// is only emitted for licensed clusters so OSS/unlicensed reports stay
+// anonymous.
+func LicenseChecksum(l license.RedpandaLicense) string {
+	switch v := l.(type) {
+	case *license.V1RedpandaLicense:
+		return v.Checksum
+	case *license.V0RedpandaLicense:
+		return v.Checksum
+	default:
+		return ""
+	}
+}

--- a/operator/internal/telemetry/license_test.go
+++ b/operator/internal/telemetry/license_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/common-go/license"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLicenseChecksum(t *testing.T) {
+	require.Equal(t, "v1-checksum", LicenseChecksum(&license.V1RedpandaLicense{Checksum: "v1-checksum"}))
+	require.Equal(t, "v0-checksum", LicenseChecksum(&license.V0RedpandaLicense{Checksum: "v0-checksum"}))
+	// Unrecognized implementations yield an empty checksum rather than panicking.
+	require.Empty(t, LicenseChecksum(nil))
+}

--- a/operator/internal/telemetry/payload.go
+++ b/operator/internal/telemetry/payload.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+// Payload is the operator telemetry document sent to the /kubernetes
+// ingestion endpoint.
+type Payload struct {
+	ID              string `json:"id"`
+	OperatorVersion string `json:"operatorVersion"`
+	GoVersion       string `json:"goVersion"`
+	KubeVersion     string `json:"kubeVersion,omitempty"`
+	// IDHash is the enterprise license checksum (hex SHA-256 of the raw license
+	// token), the same value Redpanda core reports as id_hash, so licensed
+	// clusters correlate to an account. Absent (omitted) for OSS/unlicensed
+	// installs, keeping those reports anonymous.
+	IDHash string `json:"id_hash,omitempty"`
+
+	NodePools struct {
+		Enabled bool `json:"enabled"`
+		Count   int  `json:"count"`
+	} `json:"nodePools"`
+
+	StretchCluster struct {
+		Enabled bool `json:"enabled"`
+		Count   int  `json:"count"`
+		// Sizing across RedpandaBrokerPool members (stretch/multicluster mode).
+		BrokerCount    int      `json:"brokerCount,omitempty"`
+		TotalCPUCores  int      `json:"totalCpuCores,omitempty"`
+		TotalMemoryGiB int      `json:"totalMemoryGiB,omitempty"`
+		BrokerSizes    []string `json:"brokerSizes,omitempty"`
+	} `json:"stretchCluster"`
+
+	// Redpanda aggregates the fleet of v2 (chart-based) Redpanda CRs. The
+	// per-cluster feature fields are counts of clusters with the feature enabled
+	// (not a fleet-wide bool), so one cluster out of many does not flip the
+	// signal and we can gauge adoption across the fleet.
+	Redpanda struct {
+		// Count is the number of Redpanda CRs.
+		Count int `json:"count"`
+		// BrokerCount is the total desired broker count across the fleet: the sum
+		// of each cluster's rendered statefulset.replicas plus every NodePool's
+		// spec.replicas. This is the primary scale metric (cluster count alone
+		// hides 3-broker vs 30-broker installs).
+		BrokerCount int `json:"brokerCount"`
+		// TotalCPUCores / TotalMemoryGiB are the aggregate provisioned capacity
+		// across the fleet (Σ per-broker × replicas), computed from rendered chart
+		// values so installs relying on chart defaults are not undercounted.
+		TotalCPUCores  int `json:"totalCpuCores,omitempty"`
+		TotalMemoryGiB int `json:"totalMemoryGiB,omitempty"`
+		// BrokerSizes are the distinct per-broker sizes in use, e.g. "4c/16Gi" —
+		// like Versions, anonymous and useful for fleet segmentation.
+		BrokerSizes []string `json:"brokerSizes,omitempty"`
+		// Versions are the distinct spec.image.tag values in use (for support and
+		// EOL planning).
+		Versions []string `json:"versions"`
+		// TLS counts clusters with spec.tls.enabled.
+		TLS int `json:"tlsEnabled"`
+		// SASL counts clusters with spec.auth.sasl.enabled.
+		SASL int `json:"saslEnabled"`
+		// TieredStorage counts clusters with tiered (cloud) storage enabled.
+		TieredStorage int `json:"tieredStorageEnabled"`
+		// Console counts clusters using the deprecated inline console
+		// (spec.console.enabled).
+		Console int `json:"consoleEnabled"`
+		// ManagedConnectors counts clusters using the deprecated managed
+		// Connectors deployment (spec.connectors.enabled) — this is NOT Redpanda
+		// Connect; the field is named accordingly to avoid misleading dashboards.
+		ManagedConnectors int `json:"managedConnectorsEnabled"`
+	} `json:"redpanda"`
+
+	// VectorizedClusters counts deprecated v1 (vectorized Cluster CR) installs
+	// and their aggregate sizing.
+	VectorizedClusters struct {
+		Count          int      `json:"count"`
+		BrokerCount    int      `json:"brokerCount,omitempty"`
+		TotalCPUCores  int      `json:"totalCpuCores,omitempty"`
+		TotalMemoryGiB int      `json:"totalMemoryGiB,omitempty"`
+		BrokerSizes    []string `json:"brokerSizes,omitempty"`
+	} `json:"vectorizedClusters"`
+
+	Storage struct {
+		CSIDrivers []string `json:"csiDrivers"`
+	} `json:"storage"`
+
+	// Resources counts the supporting Redpanda CR types.
+	Resources struct {
+		Topics      int `json:"topics"`
+		Users       int `json:"users"`
+		Schemas     int `json:"schemas"`
+		Roles       int `json:"roles"`
+		ShadowLinks int `json:"shadowLinks"`
+		Consoles    int `json:"consoles"`
+	} `json:"resources"`
+
+	CRDCount int `json:"crdCount"`
+	// Features reports enabled operator-shape flags (controllers, webhook, leader
+	// election, cloud-secrets provider, PVC Unbinder, etc.). PVC Unbinder usage
+	// is reported here under "pvcUnbinder" rather than as a dedicated field.
+	Features map[string]bool `json:"features"`
+}

--- a/operator/internal/telemetry/runnable.go
+++ b/operator/internal/telemetry/runnable.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package telemetry
+
+import (
+	"context"
+	_ "embed"
+	"time"
+
+	"github.com/go-logr/logr"
+	commontelemetry "github.com/redpanda-data/common-go/telemetry"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+)
+
+//go:embed key.pem
+var signingKey []byte
+
+// Enabled reports whether a signing key is embedded in this build.
+func Enabled() bool { return len(signingKey) > 0 }
+
+type logrShim struct{ l logr.Logger }
+
+func (s logrShim) Debug(msg string, kv ...any) { s.l.V(1).Info(msg, kv...) }
+
+// Options configures a telemetry Runnable.
+type Options struct {
+	Endpoint        string
+	ID              string
+	OperatorVersion string
+	// IDHash is the enterprise license checksum (id_hash); empty for
+	// OSS/unlicensed installs, in which case it is omitted from the payload.
+	IDHash   string
+	Features map[string]bool
+	// Delay is the wait before the first report; zero means the shared library default (5m).
+	Delay  time.Duration
+	Period time.Duration
+}
+
+// Runnable adapts the shared telemetry Reporter to the controller-runtime
+// manager.Runnable interface so it can be added to the manager.
+type Runnable struct{ reporter *commontelemetry.Reporter }
+
+// Engage implements the multicluster-runtime cluster-aware interface. Operator
+// telemetry is scoped to the operator installation as a whole: it reports a
+// single aggregate cluster-shape record collected from the uncached API reader
+// by the periodic loop in Start. There is no per-engaged-cluster work to
+// perform, so this is a no-op that accepts the engagement; returning a non-nil
+// error here would cause the manager to retry engaging the cluster.
+func (r *Runnable) Engage(_ context.Context, _ string, _ cluster.Cluster) error {
+	return nil
+}
+
+// NewRunnable builds a telemetry Runnable backed by the shared client. If no
+// signing key is embedded, the underlying client is a disabled no-op. reader
+// should be the manager's uncached API reader (mgr.GetAPIReader()); the
+// discovery client resolves the Kubernetes server version each cycle and may be
+// nil, in which case kubeVersion is omitted.
+func NewRunnable(reader client.Reader, disco discovery.ServerVersionInterface, log logr.Logger, opts Options) (*Runnable, error) {
+	tc, err := commontelemetry.New(commontelemetry.Config{
+		Endpoint:      opts.Endpoint,
+		Path:          "/kubernetes",
+		UserAgent:     "RedpandaOperator/" + opts.OperatorVersion,
+		SigningKeyPEM: signingKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	collector := &Collector{
+		Reader:          reader,
+		ID:              opts.ID,
+		OperatorVersion: opts.OperatorVersion,
+		IDHash:          opts.IDHash,
+		Features:        opts.Features,
+		Discovery:       disco,
+	}
+
+	return &Runnable{reporter: &commontelemetry.Reporter{
+		Client: tc,
+		// Collect returns *Payload; adapt it to the Reporter's any-typed collector.
+		Collector: func(ctx context.Context) (any, error) { return collector.Collect(ctx) },
+		Delay:     opts.Delay,
+		Period:    opts.Period,
+		Logger:    logrShim{l: log},
+	}}, nil
+}
+
+// Start runs the telemetry reporter until the context is cancelled.
+func (r *Runnable) Start(ctx context.Context) error { return r.reporter.Run(ctx) }

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -39,6 +39,16 @@ tasks:
         -X "github.com/redpanda-data/redpanda-operator/operator/cmd/version.commit={{.COMMIT}}"
         -X "github.com/redpanda-data/redpanda-operator/operator/cmd/version.Version={{.OPERATOR_VERSION}}"
     cmds:
+    # Inject the telemetry signing key (official builds only). When
+    # TELEMETRY_PRIVATE_KEY is set, write it to the //go:embed'd key.pem so the
+    # built operator emits anonymous telemetry; otherwise the committed empty
+    # key.pem leaves the telemetry client disabled (dev builds send nothing).
+    # Must run before `go build`, which embeds key.pem at compile time.
+    - |
+      if [ -n "${TELEMETRY_PRIVATE_KEY:-}" ]; then
+        echo "Injecting telemetry signing key into operator/internal/telemetry/key.pem"
+        printf '%s' "$TELEMETRY_PRIVATE_KEY" > operator/internal/telemetry/key.pem
+      fi
     - |
       for goos in ${BUILD_GOOS:-linux darwin}; do
         for goarch in ${BUILD_GOARCH:-arm64 amd64}; do


### PR DESCRIPTION
## What

Adds an opt-out **Kubernetes telemetry producer** to the operator so we can understand operator feature adoption in self-managed environments and segment usage across cloud / helm / operator-managed deployments (K8S-835). It reports aggregate cluster-shape metrics through the shared `github.com/redpanda-data/common-go/telemetry` client to the `/kubernetes` ingestion endpoint.

**Data classification:** reports are **anonymous for OSS/unlicensed installs** (aggregate counts and shape only — no identifiers). For **licensed clusters** they additionally carry the enterprise license checksum (`id_hash`), which makes those reports **pseudonymous** (reverse-lookupable to an account) rather than anonymous — see *Privacy* below.

## Architecture

- Transport + the periodic collect→sign→POST loop (RS256-signed JWT, drop-on-error) live in the shared **`common-go/telemetry`** client. This PR wires it in as a controller-runtime **`manager.Runnable`**.
- The runnable is **cluster-aware** (`Engage`) so it slots into the multicluster-runtime manager used by both the `run` and `multicluster` sub-commands; it reports a single install-scoped record via `Start`, so `Engage` is a no-op.
- The collector reads through the manager's **uncached `GetAPIReader()`**, not the cached client: this is a once-per-cycle read, so an informer cache would be pure overhead (it would watch+cache every PVC and CRD cluster-wide) and a forbidden read on the cached client would retry forever instead of failing fast. Direct reads also let the RBAC be `list`-only (no `watch`).
- **Per-field degradation**: a missing CRD (`NoMatch`) or missing RBAC (`Forbidden`) for one resource leaves that field zero and collection continues — so installs that haven't applied a new CRD/role yet still report everything else, instead of vanishing from the dataset. Any other error drops the cycle (no misleading all-zero payloads). Each collection is wrapped in a 30s timeout.

## What it reports (`/kubernetes` payload)

- **Identity**: operator Deployment UID (resolved Pod→ReplicaSet→Deployment via the uncached reader, pre-`Start`), overridable with `--telemetry-source-identifier`. Operator / Go / Kubernetes versions (Kube version resolved each cycle via the discovery client, best-effort).
- **NodePools** and **StretchCluster**: enablement + count.
- **Redpanda fleet** (`redpanda`): cluster `count`, total `brokerCount` (Σ `statefulset.replicas` + Σ NodePool `replicas`), distinct image `versions`, and **per-cluster adoption as counts** — `tlsEnabled`, `saslEnabled`, `tieredStorageEnabled`, `consoleEnabled`, `managedConnectorsEnabled` (the deprecated managed-Connectors deployment — named to avoid being confused with Redpanda Connect).
- **Broker sizing**: aggregate provisioned capacity (`totalCpuCores`, `totalMemoryGiB`) and distinct per-broker sizes (`brokerSizes`, e.g. `4c/16Gi`) — derived from the **chart-rendered** values (`GetValues()` + `GetResourceRequirements()`) so installs relying on chart defaults are not undercounted; same aggregates for StretchCluster (from `RedpandaBrokerPool` CRs) and vectorized v1 clusters (from spec).
- **Vectorized v1** Cluster count.
- **Supporting CR counts**: topics, users, schemas, roles, shadow links, consoles.
- **Storage**: distinct CSI driver names (from PVC `volume.kubernetes.io/storage-provisioner`). CSI *version* is intentionally omitted — no reliable cross-driver source (cf. aws-efs-csi-driver#1783).
- **CRD count** (`cluster.redpanda.com`).
- **Features map** (operator-shape, zero extra API calls): controllers (`vectorizedControllers`, `redpandaControllers`, `v2NodepoolController`, `consoleController`, `decommission`, `legacyDecommission`, `ghostBrokerDecommission`, `ghostbuster`), and config (`pvcUnbinder`, `autoDeletePVCs`, `allowPVRebinding`, `webhook`, `namespaceScoped`, `leaderElection`, `cloudSecrets` + provider booleans `cloudSecretsAWS`/`GCP`/`Azure`). PVC Unbinder is reported here only (no duplicate dedicated field).
- **Ad-hoc features for internal usage** (`--telemetry-features`, on both `run` and `multicluster`): deployer-supplied `name=bool` pairs merged into the features map of every report — e.g. our Cloud deployments can tag themselves with `--telemetry-features redpanda-cloud=true` so cloud-managed installs are segmentable without a code change. Repeatable/comma-separated; entries override built-in flags; non-boolean values fail fast at startup.

## Opt-out & gating (privacy)

- `telemetry.enabled` value in `operator/chart/values.yaml` (discoverable opt-out), plus the `--disable-telemetry` flag.
- Disabled in any build without an embedded signing key: the committed `key.pem` is **empty**, so `telemetry.Enabled()` is false and the client is a disabled no-op. Official builds inject the real key via the `TELEMETRY_PRIVATE_KEY` env var in `taskfiles/build.yml` (written to the `//go:embed`'d `key.pem` before `go build`). The public half lives in analytics-metrics.
- **OSS / unlicensed reports are anonymous**: aggregate counts and cluster shape only, no secret values (cloud-secrets reports the **provider only**), driver names not contents — and notably **no `id_hash`** (the field is omitted when no enterprise license is present).
- **Licensed reports are pseudonymous, not anonymous.** They include `id_hash` — the enterprise license checksum (hex SHA-256 of the raw license token) — which is reverse-lookupable to an account via the `checksum → account` mapping. This is **not a new data category for Redpanda**: it's the same fingerprint Redpanda core already emits as `id_hash` to the same endpoint family, and the operator value uses the identical construction, so it correlates against the *existing* mapping rather than a parallel one. It should ship under the same privacy / disclosure / retention posture core's `id_hash` already operates under (pseudonymization, with the join/mapping store access-controlled). `id_hash` is gated to valid enterprise licenses (`AllowsEnterpriseFeatures()`).

## RBAC & chart

- New markers: `list` on `apiextensions/customresourcedefinitions` and `get` on `apps/replicasets`; regenerated roles, chart RBAC, and golden templates.
- Chart Deployment sets `POD_NAMESPACE`/`POD_NAME` via the downward API so Deployment-UID resolution works (and reports are server-side dedupable across replicas).

## Testing

Unit tests with the controller-runtime fake client: collector field-by-field on a populated cluster and an empty cluster; per-field degradation on `NoMatch`+`Forbidden`; non-tolerated errors still drop the cycle; best-effort Kube-version (error + nil discovery); CSI driver sort/dedup; and identity resolution (owner-ref walk + env/UID fallbacks).

## Dependencies / merge order

Depends on the shared client module ([common-go#172](https://github.com/redpanda-data/common-go/pull/172), merged and released — `go.mod` pins the tagged **`common-go/telemetry v0.1.0`**) and the matching ingestion endpoint ([analytics-metrics#18](https://github.com/redpanda-data/analytics-metrics/pull/18)). Companion consumer bumps: [connect#4507](https://github.com/redpanda-data/connect/pull/4507), [console-enterprise#795](https://github.com/redpanda-data/console-enterprise/pull/795).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


