### PR TITLE
fix(operator): don't call SR DeleteACLs with an empty list when deleting a user

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260624-141454.yaml
+++ b/.changes/unreleased/operator-Fixed-20260624-141454.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: Fixed User deletion getting stuck on clusters without an enterprise license. Schema Registry ACL cleanup no longer issues a DeleteACLs request when there are no ACLs to delete, which previously failed with "Invalid license: not present" and prevented the finalizer from being removed.
+time: 2026-06-24T14:14:54+02:00

--- a/operator/pkg/client/acls/sr_delete_test.go
+++ b/operator/pkg/client/acls/sr_delete_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acls
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/redpanda-data/common-go/rpsr"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSRACLClient is a test double for rpsr.ACLClient. It records DeleteACLs
+// invocations and lets a test inject the failure a licenseless broker returns
+// for DELETE /security/acls.
+type fakeSRACLClient struct {
+	listResult   []rpsr.ACL
+	listErr      error
+	deleteErr    error
+	deleteCalled bool
+	deletedACLs  []rpsr.ACL
+}
+
+func (f *fakeSRACLClient) ListACLs(_ context.Context, _ *rpsr.ACL) ([]rpsr.ACL, error) {
+	return f.listResult, f.listErr
+}
+
+func (f *fakeSRACLClient) ListACLsBatch(_ context.Context, _ []rpsr.ACL) ([]rpsr.ACL, error) {
+	return f.listResult, f.listErr
+}
+
+func (f *fakeSRACLClient) CreateACLs(_ context.Context, _ []rpsr.ACL) error {
+	return nil
+}
+
+func (f *fakeSRACLClient) DeleteACLs(_ context.Context, acls []rpsr.ACL) error {
+	f.deleteCalled = true
+	f.deletedACLs = acls
+	return f.deleteErr
+}
+
+// TestDeleteAllSRACLSkipsEmptyDelete is a regression test for #1623. On a
+// cluster without an enterprise license, listing SR ACLs is permitted and
+// returns nothing, but issuing a DeleteACLs request (DELETE /security/acls) —
+// even with an empty list — is rejected with "Invalid license: not present".
+// That error blocked the User finalizer, leaving the object stuck Terminating.
+// deleteAllSRACL must therefore skip the delete when there is nothing to
+// delete, so the enterprise gate can never block user deletion.
+func TestDeleteAllSRACLSkipsEmptyDelete(t *testing.T) {
+	fake := &fakeSRACLClient{
+		listResult: nil, // a licenseless cluster has no SR ACLs to begin with
+		deleteErr:  errors.New("Invalid license: not present"),
+	}
+	s := &Syncer{srClient: fake}
+
+	err := s.deleteAllSRACL(context.Background(), "User:alice")
+	require.NoError(t, err)
+	require.False(t, fake.deleteCalled,
+		"DeleteACLs must not be called when there are no SR ACLs to delete")
+}
+
+// TestDeleteAllSRACLDeletesWhenPresent documents that the guard only skips the
+// empty case: when SR ACLs exist they are still deleted.
+func TestDeleteAllSRACLDeletesWhenPresent(t *testing.T) {
+	fake := &fakeSRACLClient{
+		listResult: []rpsr.ACL{{Principal: "User:alice"}},
+	}
+	s := &Syncer{srClient: fake}
+
+	err := s.deleteAllSRACL(context.Background(), "User:alice")
+	require.NoError(t, err)
+	require.True(t, fake.deleteCalled, "DeleteACLs must be called when SR ACLs exist")
+	require.Len(t, fake.deletedACLs, 1)
+}

--- a/operator/pkg/client/acls/syncer.go
+++ b/operator/pkg/client/acls/syncer.go
@@ -167,8 +167,10 @@ func (s *Syncer) deleteAllSRACL(ctx context.Context, principal string) error {
 		return fmt.Errorf("listing SR ACLs: %w", err)
 	}
 
-	if err := s.srClient.DeleteACLs(ctx, existing); err != nil {
-		return fmt.Errorf("deleting SR ACLs: %w", err)
+	if len(existing) > 0 {
+		if err := s.srClient.DeleteACLs(ctx, existing); err != nil {
+			return fmt.Errorf("deleting SR ACLs: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Re-opens #1624 from a branch in this repository so CI can run — our test workflows don't execute on PRs from forks. The original commit and authorship by @LucasMrqes-padoa are preserved; the second commit only adds regression tests.

Closes #1623.

## Problem

Deleting a `User` (cluster.redpanda.com) whose ACLs are managed by the operator fails on a cluster **without an enterprise license**. The finalizer is never removed, so the object is stuck `Terminating`:

```
{"level":"error","controller":"user","error":"deleting SR ACLs: Invalid license: not present"}
```

In `deleteAllSRACL`, listing SR ACLs is permitted without a license (the error says *deleting*, not *listing*), so `existing` comes back empty — but `DeleteACLs(ctx, existing)` was called unconditionally, and an empty `DELETE /security/acls` is still rejected with `Invalid license: not present`. Schema Registry ACLs are an enterprise feature, but cleaning them up should never block a user from *deleting* a resource.

## Fix

Guard the delete with `if len(existing) > 0`, mirroring the guards the sibling `syncSRACL` already applies to its mutating calls. When there are no SR ACLs to delete, no request is issued and the finalizer proceeds.

## Tests

Adds deterministic unit tests over a fake `rpsr.ACLClient` (`sr_delete_test.go`):

- `TestDeleteAllSRACLSkipsEmptyDelete` — empty list ⇒ `DeleteACLs` is **not** called (red on the old code, green with the guard).
- `TestDeleteAllSRACLDeletesWhenPresent` — non-empty list ⇒ `DeleteACLs` is still issued.

The existing SR integration test (`TestIntegrationSyncerSR`) calls `t.Skip` when no enterprise license is present, so this exact licenseless path was previously uncovered.

## Follow-up (not in this PR)

The `len(existing) > 0` guard fully fixes the reported case because a cluster that was **never** licensed has no SR ACLs, so `existing` is always empty. It does **not** cover a cluster that *had* a license, created SR ACLs, then lost it (trial expiry / non-renewal): there `existing` is non-empty, the guard doesn't skip, and `DeleteACLs(ctx, existing)` is issued again — which still fails if the broker also gates *non-empty* SR ACL deletes on the license, reproducing the same stuck-`Terminating` symptom. To fully guarantee that enterprise SR ACL cleanup can never block user deletion, a follow-up could treat a `license not present` / enterprise-gated error from SR ACL cleanup as non-fatal on the delete path (log and continue so the finalizer is removed). Kept out of this PR to keep the fix minimal.
