### PR TITLE
operator: stop rpk-profile-updater crashloop in v1 factory integration test

### DIFF
--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -194,6 +194,19 @@ func TestIntegrationFactoryOperatorV1(t *testing.T) {
 			Image:    "docker.io/redpandadata/redpanda",
 			Version:  "v24.3.5",
 			Replicas: ptr.To(int32(1)),
+			// The rpk-profile-updater sidecar (K8S-755) runs the
+			// `rpk-profile-watcher` subcommand out of the configurator image.
+			// This test pins an old, hardcoded configurator nightly (see
+			// ConfiguratorTag below) that predates that subcommand, so the
+			// sidecar crashloops, the pod never becomes Ready, and
+			// OperatorQuiescent never flips True. This test exercises the
+			// client Factory, not rpk-profile freshness, so turn the sidecar
+			// off via its documented kill switch. (The Cluster is created
+			// directly without the defaulting webhook, so RpkProfileUpdater is
+			// otherwise nil, which the StatefulSet treats as enabled.)
+			Sidecars: vectorizedv1alpha1.Sidecars{
+				RpkProfileUpdater: &vectorizedv1alpha1.Sidecar{Enabled: false},
+			},
 			Configuration: vectorizedv1alpha1.RedpandaConfig{
 				RPCServer: vectorizedv1alpha1.SocketAddress{
 					Port: 33145,


### PR DESCRIPTION
## What

Disable the `rpk-profile-updater` sidecar in `TestIntegrationFactoryOperatorV1` (`operator/pkg/client/factory_test.go`) via its documented kill switch (`spec.sidecars.rpkProfileUpdater.enabled: false`).

## Why

This test has been failing in the integration suite and getting bucketed as "flaky." It is not flaky — it is a deterministic regression.

**Root cause chain:**

1. The K8S-755 change ([commit 419ebdd1](https://github.com/redpanda-data/redpanda-operator/commit/419ebdd137d82a817ecee8f67f618799735c94e2)) added a new `rpk-profile-updater` sidecar to every v1 broker pod, **enabled by default**. The sidecar runs `/redpanda-operator rpk-profile-watcher` out of `r.fullConfiguratorImage()`.
2. `TestIntegrationFactoryOperatorV1` **hardcodes** the configurator image to `redpandadata/redpanda-operator-nightly:v0.0.0-20250129gita89e202` — a binary built in **Jan 2025**, ~17 months before the `rpk-profile-watcher` subcommand existed. Running an unknown subcommand exits non-zero → **CrashLoopBackOff**.
3. A crashlooping container keeps the pod `NotReady` → `getQuiescentCondition` (`cluster_controller.go`) sees `readyReplicas != replicas` → the cluster's `OperatorQuiescent` condition never flips `True`.
4. The test's `require.Eventuallyf(... OperatorQuiescent ..., 5*time.Minute)` at `factory_test.go:224` times out (~434s) with `Condition never satisfied`.

The test creates the `Cluster` directly without the defaulting webhook, so `spec.sidecars.rpkProfileUpdater` is `nil`, which the StatefulSet treats as enabled — hence the sidecar runs and crashes.

## Fix

This test exercises the client `Factory` (admin / Kafka / schema-registry clients), not rpk-profile freshness, so the sidecar is irrelevant here. Turn it off via the documented kill switch. In production the sidecar always uses the current operator image, so the subcommand exists — this incompatibility is purely an artifact of the test pinning an ancient configurator image (see the existing TODO at the `WithConfiguratorSettings` call).

## Follow-up (not in this PR)

The hardcoded ancient configurator image is fragile by design. Any future v1 sidecar that shells a new operator subcommand will hit the same wall until this test is wired to inject the locally-built operator image.

## Test

`go vet ./operator/pkg/client/` passes. Full verification requires the k3d-based integration run:

```
nix develop -c go test ./operator/pkg/client/ -run TestIntegrationFactoryOperatorV1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)