### PR TITLE
ci: migrate jira_helper to the new Jira Cloud search API

### DIFF
--- a/.github/workflows/scripts/jira_helper.py
+++ b/.github/workflows/scripts/jira_helper.py
@@ -304,7 +304,10 @@ issue that triggered this issue's creation.
     def _find_jira_issue_by_gh_issue_url(self) -> str:
         issue_url = os.environ['ISSUE_URL']
         jql_request = f'project = {self._project_key} and "External GitHub Issue[URL Field]" = "{issue_url}"'
-        issues = self._jira.jql(jql=jql_request, fields='summary')
+        # Jira Cloud removed /rest/api/{2,3}/search (HTTP 410, see
+        # https://developer.atlassian.com/changelog/#CHANGE-2046); enhanced_jql
+        # targets the replacement /rest/api/2/search/jql endpoint.
+        issues = self._jira.enhanced_jql(jql_request, fields='summary')
         issues = issues['issues']
         if len(issues) == 0:
             raise NoJiraIssueFound()

--- a/.github/workflows/scripts/requirements.txt
+++ b/.github/workflows/scripts/requirements.txt
@@ -1,1 +1,1 @@
-atlassian-python-api~=3.41.11
+atlassian-python-api~=4.0.7


### PR DESCRIPTION
## Problem

Every run of the **Manage JIRA Issue** workflow currently fails, fully breaking GitHub → JIRA issue sync (create/close/reopen/edit/label all hit the same code path):

```
requests.exceptions.HTTPError: The requested API has been removed.
Please migrate to the /rest/api/3/search/jql API. A full migration
guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046
```

Atlassian removed the legacy `/rest/api/2/search` endpoint (HTTP **410 Gone**, [CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)). The pinned `atlassian-python-api~=3.41.11` implements `Jira.jql()` against that endpoint, and `jira_helper.py` calls it in `_find_jira_issue_by_gh_issue_url()` — the first thing executed for every event type, so the workflow dies before any event handling happens.

## Fix

- Bump `atlassian-python-api` to `~=4.0.7`.
- Switch the lookup from `jql()` to `enhanced_jql()`, which targets the replacement `search/jql` endpoint.

The surrounding logic is unchanged: the new endpoint still returns an `issues` array with per-issue `id`, so the existing 0/1/many handling keeps working. The JQL is bounded (`project = ... and "External GitHub Issue[URL Field]" = ...`) as the new API requires, and the single-page default of 50 results is more than enough for an exact-URL match.

## Verification

- `https://redpandadata.atlassian.net/rest/api/2/search/jql` responds **200** (`{"issues": [...], "isLast": ...}`) while the old `/rest/api/2/search` returns **410** — confirmed with `atlassian-python-api` 4.0.7's `enhanced_jql()` against the live instance.
- All other Jira methods the script uses (`issue_create`, `issue_add_comment`, `issue_transition`, `issue_field_value`, `update_issue_field`) keep their signatures in 4.0.7.
- `python -m py_compile jira_helper.py` passes; 4.0.7 declares no `requires_python` restriction, so the workflow's Python 3.9 is fine.

The workflow only triggers on real issue events, so the end-to-end path will be exercised by the first issue event after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)