### PR TITLE
operator: fix dropped canonicalClusterName in PodsToRoll/addDesired

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -2510,6 +2510,8 @@ github.com/montanaflynn/stats v0.7.0 h1:r3y12KyNxj/Sb/iOE46ws+3mS1+MZca1wlHQFPsY
 github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
+github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
@@ -3701,6 +3703,7 @@ golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 h1:bTLqdHv7xrGlFbvf5/T
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa h1:efT73AJZfAAUV7SOip6pWGkwJDzIGiKBZGVzHYa+ve4=
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
+golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 h1:HjU6IWBiAgRIdAJ9/y1rwCn+UELEmwV+VsTLzj/W4sE=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -529,7 +529,7 @@ func (r *ResourceClient[T, U]) FetchExistingAndDesiredPools(ctx context.Context,
 
 		wrapped := []*MulticlusterStatefulSet{}
 		for _, set := range desired {
-			wrapped = append(wrapped, &MulticlusterStatefulSet{StatefulSet: set, clusterName: clusterName, canonicalClusterName: CanonicalClusterName(clusterName, r.manager.GetLocalClusterName)})
+			wrapped = append(wrapped, newMulticlusterStatefulSet(set, clusterName, canonical))
 		}
 
 		// ensure we have and OnDelete type for our statefulset
@@ -892,11 +892,7 @@ func (r *ResourceClient[T, U]) fetchExistingPools(ctx context.Context, cluster U
 		}
 
 		existing = append(existing, &poolWithOrdinals{
-			set: &MulticlusterStatefulSet{
-				StatefulSet:          &statefulSet,
-				clusterName:          clusterName,
-				canonicalClusterName: CanonicalClusterName(clusterName, r.manager.GetLocalClusterName),
-			},
+			set:       newMulticlusterStatefulSet(&statefulSet, clusterName, canonical),
 			revisions: sortRevisions(ownedRevisions),
 			pods:      withOrdinals,
 		})

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -48,6 +48,28 @@ func (p *MulticlusterPod) GetCanonicalClusterName() string {
 	return p.canonicalClusterName
 }
 
+// newMulticlusterStatefulSet builds a MulticlusterStatefulSet, setting its
+// cluster name and canonical cluster name together so callers can't
+// accidentally set one without the other.
+func newMulticlusterStatefulSet(set *appsv1.StatefulSet, clusterName, canonicalClusterName string) *MulticlusterStatefulSet {
+	return &MulticlusterStatefulSet{
+		StatefulSet:          set,
+		clusterName:          clusterName,
+		canonicalClusterName: canonicalClusterName,
+	}
+}
+
+// newMulticlusterPod builds a MulticlusterPod, setting its cluster name and
+// canonical cluster name together so callers can't accidentally set one
+// without the other.
+func newMulticlusterPod(pod *corev1.Pod, clusterName, canonicalClusterName string) *MulticlusterPod {
+	return &MulticlusterPod{
+		Pod:                  pod,
+		clusterName:          clusterName,
+		canonicalClusterName: canonicalClusterName,
+	}
+}
+
 // podWithOrdinals is a container for sorting pods
 // by their ordinals
 type podsWithOrdinals struct {
@@ -87,6 +109,12 @@ func (s *ScaleDownSet) GetCanonicalClusterName() string {
 	return s.StatefulSet.canonicalClusterName
 }
 
+// ClusterNamespacedName is used as the map key correlating a pool's existing
+// and desired state (see PoolTracker.existingPools/desiredPools). The existing
+// and desired MulticlusterStatefulSet for the same real pool must therefore
+// report the same CanonicalClusterName — if one side drops or mis-derives it,
+// the two are treated as unrelated pools (spurious create + orphaned delete)
+// instead of being correlated.
 type ClusterNamespacedName struct {
 	Cluster              string
 	Namespace            string
@@ -277,7 +305,7 @@ func (p *PoolTracker) ToCreate() []*MulticlusterStatefulSet {
 				set.Labels = map[string]string{}
 			}
 			set.Labels[generationLabel] = generation
-			sets = append(sets, &MulticlusterStatefulSet{StatefulSet: set, clusterName: mcset.clusterName, canonicalClusterName: mcset.canonicalClusterName})
+			sets = append(sets, newMulticlusterStatefulSet(set, mcset.clusterName, mcset.canonicalClusterName))
 		}
 	}
 
@@ -303,7 +331,7 @@ func (p *PoolTracker) ToScaleUp() []*MulticlusterStatefulSet {
 					set.Labels = map[string]string{}
 				}
 				set.Labels[generationLabel] = generation
-				sets = append(sets, &MulticlusterStatefulSet{StatefulSet: set, clusterName: mcset.clusterName, canonicalClusterName: mcset.canonicalClusterName})
+				sets = append(sets, newMulticlusterStatefulSet(set, mcset.clusterName, mcset.canonicalClusterName))
 			}
 		}
 	}
@@ -346,7 +374,7 @@ func (p *PoolTracker) RequiresUpdate() []*MulticlusterStatefulSet {
 					set.Labels = map[string]string{}
 				}
 				set.Labels[generationLabel] = generation
-				sets = append(sets, &MulticlusterStatefulSet{StatefulSet: set, clusterName: mcset.clusterName, canonicalClusterName: mcset.canonicalClusterName})
+				sets = append(sets, newMulticlusterStatefulSet(set, mcset.clusterName, mcset.canonicalClusterName))
 			}
 		}
 	}
@@ -393,7 +421,7 @@ func (p *PoolTracker) ToScaleDown() []*ScaleDownSet {
 
 				set.Spec.Replicas = ptr.To(existingReplicas - 1)
 				sets = append(sets, &ScaleDownSet{
-					StatefulSet: &MulticlusterStatefulSet{StatefulSet: set, clusterName: mcset.clusterName, canonicalClusterName: mcset.canonicalClusterName},
+					StatefulSet: newMulticlusterStatefulSet(set, mcset.clusterName, mcset.canonicalClusterName),
 					LastPod:     lastPod.pod.DeepCopy(),
 				})
 			}
@@ -413,7 +441,7 @@ func (p *PoolTracker) ToScaleDown() []*ScaleDownSet {
 
 				set.Spec.Replicas = ptr.To(existingReplicas - 1)
 				sets = append(sets, &ScaleDownSet{
-					StatefulSet: &MulticlusterStatefulSet{StatefulSet: set, clusterName: mcset.clusterName, canonicalClusterName: mcset.canonicalClusterName},
+					StatefulSet: newMulticlusterStatefulSet(set, mcset.clusterName, mcset.canonicalClusterName),
 					LastPod:     lastPod.pod.DeepCopy(),
 				})
 			}
@@ -446,7 +474,7 @@ func (p *PoolTracker) ToDelete() []*MulticlusterStatefulSet {
 				// })
 
 				mcset := p.existingPools[nn].set
-				sets = append(sets, &MulticlusterStatefulSet{StatefulSet: mcset.DeepCopy(), clusterName: mcset.clusterName, canonicalClusterName: mcset.canonicalClusterName})
+				sets = append(sets, newMulticlusterStatefulSet(mcset.DeepCopy(), mcset.clusterName, mcset.canonicalClusterName))
 			}
 		}
 	}
@@ -511,11 +539,11 @@ func (p *PoolTracker) PodsToRoll() []*MulticlusterPod {
 			// the CurrentRevision on the StatefulSet can't be used here due to leveraging onDelete
 			if len(existing.revisions) == 0 {
 				// we have no revisions, just assume this needs to be rolled
-				pods = append(pods, &MulticlusterPod{Pod: withOrdinals.pod.DeepCopy(), clusterName: existing.set.clusterName})
+				pods = append(pods, newMulticlusterPod(withOrdinals.pod.DeepCopy(), existing.set.clusterName, existing.set.canonicalClusterName))
 			} else {
 				lastRevision := existing.revisions[len(existing.revisions)-1]
 				if withOrdinals.pod.Labels[appsv1.StatefulSetRevisionLabel] != lastRevision.Name {
-					pods = append(pods, &MulticlusterPod{Pod: withOrdinals.pod.DeepCopy(), clusterName: existing.set.clusterName})
+					pods = append(pods, newMulticlusterPod(withOrdinals.pod.DeepCopy(), existing.set.clusterName, existing.set.canonicalClusterName))
 				}
 			}
 		}
@@ -601,6 +629,6 @@ func (p *PoolTracker) addExisting(pools ...*poolWithOrdinals) {
 // addDesired statefulsets to the tracker
 func (p *PoolTracker) addDesired(sets ...*MulticlusterStatefulSet) {
 	for _, set := range sets {
-		p.desiredPools[objectKeyFromObject(set)] = &poolWithOrdinals{set: &MulticlusterStatefulSet{StatefulSet: set.DeepCopy(), clusterName: set.clusterName}}
+		p.desiredPools[objectKeyFromObject(set)] = &poolWithOrdinals{set: newMulticlusterStatefulSet(set.DeepCopy(), set.clusterName, set.canonicalClusterName)}
 	}
 }

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -205,16 +205,18 @@ func TestPoolTrackerToCreate(t *testing.T) {
 			}},
 		},
 		"no-existing": {
-			expectedSetsToCreate: []string{"pool-1", "pool-2"},
+			expectedSetsToCreate: []string{"canonical-1//pool-1", "canonical-2//pool-2"},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
 					},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
@@ -223,9 +225,10 @@ func TestPoolTrackerToCreate(t *testing.T) {
 			}},
 		},
 		"some-existing": {
-			expectedSetsToCreate: []string{"pool-2"},
+			expectedSetsToCreate: []string{"canonical-2//pool-2"},
 			existingPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -233,14 +236,16 @@ func TestPoolTrackerToCreate(t *testing.T) {
 				},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
 					},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
@@ -257,17 +262,14 @@ func TestPoolTrackerToCreate(t *testing.T) {
 			pools := []*poolWithOrdinals{}
 			for _, set := range tt.existingPools {
 				pools = append(pools, &poolWithOrdinals{
-					set: &MulticlusterStatefulSet{
-						StatefulSet: set.DeepCopy(),
-						clusterName: set.clusterName,
-					},
+					set: newMulticlusterStatefulSet(set.DeepCopy(), set.clusterName, set.canonicalClusterName),
 				})
 			}
 
 			tracker.addExisting(pools...)
 			tracker.addDesired(tt.desiredPools...)
 
-			actual := objectNames(tracker.ToCreate())
+			actual := clusterObjectNamespaceNames(tracker.ToCreate())
 			require.ElementsMatch(t, tt.expectedSetsToCreate, actual)
 		})
 	}
@@ -317,9 +319,10 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 			}},
 		},
 		"all-scale-ups": {
-			expectedSetsToScaleUp: []string{"pool-1"},
+			expectedSetsToScaleUp: []string{"canonical-1//pool-1"},
 			existingPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -328,7 +331,8 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 				},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -338,9 +342,10 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 			}},
 		},
 		"some-scale-ups": {
-			expectedSetsToScaleUp: []string{"pool-1"},
+			expectedSetsToScaleUp: []string{"canonical-1//pool-1"},
 			existingPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -348,7 +353,8 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
@@ -357,7 +363,8 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 				},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -365,7 +372,8 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
@@ -403,17 +411,14 @@ func TestPoolTrackerToScaleUp(t *testing.T) {
 			pools := []*poolWithOrdinals{}
 			for _, set := range tt.existingPools {
 				pools = append(pools, &poolWithOrdinals{
-					set: &MulticlusterStatefulSet{
-						clusterName: mcmanager.LocalCluster,
-						StatefulSet: set.DeepCopy(),
-					},
+					set: newMulticlusterStatefulSet(set.DeepCopy(), set.clusterName, set.canonicalClusterName),
 				})
 			}
 
 			tracker.addExisting(pools...)
 			tracker.addDesired(tt.desiredPools...)
 
-			actual := objectNames(tracker.ToScaleUp())
+			actual := clusterObjectNamespaceNames(tracker.ToScaleUp())
 			require.ElementsMatch(t, tt.expectedSetsToScaleUp, actual)
 		})
 	}
@@ -512,9 +517,10 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 		},
 		"updates": {
 			generation:           1,
-			expectedSetsToUpdate: []string{"pool-1"},
+			expectedSetsToUpdate: []string{"canonical-1//pool-1"},
 			existingPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "pool-1",
@@ -524,7 +530,8 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 				},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -537,9 +544,10 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 			// StretchCluster generation unchanged, but NodePool generation bumped
 			// (e.g. user changed spec.image.tag on the NodePool).
 			generation:           1,
-			expectedSetsToUpdate: []string{"pool-1"},
+			expectedSetsToUpdate: []string{"canonical-1//pool-1"},
 			existingPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -552,7 +560,8 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 				},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -596,9 +605,10 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 		"only-one-pool-nodepool-generation-changed": {
 			// Two pools, only pool-2 has a NodePool generation bump.
 			generation:           1,
-			expectedSetsToUpdate: []string{"pool-2"},
+			expectedSetsToUpdate: []string{"canonical-2//pool-2"},
 			existingPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -610,7 +620,8 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
@@ -623,7 +634,8 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 				},
 			}},
 			desiredPools: []*MulticlusterStatefulSet{{
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-1",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-1",
@@ -634,7 +646,8 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 					Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
@@ -655,14 +668,14 @@ func TestPoolTrackerRequiresUpdate(t *testing.T) {
 			pools := []*poolWithOrdinals{}
 			for _, set := range tt.existingPools {
 				pools = append(pools, &poolWithOrdinals{
-					set: &MulticlusterStatefulSet{StatefulSet: set.DeepCopy(), clusterName: set.clusterName},
+					set: newMulticlusterStatefulSet(set.DeepCopy(), set.clusterName, set.canonicalClusterName),
 				})
 			}
 
 			tracker.addExisting(pools...)
 			tracker.addDesired(tt.desiredPools...)
 
-			actual := objectNames(tracker.RequiresUpdate())
+			actual := clusterObjectNamespaceNames(tracker.RequiresUpdate())
 			require.ElementsMatch(t, tt.expectedSetsToUpdate, actual)
 		})
 	}
@@ -899,7 +912,7 @@ func TestPoolTrackerToDelete(t *testing.T) {
 			}},
 		},
 		"can-delete": {
-			expectedSetsToDelete: []string{"pool-2", "pool-3"},
+			expectedSetsToDelete: []string{"canonical-2//pool-2", "canonical-3//pool-3"},
 			existingPools: []*MulticlusterStatefulSet{{
 				clusterName: mcmanager.LocalCluster,
 				StatefulSet: &appsv1.StatefulSet{
@@ -908,14 +921,16 @@ func TestPoolTrackerToDelete(t *testing.T) {
 					},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-2",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-2",
 					},
 				},
 			}, {
-				clusterName: mcmanager.LocalCluster,
+				clusterName:          mcmanager.LocalCluster,
+				canonicalClusterName: "canonical-3",
 				StatefulSet: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pool-3",
@@ -940,7 +955,7 @@ func TestPoolTrackerToDelete(t *testing.T) {
 			pools := []*poolWithOrdinals{}
 			for _, set := range tt.existingPools {
 				pools = append(pools, &poolWithOrdinals{
-					set: &MulticlusterStatefulSet{StatefulSet: set.DeepCopy(), clusterName: set.clusterName},
+					set: newMulticlusterStatefulSet(set.DeepCopy(), set.clusterName, set.canonicalClusterName),
 				})
 			}
 
@@ -948,7 +963,7 @@ func TestPoolTrackerToDelete(t *testing.T) {
 			tracker.addDesired(tt.desiredPools...)
 			tracker.MarkClusterObserved(mcmanager.LocalCluster)
 
-			actual := objectNames(tracker.ToDelete())
+			actual := clusterObjectNamespaceNames(tracker.ToDelete())
 			require.ElementsMatch(t, tt.expectedSetsToDelete, actual)
 		})
 	}
@@ -956,7 +971,8 @@ func TestPoolTrackerToDelete(t *testing.T) {
 
 func TestPoolTrackerPodsToRoll(t *testing.T) {
 	pool1 := &MulticlusterStatefulSet{
-		clusterName: mcmanager.LocalCluster,
+		clusterName:          mcmanager.LocalCluster,
+		canonicalClusterName: "canonical-1",
 		StatefulSet: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pool-1",
@@ -973,7 +989,8 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 		},
 	}}
 	pool2 := &MulticlusterStatefulSet{
-		clusterName: mcmanager.LocalCluster,
+		clusterName:          mcmanager.LocalCluster,
+		canonicalClusterName: "canonical-2",
 		StatefulSet: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pool-2",
@@ -1021,7 +1038,7 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 			}},
 		},
 		"all-out-of-date": {
-			expectedPodsToRoll: []string{"pod-1", "pod-2"},
+			expectedPodsToRoll: []string{"canonical-1//pod-1", "canonical-1//pod-2"},
 			existingPools: []*poolWithOrdinals{{
 				pods: []*podsWithOrdinals{{
 					pod: &corev1.Pod{
@@ -1047,7 +1064,7 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 			}},
 		},
 		"no-revisions": {
-			expectedPodsToRoll: []string{"pod-1", "pod-2"},
+			expectedPodsToRoll: []string{"canonical-1//pod-1", "canonical-1//pod-2"},
 			existingPools: []*poolWithOrdinals{{
 				pods: []*podsWithOrdinals{{
 					pod: &corev1.Pod{
@@ -1072,7 +1089,7 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 			}},
 		},
 		"mixed": {
-			expectedPodsToRoll: []string{"pod-1", "pod-3"},
+			expectedPodsToRoll: []string{"canonical-1//pod-1", "canonical-2//pod-3"},
 			existingPools: []*poolWithOrdinals{{
 				pods: []*podsWithOrdinals{{
 					pod: &corev1.Pod{
@@ -1126,7 +1143,7 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 			tracker := NewPoolTracker(0, false)
 			tracker.addExisting(tt.existingPools...)
 
-			actual := objectNames(tracker.PodsToRoll())
+			actual := clusterObjectNamespaceNames(tracker.PodsToRoll())
 			require.ElementsMatch(t, tt.expectedPodsToRoll, actual)
 		})
 	}


### PR DESCRIPTION
## Summary
- `PodsToRoll()` and `addDesired()` in the lifecycle pool tracker were silently dropping `canonicalClusterName` (defaulting to `""`) when building `MulticlusterPod`/`MulticlusterStatefulSet` via raw struct literals — the same bug class already fixed twice before elsewhere in `pool.go`, because omitting a field from a literal compiles cleanly with no warning.
- Introduce `newMulticlusterStatefulSet`/`newMulticlusterPod` constructors that require `clusterName` and `canonicalClusterName` as explicit arguments, so omitting one is now a compile error. Migrate every construction site in `pool.go` and `client.go` to use them, fixing the two live drops.
- Document a related invariant found while adding coverage: `ClusterNamespacedName` (the map key `PoolTracker` uses to correlate a pool's existing vs. desired state) embeds `CanonicalClusterName`, so existing/desired entries for the same pool must agree on it or they silently fail to correlate.

## Test plan
- [x] Added regression coverage for `canonicalClusterName` propagation in `TestPoolTrackerPodsToRoll`, `TestPoolTrackerRequiresUpdate`, `TestPoolTrackerToDelete`, `TestPoolTrackerToCreate`, and `TestPoolTrackerToScaleUp`, using the previously-unused `clusterObjectNamespaceNames` test helper.
- [x] Followed TDD: confirmed each new assertion failed for the expected reason against the old code before fixing it.
- [x] `nix develop -c go test ./operator/internal/lifecycle/... -count=1` passes.
- [x] `nix develop -c go vet ./operator/internal/lifecycle/...` clean.
- [x] `nix develop -c task lint` clean (golangci-lint, helm lint --strict, actionlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)