### PR TITLE
operator: fix broker container fields dropped by slice-pointer aliasing (#1577)

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260610-120000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260610-120000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed `clusterSpec.statefulset.extraVolumeMounts`, `livenessProbe`, and `startupProbe` being silently dropped from the `redpanda` (broker) container — they previously only applied to the `sidecar` container.
+time: 2026-06-10T12:00:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260612-100000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260612-100000.yaml
@@ -1,4 +1,4 @@
 project: operator
 kind: Fixed
-body: Fixed `clusterSpec.statefulset` overrides (probes, `extraVolumeMounts`) being silently dropped when `podTemplate.spec.containers` or `podTemplate.spec.initContainers` contains duplicate entries with the same name — duplicates are now collapsed (last entry wins) to match the chart's merge semantics.
+body: Fixed `clusterSpec.statefulset` overrides (probes, `extraVolumeMounts`) being silently dropped when `podTemplate.spec.containers` or `podTemplate.spec.initContainers` contains duplicate entries with the same name — conversion now applies overrides to the entry the chart actually renders (the last duplicate, matching the chart's merge semantics).
 time: 2026-06-12T10:00:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260612-100000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260612-100000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed `clusterSpec.statefulset` overrides (probes, `extraVolumeMounts`) being silently dropped when `podTemplate.spec.containers` or `podTemplate.spec.initContainers` contains duplicate entries with the same name — duplicates are now collapsed (last entry wins) to match the chart's merge semantics.
+time: 2026-06-12T10:00:00.000000-07:00

--- a/operator/api/redpanda/v1alpha2/conversion/helpers.go
+++ b/operator/api/redpanda/v1alpha2/conversion/helpers.go
@@ -84,7 +84,12 @@ func convertJSONNotNil[T any, U *T, V any](from U, to *V) error {
 }
 
 // containerOrInit returns a pointer to the container with the given name,
-// appending one if it doesn't exist yet.
+// appending one if it doesn't exist yet. If multiple entries share the name
+// (the CRD schema is a plain array, no listType=map, so duplicates pass
+// admission), the LAST one is returned: the chart's pod template merge
+// (mergeSliceBy) keys overrides by name with last-wins semantics, so the
+// last entry is the one the chart actually renders — a write to any earlier
+// duplicate would be silently dropped at render time.
 //
 // WARNING: The returned pointer points into the slice's backing array. Any
 // subsequent append to the slice may reallocate that array, after which
@@ -92,7 +97,7 @@ func convertJSONNotNil[T any, U *T, V any](from U, to *V) error {
 // the returned pointer across another containerOrInit (or append) on the
 // same slice — use containersOrInit to acquire multiple pointers at once.
 func containerOrInit(containers *[]applycorev1.ContainerApplyConfiguration, name string) *applycorev1.ContainerApplyConfiguration {
-	for i := range *containers {
+	for i := len(*containers) - 1; i >= 0; i-- {
 		container := &(*containers)[i]
 		if ptr.Deref(container.Name, "") == name {
 			return container
@@ -103,28 +108,6 @@ func containerOrInit(containers *[]applycorev1.ContainerApplyConfiguration, name
 	}
 	*containers = append(*containers, container)
 	return &(*containers)[len(*containers)-1]
-}
-
-// dedupeContainersByName collapses duplicate named entries in a container
-// list, keeping the content of the last occurrence at the position of the
-// first. The CRD schema accepts duplicates (plain array, no listType=map) and
-// the chart's pod template merge (mergeSliceBy) keys overrides by name with
-// last-wins semantics, so containerOrInit's first-match lookup would
-// otherwise mutate an entry the chart never renders — silently dropping the
-// write. Entries without a name are passed through untouched.
-func dedupeContainersByName(containers []applycorev1.ContainerApplyConfiguration) []applycorev1.ContainerApplyConfiguration {
-	indexByName := make(map[string]int, len(containers))
-	out := make([]applycorev1.ContainerApplyConfiguration, 0, len(containers))
-	for _, container := range containers {
-		name := ptr.Deref(container.Name, "")
-		if i, ok := indexByName[name]; ok && name != "" {
-			out[i] = container
-			continue
-		}
-		indexByName[name] = len(out)
-		out = append(out, container)
-	}
-	return out
 }
 
 // containersOrInit returns pointers to the containers with the given names,

--- a/operator/api/redpanda/v1alpha2/conversion/helpers.go
+++ b/operator/api/redpanda/v1alpha2/conversion/helpers.go
@@ -83,6 +83,14 @@ func convertJSONNotNil[T any, U *T, V any](from U, to *V) error {
 	return convertJSON(from, to)
 }
 
+// containerOrInit returns a pointer to the container with the given name,
+// appending one if it doesn't exist yet.
+//
+// WARNING: The returned pointer points into the slice's backing array. Any
+// subsequent append to the slice may reallocate that array, after which
+// writes through previously returned pointers are silently lost. Never hold
+// the returned pointer across another containerOrInit (or append) on the
+// same slice — use containersOrInit to acquire multiple pointers at once.
 func containerOrInit(containers *[]applycorev1.ContainerApplyConfiguration, name string) *applycorev1.ContainerApplyConfiguration {
 	for i := range *containers {
 		container := &(*containers)[i]
@@ -95,6 +103,22 @@ func containerOrInit(containers *[]applycorev1.ContainerApplyConfiguration, name
 	}
 	*containers = append(*containers, container)
 	return &(*containers)[len(*containers)-1]
+}
+
+// containersOrInit returns pointers to the containers with the given names,
+// appending any that don't exist yet. All appends happen before any pointer
+// is taken, so, unlike consecutive containerOrInit calls, the returned
+// pointers all point into the slice's final backing array and stay valid
+// while mutating any of them.
+func containersOrInit(containers *[]applycorev1.ContainerApplyConfiguration, names ...string) []*applycorev1.ContainerApplyConfiguration {
+	for _, name := range names {
+		containerOrInit(containers, name)
+	}
+	out := make([]*applycorev1.ContainerApplyConfiguration, len(names))
+	for i, name := range names {
+		out[i] = containerOrInit(containers, name)
+	}
+	return out
 }
 
 type containerSpec interface {

--- a/operator/api/redpanda/v1alpha2/conversion/helpers.go
+++ b/operator/api/redpanda/v1alpha2/conversion/helpers.go
@@ -105,6 +105,28 @@ func containerOrInit(containers *[]applycorev1.ContainerApplyConfiguration, name
 	return &(*containers)[len(*containers)-1]
 }
 
+// dedupeContainersByName collapses duplicate named entries in a container
+// list, keeping the content of the last occurrence at the position of the
+// first. The CRD schema accepts duplicates (plain array, no listType=map) and
+// the chart's pod template merge (mergeSliceBy) keys overrides by name with
+// last-wins semantics, so containerOrInit's first-match lookup would
+// otherwise mutate an entry the chart never renders — silently dropping the
+// write. Entries without a name are passed through untouched.
+func dedupeContainersByName(containers []applycorev1.ContainerApplyConfiguration) []applycorev1.ContainerApplyConfiguration {
+	indexByName := make(map[string]int, len(containers))
+	out := make([]applycorev1.ContainerApplyConfiguration, 0, len(containers))
+	for _, container := range containers {
+		name := ptr.Deref(container.Name, "")
+		if i, ok := indexByName[name]; ok && name != "" {
+			out[i] = container
+			continue
+		}
+		indexByName[name] = len(out)
+		out = append(out, container)
+	}
+	return out
+}
+
 // containersOrInit returns pointers to the containers with the given names,
 // appending any that don't exist yet. All appends happen before any pointer
 // is taken, so, unlike consecutive containerOrInit calls, the returned

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -202,24 +202,32 @@ func convertStatefulsetV2Fields(state *redpanda.RenderState, values *redpanda.Va
 		values.Statefulset.PodTemplate.Spec.TerminationGracePeriodSeconds = ptr.To(int64(*spec.TerminationGracePeriodSeconds))
 	}
 
-	if redpandaContainer.LivenessProbe == nil {
-		redpandaContainer.LivenessProbe = &applycorev1.ProbeApplyConfiguration{}
+	// Only materialize probe overrides the CR actually sets; unconditionally
+	// initializing them would emit a spurious `livenessProbe: {}` (etc.) on
+	// every rendered pod template.
+	if spec.LivenessProbe != nil {
+		if redpandaContainer.LivenessProbe == nil {
+			redpandaContainer.LivenessProbe = &applycorev1.ProbeApplyConfiguration{}
+		}
+		if err := convertJSONNotNil(spec.LivenessProbe, redpandaContainer.LivenessProbe); err != nil {
+			return err
+		}
 	}
-	if redpandaContainer.StartupProbe == nil {
-		redpandaContainer.StartupProbe = &applycorev1.ProbeApplyConfiguration{}
+	if spec.StartupProbe != nil {
+		if redpandaContainer.StartupProbe == nil {
+			redpandaContainer.StartupProbe = &applycorev1.ProbeApplyConfiguration{}
+		}
+		if err := convertJSONNotNil(spec.StartupProbe, redpandaContainer.StartupProbe); err != nil {
+			return err
+		}
 	}
-	if sidecarContainer.ReadinessProbe == nil {
-		sidecarContainer.ReadinessProbe = &applycorev1.ProbeApplyConfiguration{}
-	}
-
-	if err := convertJSONNotNil(spec.LivenessProbe, redpandaContainer.LivenessProbe); err != nil {
-		return err
-	}
-	if err := convertJSONNotNil(spec.StartupProbe, redpandaContainer.StartupProbe); err != nil {
-		return err
-	}
-	if err := convertJSONNotNil(spec.ReadinessProbe, sidecarContainer.ReadinessProbe); err != nil {
-		return err
+	if spec.ReadinessProbe != nil {
+		if sidecarContainer.ReadinessProbe == nil {
+			sidecarContainer.ReadinessProbe = &applycorev1.ProbeApplyConfiguration{}
+		}
+		if err := convertJSONNotNil(spec.ReadinessProbe, sidecarContainer.ReadinessProbe); err != nil {
+			return err
+		}
 	}
 
 	if err := convertAndAppendJSONNotNil(spec.Tolerations, &values.Statefulset.PodTemplate.Spec.Tolerations); err != nil {

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -178,6 +178,12 @@ func convertStatefulsetV2Fields(state *redpanda.RenderState, values *redpanda.Va
 		values.Statefulset.PodTemplate.Spec.InitContainers = []applycorev1.ContainerApplyConfiguration{}
 	}
 
+	// Collapse duplicate container names before taking any pointers: the
+	// chart's pod template merge keeps only the last duplicate, so a write
+	// to any earlier duplicate would be silently dropped at render time.
+	values.Statefulset.PodTemplate.Spec.Containers = dedupeContainersByName(values.Statefulset.PodTemplate.Spec.Containers)
+	values.Statefulset.PodTemplate.Spec.InitContainers = dedupeContainersByName(values.Statefulset.PodTemplate.Spec.InitContainers)
+
 	// NB: Both pointers must be acquired in a single containersOrInit call.
 	// Two consecutive containerOrInit calls used to leave the first returned
 	// pointer dangling into a stale backing array (the second call's append
@@ -273,6 +279,10 @@ func convertStatefulsetInitContainersV2Fields(state *redpanda.RenderState, value
 	if err := convertAndAppendYAMLNotNil(state, spec.ExtraInitContainers, &values.Statefulset.PodTemplate.Spec.InitContainers); err != nil {
 		return err
 	}
+	// extraInitContainers may duplicate an entry already declared in
+	// podTemplate.spec.initContainers; collapse again so the writes below
+	// land on the entry the chart's last-wins merge actually renders.
+	values.Statefulset.PodTemplate.Spec.InitContainers = dedupeContainersByName(values.Statefulset.PodTemplate.Spec.InitContainers)
 
 	if err := convertInitContainer(state, values, redpanda.RedpandaConfiguratorContainerName, spec.Configurator); err != nil {
 		return err

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -178,12 +178,6 @@ func convertStatefulsetV2Fields(state *redpanda.RenderState, values *redpanda.Va
 		values.Statefulset.PodTemplate.Spec.InitContainers = []applycorev1.ContainerApplyConfiguration{}
 	}
 
-	// Collapse duplicate container names before taking any pointers: the
-	// chart's pod template merge keeps only the last duplicate, so a write
-	// to any earlier duplicate would be silently dropped at render time.
-	values.Statefulset.PodTemplate.Spec.Containers = dedupeContainersByName(values.Statefulset.PodTemplate.Spec.Containers)
-	values.Statefulset.PodTemplate.Spec.InitContainers = dedupeContainersByName(values.Statefulset.PodTemplate.Spec.InitContainers)
-
 	// NB: Both pointers must be acquired in a single containersOrInit call.
 	// Two consecutive containerOrInit calls used to leave the first returned
 	// pointer dangling into a stale backing array (the second call's append
@@ -279,10 +273,6 @@ func convertStatefulsetInitContainersV2Fields(state *redpanda.RenderState, value
 	if err := convertAndAppendYAMLNotNil(state, spec.ExtraInitContainers, &values.Statefulset.PodTemplate.Spec.InitContainers); err != nil {
 		return err
 	}
-	// extraInitContainers may duplicate an entry already declared in
-	// podTemplate.spec.initContainers; collapse again so the writes below
-	// land on the entry the chart's last-wins merge actually renders.
-	values.Statefulset.PodTemplate.Spec.InitContainers = dedupeContainersByName(values.Statefulset.PodTemplate.Spec.InitContainers)
 
 	if err := convertInitContainer(state, values, redpanda.RedpandaConfiguratorContainerName, spec.Configurator); err != nil {
 		return err

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -178,8 +178,13 @@ func convertStatefulsetV2Fields(state *redpanda.RenderState, values *redpanda.Va
 		values.Statefulset.PodTemplate.Spec.InitContainers = []applycorev1.ContainerApplyConfiguration{}
 	}
 
-	redpandaContainer := containerOrInit(&values.Statefulset.PodTemplate.Spec.Containers, redpanda.RedpandaContainerName)
-	sidecarContainer := containerOrInit(&values.Statefulset.PodTemplate.Spec.Containers, redpanda.SidecarContainerName)
+	// NB: Both pointers must be acquired in a single containersOrInit call.
+	// Two consecutive containerOrInit calls used to leave the first returned
+	// pointer dangling into a stale backing array (the second call's append
+	// reallocates it), silently discarding every write to the redpanda
+	// container below. See https://github.com/redpanda-data/redpanda-operator/issues/1577.
+	brokerAndSidecar := containersOrInit(&values.Statefulset.PodTemplate.Spec.Containers, redpanda.RedpandaContainerName, redpanda.SidecarContainerName)
+	redpandaContainer, sidecarContainer := brokerAndSidecar[0], brokerAndSidecar[1]
 
 	if spec.Annotations != nil {
 		values.Statefulset.PodTemplate.Annotations = spec.Annotations

--- a/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
 	"pgregory.net/rapid"
@@ -169,6 +170,142 @@ func TestConvertStatefulsetV2FieldsBrokerContainer(t *testing.T) {
 
 	sidecar := containerByName(redpanda.SidecarContainerName)
 	require.Contains(t, mountNames(sidecar), "io-config", "extraVolumeMounts must also land on the sidecar container")
+}
+
+// TestDuplicateBrokerContainerOverridesSurviveRender guards the agreement
+// between the conversion helpers and the chart's pod template merge when a CR
+// carries duplicate entries for the same container name (the CRD schema is a
+// plain array, so duplicates pass admission). containerOrInit matches the
+// first duplicate while the chart's mergeSliceBy keeps the last, so without
+// normalization every conversion write to the broker container (probes,
+// extraVolumeMounts) lands on an entry the chart never renders — the same
+// silent-drop failure as issue #1577, for malformed-but-accepted input.
+func TestDuplicateBrokerContainerOverridesSurviveRender(t *testing.T) {
+	cluster := &redpandav1alpha2.Redpanda{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rp",
+			Namespace: "redpanda",
+		},
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+				Statefulset: &redpandav1alpha2.Statefulset{
+					ExtraVolumeMounts: ptr.To("- name: io-config\n  mountPath: /etc/redpanda-io-config"),
+					LivenessProbe: &redpandav1alpha2.LivenessProbe{
+						InitialDelaySeconds: ptr.To(33),
+					},
+					StartupProbe: &redpandav1alpha2.StartupProbe{
+						InitialDelaySeconds: ptr.To(44),
+					},
+					PodTemplate: &redpandav1alpha2.PodTemplate{
+						Spec: &applycorev1.PodSpecApplyConfiguration{
+							Containers: []applycorev1.ContainerApplyConfiguration{
+								{
+									Name: ptr.To(redpanda.RedpandaContainerName),
+									Env: []applycorev1.EnvVarApplyConfiguration{
+										{Name: ptr.To("FROM_FIRST_DUPLICATE"), Value: ptr.To("1")},
+									},
+								},
+								{
+									Name: ptr.To(redpanda.RedpandaContainerName),
+									Env: []applycorev1.EnvVarApplyConfiguration{
+										{Name: ptr.To("FROM_LAST_DUPLICATE"), Value: ptr.To("1")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	state, err := ConvertV2ToRenderState(nil, &V2Defaulters{}, cluster, nil)
+	require.NoError(t, err)
+
+	sets := redpanda.StatefulSets(state)
+	require.NotEmpty(t, sets)
+
+	var broker *corev1.Container
+	for i, container := range sets[0].Spec.Template.Spec.Containers {
+		if container.Name == redpanda.RedpandaContainerName {
+			require.Nil(t, broker, "rendered pod spec must contain exactly one redpanda container")
+			broker = &sets[0].Spec.Template.Spec.Containers[i]
+		}
+	}
+	require.NotNil(t, broker, "redpanda container not found in rendered StatefulSet")
+
+	require.NotNil(t, broker.LivenessProbe)
+	require.Equal(t, int32(33), broker.LivenessProbe.InitialDelaySeconds, "livenessProbe must survive duplicate container overrides")
+	require.NotNil(t, broker.StartupProbe)
+	require.Equal(t, int32(44), broker.StartupProbe.InitialDelaySeconds, "startupProbe must survive duplicate container overrides")
+
+	mountNames := functional.MapFn(func(m corev1.VolumeMount) string { return m.Name }, broker.VolumeMounts)
+	require.Contains(t, mountNames, "io-config", "extraVolumeMounts must survive duplicate container overrides")
+
+	envNames := functional.MapFn(func(e corev1.EnvVar) string { return e.Name }, broker.Env)
+	require.Contains(t, envNames, "FROM_LAST_DUPLICATE", "the last duplicate wins, matching the chart's merge semantics")
+	require.NotContains(t, envNames, "FROM_FIRST_DUPLICATE", "earlier duplicates are dropped wholesale, matching the chart's merge semantics")
+}
+
+// TestDuplicateInitContainerOverridesSurviveRender covers the second entry
+// vector for duplicate container names: extraInitContainers is appended to
+// the pod template's initContainers during conversion, so an entry there can
+// duplicate one declared in podTemplate.spec.initContainers. Conversion
+// writes (e.g. the configurator's extraVolumeMounts) must land on the entry
+// the chart's last-wins merge actually renders.
+func TestDuplicateInitContainerOverridesSurviveRender(t *testing.T) {
+	cluster := &redpandav1alpha2.Redpanda{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rp",
+			Namespace: "redpanda",
+		},
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+				Statefulset: &redpandav1alpha2.Statefulset{
+					InitContainers: &redpandav1alpha2.InitContainers{
+						Configurator: &redpandav1alpha2.Configurator{
+							ExtraVolumeMounts: ptr.To("- name: cfg-extra\n  mountPath: /cfg-extra"),
+						},
+						ExtraInitContainers: ptr.To("- name: " + redpanda.RedpandaConfiguratorContainerName + "\n  env:\n  - name: FROM_LAST_DUPLICATE\n    value: \"1\""),
+					},
+					PodTemplate: &redpandav1alpha2.PodTemplate{
+						Spec: &applycorev1.PodSpecApplyConfiguration{
+							InitContainers: []applycorev1.ContainerApplyConfiguration{
+								{
+									Name: ptr.To(redpanda.RedpandaConfiguratorContainerName),
+									Env: []applycorev1.EnvVarApplyConfiguration{
+										{Name: ptr.To("FROM_FIRST_DUPLICATE"), Value: ptr.To("1")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	state, err := ConvertV2ToRenderState(nil, &V2Defaulters{}, cluster, nil)
+	require.NoError(t, err)
+
+	sets := redpanda.StatefulSets(state)
+	require.NotEmpty(t, sets)
+
+	var configurator *corev1.Container
+	for i, container := range sets[0].Spec.Template.Spec.InitContainers {
+		if container.Name == redpanda.RedpandaConfiguratorContainerName {
+			require.Nil(t, configurator, "rendered pod spec must contain exactly one configurator init container")
+			configurator = &sets[0].Spec.Template.Spec.InitContainers[i]
+		}
+	}
+	require.NotNil(t, configurator, "configurator init container not found in rendered StatefulSet")
+
+	mountNames := functional.MapFn(func(m corev1.VolumeMount) string { return m.Name }, configurator.VolumeMounts)
+	require.Contains(t, mountNames, "cfg-extra", "configurator extraVolumeMounts must survive duplicate init container overrides")
+
+	envNames := functional.MapFn(func(e corev1.EnvVar) string { return e.Name }, configurator.Env)
+	require.Contains(t, envNames, "FROM_LAST_DUPLICATE", "the last duplicate wins, matching the chart's merge semantics")
+	require.NotContains(t, envNames, "FROM_FIRST_DUPLICATE", "earlier duplicates are dropped wholesale, matching the chart's merge semantics")
 }
 
 func TestConvertV2Fields(t *testing.T) {

--- a/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
 	"pgregory.net/rapid"
 
 	"github.com/redpanda-data/redpanda-operator/charts/redpanda/v25"
+	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2/fuzzing"
 	"github.com/redpanda-data/redpanda-operator/operator/pkg/functional"
@@ -112,6 +114,61 @@ func TestPersistentVolumeClaimRetentionPolicyPrecedence(t *testing.T) {
 			require.Equal(t, tc.wantDeleted, got.WhenDeleted)
 		})
 	}
+}
+
+// TestConvertStatefulsetV2FieldsBrokerContainer is a regression test for
+// https://github.com/redpanda-data/redpanda-operator/issues/1577:
+// convertStatefulsetV2Fields retained a pointer to the redpanda container
+// across the append that adds the sidecar container. The append reallocated
+// the slice's backing array, so extraVolumeMounts, livenessProbe, and
+// startupProbe were written to an orphaned copy and silently dropped from
+// the broker container — they only ever landed on the sidecar.
+func TestConvertStatefulsetV2FieldsBrokerContainer(t *testing.T) {
+	dot, err := redpanda.Chart.Dot(nil, helmette.Release{
+		Name:      "redpanda",
+		Namespace: "redpanda",
+		Service:   "Helm",
+	}, struct{}{})
+	require.NoError(t, err)
+
+	state := &redpanda.RenderState{Dot: dot}
+	values := redpanda.Values{}
+	spec := &redpandav1alpha2.Statefulset{
+		ExtraVolumeMounts: ptr.To("- name: io-config\n  mountPath: /etc/redpanda-io-config"),
+		LivenessProbe: &redpandav1alpha2.LivenessProbe{
+			InitialDelaySeconds: ptr.To(33),
+		},
+		StartupProbe: &redpandav1alpha2.StartupProbe{
+			InitialDelaySeconds: ptr.To(44),
+		},
+	}
+
+	require.NoError(t, convertStatefulsetV2Fields(state, &values, spec))
+
+	containerByName := func(name string) *applycorev1.ContainerApplyConfiguration {
+		for i, container := range values.Statefulset.PodTemplate.Spec.Containers {
+			if ptr.Deref(container.Name, "") == name {
+				return &values.Statefulset.PodTemplate.Spec.Containers[i]
+			}
+		}
+		t.Fatalf("container %q not found", name)
+		return nil
+	}
+	mountNames := func(container *applycorev1.ContainerApplyConfiguration) []string {
+		return functional.MapFn(func(m applycorev1.VolumeMountApplyConfiguration) string {
+			return ptr.Deref(m.Name, "")
+		}, container.VolumeMounts)
+	}
+
+	broker := containerByName(redpanda.RedpandaContainerName)
+	require.Contains(t, mountNames(broker), "io-config", "extraVolumeMounts must land on the broker container")
+	require.NotNil(t, broker.LivenessProbe)
+	require.Equal(t, ptr.To(int32(33)), broker.LivenessProbe.InitialDelaySeconds, "livenessProbe must land on the broker container")
+	require.NotNil(t, broker.StartupProbe)
+	require.Equal(t, ptr.To(int32(44)), broker.StartupProbe.InitialDelaySeconds, "startupProbe must land on the broker container")
+
+	sidecar := containerByName(redpanda.SidecarContainerName)
+	require.Contains(t, mountNames(sidecar), "io-config", "extraVolumeMounts must also land on the sidecar container")
 }
 
 func TestConvertV2Fields(t *testing.T) {

--- a/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
@@ -175,11 +175,11 @@ func TestConvertStatefulsetV2FieldsBrokerContainer(t *testing.T) {
 // TestDuplicateBrokerContainerOverridesSurviveRender guards the agreement
 // between the conversion helpers and the chart's pod template merge when a CR
 // carries duplicate entries for the same container name (the CRD schema is a
-// plain array, so duplicates pass admission). containerOrInit matches the
-// first duplicate while the chart's mergeSliceBy keeps the last, so without
-// normalization every conversion write to the broker container (probes,
-// extraVolumeMounts) lands on an entry the chart never renders — the same
-// silent-drop failure as issue #1577, for malformed-but-accepted input.
+// plain array, so duplicates pass admission). The chart's mergeSliceBy keeps
+// only the last duplicate, so a conversion write to any earlier duplicate
+// (probes, extraVolumeMounts) would land on an entry the chart never renders
+// — the same silent-drop failure as issue #1577, for malformed-but-accepted
+// input. containerOrInit therefore has to match the LAST duplicate.
 func TestDuplicateBrokerContainerOverridesSurviveRender(t *testing.T) {
 	cluster := &redpandav1alpha2.Redpanda{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/internal/lifecycle/testdata/redpanda-cases.values.golden.txtar
+++ b/operator/internal/lifecycle/testdata/redpanda-cases.values.golden.txtar
@@ -327,7 +327,6 @@ values:
         containers:
         - name: redpanda
         - name: sidecar
-          readinessProbe: {}
           resources: {}
           securityContext: {}
         initContainers:
@@ -928,7 +927,6 @@ values:
         containers:
         - name: redpanda
         - name: sidecar
-          readinessProbe: {}
           resources:
             requests:
               cpu: 16m
@@ -1302,7 +1300,6 @@ values:
         containers:
         - name: redpanda
         - name: sidecar
-          readinessProbe: {}
           resources: {}
           securityContext: {}
         initContainers:
@@ -1903,7 +1900,6 @@ values:
         containers:
         - name: redpanda
         - name: sidecar
-          readinessProbe: {}
           resources: {}
           securityContext: {}
         initContainers:


### PR DESCRIPTION
## What

Fixes a Go slice-pointer aliasing bug in the v1alpha2 → chart-values conversion that caused `clusterSpec.statefulset.extraVolumeMounts`, `livenessProbe`, and `startupProbe` to be **silently dropped from the `redpanda` (broker) container** in the rendered StatefulSet. `extraVolumeMounts` only ever landed on the `sidecar` container; the probes were lost entirely. No error, no warning, no status condition — the pod runs and the cluster looks healthy.

Fixes #1577
Ref: K8S-873

## Root cause

`convertStatefulsetV2Fields` retained the pointer returned by `containerOrInit` for the redpanda container across the call that appends the sidecar container:

```go
redpandaContainer := containerOrInit(&containers, "redpanda") // append #1, cap 0→1
sidecarContainer  := containerOrInit(&containers, "sidecar")  // append #2 → backing array REALLOCATED
```

`containerOrInit` returns `&(*containers)[i]` — a pointer into the slice's backing array. The second append exceeds capacity and reallocates; `redpandaContainer` keeps pointing into the orphaned old array. Every subsequent write through it (probes at the top of the function, `extraVolumeMounts` later) is discarded. Writes through `sidecarContainer` (which points into the live array) survive — which is why the mount shows up on the wrong container rather than disappearing completely.

Present since the v25 rendering pipeline (`b52f7120`); no existing test asserted per-container content of the conversion output, so it shipped silently.

## Fix

- New `containersOrInit` helper: performs **all appends before handing out any pointers**, so the returned pointers all reference the slice's final backing array. `convertStatefulsetV2Fields` acquires both container pointers through it in one call. Container order in the rendered pod spec is unchanged.
- Documented the invalidation hazard on `containerOrInit` and pointed multi-pointer callers at `containersOrInit`.
- The other `containerOrInit` call sites were audited: they either mutate immediately before any further append to the same slice, or operate on different slices, so they're currently correct — the new helper plus the doc warning is the guard against reintroduction.

## Regression test

`TestConvertStatefulsetV2FieldsBrokerContainer` converts a `Statefulset` spec carrying `extraVolumeMounts`, `livenessProbe`, and `startupProbe`, and asserts all three land on the **`redpanda`** container (and the mount also on the sidecar). Against the previous code it fails with `extraVolumeMounts must land on the broker container`.

## Step-by-step A/B validation

Reproduces the bug on the latest released operator, then validates the fix via an in-place operator upgrade. Works on any cluster with a default StorageClass (validated end-to-end on EKS 1.35 — results in [this comment](https://github.com/redpanda-data/redpanda-operator/pull/1587#issuecomment-4673228569)).

**1. Install the pre-fix operator (control) using this branch's chart:**

```bash
helm install redpanda-operator ./operator/chart -n redpanda --create-namespace \
  --set image.repository=docker.redpanda.com/redpandadata/redpanda-operator \
  --set image.tag=v26.2.1-beta.2 \
  --set crds.enabled=true --wait
```

**2. Create a Redpanda CR exercising all three affected fields**, plus the ConfigMap it mounts. The mountPath is deliberately outside the operator-managed `/etc/redpanda` emptyDir so content can't be shadowed:

```yaml
apiVersion: v1
kind: ConfigMap
metadata: { name: io-config, namespace: redpanda }
data:
  io-config.yaml: |
    disks:
      - mountpoint: /var/lib/redpanda/data
        read_iops: 100000
---
apiVersion: cluster.redpanda.com/v1alpha2
kind: Redpanda
metadata: { name: rp, namespace: redpanda }
spec:
  clusterSpec:
    tls: { enabled: false }
    console: { enabled: false }
    statefulset:
      replicas: 1
      extraVolumes: |-
        - name: io-config
          configMap:
            name: io-config
      extraVolumeMounts: |-
        - name: io-config
          mountPath: /etc/redpanda-io-config
      livenessProbe: { initialDelaySeconds: 33 }
      startupProbe: { initialDelaySeconds: 44 }
```

**3. Wait for Ready, then observe the bug (control):**

```bash
# Per-container volumeMounts of the rendered StatefulSet:
kubectl -n redpanda get sts rp -o json | \
  jq '.spec.template.spec.containers[] | {name, mounts: [.volumeMounts[]?.name]}'
# BUG: "io-config" appears ONLY under the sidecar container, not redpanda.

# Broker probe delays (CR sets 33/44):
kubectl -n redpanda get sts rp -o json | \
  jq '.spec.template.spec.containers[] | select(.name=="redpanda")
      | {liveness: .livenessProbe.initialDelaySeconds, startup: .startupProbe.initialDelaySeconds}'
# BUG: {liveness: 10, startup: 1} — chart defaults, CR values silently ignored.

kubectl -n redpanda exec rp-0 -c redpanda -- cat /etc/redpanda-io-config/io-config.yaml
# BUG: No such file or directory.
```

**4. Upgrade the operator in place to this branch's image** (built via `task build:image` and pushed to a registry the cluster can pull from):

```bash
helm upgrade redpanda-operator ./operator/chart -n redpanda \
  --set image.repository=<registry>/redpanda-operator \
  --set image.tag=<this-branch-tag> \
  --set crds.enabled=true --wait
```

**5. Trigger a re-render.** The operator does not re-render a converged cluster at rollout; bump the CR's generation with any spec change — a render-neutral touch works (e.g. re-apply `extraVolumeMounts` with a YAML comment prepended to the string). The broker pod rolls once.

**6. Validate the fix** — re-run the three checks from step 3 and expect:

| Check | Control (`v26.2.1-beta.2`) | Fixed |
|---|---|---|
| `io-config` mount on `redpanda` container | absent | **present** (sidecar keeps it too) |
| Broker `livenessProbe`/`startupProbe` initialDelaySeconds | 10 / 1 (defaults) | **33 / 44** (CR values) |
| `cat /etc/redpanda-io-config/io-config.yaml` in `-c redpanda` | `No such file or directory` | ConfigMap content |

The unit-level equivalent is `go test ./operator/api/redpanda/v1alpha2/conversion/ -run TestConvertStatefulsetV2FieldsBrokerContainer` — it fails on pre-fix code and passes here.

## Follow-up: duplicate container names (`386c693c`, `3303fa49`)

The adversarial review of this PR surfaced a second, pre-existing path to the same silent-drop failure class: the CRD exposes `podTemplate.spec.containers` / `initContainers` as plain arrays (no `x-kubernetes-list-type: map`), so duplicate entries with the same `name` pass admission — and the two layers then disagree on which duplicate counts:

- conversion (`containerOrInit`) mutates the **first** entry matching a name;
- the chart's pod template merge (`mergeSliceBy` via `StrategicMergePatch`) keys overrides by name with **last-wins** semantics.

With duplicates present, every conversion write to the broker or an init container (probes, `extraVolumeMounts`, configurator resources/mounts) landed on an entry the chart never renders and was silently dropped.

The fix makes `containerOrInit` match the **last** entry sharing a name instead of the first, so conversion writes go directly to the entry the chart renders. The user-provided container lists stored in values are left untouched (an earlier iteration, `386c693c`, normalized them via a dedupe pass; `3303fa49` replaced that with the last-match lookup — rendered output is identical and the regression tests pass with either mechanism). This also covers the second vector by which duplicates arise: an `extraInitContainers` entry duplicating one declared in `podTemplate.spec.initContainers` is appended later in the list, and the last-match lookup naturally targets it.

Aligning conversion with the chart was chosen over rejecting duplicates deliberately: the chart already rendered only the last duplicate, so nothing changes for existing CRs except that conversion writes now survive — safe to backport, whereas a new validation error could break reconciliation of currently-working clusters. Rejecting duplicates at admission (`listType=map` / CEL) would be a CRD schema change with upgrade implications and is intentionally **not** done here.

Two regression tests cover this through the full render path (`ConvertV2ToRenderState` → `redpanda.StatefulSets`), both failing without the fix:

- `TestDuplicateBrokerContainerOverridesSurviveRender` — duplicate `redpanda` entries in `podTemplate.spec.containers`; pre-fix the broker rendered chart-default probe delays (10/1) instead of the CR's (33/44) and lost the extra volume mount.
- `TestDuplicateInitContainerOverridesSurviveRender` — `extraInitContainers` entry duplicating a `podTemplate.spec.initContainers` entry; pre-fix the configurator's `extraVolumeMounts` were silently dropped.

Both also pin the last-wins semantics and that exactly one container with the name is rendered. Both fail against a first-match lookup (verified). Rendered output for CRs without duplicates is unchanged (lifecycle golden files untouched).

## Impact / notes for reviewers

- Anyone relying on the documented behavior of `clusterSpec.statefulset.extraVolumeMounts` (e.g. mounting a ConfigMap such as a custom `io-config.yaml` for the broker) silently lost the mount on the broker since v25; the legacy chart 5.x applied it to the broker. After this fix the field behaves as documented again.
- Mounts whose `mountPath` sits under the operator-managed `/etc/redpanda` emptyDir can still be shadowed by files the configurator creates there — unrelated to this bug, but worth knowing when choosing mount paths.
- The related `additionalRedpandaCmdFlags` / `rpk.additional_start_flags` conflict for flags rpk special-cases (e.g. `--io-properties-file`) is a separate design-level issue and is **not** addressed here (tracked in K8S-873 as its second item).
