### PR TITLE
fix(operator): don't call SR DeleteACLs with an empty list when deleting a user

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260624-141454.yaml
+++ b/.changes/unreleased/operator-Fixed-20260624-141454.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed User deletion getting stuck on clusters without an enterprise license. Schema Registry ACL cleanup no longer issues a DeleteACLs request when there are no ACLs to delete, which previously failed with "Invalid license: not present" and prevented the finalizer from being removed.
+time: 2026-06-24T14:14:54+02:00

--- a/operator/pkg/client/acls/syncer.go
+++ b/operator/pkg/client/acls/syncer.go
@@ -167,8 +167,10 @@ func (s *Syncer) deleteAllSRACL(ctx context.Context, principal string) error {
 		return fmt.Errorf("listing SR ACLs: %w", err)
 	}
 
-	if err := s.srClient.DeleteACLs(ctx, existing); err != nil {
-		return fmt.Errorf("deleting SR ACLs: %w", err)
+	if len(existing) > 0 {
+		if err := s.srClient.DeleteACLs(ctx, existing); err != nil {
+			return fmt.Errorf("deleting SR ACLs: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- Guard `deleteAllSRACL` so `DeleteACLs` is only called when there are SR ACLs to delete, matching the existing `len()` guards in `syncSRACL`.
- Fixes User CRs becoming stuck in `Terminating` on licenseless clusters, where the empty `DELETE /security/acls` call was rejected with `Invalid license: not present`.

Closes #1623
