### PR TITLE
operator: report host-tuner adoption in telemetry

### DIFF
--- a/.changes/unreleased/operator-Added-20260702-host-tuners-telemetry.yaml
+++ b/.changes/unreleased/operator-Added-20260702-host-tuners-telemetry.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: Anonymous operator telemetry now reports how many Redpanda and StretchCluster resources have the opt-in chroot host tuners enabled (`spec.tuning.apply_host_tuners`), as `redpanda.hostTunersEnabled` and `stretchCluster.hostTunersEnabled`.
+time: 2026-07-02T12:00:00.000000-07:00

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -141574,8 +141574,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 ---
@@ -142000,8 +142000,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 ---
@@ -142117,8 +142117,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 spec:
@@ -142228,8 +142228,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 spec:
@@ -142257,15 +142257,15 @@ spec:
         - name: REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE
           value: helm
         - name: REDPANDA_METRICS_K8S_CHART_VERSION
-          value: 3.7.0
+          value: 3.8.0
         - name: REDPANDA_METRICS_K8S_CONSOLE_IMAGE_VERSION
-          value: redpandadata/console:v3.7.0
+          value: redpandadata/console:v3.8.0
         - name: REDPANDA_METRICS_K8S_VERSION
           value: v1.99.0-gke
         - name: REDPANDA_METRICS_K8S_ENVIRONMENT
           value: GCP
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.7.0
+        image: docker.redpanda.com/redpandadata/console:v3.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -143152,8 +143152,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 ---
@@ -143578,8 +143578,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 ---
@@ -143695,8 +143695,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 spec:
@@ -143806,8 +143806,8 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
-    app.kubernetes.io/version: v3.7.0
-    helm.sh/chart: console-3.7.0
+    app.kubernetes.io/version: v3.8.0
+    helm.sh/chart: console-3.8.0
   name: redpanda-console
   namespace: default
 spec:
@@ -143835,15 +143835,15 @@ spec:
         - name: REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE
           value: helm
         - name: REDPANDA_METRICS_K8S_CHART_VERSION
-          value: 3.7.0
+          value: 3.8.0
         - name: REDPANDA_METRICS_K8S_CONSOLE_IMAGE_VERSION
-          value: redpandadata/console:v3.7.0
+          value: redpandadata/console:v3.8.0
         - name: REDPANDA_METRICS_K8S_VERSION
           value: v1.99.0-gke
         - name: REDPANDA_METRICS_K8S_ENVIRONMENT
           value: GCP
         envFrom: []
-        image: docker.redpanda.com/redpandadata/console:v3.7.0
+        image: docker.redpanda.com/redpandadata/console:v3.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -134,6 +134,11 @@ func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
 	} else if ok {
 		payload.StretchCluster.Count = len(stretchClusters.Items)
 		payload.StretchCluster.Enabled = payload.StretchCluster.Count > 0
+		for i := range stretchClusters.Items {
+			if tuning := stretchClusters.Items[i].Spec.Tuning; tuning != nil && ptrBool(tuning.ApplyHostTuners) {
+				payload.StretchCluster.HostTuners++
+			}
+		}
 	}
 
 	// Stretch/multicluster broker sizing lives on RedpandaBrokerPool CRs.
@@ -285,6 +290,13 @@ func (c *Collector) aggregateRedpandas(payload *Payload, items []redpandav1alpha
 			spec.External.Gateway != nil && ptrBool(spec.External.Gateway.Enabled) &&
 			len(spec.External.Gateway.ParentRefs) > 0 {
 			payload.Redpanda.GatewayAPIExternalAccess++
+		}
+		// Host tuners are a pure opt-in (the chart defaults apply_host_tuners to
+		// false), so the raw spec is the effective state — no need to consult the
+		// rendered values. The always-on tune_aio_events tuner is deliberately not
+		// counted; this tracks adoption of the chroot host-tuner mode only.
+		if spec.Tuning != nil && ptrBool(spec.Tuning.ApplyHostTuners) {
+			payload.Redpanda.HostTuners++
 		}
 
 		// Broker count + sizing: chart-rendered. Fall back to raw replicas for the

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -67,6 +67,9 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 		},
 		&redpandav1alpha2.StretchCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "sc-1", Namespace: "default"},
+			Spec: redpandav1alpha2.StretchClusterSpec{
+				Tuning: &redpandav1alpha2.StretchTuning{ApplyHostTuners: ptr.To(true)},
+			},
 		},
 		&redpandav1alpha2.RedpandaBrokerPool{
 			ObjectMeta: metav1.ObjectMeta{Name: "bp-1", Namespace: "default"},
@@ -142,6 +145,10 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 							},
 						},
 					},
+					Tuning: &redpandav1alpha2.Tuning{
+						TuneAioEvents:   ptr.To(true),
+						ApplyHostTuners: ptr.To(true),
+					},
 				},
 			},
 		},
@@ -203,6 +210,7 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 	require.Equal(t, 1, payload.Redpanda.Console)
 	require.Equal(t, 1, payload.Redpanda.ManagedConnectors)
 	require.Equal(t, 1, payload.Redpanda.GatewayAPIExternalAccess)
+	require.Equal(t, 1, payload.Redpanda.HostTuners)
 	// Sizing: 4c/16Gi per broker × 5 brokers (rp-1 default pool + correlated np-1).
 	require.Equal(t, 20, payload.Redpanda.TotalCPUCores)
 	require.Equal(t, 80, payload.Redpanda.TotalMemoryGiB)
@@ -213,6 +221,7 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 	require.Equal(t, 24, payload.StretchCluster.TotalCPUCores)
 	require.Equal(t, 96, payload.StretchCluster.TotalMemoryGiB)
 	require.Equal(t, []string{"8c/32Gi"}, payload.StretchCluster.BrokerSizes)
+	require.Equal(t, 1, payload.StretchCluster.HostTuners)
 
 	// Vectorized sizing: 2c/8Gi × 1.
 	require.Equal(t, 1, payload.VectorizedClusters.Count)
@@ -285,6 +294,8 @@ func TestCollect_EmptyCluster(t *testing.T) {
 	require.Empty(t, payload.Redpanda.Versions)
 	require.Equal(t, 0, payload.Redpanda.ManagedConnectors)
 	require.Equal(t, 0, payload.Redpanda.GatewayAPIExternalAccess)
+	require.Equal(t, 0, payload.Redpanda.HostTuners)
+	require.Equal(t, 0, payload.StretchCluster.HostTuners)
 	require.Equal(t, 0, payload.VectorizedClusters.Count)
 	require.Empty(t, payload.Storage.CSIDrivers)
 	require.Equal(t, 0, payload.Resources.Topics)
@@ -332,6 +343,47 @@ func TestAggregateRedpandas_GatewayCountRequiresParentRefs(t *testing.T) {
 
 	require.Equal(t, 0, payload.Redpanda.GatewayAPIExternalAccess,
 		"half-configured gateway clusters (no parentRefs / external disabled) must not be counted")
+}
+
+// TestAggregateRedpandas_HostTunersRequiresOptIn locks the hostTunersEnabled
+// counter to spec.tuning.apply_host_tuners only: the long-standing
+// tune_aio_events tuner (a chart default) must not count as host-tuner
+// adoption, and an explicit apply_host_tuners=false must not count either.
+func TestAggregateRedpandas_HostTunersRequiresOptIn(t *testing.T) {
+	c := &Collector{}
+	items := []redpandav1alpha2.Redpanda{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "aio-only", Namespace: "default"},
+			Spec: redpandav1alpha2.RedpandaSpec{
+				ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+					Tuning: &redpandav1alpha2.Tuning{TuneAioEvents: ptr.To(true)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "explicitly-off", Namespace: "default"},
+			Spec: redpandav1alpha2.RedpandaSpec{
+				ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+					Tuning: &redpandav1alpha2.Tuning{ApplyHostTuners: ptr.To(false)},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "opted-in", Namespace: "default"},
+			Spec: redpandav1alpha2.RedpandaSpec{
+				ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+					Tuning: &redpandav1alpha2.Tuning{ApplyHostTuners: ptr.To(true)},
+				},
+			},
+		},
+	}
+
+	payload := &Payload{}
+	var rp sizing
+	c.aggregateRedpandas(payload, items, &rp, map[string]corev1.ResourceRequirements{})
+
+	require.Equal(t, 1, payload.Redpanda.HostTuners,
+		"only clusters with apply_host_tuners=true count as host-tuner adoption")
 }
 
 func TestCollect_CSIDriversSortedAndDistinct(t *testing.T) {

--- a/operator/internal/telemetry/payload.go
+++ b/operator/internal/telemetry/payload.go
@@ -35,6 +35,10 @@ type Payload struct {
 		TotalCPUCores  int      `json:"totalCpuCores,omitempty"`
 		TotalMemoryGiB int      `json:"totalMemoryGiB,omitempty"`
 		BrokerSizes    []string `json:"brokerSizes,omitempty"`
+		// HostTuners counts StretchClusters with the chroot-based host tuning
+		// init container enabled (spec.tuning.apply_host_tuners); see
+		// redpanda.hostTunersEnabled.
+		HostTuners int `json:"hostTunersEnabled,omitempty"`
 	} `json:"stretchCluster"`
 
 	// Redpanda aggregates the fleet of v2 (chart-based) Redpanda CRs. The
@@ -76,6 +80,13 @@ type Payload struct {
 		// GatewayAPIExternalAccess counts clusters using Gateway API TLSRoute-based
 		// external access (spec.external.gateway.enabled).
 		GatewayAPIExternalAccess int `json:"gatewayAPIExternalAccessEnabled"`
+		// HostTuners counts clusters with the chroot-based host tuning init
+		// container enabled (spec.tuning.apply_host_tuners), which lets
+		// `rpk redpanda tune all` apply host-level tuners like disk_irq,
+		// disk_scheduler, disk_nomerges and net. The long-standing
+		// tune_aio_events tuner is not counted here — only the opt-in
+		// host-tuner mode.
+		HostTuners int `json:"hostTunersEnabled"`
 	} `json:"redpanda"`
 
 	// VectorizedClusters counts deprecated v1 (vectorized Cluster CR) installs


### PR DESCRIPTION
Stacked on #1522 (requires the `apply_host_tuners` CRD fields introduced there); retarget to `main` once #1522 merges.

Adds host-tuner adoption to the operator's anonymous telemetry payload so we can see how many clusters have turned on the opt-in chroot tuning init container:

- `redpanda.hostTunersEnabled` — count of Redpanda CRs with `spec.tuning.apply_host_tuners: true`
- `stretchCluster.hostTunersEnabled` — same count over StretchCluster CRs

Design notes:
- The counter reads the raw spec, matching the existing feature-adoption pattern in the collector. `apply_host_tuners` is a pure opt-in (chart default `false`), so the explicit spec value is the effective state and no chart rendering is needed.
- The long-standing `tune_aio_events` tuner is deliberately **not** counted — it defaults on in the chart and would not signal host-tuner adoption. A dedicated test locks this semantic (aio-only and explicit `apply_host_tuners: false` clusters do not count).

Scope note: this telemetry is operator-side only. Pure `helm install` deployments (no operator) have no phone-home mechanism in the chart, so they are not captured by this signal.
