### PR TITLE
operator: fix StretchCluster status never reaching Stable (K8S-883, K8S-884)

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260629-100000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260629-100000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: "Multicluster `StretchCluster`: a peer that is registered with the manager but whose `StretchCluster` CR has been removed is no longer reported as `SpecSynced=ClusterUnreachable`. Such a peer is reachable — its CR is simply absent — so it is now treated as not participating: it is named distinctly in the condition message and no longer blocks the cluster from reaching `Stable` when the data plane is otherwise healthy."
+time: 2026-06-29T10:00:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260629-110000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260629-110000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: "Multicluster `StretchCluster`: when SASL authentication is disabled, the `BootstrapUserSynced` condition is now set to a final `True` state (reason `Synced`) instead of being left at its default `Unknown`. Previously the bootstrap-user sync returned early without setting the condition, leaving it non-final, which blocked the `Quiesced` aggregate — and therefore `Stable` — from ever reaching `True` on an otherwise healthy cluster."
+time: 2026-06-29T11:00:00.000000-07:00

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -347,9 +347,13 @@ func (r *MulticlusterReconciler) findAliveCluster(ctx context.Context, sc *redpa
 // checkSpecConsistency fetches the StretchCluster from every reachable cluster
 // and verifies that .Spec is identical. Unreachable clusters are skipped with a
 // logged warning — reconciliation continues on the clusters that are available
-// rather than being blocked by a transient outage. If drift is detected on a
-// reachable cluster it sets SpecSynced=False and returns drifted=true so the
-// caller can abort. When all reachable specs are aligned it sets SpecSynced=True.
+// rather than being blocked by a transient outage. A peer that is reachable but
+// has no StretchCluster CR (NotFound) is treated as not participating: it is
+// recorded separately and does not block, so the cluster can still reach Stable
+// when the only outlier is an intentionally-absent peer (K8S-883). If drift is
+// detected on a reachable cluster it sets SpecSynced=False and returns
+// drifted=true so the caller can abort. When all participating reachable specs
+// are aligned it sets SpecSynced=True.
 //
 // Records observability gauges as a side effect — `member_reachable` for every
 // member cluster, and `spec_drift` for reachable members (left untouched for
@@ -360,6 +364,12 @@ func (r *MulticlusterReconciler) checkSpecConsistency(ctx context.Context, state
 	localSpec := sc.Spec
 	var driftDetails []string
 	var unreachable []string
+	// Peers that are reachable but have no StretchCluster CR. These are NOT
+	// unreachable — the peer is simply not participating in this stretch
+	// (intentionally removed, or not yet created). Tracked separately so the
+	// status can report them distinctly from a genuine connectivity failure
+	// (K8S-883).
+	var missingStretchCluster []string
 
 	// The local cluster is always reachable from this operator and is
 	// (by definition) aligned with itself. Record both gauges so the
@@ -404,6 +414,20 @@ func (r *MulticlusterReconciler) checkSpecConsistency(ctx context.Context, state
 
 		remoteSC := &redpandav1alpha2.StretchCluster{}
 		if err := remote.GetClient().Get(ctx, client.ObjectKeyFromObject(sc), remoteSC); err != nil {
+			// A NotFound on a reachable peer is fundamentally different from an
+			// unreachable cluster: the peer answered, it just has no
+			// StretchCluster CR. Conflating the two reports "cluster
+			// unreachable" for a perfectly reachable peer (misleading) and, by
+			// keeping SpecSynced non-True, blocks the cluster from ever
+			// reaching Stable even when the data plane is healthy (K8S-883).
+			// Treat such a peer as not participating: record it as reachable,
+			// track it separately, and do not block on it.
+			if apierrors.IsNotFound(err) {
+				l.Info("peer has no StretchCluster, treating as not participating", "cluster", clusterName)
+				missingStretchCluster = append(missingStretchCluster, clusterName)
+				observability.RecordStretchClusterMemberReachable(sc.Name, canonical, true)
+				continue
+			}
 			l.Info("could not fetch StretchCluster from cluster, skipping", "cluster", clusterName, "error", err)
 			unreachable = append(unreachable, clusterName)
 			observability.RecordStretchClusterMemberReachable(sc.Name, canonical, false)
@@ -422,15 +446,29 @@ func (r *MulticlusterReconciler) checkSpecConsistency(ctx context.Context, state
 	}
 
 	if len(driftDetails) == 0 {
-		if len(unreachable) > 0 {
+		switch {
+		case len(unreachable) > 0:
 			msg := fmt.Sprintf("clusters unreachable, spec consistency could not be verified: %s", strings.Join(unreachable, ", "))
+			if len(missingStretchCluster) > 0 {
+				msg += fmt.Sprintf("; peers reachable but without a StretchCluster (not participating): %s", strings.Join(missingStretchCluster, ", "))
+			}
 			l.Info(msg)
 			// Reachable specs are aligned but some clusters are down. Use the
 			// ClusterUnreachable reason so operators can distinguish a partial
 			// check from a genuine drift or error. Reconciliation continues on
 			// live clusters — we do NOT block on an unreachable peer.
 			state.status.StretchClusterStatus.SetSpecSynced(statuses.StretchClusterSpecSyncedReasonClusterUnreachable, msg)
-		} else {
+		case len(missingStretchCluster) > 0:
+			// Every reachable, participating peer agrees. The only outliers are
+			// peers that are reachable but have no StretchCluster CR — they are
+			// not participating, so they must not block stability. Resolve to
+			// Synced=True while clearly naming the absent peers so operators can
+			// tell "peer missing StretchCluster" apart from drift or an
+			// unreachable cluster (K8S-883).
+			msg := fmt.Sprintf("spec consistent across all participating clusters; peers reachable but without a StretchCluster (not participating): %s", strings.Join(missingStretchCluster, ", "))
+			l.Info(msg)
+			state.status.StretchClusterStatus.SetSpecSynced(statuses.StretchClusterSpecSyncedReasonSynced, msg)
+		default:
 			state.status.StretchClusterStatus.SetSpecSynced(statuses.StretchClusterSpecSyncedReasonSynced)
 		}
 		return false, ctrl.Result{}

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -611,6 +611,15 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 
 	if !sc.Spec.Auth.IsSASLEnabled() {
 		logger.V(log.TraceLevel).Info("SASL is not enabled, skipping bootstrap user sync")
+		// There is no bootstrap user to manage when SASL is disabled, so the
+		// condition is trivially reconciled. We must still set it to a final
+		// state: leaving it at its CRD default (Unknown/NotReconciled) keeps it
+		// non-final, which blocks the Quiesced aggregate — and therefore Stable
+		// — from ever reaching True on an otherwise healthy cluster (K8S-884).
+		state.status.StretchClusterStatus.SetBootstrapUserSynced(
+			statuses.StretchClusterBootstrapUserSyncedReasonSynced,
+			"SASL is disabled; no bootstrap user secret is required",
+		)
 		return ctrl.Result{}, nil
 	}
 	clusterNames := r.Manager.GetClusterNames()

--- a/operator/internal/controller/redpanda/multicluster_spec_consistency_test.go
+++ b/operator/internal/controller/redpanda/multicluster_spec_consistency_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
+)
+
+// specConsistencyCluster is a fake cluster.Cluster whose only useful behaviour
+// is returning a pre-seeded client. Everything else is left nil — the spec
+// consistency check only ever calls GetClient.
+type specConsistencyCluster struct {
+	cluster.Cluster
+	client client.Client
+}
+
+func (c *specConsistencyCluster) GetClient() client.Client { return c.client }
+
+// specConsistencyManager is a fake multicluster.Manager that returns a fixed
+// set of peer clusters, each with its own reachability and client. Only the
+// four methods checkSpecConsistency touches are implemented; the embedded
+// interface satisfies the rest (and panics if anything unexpected is called).
+type specConsistencyManager struct {
+	multicluster.Manager
+	local     string
+	names     []string
+	reachable map[string]bool
+	clients   map[string]client.Client
+}
+
+func (m *specConsistencyManager) GetClusterNames() []string   { return m.names }
+func (m *specConsistencyManager) GetLocalClusterName() string { return m.local }
+
+func (m *specConsistencyManager) IsClusterReachable(name string) bool {
+	reachable, ok := m.reachable[name]
+	return !ok || reachable // default: reachable
+}
+
+func (m *specConsistencyManager) GetCluster(_ context.Context, name string) (cluster.Cluster, error) {
+	return &specConsistencyCluster{client: m.clients[name]}, nil
+}
+
+func specConsistencyScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+	return scheme
+}
+
+func localStretchCluster() *redpandav1alpha2.StretchCluster {
+	return &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "redpanda", Namespace: "redpanda"},
+		Spec: redpandav1alpha2.StretchClusterSpec{
+			CommonLabels: map[string]string{"team": "redpanda"},
+		},
+	}
+}
+
+// readSpecSynced runs UpdateConditions onto a throwaway object and returns the
+// resulting SpecSynced condition.
+func readSpecSynced(t *testing.T, state *stretchClusterReconciliationState) *metav1.Condition {
+	t.Helper()
+	sc := &redpandav1alpha2.StretchCluster{}
+	state.status.StretchClusterStatus.UpdateConditions(sc)
+	return apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterSpecSynced)
+}
+
+// K8S-883: a peer that is registered in the manager but whose StretchCluster CR
+// has been removed is *reachable* — its CR is simply NotFound. The spec
+// consistency check must NOT report this as ClusterUnreachable (which is
+// misleading and, by leaving SpecSynced perpetually non-True, blocks the
+// cluster from ever reaching Stable). With every reachable, participating peer
+// in agreement, SpecSynced must resolve to True.
+func TestCheckSpecConsistency_ReachablePeerMissingStretchClusterIsNotUnreachable(t *testing.T) {
+	scheme := specConsistencyScheme(t)
+	sc := localStretchCluster()
+
+	// peer-b is reachable but has no StretchCluster CR (empty client).
+	mgr := &specConsistencyManager{
+		local: "local",
+		names: []string{"local", "peer-b"},
+		clients: map[string]client.Client{
+			"peer-b": fake.NewClientBuilder().WithScheme(scheme).Build(),
+		},
+	}
+
+	r := &MulticlusterReconciler{Manager: mgr}
+	state := &stretchClusterReconciliationState{status: lifecycle.NewStretchClusterStatus()}
+
+	drifted, _ := r.checkSpecConsistency(context.Background(), state, sc, "local")
+	require.False(t, drifted, "a missing peer CR must not be treated as drift")
+
+	cond := readSpecSynced(t, state)
+	require.NotNil(t, cond)
+	require.Equal(t, metav1.ConditionTrue, cond.Status,
+		"reachable peer with no StretchCluster must not block SpecSynced from reaching True")
+	require.Equal(t, string(statuses.StretchClusterSpecSyncedReasonSynced), cond.Reason,
+		"a reachable peer missing its CR must not be reported as ClusterUnreachable")
+	require.Contains(t, cond.Message, "peer-b",
+		"the message should clearly name the peer missing its StretchCluster")
+}
+
+// Regression guard: a genuinely unreachable peer (background probe down) must
+// still surface as ClusterUnreachable so operators can distinguish a real
+// connectivity problem from an intentionally-absent peer.
+func TestCheckSpecConsistency_UnreachablePeerReportsClusterUnreachable(t *testing.T) {
+	scheme := specConsistencyScheme(t)
+	sc := localStretchCluster()
+
+	mgr := &specConsistencyManager{
+		local:     "local",
+		names:     []string{"local", "peer-b"},
+		reachable: map[string]bool{"peer-b": false},
+		clients:   map[string]client.Client{"peer-b": fake.NewClientBuilder().WithScheme(scheme).Build()},
+	}
+
+	r := &MulticlusterReconciler{Manager: mgr}
+	state := &stretchClusterReconciliationState{status: lifecycle.NewStretchClusterStatus()}
+
+	drifted, _ := r.checkSpecConsistency(context.Background(), state, sc, "local")
+	require.False(t, drifted)
+
+	cond := readSpecSynced(t, state)
+	require.NotNil(t, cond)
+	require.Equal(t, metav1.ConditionFalse, cond.Status)
+	require.Equal(t, string(statuses.StretchClusterSpecSyncedReasonClusterUnreachable), cond.Reason)
+}
+
+// Regression guard: when every peer is reachable and has an identical spec the
+// condition resolves to Synced=True.
+func TestCheckSpecConsistency_AllPeersAlignedIsSynced(t *testing.T) {
+	scheme := specConsistencyScheme(t)
+	sc := localStretchCluster()
+
+	peerSC := localStretchCluster() // identical spec
+	mgr := &specConsistencyManager{
+		local: "local",
+		names: []string{"local", "peer-b"},
+		clients: map[string]client.Client{
+			"peer-b": fake.NewClientBuilder().WithScheme(scheme).WithObjects(peerSC).Build(),
+		},
+	}
+
+	r := &MulticlusterReconciler{Manager: mgr}
+	state := &stretchClusterReconciliationState{status: lifecycle.NewStretchClusterStatus()}
+
+	drifted, _ := r.checkSpecConsistency(context.Background(), state, sc, "local")
+	require.False(t, drifted)
+
+	cond := readSpecSynced(t, state)
+	require.NotNil(t, cond)
+	require.Equal(t, metav1.ConditionTrue, cond.Status)
+	require.Equal(t, string(statuses.StretchClusterSpecSyncedReasonSynced), cond.Reason)
+}

--- a/operator/internal/controller/redpanda/sync_bootstrap_user_sasl_disabled_test.go
+++ b/operator/internal/controller/redpanda/sync_bootstrap_user_sasl_disabled_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
+)
+
+// K8S-884: with SASL disabled, syncBootstrapUser used to return before ever
+// calling SetBootstrapUserSynced, leaving the condition at its CRD default of
+// Unknown/NotReconciled. Because the Quiesced aggregate requires every
+// condition to be in a final state, a perpetually-Unknown BootstrapUserSynced
+// blocked Quiesced — and therefore Stable — from ever reaching True on an
+// otherwise fully healthy cluster.
+//
+// The fix must set BootstrapUserSynced to a final True state when SASL is
+// disabled (there is no bootstrap user to manage, so the condition is
+// trivially reconciled).
+func TestSyncBootstrapUser_SASLDisabledSetsFinalTrueCondition(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"cluster-a", "cluster-b", "cluster-c"}
+	// SASL disabled: no spec.auth at all (the default in stretch-beta manifests).
+	sc := &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "stretch", Namespace: "default"},
+		Spec:       redpandav1alpha2.StretchClusterSpec{},
+	}
+	require.False(t, sc.Spec.Auth.IsSASLEnabled(), "precondition: SASL must be disabled")
+
+	state := newTestState(sc, clusterNames)
+
+	// SASL-disabled short-circuits before touching the manager, so a bare
+	// reconciler is sufficient.
+	r := &MulticlusterReconciler{}
+
+	result, err := r.syncBootstrapUser(ctx, state, nil)
+	require.NoError(t, err)
+	require.Zero(t, result.RequeueAfter)
+
+	state.status.StretchClusterStatus.UpdateConditions(sc)
+	cond := apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterBootstrapUserSynced)
+	require.NotNil(t, cond, "BootstrapUserSynced must be set (not left Unknown) when SASL is disabled")
+	require.Equal(t, metav1.ConditionTrue, cond.Status,
+		"BootstrapUserSynced must reach a final True state so Quiesced/Stable can converge")
+}


### PR DESCRIPTION
Fixes two independent status-reporting defects that each keep a healthy multicluster `StretchCluster` from ever reaching `Stable=True`. Both are pure status defects — the data plane is healthy in both cases.

---

## K8S-883 — misleading `ClusterUnreachable` for a peer missing its CR

[K8S-883](https://redpandadata.atlassian.net/browse/K8S-883): When a peer is registered with the manager but its `StretchCluster` CR has been removed, the spec-consistency check on every *other* peer got stuck at `SpecSynced=False reason=ClusterUnreachable`. The message claimed the peer was unreachable, which is false — the peer answers, its CR is simply `NotFound`.

**Root cause:** `checkSpecConsistency` ([`multicluster_controller.go`](operator/internal/controller/redpanda/multicluster_controller.go)) lumped *every* peer-fetch error — including `NotFound` on a reachable peer — into the `unreachable` list.

**Fix:** distinguish `apierrors.IsNotFound` (peer reachable, CR absent → *not participating*) from a genuine connectivity failure. A reachable peer with no CR is recorded as reachable, tracked separately, and no longer blocks; when it is the only outlier, `SpecSynced` resolves to `Synced=True` with a message naming the absent peer(s). A genuinely unreachable peer still reports `ClusterUnreachable`.

**Tests:** [`multicluster_spec_consistency_test.go`](operator/internal/controller/redpanda/multicluster_spec_consistency_test.go) — missing-CR peer → Synced/True (the bug), unreachable peer → ClusterUnreachable/False (guard), all-aligned → Synced/True (guard).

---

## K8S-884 — `BootstrapUserSynced` stuck `Unknown` when SASL is disabled

[K8S-884](https://redpandadata.atlassian.net/browse/K8S-884): A healthy `StretchCluster` with SASL disabled (no `spec.auth`) permanently reported `BootstrapUserSynced=Unknown`, `Quiesced=False`, `Stable=False`.

**Root cause:** `syncBootstrapUser` returned early when SASL was disabled without ever calling `SetBootstrapUserSynced`, leaving the condition at its CRD default (`Unknown`/`NotReconciled`). `Quiesced` only resolves once every condition reaches a final state, so a non-final `BootstrapUserSynced` blocked `Quiesced` → `Stable` indefinitely.

**Fix:** when SASL is disabled there is no bootstrap user to manage, so the condition is now set to a final `True` state (reason `Synced`, message noting SASL is disabled) before returning, letting `Quiesced`/`Stable` converge.

**Tests:** `TestSyncBootstrapUser_SASLDisabledSetsFinalTrueCondition` in [`sync_bootstrap_user_sasl_disabled_test.go`](operator/internal/controller/redpanda/sync_bootstrap_user_sasl_disabled_test.go); existing SASL-enabled bootstrap-user tests unaffected.

---

## Verification

- New + existing tests pass; `go build` / `go vet` clean; `golangci-lint` reports 0 issues on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[K8S-883]: https://redpandadata.atlassian.net/browse/K8S-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[K8S-884]: https://redpandadata.atlassian.net/browse/K8S-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ