### PR TITLE
Fix Console chart LoadBalancer notes condition

### DIFF
--- a/charts/console/chart/notes.go
+++ b/charts/console/chart/notes.go
@@ -49,7 +49,7 @@ func Notes(dot *helmette.Dot) []string {
 			fmt.Sprintf(`  export NODE_IP=$(kubectl get nodes --namespace %s -o jsonpath="{.items[0].status.addresses[0].address}")`, dot.Release.Namespace),
 			"  echo http://$NODE_IP:$NODE_PORT",
 		)
-	} else if helmette.Contains("NodePort", string(values.Service.Type)) {
+	} else if helmette.Contains("LoadBalancer", string(values.Service.Type)) {
 		commands = append(
 			commands,
 			`    NOTE: It may take a few minutes for the LoadBalancer IP to be available.`,

--- a/charts/console/chart/notes_test.go
+++ b/charts/console/chart/notes_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package chart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/redpanda-data/redpanda-operator/charts/console/v3"
+	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
+)
+
+func TestNotesForLoadBalancerService(t *testing.T) {
+	dot, err := Chart.Dot(nil, helmette.Release{
+		Name:      "console",
+		Namespace: "test-namespace",
+		Service:   "Helm",
+	}, PartialValues{
+		PartialRenderValues: console.PartialRenderValues{
+			Service: &console.PartialServiceConfig{
+				Type: ptr.To(corev1.ServiceTypeLoadBalancer),
+				Port: ptr.To[int32](8081),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	notes := Notes(dot)
+
+	assert.Contains(t, notes, `    NOTE: It may take a few minutes for the LoadBalancer IP to be available.`)
+	assert.Contains(t, notes, `          You can watch the status of by running 'kubectl get --namespace test-namespace svc -w console'`)
+	assert.Contains(t, notes, `  export SERVICE_IP=$(kubectl get svc --namespace test-namespace console --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")`)
+	assert.Contains(t, notes, `  echo http://$SERVICE_IP:8081`)
+	assert.NotContains(t, notes, `  export NODE_PORT=`)
+}

--- a/charts/console/chart/templates/_chart.notes.tpl
+++ b/charts/console/chart/templates/_chart.notes.tpl
@@ -39,7 +39,7 @@
 {{- end -}}
 {{- if (contains "NodePort" (toString $values.service.type)) -}}
 {{- $commands = (concat (default (list) $commands) (list (printf `  export NODE_PORT=$(kubectl get --namespace %s -o jsonpath="{.spec.ports[0].nodePort}" services %s)` $dot.Release.Namespace (get (fromJson (include "chart.Fullname" (dict "a" (list $dot)))) "r")) (printf `  export NODE_IP=$(kubectl get nodes --namespace %s -o jsonpath="{.items[0].status.addresses[0].address}")` $dot.Release.Namespace) "  echo http://$NODE_IP:$NODE_PORT")) -}}
-{{- else -}}{{- if (contains "NodePort" (toString $values.service.type)) -}}
+{{- else -}}{{- if (contains "LoadBalancer" (toString $values.service.type)) -}}
 {{- $commands = (concat (default (list) $commands) (list `    NOTE: It may take a few minutes for the LoadBalancer IP to be available.` (printf `          You can watch the status of by running 'kubectl get --namespace %s svc -w %s'` $dot.Release.Namespace (get (fromJson (include "chart.Fullname" (dict "a" (list $dot)))) "r")) (printf `  export SERVICE_IP=$(kubectl get svc --namespace %s %s --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")` $dot.Release.Namespace (get (fromJson (include "chart.Fullname" (dict "a" (list $dot)))) "r")) (printf `  echo http://$SERVICE_IP:%d` ($values.service.port | int)))) -}}
 {{- else -}}{{- if (contains "ClusterIP" (toString $values.service.type)) -}}
 {{- $commands = (concat (default (list) $commands) (list (printf `  export POD_NAME=$(kubectl get pods --namespace %s -l "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s" -o jsonpath="{.items[0].metadata.name}")` $dot.Release.Namespace (get (fromJson (include "chart.Name" (dict "a" (list $dot)))) "r") $dot.Release.Name) (printf `  export CONTAINER_PORT=$(kubectl get pod --namespace %s $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")` $dot.Release.Namespace) `  echo "Visit http://127.0.0.1:8080 to use your application"` (printf `  kubectl --namespace %s port-forward $POD_NAME 8080:$CONTAINER_PORT` $dot.Release.Namespace))) -}}
@@ -51,4 +51,3 @@
 {{- break -}}
 {{- end -}}
 {{- end -}}
-


### PR DESCRIPTION
## Summary

Fix the Console chart NOTES service-type branching so `service.type=LoadBalancer` shows the intended LoadBalancer access instructions.

The current chart checks `NodePort` twice. The second branch contains LoadBalancer-specific guidance, including waiting for the external IP and reading `.status.loadBalancer.ingress`, but it is unreachable.

## Testing

- `go test ./charts/console/chart -run '^TestNotesForLoadBalancerService$' -count=1`
- `go test ./charts/console/chart -run '^(TestNotesForLoadBalancerService|TestChartYAML|TestValues)$' -count=1`
