### PR TITLE
acceptance: cover Secret-referenced cluster config in Helm→operator migration

### DIFF
--- a/acceptance/features/migration.feature
+++ b/acceptance/features/migration.feature
@@ -38,11 +38,12 @@ Feature: Helm chart to Redpanda Operator migration
         And I store "{.metadata.generation}" of Kubernetes object with type "StatefulSet.v1.apps" and name "name-override" as "generation"
         # Before migrating, assert the Secret-referenced property is applied to the running,
         # Helm-managed cluster. iceberg_rest_catalog_client_secret is a Redpanda secret, so the
-        # Admin API redacts its value to "[secret]" once set, while the rendered bootstrap file
+        # Admin API redacts its value once set; rpk YAML-encodes the redacted "[secret]" marker
+        # and single-quotes it because it begins with "[". The rendered bootstrap file instead
         # holds the cleartext resolved from the Secret.
         And I exec "rpk cluster config get iceberg_rest_catalog_client_secret" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
         """
-        [secret]
+        '[secret]'
         """
         And I exec "grep iceberg_rest_catalog_client_secret /etc/redpanda/.bootstrap.yaml" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
         """
@@ -79,7 +80,7 @@ Feature: Helm chart to Redpanda Operator migration
         # still be set on the running cluster and still resolved in the bootstrap file.
         And I exec "rpk cluster config get iceberg_rest_catalog_client_secret" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
         """
-        [secret]
+        '[secret]'
         """
         And I exec "grep iceberg_rest_catalog_client_secret /etc/redpanda/.bootstrap.yaml" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
         """

--- a/acceptance/features/migration.feature
+++ b/acceptance/features/migration.feature
@@ -2,7 +2,20 @@ Feature: Helm chart to Redpanda Operator migration
 
   @skip:gke @skip:aks @skip:eks
   Scenario: Migrate from a Helm chart release to a Redpanda custom resource
-        Given I helm install "redpanda-migration-example" "../charts/redpanda/chart" with values:
+        # K8S-658: a cluster configuration property sourced from a Kubernetes Secret via
+        # config.extraClusterConfiguration must survive the migration. The Secret is created
+        # up front and is never modified while the Helm release is migrated to a Redpanda CR.
+        Given I apply Kubernetes manifest:
+        """
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: iceberg-config
+        stringData:
+          iceberg_rest_catalog_client_secret: PLACEHOLDER
+        """
+        And I helm install "redpanda-migration-example" "../charts/redpanda/chart" with values:
         """
     # tag::helm-values[]
         fullnameOverride: name-override
@@ -14,8 +27,27 @@ Feature: Helm chart to Redpanda Operator migration
             image:
               repository: localhost/redpanda-operator
               tag: dev
+        # Also test-specific (K8S-658): reference the Secret created above for a cluster config property.
+        config:
+          extraClusterConfiguration:
+            iceberg_rest_catalog_client_secret:
+              secretKeyRef:
+                name: iceberg-config
+                key: iceberg_rest_catalog_client_secret
         """
         And I store "{.metadata.generation}" of Kubernetes object with type "StatefulSet.v1.apps" and name "name-override" as "generation"
+        # Before migrating, assert the Secret-referenced property is applied to the running,
+        # Helm-managed cluster. iceberg_rest_catalog_client_secret is a Redpanda secret, so the
+        # Admin API redacts its value to "[secret]" once set, while the rendered bootstrap file
+        # holds the cleartext resolved from the Secret.
+        And I exec "rpk cluster config get iceberg_rest_catalog_client_secret" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
+        """
+        [secret]
+        """
+        And I exec "grep iceberg_rest_catalog_client_secret /etc/redpanda/.bootstrap.yaml" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
+        """
+        iceberg_rest_catalog_client_secret: "PLACEHOLDER"
+        """
         When I apply Kubernetes manifest:
         """
     # tag::redpanda-custom-resource-manifest[]
@@ -29,6 +61,13 @@ Feature: Helm chart to Redpanda Operator migration
           clusterSpec:
             fullnameOverride: name-override
     # end::redpanda-custom-resource-manifest[]
+            # The Secret reference is copied verbatim from the Helm values; the Secret is unchanged.
+            config:
+              extraClusterConfiguration:
+                iceberg_rest_catalog_client_secret:
+                  secretKeyRef:
+                    name: iceberg-config
+                    key: iceberg_rest_catalog_client_secret
         """
         Then cluster "redpanda-migration-example" is available
         And the Kubernetes object of type "StatefulSet.v1.apps" with name "name-override" has an OwnerReference pointing to the cluster "redpanda-migration-example"
@@ -36,3 +75,13 @@ Feature: Helm chart to Redpanda Operator migration
         And the cluster "redpanda-migration-example" is healthy
         # this winds up being incremented due to us forcibly swapping the cluster's StatefulSets to leverage OnDelete semantics
         And the recorded value "generation" is one less than "{.metadata.generation}" of the Kubernetes object with type "StatefulSet.v1.apps" and name "name-override"
+        # After the operator has taken over reconciliation, the Secret-referenced property must
+        # still be set on the running cluster and still resolved in the bootstrap file.
+        And I exec "rpk cluster config get iceberg_rest_catalog_client_secret" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
+        """
+        [secret]
+        """
+        And I exec "grep iceberg_rest_catalog_client_secret /etc/redpanda/.bootstrap.yaml" in a Pod matching "app.kubernetes.io/instance=redpanda-migration-example,app.kubernetes.io/component=redpanda-statefulset", it will output:
+        """
+        iceberg_rest_catalog_client_secret: "PLACEHOLDER"
+        """


### PR DESCRIPTION
## What

Extends the existing **Helm-chart-to-operator migration** acceptance scenario (`acceptance/features/migration.feature`) to verify that a Redpanda cluster configuration property sourced from a **Kubernetes Secret** via `config.extraClusterConfiguration` survives the migration from a Helm release to a Redpanda custom resource.

## Why

This validates, end-to-end, the `extraClusterConfiguration` capability documented in [redpanda-data/docs#1187](https://github.com/redpanda-data/docs/pull/1187) ("Set Redpanda cluster properties from Kubernetes Secrets or ConfigMaps") for the migration path. Tracked by [K8S-658](https://redpandadata.atlassian.net/browse/K8S-658).

## How

The scenario now:

1. **Creates an `iceberg-config` Secret up front**, before the Helm install, holding `iceberg_rest_catalog_client_secret: PLACEHOLDER`.
2. **References the Secret** through `secretKeyRef` in both the Helm values and the Redpanda custom resource. The Secret content is never modified during the migration.
3. **Asserts before the custom resource is applied** that the property is applied to the running, Helm-managed cluster.
4. **Asserts after the operator takes over reconciliation** that the value is still set.

### Assertion notes

`iceberg_rest_catalog_client_secret` is flagged `is_secret` in Redpanda, so the Admin API redacts it:

- `rpk cluster config get iceberg_rest_catalog_client_secret` → `[secret]` (set to a non-default value).
- The rendered `/etc/redpanda/.bootstrap.yaml` holds the cleartext resolved from the Secret → `iceberg_rest_catalog_client_secret: "PLACEHOLDER"`.

Both assertions run before the custom resource is applied (Helm-managed) and again after the operator takes over.

The existing migration coverage (owner references, Helm-release secret deletion, health check, generation invariant) and the documentation-region tags (`helm-values`, `redpanda-custom-resource-manifest`) are preserved; the Secret-specific content sits outside those tagged regions, like the existing test-specific sidecar block.

## Testing

- Feature file parses with godog's gherkin parser (1 scenario, 13 steps).
- All embedded manifests validated as YAML; `secretKeyRef` nesting confirmed in both Helm values and the CR.

The full acceptance suite requires a k3d/vcluster environment and the `localhost/redpanda-operator:dev` image, so it was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[K8S-658]: https://redpandadata.atlassian.net/browse/K8S-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ