### PR TITLE
operator: decommissioner startup log + per-controller log levels

### DIFF
--- a/.changes/unreleased/operator-Added-20260612-160000.yaml
+++ b/.changes/unreleased/operator-Added-20260612-160000.yaml
@@ -1,0 +1,15 @@
+project: operator
+kind: Added
+body: |-
+    The broker decommission controller now logs at startup ("starting
+    StatefulSetDecommissioner controller"), so you can confirm it is enabled
+    from the operator logs without running a disruptive scale-down. Its PVC
+    cleanup is also logged at info level when a claim is removed.
+
+    Added per-controller log-level flags `--decommission-log-level` and
+    `--pvcunbinder-log-level` (error|info|debug|trace; empty inherits
+    `--log-level`). These let you raise the verbosity of a single controller —
+    for example to observe broker decommissioning and PVC cleanup — without
+    making the whole operator verbose. Pass them via the operator chart's
+    `additionalCmdFlags`.
+time: 2026-06-12T16:00:00.000000-00:00

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -77560,11 +77560,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -77936,11 +77973,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -78531,11 +78605,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/fluxcd/pkg/runtime/logger"
+	"github.com/go-logr/logr"
 	"github.com/redpanda-data/common-go/kube"
 	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/spf13/cobra"
@@ -109,6 +111,12 @@ type RunOptions struct {
 	decommissionWaitInterval    time.Duration
 	metricsTimeout              time.Duration
 	rpClientTimeout             time.Duration
+	// Per-controller log-level overrides. Empty means "inherit the global
+	// --log-level". Accepts the same vocabulary as --log-level
+	// (error|info|debug|trace) and lets an operator raise the verbosity of a
+	// single controller without making the whole operator noisy.
+	decommissionLogLevel string
+	pvcUnbinderLogLevel  string
 	// Per-controller default reconcile (sync) intervals. A per-CR spec.interval
 	// (Topic) always takes precedence; the others have no per-CR field today.
 	topicSyncInterval                   time.Duration
@@ -169,6 +177,8 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.redpandaDefaultRepository, "redpanda-repository", DefaultRedpandaRepository, "The default docker repository to pull redpanda images from")
 	cmd.Flags().StringVar(&o.configuratorImagePullPolicy, "configurator-image-pull-policy", "Always", "Set the configurator image pull policy")
 	cmd.Flags().DurationVar(&o.decommissionWaitInterval, "decommission-wait-interval", 8*time.Second, "Set the time to wait for a node decommission to happen in the cluster")
+	cmd.Flags().StringVar(&o.decommissionLogLevel, "decommission-log-level", "", "Log level (error|info|debug|trace) for the broker decommission controller only. Empty inherits --log-level. Use this to surface decommission/PVC-cleanup detail without making the whole operator verbose.")
+	cmd.Flags().StringVar(&o.pvcUnbinderLogLevel, "pvcunbinder-log-level", "", "Log level (error|info|debug|trace) for the PVCUnbinder controller only. Empty inherits --log-level.")
 	cmd.Flags().DurationVar(&o.metricsTimeout, "metrics-timeout", 8*time.Second, "Set the timeout for a checking metrics Admin API endpoint. If set to 0, then the 2 seconds default will be used")
 	cmd.Flags().DurationVar(&o.rpClientTimeout, "cluster-connection-timeout", 10*time.Second, "Set the timeout for internal clients used to connect to Redpanda clusters")
 	// Per-controller default reconcile (sync) intervals. These replace the
@@ -217,6 +227,18 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("allow-pvc-deletion", false, "Deprecated: Ignored if specified")
 	cmd.Flags().Bool("operator-mode", true, "A deprecated and unused flag")
 	cmd.Flags().Bool("enable-shadowlinks", false, "Specifies whether or not to enabled the shadow links controller")
+}
+
+// controllerLogger returns a dedicated logger for a single controller built at
+// the requested level (error|info|debug|trace), or nil to inherit the global
+// logger. This lets an operator raise the verbosity of one controller (e.g.
+// the broker decommissioner) without making the entire operator noisy.
+func controllerLogger(level, name string) *logr.Logger {
+	if level == "" {
+		return nil
+	}
+	l := logger.NewLogger(logger.Options{LogLevel: level}).WithName(name)
+	return &l
 }
 
 func (o *RunOptions) ControllerEnabled(controller Controller) bool {
@@ -570,10 +592,14 @@ func Run(
 		if err != nil {
 			return err
 		}
+		// Unlike most controllers, the decommissioner is event-driven on
+		// StatefulSet changes and is otherwise silent, so log at startup that
+		// it is loaded — this is how an operator can confirm the broker
+		// decommissioner is enabled without running a disruptive scale-down.
+		setupLog.Info("starting StatefulSetDecommissioner controller", "selector", selector.String(), "log-level", opts.decommissionLogLevel)
+
 		adapter := redpandaDecommissionerAdapter{client: mgr.GetClient(), factory: factory}
-		d := decommissioning.NewStatefulSetDecommissioner(
-			mgr,
-			adapter.getAdminClient,
+		decommissionOpts := []decommissioning.Option{
 			decommissioning.WithSelector(selector),
 			decommissioning.WithFilter(adapter.filter),
 			// A V2 cluster may span multiple StatefulSets (NodePools); the
@@ -581,6 +607,15 @@ func Run(
 			// replicas, while the per-pool scale-down decision uses each
 			// StatefulSet's own replicas (handled inside the decommissioner).
 			decommissioning.WithDesiredReplicasFetcher(adapter.desiredReplicas),
+		}
+		if l := controllerLogger(opts.decommissionLogLevel, "StatefulSetDecomissioner"); l != nil {
+			decommissionOpts = append(decommissionOpts, decommissioning.WithLogger(*l))
+		}
+
+		d := decommissioning.NewStatefulSetDecommissioner(
+			mgr,
+			adapter.getAdminClient,
+			decommissionOpts...,
 		)
 
 		if err := d.SetupWithManager(mgr); err != nil {
@@ -593,13 +628,14 @@ func Run(
 	if opts.unbindPVCsAfter <= 0 {
 		setupLog.Info("PVCUnbinder controller not active", "unbind-after", opts.unbindPVCsAfter, "selector", opts.unbinderSelector, "allow-pv-rebinding", opts.allowPVRebinding)
 	} else {
-		setupLog.Info("starting PVCUnbinder controller", "unbind-after", opts.unbindPVCsAfter, "selector", opts.unbinderSelector, "allow-pv-rebinding", opts.allowPVRebinding)
+		setupLog.Info("starting PVCUnbinder controller", "unbind-after", opts.unbindPVCsAfter, "selector", opts.unbinderSelector, "allow-pv-rebinding", opts.allowPVRebinding, "log-level", opts.pvcUnbinderLogLevel)
 
 		if err := (&pvcunbinder.Controller{
 			Client:         mgr.GetClient(),
 			Timeout:        opts.unbindPVCsAfter,
 			Selector:       opts.unbinderSelector.Selector,
 			AllowRebinding: opts.allowPVRebinding,
+			Logger:         controllerLogger(opts.pvcUnbinderLogLevel, "PVCUnbinder"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PVCUnbinder")
 			return err

--- a/operator/internal/controller/decommissioning/statefulset_decomissioner.go
+++ b/operator/internal/controller/decommissioning/statefulset_decomissioner.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/redpanda-data/common-go/rpadmin"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -116,6 +117,17 @@ func WithSyncPeriod(d time.Duration) Option {
 	}
 }
 
+// WithLogger sets a dedicated logger for this controller. When set, it is
+// injected into the reconcile context so the decommissioner can be run at a
+// different verbosity than the rest of the operator (see the
+// --decommission-log-level operator flag). When unset, the manager's logger
+// is used as before.
+func WithLogger(logger logr.Logger) Option {
+	return func(ssd *StatefulSetDecomissioner) {
+		ssd.logger = &logger
+	}
+}
+
 type ClientGetter func(context.Context, *appsv1.StatefulSet) (*rpadmin.AdminAPI, error)
 
 type StatefulSetDecomissioner struct {
@@ -135,6 +147,10 @@ type StatefulSetDecomissioner struct {
 	// decommissionOnTooHighOrdinal allows the decommissioner to decommission a node, if it has an
 	decommissionOnTooHighOrdinal bool
 	desiredReplicasFetcher       func(ctx context.Context, set *appsv1.StatefulSet) (int32, error)
+
+	// logger, when non-nil, overrides the context logger so this controller
+	// can run at an independent verbosity. Set via WithLogger.
+	logger *logr.Logger
 }
 
 func NewStatefulSetDecommissioner(mgr ctrl.Manager, getter ClientGetter, options ...Option) *StatefulSetDecomissioner {
@@ -222,6 +238,11 @@ func (s *StatefulSetDecomissioner) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (s *StatefulSetDecomissioner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// If a dedicated logger was configured (e.g. via --decommission-log-level),
+	// inject it so all downstream LoggerFrom(ctx) calls run at that verbosity.
+	if s.logger != nil {
+		ctx = ctrl.LoggerInto(ctx, *s.logger)
+	}
 	log := ctrl.LoggerFrom(ctx, "namespace", req.Namespace, "name", req.Name).WithName("StatefulSetDecomissioner.Reconcile")
 
 	set := &appsv1.StatefulSet{}
@@ -378,7 +399,10 @@ func (s *StatefulSetDecomissioner) Decommission(ctx context.Context, set *appsv1
 					}, unboundVolumeClaims), ", "), client.ObjectKeyFromObject(claim).String(),
 				)
 
-				log.V(traceLevel).Info(message)
+				// Deleting a PVC is a notable state change; log at info so it's
+				// visible at the default operator log level (matches the broker
+				// decommission log below and the emitted Kubernetes Event).
+				log.Info(message)
 				s.recorder.Eventf(set, corev1.EventTypeNormal, eventReasonUnboundPersistentVolumeClaims, message)
 
 				return nil

--- a/operator/internal/controller/pvcunbinder/pvcunbinder.go
+++ b/operator/internal/controller/pvcunbinder/pvcunbinder.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -207,6 +208,10 @@ type Controller struct {
 	//
 	// Falls back to Client when nil (tests).
 	Reader client.Reader
+	// Logger, when non-nil, overrides the context logger so this controller
+	// can run at an independent verbosity (see --pvcunbinder-log-level). When
+	// nil, the manager's logger is used.
+	Logger *logr.Logger
 }
 
 // reader returns the uncached Reader if configured, otherwise the
@@ -342,6 +347,11 @@ func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 // state that Gate 0 either holds on (siblings) or resumes from (the same pod
 // retrying — see checkPVGates' own-claim exemption).
 func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// If a dedicated logger was configured (--pvcunbinder-log-level), inject it
+	// so downstream LoggerFrom(ctx) calls run at that verbosity.
+	if r.Logger != nil {
+		ctx = ctrl.LoggerInto(ctx, *r.Logger)
+	}
 	logger := ctrl.LoggerFrom(ctx).WithName("PVCUnbinder")
 	ctx = log.IntoContext(ctx, logger)
 


### PR DESCRIPTION
## What

Improves observability of the broker decommission controller and adds per-controller log-level control:

1. **Decommissioner startup log** — the v2 NodePool-aware decommissioner now logs `"starting StatefulSetDecommissioner controller"` at startup (mirroring the PVCUnbinder). It is StatefulSet-event-driven and otherwise silent, so there was previously no way to confirm it was enabled.
2. **PVC-cleanup log at info** — the decommissioner's "unbound persistent volume claims … decommissioning" message moves from `trace` (V2) to `info`, matching the broker-decommission log and the emitted `DecommissioningUnboundPersistentVolumeClaims` Kubernetes Event.
3. **Per-controller log-level flags** — `--decommission-log-level` and `--pvcunbinder-log-level` (`error|info|debug|trace`; empty inherits `--log-level`). Each builds a dedicated logger injected into that controller's reconcile context, so an operator can raise the verbosity of one controller without making the whole operator noisy. Settable via the operator chart's `additionalCmdFlags`.

## Why

From a customer support thread (operator v25.3.6, PVCUnbinder + broker decommissioner both enabled). Three reported issues, all observability-related:

- *"The decommission controller produces no logs until a functional test runs; the PVCUnbinder logs immediately."* — expected (event-driven + no startup log), but confusing. Fixed by number 1 above.
- *"How do we confirm the decommissioner is enabled in production without a disruptive test?"* — previously only by inspecting Deployment flags. Now: check the operator log for the startup line. Fixed by number 1.
- *"Scaling 6→5 removes the pod but its PVC isn't cleared."* — not a bug: the decommissioner deletes the PVC (`cleanupPVCs` defaults true) after the ~1-minute delayed-cache window (`30s × 2`), but the deletion was only logged at `trace`, so the customer's test (checking immediately) saw nothing. Number 2 makes the deletion visible at the default level; #3 lets them dial the decommissioner to `debug`/`trace` to watch the full cycle.

## Usage

Raise just the decommissioner's verbosity via Helm:

```yaml
# operator chart values.yaml
additionalCmdFlags:
  - --decommission-log-level=debug
```

## Notes / draft

- Marked **draft** for maintainer feedback on the approach (per-controller dedicated loggers via `logger.NewLogger`, injected with `ctrl.LoggerInto`).
- No chart template/schema/golden changes — uses the existing `additionalCmdFlags` passthrough rather than new first-class chart values. First-class `logLevels.<controller>` chart values could be a follow-up if preferred.
- Validated locally in the Nix dev shell: `task lint` — golangci-lint **0 issues**, `helm lint --strict` **4/4 charts pass**, actionlint clean. `go build` / `go vet` clean.
