### PR TITLE
operator/chart: regenerate golden file for tlsroutes RBAC rule

### DIFF
--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -90724,6 +90724,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - podmonitors
@@ -91579,6 +91591,18 @@ rules:
   - discovery.k8s.io
   resources:
   - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
   verbs:
   - create
   - delete


### PR DESCRIPTION
## What

Regenerates `operator/chart/testdata/template-cases.golden.txtar` to fix the failing `TestTemplate/fix-additional-flags` unit test.

## Why

The golden file was missing the `tlsroutes` (`gateway.networking.k8s.io`) RBAC rule on the `operator-default` and `operator-migration-job-default` ClusterRoles. The rendered chart output now includes this rule, so the golden file was out of date.

## How

```
nix develop -c go test -run '^TestTemplate$' github.com/redpanda-data/redpanda-operator/operator/chart -update-golden
```

Verified the test passes without the update flag afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)