### PR TITLE
operator: changelog + ToScaleDown canonical coverage for the PoolTracker canonicalClusterName fix

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260701-184211.yaml
+++ b/.changes/unreleased/operator-Fixed-20260701-184211.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: 'Multicluster `StretchCluster`: `PoolTracker` no longer drops the canonical cluster name from the pods it selects for a rolling restart or from the StatefulSets it creates, scales, or updates. These previously carried an empty canonical cluster name, so the operator logged a blank cluster identifier for those operations in stretch/multicluster deployments. Construction now goes through helpers that require the canonical cluster name, preventing the omission from recurring.'
+time: 2026-07-01T18:42:11.514785+02:00

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -689,10 +689,11 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 	}{
 		"no-op": {},
 		"deleted-set": {
-			expectedSetsToScaleDown: []string{"pool-1(2): pod-3"},
+			expectedSetsToScaleDown: []string{"canonical-1/pool-1(2): pod-3"},
 			existingPools: []*poolWithOrdinals{{
 				set: &MulticlusterStatefulSet{
-					clusterName: mcmanager.LocalCluster,
+					clusterName:          mcmanager.LocalCluster,
+					canonicalClusterName: "canonical-1",
 					StatefulSet: &appsv1.StatefulSet{
 						ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
 						Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
@@ -745,10 +746,11 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 			}},
 		},
 		"scaling-down-set": {
-			expectedSetsToScaleDown: []string{"pool-1(2): pod-3", "pool-3(0): pod-1"},
+			expectedSetsToScaleDown: []string{"canonical-1/pool-1(2): pod-3", "canonical-3/pool-3(0): pod-1"},
 			existingPools: []*poolWithOrdinals{{
 				set: &MulticlusterStatefulSet{
-					clusterName: mcmanager.LocalCluster,
+					clusterName:          mcmanager.LocalCluster,
+					canonicalClusterName: "canonical-1",
 					StatefulSet: &appsv1.StatefulSet{
 						ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
 						Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
@@ -769,7 +771,8 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 				}},
 			}, {
 				set: &MulticlusterStatefulSet{
-					clusterName: mcmanager.LocalCluster,
+					clusterName:          mcmanager.LocalCluster,
+					canonicalClusterName: "canonical-2",
 					StatefulSet: &appsv1.StatefulSet{
 						ObjectMeta: metav1.ObjectMeta{Name: "pool-2"},
 						Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
@@ -782,7 +785,8 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 				}},
 			}, {
 				set: &MulticlusterStatefulSet{
-					clusterName: mcmanager.LocalCluster,
+					clusterName:          mcmanager.LocalCluster,
+					canonicalClusterName: "canonical-3",
 					StatefulSet: &appsv1.StatefulSet{
 						ObjectMeta: metav1.ObjectMeta{Name: "pool-3"},
 						Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
@@ -795,13 +799,15 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 				}},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
 					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{Name: "pool-2"},
 					Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
@@ -820,7 +826,10 @@ func TestPoolTrackerToScaleDown(t *testing.T) {
 			toIDs := func(list []*ScaleDownSet) []string {
 				ids := []string{}
 				for _, o := range list {
-					ids = append(ids, fmt.Sprintf("%s(%d): %s", o.StatefulSet.Name, ptr.Deref(o.StatefulSet.Spec.Replicas, 0), o.LastPod.Name))
+					// prefix the canonical cluster name so a dropped canonical in
+					// ToScaleDown's ScaleDownSet construction is caught, the same
+					// way the sibling tests assert clusterObjectNamespaceNames.
+					ids = append(ids, fmt.Sprintf("%s/%s(%d): %s", o.GetCanonicalClusterName(), o.StatefulSet.Name, ptr.Deref(o.StatefulSet.Spec.Replicas, 0), o.LastPod.Name))
 				}
 				return ids
 			}


### PR DESCRIPTION
## Context

The `canonicalClusterName` fix this PR originally carried has since landed on `main` in a superior, constructor-based form as commit `50a8a492` ("operator: fix dropped canonicalClusterName in PodsToRoll/addDesired"). This branch has been **rebased onto that commit**, so it no longer duplicates the code change — it now contains only the two things `50a8a492` left out.

## What this PR now does

1. **Adds the missing changelog entry.** `50a8a492` landed without a changie entry. This adds the `Fixed` entry, describing the observable impact accurately: the wrapper objects for rolled pods and for created/scaled/updated StatefulSets carried an empty canonical cluster name, so the operator logged a blank cluster identifier in stretch/multicluster deployments. (Note: the correlation *map key* was never affected — it is computed from sources whose canonical name was intact — so this is a logging/observability fix, not a keying fix.)

2. **Closes the one test-coverage gap `50a8a492` left.** `TestPoolTrackerToScaleDown` used a bespoke formatter that never read `canonicalClusterName`, unlike the sibling tests (`ToCreate`/`ToScaleUp`/`RequiresUpdate`/`ToDelete`/`PodsToRoll`) that commit switched to `clusterObjectNamespaceNames`. So a canonical drop in `ToScaleDown`'s `ScaleDownSet` construction would not have been caught. The test now prefixes the canonical cluster name (verified to fail if `ToScaleDown` drops canonical).

## Review

Rebased and reviewed via staff-engineer, security, documentation, and codex adversarial passes. Security and codex found nothing. Two low-severity findings were surfaced and fixed here: the changelog "cross-cluster object keys" overclaim (reworded) and the `ToScaleDown` coverage gap (closed above).

## Test plan

- [x] `nix develop -c go test ./operator/internal/lifecycle/...` — ok (envtest included)
- [x] `nix develop -c golangci-lint run ./operator/internal/lifecycle/...` — 0 issues
- [x] Mutation-tested the new assertion: reverting `ToScaleDown`'s canonical propagation makes `TestPoolTrackerToScaleDown` fail
- [x] `changie batch --dry-run` parses/renders the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)