### PR TITLE
acceptance: retry stretch Kafka client build on cold-cache informer sync

### DIFF
--- a/acceptance/steps/helpers.go
+++ b/acceptance/steps/helpers.go
@@ -411,12 +411,17 @@ const (
 // proxy/port-forward to a vcluster API server can be transiently disrupted under
 // CI load. Rebuilding from scratch re-establishes fresh port-forwards and
 // re-engages every cluster.
-func setupMulticlusterManager(ctx context.Context, nodes []*vclusterNode) (multicluster.Manager, map[string]*rest.Config) {
+//
+// Any types passed in warm are registered and synced per cluster during
+// engagement (under the generous engage budget), so a caller's first cached
+// read of those types hits a warm cache instead of paying the cold
+// informer-sync cost under its own (typically shorter) per-call timeout.
+func setupMulticlusterManager(ctx context.Context, nodes []*vclusterNode, warm ...runtimeclient.Object) (multicluster.Manager, map[string]*rest.Config) {
 	t := framework.T(ctx)
 
 	var lastErr error
 	for attempt := 1; attempt <= multiclusterManagerSetupAttempts; attempt++ {
-		mgr, pfCfgs, cancel, err := tryEngageMulticlusterManager(ctx, t, nodes)
+		mgr, pfCfgs, cancel, err := tryEngageMulticlusterManager(ctx, t, nodes, warm...)
 		if err == nil {
 			// Keep the successful attempt's port-forwards and manager goroutine
 			// alive for the rest of the scenario; tear them down at cleanup.
@@ -446,7 +451,12 @@ func setupMulticlusterManager(ctx context.Context, nodes []*vclusterNode) (multi
 // longer needed — cancelling tears down the port-forwards and the manager
 // goroutine. On failure it tears down everything it created and returns an error
 // naming which clusters did and did not come up.
-func tryEngageMulticlusterManager(ctx context.Context, t framework.TestingT, nodes []*vclusterNode) (mgr multicluster.Manager, pfCfgs map[string]*rest.Config, cancel context.CancelFunc, err error) {
+//
+// For every type in warm, each cluster's informer for that type is started and
+// synced before the attempt is considered successful, so a caller's first
+// cached read of those types hits a warm cache rather than triggering (and
+// blocking on) a cold initial sync under its own per-call timeout.
+func tryEngageMulticlusterManager(ctx context.Context, t framework.TestingT, nodes []*vclusterNode, warm ...runtimeclient.Object) (mgr multicluster.Manager, pfCfgs map[string]*rest.Config, cancel context.CancelFunc, err error) {
 	attemptCtx, attemptCancel := context.WithCancel(ctx)
 	// On any error path, release everything this attempt created. On success the
 	// cancel is handed to the caller instead (see the success return below).
@@ -508,6 +518,24 @@ func tryEngageMulticlusterManager(ctx context.Context, t framework.TestingT, nod
 			// remaining budget waiting on a single cluster's cache.
 			waitCtx, waitCancel := context.WithTimeout(engageCtx, 2*time.Second)
 			ok := cl.GetCache().WaitForCacheSync(waitCtx)
+			// Pre-warm the caller's informers. controller-runtime starts an
+			// informer lazily on the first Get/List of a type, and
+			// WaitForCacheSync only waits for informers already registered —
+			// so without this the first cached read of a warm type pays the
+			// cold initial-sync cost under its own (short) per-call timeout.
+			// GetInformer both registers the informer and blocks until its
+			// initial sync completes; once warmed, repeat calls return
+			// immediately. A miss within waitCtx just leaves this cluster
+			// unsynced for now — the informer keeps syncing in the background,
+			// so a later poll iteration finds it ready.
+			for _, obj := range warm {
+				if !ok {
+					break
+				}
+				if _, ierr := cl.GetCache().GetInformer(waitCtx, obj); ierr != nil {
+					ok = false
+				}
+			}
 			waitCancel()
 			if ok {
 				synced[name] = true

--- a/acceptance/steps/stretch_rolling_restart.go
+++ b/acceptance/steps/stretch_rolling_restart.go
@@ -122,7 +122,12 @@ func getKafkaFactory(ctx context.Context, t framework.TestingT, clusterName stri
 func initKafkaFactory(ctx context.Context, _ framework.TestingT, clusterName string) (context.Context, *kafkaFactoryState) {
 	nodes := getNodes(ctx, clusterName)
 
-	mgr, pfCfgs := setupMulticlusterManager(ctx, nodes)
+	// Pre-warm the RedpandaBrokerPool informer per cluster: stretchClusterKafkaClient's
+	// factory.KafkaClient lists RedpandaBrokerPools to find a representative pool, and
+	// that first List would otherwise trigger a cold informer sync under the factory's
+	// short per-call RemoteCallTimeout. Warming it here, under the generous engage
+	// budget, makes that later List a warm-cache hit.
+	mgr, pfCfgs := setupMulticlusterManager(ctx, nodes, &redpandav1alpha2.RedpandaBrokerPool{})
 	dialer := vclusterPodDialer(nodes, pfCfgs)
 	factory := internalclient.NewFactory(mgr, nil).WithDialer(dialer)
 
@@ -153,28 +158,15 @@ func stretchClusterKafkaClient(ctx context.Context, t framework.TestingT, cluste
 		return false
 	}, 30*time.Second, 1*time.Second, "no StretchCluster found in vclusters for %q", clusterName)
 
-	// Building the client lists RedpandaBrokerPools through the factory's
-	// cached multicluster client. This call is the first use of a
-	// freshly-built manager whose informers haven't started yet, so the
-	// List starts the RedpandaBrokerPool informer and blocks on its initial
-	// cache sync — which crosses the port-forwarded vcluster connections and
-	// can exceed the factory's per-call RemoteCallTimeout on the first
-	// attempt, surfacing as "finding representative broker pool: Timeout:
-	// failed waiting for *v1alpha2.RedpandaBrokerPool Informer to sync".
-	// That is transient: the informer keeps syncing in the background, so a
-	// later attempt succeeds. Retry rather than failing the scenario on a
-	// cold-cache timeout (the sentinel/consume steps that follow already
-	// retry their own RPCs the same way).
-	var cl *kgo.Client
-	require.Eventually(t, func() bool {
-		var err error
-		cl, err = state.factory.KafkaClient(ctx, &sc, extraOpts...)
-		if err != nil {
-			t.Logf("creating stretch cluster kafka client for %q: %v", clusterName, err)
-			return false
-		}
-		return true
-	}, 2*time.Minute, 5*time.Second, "creating stretch cluster kafka client for %q", clusterName)
+	// Building the client lists RedpandaBrokerPools through the factory's cached
+	// multicluster client to find a representative pool. That cache is pre-warmed
+	// for RedpandaBrokerPool during manager engagement (see initKafkaFactory ->
+	// setupMulticlusterManager), so this List is a warm-cache hit and no longer
+	// risks the cold informer-sync timeout. Fail fast on any error here so a
+	// genuine readiness problem (no representative pool, TLS/auth failure) surfaces
+	// immediately instead of being masked behind a long retry.
+	cl, err := state.factory.KafkaClient(ctx, &sc, extraOpts...)
+	require.NoError(t, err, "creating stretch cluster kafka client for %q", clusterName)
 	return cl
 }
 

--- a/acceptance/steps/stretch_rolling_restart.go
+++ b/acceptance/steps/stretch_rolling_restart.go
@@ -153,8 +153,28 @@ func stretchClusterKafkaClient(ctx context.Context, t framework.TestingT, cluste
 		return false
 	}, 30*time.Second, 1*time.Second, "no StretchCluster found in vclusters for %q", clusterName)
 
-	cl, err := state.factory.KafkaClient(ctx, &sc, extraOpts...)
-	require.NoError(t, err, "creating stretch cluster kafka client")
+	// Building the client lists RedpandaBrokerPools through the factory's
+	// cached multicluster client. This call is the first use of a
+	// freshly-built manager whose informers haven't started yet, so the
+	// List starts the RedpandaBrokerPool informer and blocks on its initial
+	// cache sync — which crosses the port-forwarded vcluster connections and
+	// can exceed the factory's per-call RemoteCallTimeout on the first
+	// attempt, surfacing as "finding representative broker pool: Timeout:
+	// failed waiting for *v1alpha2.RedpandaBrokerPool Informer to sync".
+	// That is transient: the informer keeps syncing in the background, so a
+	// later attempt succeeds. Retry rather than failing the scenario on a
+	// cold-cache timeout (the sentinel/consume steps that follow already
+	// retry their own RPCs the same way).
+	var cl *kgo.Client
+	require.Eventually(t, func() bool {
+		var err error
+		cl, err = state.factory.KafkaClient(ctx, &sc, extraOpts...)
+		if err != nil {
+			t.Logf("creating stretch cluster kafka client for %q: %v", clusterName, err)
+			return false
+		}
+		return true
+	}, 2*time.Minute, 5*time.Second, "creating stretch cluster kafka client for %q", clusterName)
 	return cl
 }
 

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -77560,11 +77560,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -77936,11 +77973,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -78531,11 +78605,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION
## What

Fixes a flaky failure in the `stretch-cluster-rolling-restart` acceptance-multicluster scenario where the test fails with:

```
finding representative broker pool: Timeout: failed waiting for
*v1alpha2.RedpandaBrokerPool Informer to sync
```

(seen on [build 14182](https://buildkite.com/redpanda/redpanda-operator/builds/14182), surfaced while triaging #1604 — whose chart-only `priorityClassName` change is unrelated to this test).

## Root cause

The failure is a controller-runtime lazy-informer subtlety. controller-runtime starts an informer **lazily**, on the first `Get`/`List` of a type, and `cache.WaitForCacheSync` only waits for informers that have **already been registered** (`getHasSyncedFuncs()` iterates only the maps of already-registered informers). A type nobody has touched isn't in those maps, so `WaitForCacheSync` is effectively a no-op for it.

In this scenario, `tryEngageMulticlusterManager` already calls `WaitForCacheSync` per cluster — but nobody has touched `RedpandaBrokerPool` yet, so it doesn't cover that type. The first `factory.KafkaClient` → `representativeBrokerPool` `List` is what registers the informer **and** blocks on its cold initial sync, crossing the port-forwarded vcluster connections. That sync runs under the factory's short per-call `RemoteCallTimeout` and can exceed it on the first attempt, producing the error above.

Crucially, the failure fires **after the cluster is already healthy** — the log shows the preceding gate passing `bound and deployed RedpandaBrokerPools: 3/3` immediately before the sentinel-topic step that then fails on the cold-cache timeout. So this is a test-harness cache-warming gap, not a product or cluster-bring-up problem.

## Fix

Pre-warm the `RedpandaBrokerPool` informer during multicluster engagement, so the factory's later `List` hits a warm cache instead of paying the cold initial-sync cost under its own short timeout.

- Thread a variadic `warm ...client.Object` through `setupMulticlusterManager` → `tryEngageMulticlusterManager`. For each warm type, the existing per-cluster engage loop calls `GetInformer` (which both registers the informer **and** blocks until its initial sync completes) under the generous 90s engage budget. A miss within the loop's short sub-timeout just drops back into the poll loop — the informer keeps syncing in the background, so a later iteration finds it ready.
- `initKafkaFactory` warms `&RedpandaBrokerPool{}` — the exact type the factory reads.

With the cache warmed up front, the client build no longer risks the cold-sync timeout, so it's reverted to a plain `require.NoError` (fail-fast). This also avoids masking genuine readiness failures (no representative pool, TLS/auth errors) behind a long retry.

Test-harness only — no operator or chart code changes.

> _History: the first version of this PR wrapped the client build in a broad `require.Eventually` to ride out the cold-cache timeout. Per review ([feedback](https://github.com/redpanda-data/redpanda-operator/pull/1606#issuecomment-4720572891)), that was replaced with the root-cause pre-warm fix above._

## Not addressed here (deliberately)

A separate run of the same scenario on build 14182 failed at a **different** point — the rolling-upgrade disruption assertion (`stretch_rolling_restart.go:362`): *\"expected at most 1 pod unavailable at a time during rolling upgrade, got max 2.\"* That is a distinct failure mode and is **intentionally not touched** in this PR: loosening that assertion could mask a real availability regression in the operator's rolling-upgrade sequencing. It needs its own investigation (likely a separate ticket — could be genuine 2-at-a-time disruption, or a 2s-poll sampling artifact catching an old pod terminating while a new one is not-yet-ready). Flagging so it isn't lost.

## Testing

- `go build` / `go vet` clean under the `acceptance` build tag.
- Real signal is the `stretch-cluster-rolling-restart` multicluster scenario in CI, which exercises the informer timing that `build`/`vet` can't.
- Labeled `no-changelog` (test-harness change, not user-facing).
