### PR TITLE
charts/redpanda: drop the dead irqbalance pkill fallback

### DIFF
--- a/charts/redpanda/chart/templates/_statefulset.go.tpl
+++ b/charts/redpanda/chart/templates/_statefulset.go.tpl
@@ -308,7 +308,7 @@ chroot /host /bin/bash -c '
   fi
   busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
     org.freedesktop.systemd1.Manager TryRestartUnit ss "irqbalance.service" "replace" \
-    || nsenter -t 1 -p -m pkill -x irqbalance || true
+    || true
 '
 `) | toJson -}}
 {{- break -}}
@@ -325,9 +325,9 @@ chroot /host /bin/bash -c '
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $_701_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $state $pool "set-datadir-ownership")))) "r") -}}
-{{- $uid := ((index $_701_uid_gid 0) | int64) -}}
-{{- $gid := ((index $_701_uid_gid 1) | int64) -}}
+{{- $_709_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $state $pool "set-datadir-ownership")))) "r") -}}
+{{- $uid := ((index $_709_uid_gid 0) | int64) -}}
+{{- $gid := ((index $_709_uid_gid 1) | int64) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "set-datadir-ownership" "image" (printf "%s:%s" $pool.Statefulset.initContainerImage.repository $pool.Statefulset.initContainerImage.tag) "command" (list `/bin/sh` `-c` (printf `chown %d:%d -R /var/lib/redpanda/data` $uid $gid)) "securityContext" (mustMergeOverwrite (dict) (dict "runAsUser" (0 | int64) "runAsGroup" (0 | int64))) "volumeMounts" (concat (default (list) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $state)))) "r")) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" `datadir` "mountPath" `/var/lib/redpanda/data`))))))) | toJson -}}
 {{- break -}}
@@ -340,12 +340,12 @@ chroot /host /bin/bash -c '
 {{- $containerName := (index .a 2) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_727_gid_uid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $state.Values.podTemplate "redpanda")))) "r") -}}
-{{- $gid := (index $_727_gid_uid 0) -}}
-{{- $uid := (index $_727_gid_uid 1) -}}
-{{- $_728_sgid_suid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $pool.Statefulset.podTemplate "redpanda")))) "r") -}}
-{{- $sgid := (index $_728_sgid_suid 0) -}}
-{{- $suid := (index $_728_sgid_suid 1) -}}
+{{- $_735_gid_uid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $state.Values.podTemplate "redpanda")))) "r") -}}
+{{- $gid := (index $_735_gid_uid 0) -}}
+{{- $uid := (index $_735_gid_uid 1) -}}
+{{- $_736_sgid_suid := (get (fromJson (include "redpanda.giduidFromPodTemplate" (dict "a" (list $pool.Statefulset.podTemplate "redpanda")))) "r") -}}
+{{- $sgid := (index $_736_sgid_suid 0) -}}
+{{- $suid := (index $_736_sgid_suid 1) -}}
 {{- if (ne (toJson $sgid) "null") -}}
 {{- $gid = $sgid -}}
 {{- end -}}
@@ -422,9 +422,9 @@ chroot /host /bin/bash -c '
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $_807_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $state $pool "set-tiered-storage-cache-dir-ownership")))) "r") -}}
-{{- $uid := ((index $_807_uid_gid 0) | int64) -}}
-{{- $gid := ((index $_807_uid_gid 1) | int64) -}}
+{{- $_815_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $state $pool "set-tiered-storage-cache-dir-ownership")))) "r") -}}
+{{- $uid := ((index $_815_uid_gid 0) | int64) -}}
+{{- $gid := ((index $_815_uid_gid 1) | int64) -}}
 {{- $cacheDir := (get (fromJson (include "redpanda.Storage.TieredCacheDirectory" (dict "a" (list $state.Values.storage $state)))) "r") -}}
 {{- $mounts := (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $state)))) "r") -}}
 {{- $mounts = (concat (default (list) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" "datadir" "mountPath" "/var/lib/redpanda/data")))) -}}
@@ -585,9 +585,9 @@ chroot /host /bin/bash -c '
 {{- end -}}
 {{- $args = (concat (default (list) $args) (default (list) $pool.Statefulset.sideCars.args)) -}}
 {{- $volumeMounts := (concat (default (list) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $state)))) "r")) (list (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" "config" "mountPath" "/etc/redpanda")) (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" "base-config" "mountPath" "/tmp/base-config" "readOnly" true)) (mustMergeOverwrite (dict "name" "" "mountPath" "") (dict "name" "kube-api-access" "mountPath" "/var/run/secrets/kubernetes.io/serviceaccount" "readOnly" true)))) -}}
-{{- $_1224_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $state $pool "sidecar")))) "r") -}}
-{{- $uid := ((index $_1224_uid_gid 0) | int64) -}}
-{{- $gid := ((index $_1224_uid_gid 1) | int64) -}}
+{{- $_1232_uid_gid := (get (fromJson (include "redpanda.securityContextUidGid" (dict "a" (list $state $pool "sidecar")))) "r") -}}
+{{- $uid := ((index $_1232_uid_gid 0) | int64) -}}
+{{- $gid := ((index $_1232_uid_gid 1) | int64) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (mustMergeOverwrite (dict "name" "" "resources" (dict)) (dict "name" "sidecar" "image" (printf `%s:%s` $pool.Statefulset.sideCars.image.repository $pool.Statefulset.sideCars.image.tag) "command" (list `/redpanda-operator`) "args" (concat (default (list) (list `supervisor` `--`)) (default (list) $args)) "env" (concat (default (list) (get (fromJson (include "redpanda.rpkEnvVars" (dict "a" (list $state (coalesce nil))))) "r")) (default (list) (get (fromJson (include "redpanda.statefulSetRedpandaEnv" (dict "a" (list)))) "r"))) "volumeMounts" $volumeMounts "securityContext" (mustMergeOverwrite (dict) (dict "runAsUser" $uid "runAsGroup" $gid "runAsNonRoot" true "allowPrivilegeEscalation" false)) "readinessProbe" (mustMergeOverwrite (dict) (mustMergeOverwrite (dict) (dict "httpGet" (mustMergeOverwrite (dict "port" 0) (dict "path" "/healthz" "port" (8093 | int))))) (dict "failureThreshold" (3 | int) "initialDelaySeconds" (1 | int) "periodSeconds" (10 | int) "successThreshold" (1 | int) "timeoutSeconds" (0 | int)))))) | toJson -}}
 {{- break -}}

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -511,8 +511,8 @@ func statefulSetInitContainerTuning(state *RenderState) *corev1.Container {
 //     live in the file.
 //   - busctl call into the host's systemd to try-restart irqbalance
 //     after rpk rewrites IRQ affinity (systemctl can't traverse a
-//     chroot). Falls back to `nsenter -t 1 -p -m pkill` for non-systemd
-//     hosts.
+//     chroot). No non-systemd fallback — see HostTunerScript for why
+//     none can work without hostPID.
 //   - a `which` shim written into /opt/redpanda/bin (bind-mounted into
 //     the chroot, first on PATH): rpk's fstrim tuner shells out to
 //     `which`, and some minimal node images (AKS Ubuntu) ship a broken
@@ -646,10 +646,18 @@ func HostTunerStateVolumeMount() corev1.VolumeMount {
 //   - busctl TryRestartUnit into the host's systemd so a running
 //     irqbalance doesn't undo rpk's IRQ affinity work (systemctl can't
 //     traverse a chroot; TryRestartUnit, unlike RestartUnit, won't
-//     start an intentionally-stopped unit). Falls back to pkill inside
-//     the host's PID namespace via `nsenter -t 1 -p -m` — a bare pkill
-//     would read host PIDs from the bind-mounted /proc but issue
-//     kill(2) in the container's PID namespace, and always ESRCH.
+//     start an intentionally-stopped unit). This is deliberately the
+//     ONLY mechanism: there is no process-kill fallback for
+//     non-systemd hosts because none can work from here — kill(2)
+//     resolves PIDs in the caller's PID namespace (host PIDs read from
+//     the bind-mounted /proc always ESRCH), and setns(2) into the
+//     host's PID namespace is an ancestor of the container's, which
+//     the kernel rejects with EINVAL (setns(2): the target PID
+//     namespace must be a descendant of the caller's). Reaching host
+//     irqbalance on a non-systemd node would require hostPID on the
+//     whole pod, which is not worth it: every mainstream node image
+//     (COS, AL2023, Ubuntu, Bottlerocket) runs systemd, and on hosts
+//     without an irqbalance unit TryRestartUnit is a clean no-op.
 //   - a `which` shim in /opt/redpanda/bin for rpk's fstrim tuner, which
 //     shells out to `which` (missing/broken on minimal node images).
 //   - No --node-tuner-state-path: rpk's default state path
@@ -684,7 +692,7 @@ chroot /host /bin/bash -c '
   fi
   busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
     org.freedesktop.systemd1.Manager TryRestartUnit ss "irqbalance.service" "replace" \
-    || nsenter -t 1 -p -m pkill -x irqbalance || true
+    || true
 '
 `
 }

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -142579,7 +142579,7 @@ spec:
             fi
             busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
               org.freedesktop.systemd1.Manager TryRestartUnit ss "irqbalance.service" "replace" \
-              || nsenter -t 1 -p -m pkill -x irqbalance || true
+              || true
           '
         env: null
         image: docker.redpanda.com/redpandadata/redpanda:v26.1.1
@@ -144157,7 +144157,7 @@ spec:
             fi
             busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
               org.freedesktop.systemd1.Manager TryRestartUnit ss "irqbalance.service" "replace" \
-              || nsenter -t 1 -p -m pkill -x irqbalance || true
+              || true
           '
         env: null
         image: docker.redpanda.com/redpandadata/redpanda:v26.1.1

--- a/operator/multicluster/testdata/render-cases.pools.golden.txtar
+++ b/operator/multicluster/testdata/render-cases.pools.golden.txtar
@@ -6025,7 +6025,7 @@
               fi
               busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
                 org.freedesktop.systemd1.Manager TryRestartUnit ss "irqbalance.service" "replace" \
-                || nsenter -t 1 -p -m pkill -x irqbalance || true
+                || true
             '
           image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
           name: tuning


### PR DESCRIPTION
## Summary

Follow-up to #1522 (the commit was pushed to the branch minutes after the merge, so it missed the train — finding 4 from the [cross-cloud validation](https://github.com/redpanda-data/redpanda-operator/pull/1522#issuecomment-4920772444)).

Removes the `nsenter -t 1 -p -m pkill -x irqbalance` fallback from the host-tuner script rather than reordering it: **no process-kill fallback can work from the tuning container.** setns(2) only permits joining a PID namespace that is a *descendant* of (or equal to) the caller's; the host's PID namespace is an ancestor of the container's, so the kernel rejects it with EINVAL — observed verbatim on all three clouds in the validation run. A bare `pkill` is equally dead: kill(2) resolves PIDs in the caller's namespace, so host PIDs read from the bind-mounted `/proc` always ESRCH. A working fallback would require `hostPID: true` on the whole broker pod, which is not a reasonable trade.

`busctl TryRestartUnit` through the host's D-Bus socket is now the sole, documented mechanism. Every mainstream node image (COS, AL2023, Ubuntu, Bottlerocket) runs systemd, and on hosts without an irqbalance unit it's a clean no-op (also observed in validation). The script comment records the kernel rule so the fallback doesn't get re-suggested in future reviews.

No changelog: `apply_host_tuners` is still unreleased; #1522's entry remains accurate.

## Testing

- `go test ./charts/redpanda/ -run TestTemplate` and `go test ./operator/multicluster/` pass with regenerated goldens (script embedded in both renderers' output).
- The busctl-only path is exactly what ran in the [3-cloud StretchCluster validation](https://github.com/redpanda-data/redpanda-operator/pull/1522#issuecomment-4920772444): `tune all` rc=0 on every node, `TryRestartUnit` no-op'ing cleanly where no unit exists.
