### PR TITLE
operator: harden StretchCluster against silent misconfiguration

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260709-stretch-tls-disabled.yaml
+++ b/.changes/unreleased/operator-Fixed-20260709-stretch-tls-disabled.yaml
@@ -1,0 +1,15 @@
+project: operator
+kind: Fixed
+body: |-
+    RedpandaBrokerPool `tls.enabled: false` now disables TLS on the
+    defaulted external listeners too. Previously the rendered
+    redpanda.yaml kept `kafka_api_tls` / `admin_api_tls` /
+    `pandaproxy_api_tls` / `schema_registry_api_tls` entries pointing at
+    `/etc/tls/certs/external/*` (which nothing mounts when pool TLS is
+    off), and brokers crash-looped with "Could not read trust file"
+    unless every listener carried an explicit fully-shaped TLS-off
+    override. Additionally, `clusterRef.group` values containing a
+    version suffix (e.g. `cluster.redpanda.com/v1alpha2`) are now
+    rejected by CRD validation instead of silently never binding the
+    referencing object.
+time: 2026-07-09T09:05:00.000000-07:00

--- a/operator/api/redpanda/v1alpha2/common.go
+++ b/operator/api/redpanda/v1alpha2/common.go
@@ -316,6 +316,10 @@ type SchemaRegistrySASL struct {
 type ClusterRef struct {
 	// Group is used to override the object group that this reference points to.
 	// If unspecified, defaults to "cluster.redpanda.com".
+	// A bare API group only — controllers match it by string comparison, so a
+	// "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+	// silently match nothing and the referencing object would never bind.
+	// +kubebuilder:validation:XValidation:message="group must be a bare API group without a version suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)",rule="!self.contains('/')"
 	Group *string `json:"group,omitempty"`
 	// Kind is used to override the object kind that this reference points to.
 	// If unspecified, defaults to "Redpanda".

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -920,7 +920,10 @@ ClusterRef represents a reference to a cluster that is being targeted.
 |===
 | Field | Description | Default | Validation
 | *`group`* __string__ | Group is used to override the object group that this reference points to. +
-If unspecified, defaults to "cluster.redpanda.com". + |  | 
+If unspecified, defaults to "cluster.redpanda.com". +
+A bare API group only — controllers match it by string comparison, so a +
+"group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would +
+silently match nothing and the referencing object would never bind. + |  | 
 | *`kind`* __string__ | Kind is used to override the object kind that this reference points to. +
 If unspecified, defaults to "Redpanda". + |  | 
 | *`name`* __string__ | Name specifies the name of the cluster being referenced. + |  | Required: \{} +

--- a/operator/config/crd/bases/cluster.redpanda.com_brokers.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_brokers.yaml
@@ -68,7 +68,14 @@ spec:
                     description: |-
                       Group is used to override the object group that this reference points to.
                       If unspecified, defaults to "cluster.redpanda.com".
+                      A bare API group only — controllers match it by string comparison, so a
+                      "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                      silently match nothing and the referencing object would never bind.
                     type: string
+                    x-kubernetes-validations:
+                    - message: group must be a bare API group without a version suffix
+                        (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                      rule: '!self.contains(''/'')'
                   kind:
                     description: |-
                       Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_consoles.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_consoles.yaml
@@ -987,7 +987,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_groups.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_groups.yaml
@@ -212,7 +212,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_nodepools.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_nodepools.yaml
@@ -69,7 +69,14 @@ spec:
                     description: |-
                       Group is used to override the object group that this reference points to.
                       If unspecified, defaults to "cluster.redpanda.com".
+                      A bare API group only — controllers match it by string comparison, so a
+                      "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                      silently match nothing and the referencing object would never bind.
                     type: string
+                    x-kubernetes-validations:
+                    - message: group must be a bare API group without a version suffix
+                        (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                      rule: '!self.contains(''/'')'
                   kind:
                     description: |-
                       Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
@@ -82,7 +82,14 @@ spec:
                     description: |-
                       Group is used to override the object group that this reference points to.
                       If unspecified, defaults to "cluster.redpanda.com".
+                      A bare API group only — controllers match it by string comparison, so a
+                      "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                      silently match nothing and the referencing object would never bind.
                     type: string
+                    x-kubernetes-validations:
+                    - message: group must be a bare API group without a version suffix
+                        (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                      rule: '!self.contains(''/'')'
                   kind:
                     description: |-
                       Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandaroles.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandaroles.yaml
@@ -209,7 +209,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_schemas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_schemas.yaml
@@ -63,7 +63,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_shadowlinks.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_shadowlinks.yaml
@@ -195,7 +195,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.
@@ -2487,7 +2494,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_topics.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_topics.yaml
@@ -79,7 +79,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.
@@ -3621,7 +3628,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/config/crd/bases/cluster.redpanda.com_users.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_users.yaml
@@ -300,7 +300,14 @@ spec:
                         description: |-
                           Group is used to override the object group that this reference points to.
                           If unspecified, defaults to "cluster.redpanda.com".
+                          A bare API group only — controllers match it by string comparison, so a
+                          "group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would
+                          silently match nothing and the referencing object would never bind.
                         type: string
+                        x-kubernetes-validations:
+                        - message: group must be a bare API group without a version
+                            suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
+                          rule: '!self.contains(''/'')'
                       kind:
                         description: |-
                           Kind is used to override the object kind that this reference points to.

--- a/operator/multicluster/configmap_redpanda.go
+++ b/operator/multicluster/configmap_redpanda.go
@@ -159,7 +159,14 @@ func configureAPIListener(
 				entry["authentication_method"] = authMethod
 			}
 			listeners = append(listeners, entry)
-			if ext.TLS.GetCert() != "" {
+			// Mirror the internal-listener guard above: without the
+			// IsTLSEnabled check, the defaulted external listeners (which
+			// always carry cert name "external") emit *_api_tls entries
+			// even when the pool disables TLS — and because the
+			// certificate/volume side IS pool-TLS-gated
+			// (InUseServerCerts), the broker then crashloops reading
+			// /etc/tls/certs/external/* files that nothing mounts.
+			if ext.TLS.IsTLSEnabled(pool.Spec.TLS) && ext.TLS.GetCert() != "" {
 				tlsEntries = append(tlsEntries, listenerTLSEntry(pool, name, ext.TLS))
 			}
 		})

--- a/operator/multicluster/testdata/render-cases.pools.golden.txtar
+++ b/operator/multicluster/testdata/render-cases.pools.golden.txtar
@@ -15419,6 +15419,355 @@
   status:
     availableReplicas: 0
     replicas: 0
+-- tls-disabled --
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      cluster.redpanda.com/brokerpool-generation: "0"
+      cluster.redpanda.com/brokerpool-name: pool-a
+    name: tls-disabled-pool-a
+    namespace: tls-disabled
+  spec:
+    podManagementPolicy: Parallel
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/cluster-name: test
+        app.kubernetes.io/component: redpanda-pool-a-statefulset
+        app.kubernetes.io/instance: tls-disabled
+        app.kubernetes.io/name: redpanda
+    serviceName: tls-disabled
+    template:
+      metadata:
+        annotations:
+          config.redpanda.com/checksum: 67fde5e34061dbbdc117c18c14bd4e64ac947a95a1bd8cbfdc75a89e0d8c7fda
+        labels:
+          app.kubernetes.io/cluster-name: test
+          app.kubernetes.io/component: redpanda-pool-a-statefulset
+          app.kubernetes.io/instance: tls-disabled
+          app.kubernetes.io/managed-by: redpanda-operator
+          app.kubernetes.io/name: redpanda
+          cluster.redpanda.com/broker: "true"
+          redpanda.com/poddisruptionbudget: tls-disabled
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/cluster-name: test
+                  app.kubernetes.io/component: redpanda-pool-a-statefulset
+                  app.kubernetes.io/instance: tls-disabled
+                  app.kubernetes.io/name: redpanda
+              topologyKey: kubernetes.io/hostname
+        automountServiceAccountToken: false
+        containers:
+        - command:
+          - rpk
+          - redpanda
+          - start
+          - --advertise-rpc-addr=tls-disabled-pool-a-$(ORDINAL_NUMBER).tls-disabled:33145
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ORDINAL_NUMBER
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          - name: REDPANDA_METRICS_K8S_DEPLOYMENT_TYPE
+            value: operator
+          - name: REDPANDA_METRICS_K8S_CHART_VERSION
+            value: v99.9.9
+          - name: REDPANDA_METRICS_K8S_OPERATOR_IMAGE_VERSION
+            value: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                  post-start $(date): /" | tee /proc/1/fd/1; true'
+            preStop:
+              exec:
+                command:
+                - bash
+                - -c
+                - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                  pre-stop $(date): /" | tee /proc/1/fd/1; true'
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.tls-disabled.tls-disabled.svc.cluster.local.:9644/v1/status/ready"
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          name: redpanda
+          ports:
+          - containerPort: 9644
+            name: admin
+          - containerPort: 9645
+            name: admin-default
+          - containerPort: 8082
+            name: http
+          - containerPort: 8083
+            name: http-default
+          - containerPort: 9093
+            name: kafka
+          - containerPort: 9094
+            name: kafka-default
+          - containerPort: 33145
+            name: rpc
+          - containerPort: 8081
+            name: schemaregistry
+          - containerPort: 8084
+            name: schema-default
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2560Mi
+          startupProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                RESULT=$(curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.tls-disabled.tls-disabled.svc.cluster.local.:9644/v1/status/ready")
+                echo $RESULT
+                echo $RESULT | grep ready
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /var/lifecycle
+            name: lifecycle-scripts
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        - args:
+          - supervisor
+          - --
+          - /redpanda-operator
+          - sidecar
+          - --redpanda-yaml
+          - /etc/redpanda/redpanda.yaml
+          - --redpanda-cluster-namespace
+          - tls-disabled
+          - --redpanda-cluster-name
+          - tls-disabled
+          - --selector=app.kubernetes.io/name=redpanda,app.kubernetes.io/instance=tls-disabled
+          - --run-broker-probe
+          - --broker-probe-broker-url
+          - $(SERVICE_NAME).tls-disabled.tls-disabled.svc.cluster.local.:9644
+          command:
+          - /redpanda-operator
+          env:
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: ORDINAL_NUMBER
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          name: sidecar
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        initContainers:
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          name: tuning
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - SYS_RESOURCE
+            privileged: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/redpanda
+            name: base-config
+          - mountPath: /var/lib/redpanda/data
+            name: datadir
+        - command:
+          - /bin/bash
+          - -c
+          - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+            & wait $!
+          env:
+          - name: CONFIGURATOR_SCRIPT
+            value: /etc/secrets/configurator/scripts/configurator.sh
+          - name: SERVICE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: docker.redpanda.com/redpandadata/redpanda:v99.9.9
+          name: redpanda-configurator
+          resources: {}
+          volumeMounts:
+          - mountPath: /etc/redpanda
+            name: config
+          - mountPath: /tmp/base-config
+            name: base-config
+          - mountPath: /etc/secrets/configurator/scripts/
+            name: tls-disabled-pool-a-configurator
+        - command:
+          - /redpanda-operator
+          - bootstrap
+          - --in-dir
+          - /tmp/base-config
+          - --out-dir
+          - /tmp/config
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v99.9.9
+          name: bootstrap-yaml-envsubst
+          resources:
+            limits:
+              cpu: 100m
+              memory: 125Mi
+            requests:
+              cpu: 100m
+              memory: 125Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /tmp/config/
+            name: config
+          - mountPath: /tmp/base-config/
+            name: base-config
+        securityContext:
+          fsGroup: 101
+          fsGroupChangePolicy: OnRootMismatch
+          runAsUser: 101
+        serviceAccountName: tls-disabled-pool-a
+        terminationGracePeriodSeconds: 90
+        topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/cluster-name: test
+              app.kubernetes.io/component: redpanda-pool-a-statefulset
+              app.kubernetes.io/instance: tls-disabled
+              app.kubernetes.io/name: redpanda
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+        volumes:
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: tls-disabled-pool-a-sts-lifecycle
+        - configMap:
+            name: tls-disabled-pool-a
+          name: base-config
+        - emptyDir: {}
+          name: config
+        - name: tls-disabled-pool-a-configurator
+          secret:
+            defaultMode: 509
+            secretName: tls-disabled-pool-a-configurator
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+    updateStrategy:
+      type: OnDelete
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: redpanda
+          app.kubernetes.io/instance: tls-disabled
+          app.kubernetes.io/name: redpanda
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+      status: {}
+  status:
+    availableReplicas: 0
+    replicas: 0
 -- tls-issuer-ref --
 - apiVersion: apps/v1
   kind: StatefulSet

--- a/operator/multicluster/testdata/render-cases.resources.golden.txtar
+++ b/operator/multicluster/testdata/render-cases.resources.golden.txtar
@@ -31010,6 +31010,610 @@
     type: ClusterIP
   status:
     loadBalancer: {}
+-- tls-disabled --
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-external
+    namespace: tls-disabled
+  spec:
+    externalTrafficPolicy: Local
+    ports:
+    - name: admin-default
+      nodePort: 31644
+      port: 9645
+      protocol: TCP
+      targetPort: 0
+    - name: kafka-default
+      nodePort: 31092
+      port: 9094
+      protocol: TCP
+      targetPort: 0
+    - name: http-default
+      nodePort: 30082
+      port: 8083
+      protocol: TCP
+      targetPort: 0
+    - name: schema-default
+      nodePort: 30081
+      port: 8084
+      protocol: TCP
+      targetPort: 0
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/name: redpanda
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled
+    namespace: tls-disabled
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/cluster-name: test
+        app.kubernetes.io/instance: tls-disabled
+        app.kubernetes.io/name: redpanda
+        redpanda.com/poddisruptionbudget: tls-disabled
+  status:
+    currentHealthy: 0
+    desiredHealthy: 0
+    disruptionsAllowed: 0
+    expectedPods: 0
+- apiVersion: v1
+  automountServiceAccountToken: false
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a
+    namespace: tls-disabled
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: tls-disabled
+    namespace: tls-disabled
+  spec:
+    clusterIP: None
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/name: redpanda
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  data:
+    .bootstrap.json.in: '{"audit_enabled":"false","cloud_storage_cache_size":"5368709120","cloud_storage_enable_remote_read":"true","cloud_storage_enable_remote_write":"true","cloud_storage_enabled":"false","compacted_log_segment_size":"67108864","default_topic_replications":"3","enable_rack_awareness":"false","enable_sasl":"false","kafka_connection_rate_limit":"1000","kafka_enable_authorization":"false","log_segment_size_max":"268435456","log_segment_size_min":"16777216","max_compacted_log_segment_size":"536870912","storage_min_free_bytes":"1073741824"}'
+    bootstrap.yaml.fixups: '[]'
+    redpanda.yaml: |-
+      config_file: /etc/redpanda/redpanda.yaml
+      pandaproxy:
+        pandaproxy_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8082
+        - address: 0.0.0.0
+          name: default
+          port: 8083
+      pandaproxy_client:
+        brokers:
+        - address: tls-disabled-pool-a-0.tls-disabled
+          port: 9093
+        - address: tls-disabled-pool-a-1.tls-disabled
+          port: 9093
+        - address: tls-disabled-pool-a-2.tls-disabled
+          port: 9093
+      redpanda:
+        admin:
+        - address: 0.0.0.0
+          name: internal
+          port: 9644
+        - address: 0.0.0.0
+          name: default
+          port: 9645
+        crash_loop_limit: 5
+        empty_seed_starts_cluster: false
+        kafka_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 9093
+        - address: 0.0.0.0
+          name: default
+          port: 9094
+        rpc_server:
+          address: 0.0.0.0
+          port: 33145
+        seed_servers:
+        - host:
+            address: tls-disabled-pool-a-0.default
+            port: 33145
+        - host:
+            address: tls-disabled-pool-a-1.default
+            port: 33145
+        - host:
+            address: tls-disabled-pool-a-2.default
+            port: 33145
+      rpk:
+        additional_start_flags:
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
+        admin_api:
+          addresses:
+          - tls-disabled-pool-a-0.tls-disabled:9644
+          - tls-disabled-pool-a-1.tls-disabled:9644
+          - tls-disabled-pool-a-2.tls-disabled:9644
+          tls: null
+        enable_memory_locking: false
+        kafka_api:
+          brokers:
+          - tls-disabled-pool-a-0.tls-disabled:9093
+          - tls-disabled-pool-a-1.tls-disabled:9093
+          - tls-disabled-pool-a-2.tls-disabled:9093
+          tls: null
+        overprovisioned: false
+        schema_registry:
+          addresses:
+          - tls-disabled-pool-a-0.tls-disabled:8081
+          - tls-disabled-pool-a-1.tls-disabled:8081
+          - tls-disabled-pool-a-2.tls-disabled:8081
+          tls: null
+        tune_aio_events: true
+      schema_registry:
+        schema_registry_api:
+        - address: 0.0.0.0
+          name: internal
+          port: 8081
+        - address: 0.0.0.0
+          name: default
+          port: 8084
+      schema_registry_client:
+        brokers:
+        - address: tls-disabled-pool-a-0.tls-disabled
+          port: 9093
+        - address: tls-disabled-pool-a-1.tls-disabled
+          port: 9093
+        - address: tls-disabled-pool-a-2.tls-disabled
+          port: 9093
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a
+    namespace: tls-disabled
+- apiVersion: v1
+  data:
+    profile: |-
+      admin_api:
+        addresses: []
+        tls: null
+      kafka_api:
+        brokers: []
+        tls: null
+      name: default
+      schema_registry:
+        addresses: []
+        tls: null
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-rpk
+    namespace: tls-disabled
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-sidecar
+    namespace: tls-disabled
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-tls-disabled-metrics-reader
+  rules:
+  - nonResourceURLs:
+    - /metrics
+    verbs:
+    - get
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-sidecar
+    namespace: tls-disabled
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: tls-disabled-pool-a-sidecar
+  subjects:
+  - kind: ServiceAccount
+    name: tls-disabled-pool-a
+    namespace: tls-disabled
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-tls-disabled-metrics-reader
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tls-disabled-pool-a-tls-disabled-metrics-reader
+  subjects:
+  - kind: ServiceAccount
+    name: tls-disabled-pool-a
+    namespace: tls-disabled
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-sts-lifecycle
+    namespace: tls-disabled
+  stringData:
+    common.sh: |-
+      #!/usr/bin/env bash
+
+      # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+      CURL_URL="http://${SERVICE_NAME}.tls-disabled.tls-disabled.svc.cluster.local:9644"
+
+      # commands used throughout
+      CURL_NODE_ID_CMD="curl --silent --fail  ${CURL_URL}/v1/node_config"
+
+      CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+      CURL_MAINTENANCE_GET_CMD="curl -X GET --silent  ${CURL_URL}/v1/maintenance"
+    postStart.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      postStartHook () {
+        set -x
+
+        touch /tmp/postStartHookStarted
+
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Clearing maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        # a 400 here would mean not in maintenance mode
+        until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+            status=$(${CURL_MAINTENANCE_DELETE_CMD})
+            sleep 0.5
+        done
+
+        touch /tmp/postStartHookFinished
+      }
+
+      postStartHook
+      true
+    preStop.sh: |-
+      #!/usr/bin/env bash
+      # This code should be similar if not exactly the same as that found in the panda-operator, see
+      # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+      touch /tmp/preStopHookStarted
+
+      # path below should match the path defined on the statefulset
+      source /var/lifecycle/common.sh
+
+      set -x
+
+      preStopHook () {
+        until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+            sleep 0.5
+        done
+
+        echo "Setting maintenance mode on node ${NODE_ID}"
+        CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+        until [ "${status:-}" = '"200"' ]; do
+            status=$(${CURL_MAINTENANCE_PUT_CMD})
+            sleep 0.5
+        done
+
+        until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+            res=$(${CURL_MAINTENANCE_GET_CMD})
+            finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+            draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+            sleep 0.5
+        done
+
+        touch /tmp/preStopHookFinished
+      }
+      preStopHook
+      true
+  type: Opaque
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+    name: tls-disabled-pool-a-configurator
+    namespace: tls-disabled
+  stringData:
+    configurator.sh: |-
+      set -xe
+      SERVICE_NAME=$1
+      KUBERNETES_NODE_NAME=$2
+      POD_ORDINAL=${SERVICE_NAME##*-}
+
+      CONFIG=/etc/redpanda/redpanda.yaml
+
+      # Setup config files
+      cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+      LISTENER="{\"address\":\"tls-disabled-pool-a-${POD_ORDINAL}.tls-disabled\",\"name\":\"internal\",\"port\":9093}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}"
+      rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "$LISTENER"
+
+      LISTENER="{\"address\":\"tls-disabled-pool-a-${POD_ORDINAL}.tls-disabled\",\"name\":\"internal\",\"port\":8082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+      LISTENER="{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}"
+      rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "$LISTENER"
+  type: Opaque
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: tls-disabled-pool-a-0
+    namespace: tls-disabled
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "0"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: tls-disabled-pool-a-1
+    namespace: tls-disabled
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "1"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/managed-by: redpanda-operator
+      app.kubernetes.io/name: redpanda
+      monitoring.redpanda.com/enabled: "false"
+    name: tls-disabled-pool-a-2
+    namespace: tls-disabled
+  spec:
+    ipFamilyPolicy: SingleStack
+    ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: http
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: rpc
+      port: 33145
+      protocol: TCP
+      targetPort: 33145
+    - name: schemaregistry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    publishNotReadyAddresses: true
+    selector:
+      app.kubernetes.io/cluster-name: test
+      app.kubernetes.io/component: redpanda-pool-a-statefulset
+      app.kubernetes.io/instance: tls-disabled
+      app.kubernetes.io/name: redpanda
+      apps.kubernetes.io/pod-index: "2"
+    type: ClusterIP
+  status:
+    loadBalancer: {}
 -- tls-issuer-ref --
 - apiVersion: v1
   kind: Service

--- a/operator/multicluster/testdata/render-cases.txtar
+++ b/operator/multicluster/testdata/render-cases.txtar
@@ -1381,3 +1381,23 @@ spec:
     kind: StretchCluster
     name: cluster
   replicas: 3
+-- tls-disabled --
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: StretchCluster
+metadata:
+  name: cluster
+  namespace: default
+---
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: RedpandaBrokerPool
+metadata:
+  name: pool-a
+  namespace: default
+spec:
+  clusterRef:
+    group: cluster.redpanda.com
+    kind: StretchCluster
+    name: cluster
+  replicas: 3
+  tls:
+    enabled: false


### PR DESCRIPTION
## Summary

Findings 2 and 3 from the PR #1522 [cross-cloud validation](https://github.com/redpanda-data/redpanda-operator/pull/1522#issuecomment-4920772444) — two failure modes where a plausible StretchCluster manifest produces a broken or absent cluster with no signal at apply time.

### 1. Pool `tls.enabled: false` didn't reach the defaulted external listeners

`configureAPIListener` guards the *internal* listener's TLS entry with `IsTLSEnabled(pool.Spec.TLS)`, but appended *external* `*_api_tls` entries whenever a cert name was set — and `mergeDefaultExternalListener` always sets cert `external`. The certificate/volume side **is** pool-TLS-gated (`InUseServerCerts`), so the rendered config referenced `/etc/tls/certs/external/*` files nothing mounts, and brokers crash-looped:

```
Failure during startup: ... Could not read trust file /etc/tls/certs/external/ca.crt
```

The only workaround was a fully-shaped explicit TLS-off override on every listener (observed live in the validation run; the migrated-API variant of the caveat the cross-cloud template README documents for the old API). The external branch now mirrors the internal guard. **TLS-enabled rendering is byte-identical** — the golden diff is purely the new `tls-disabled` case, which now renders zero `*_api_tls` entries, zero external cert paths, and zero Certificates.

### 2. `clusterRef.group` with a version suffix silently never binds

`cluster.redpanda.com/v1alpha2` passes CRD validation, but `IsStretchCluster()` matches the group by string comparison — the pool is invisible to the controller and the StretchCluster reports `Cluster has no desired brokers` forever. A CEL rule on the shared `ClusterRef.Group` now rejects any value containing `/`:

```
group must be a bare API group without a version suffix (e.g. cluster.redpanda.com, not cluster.redpanda.com/v1alpha2)
```

This regenerates every CRD embedding `ClusterRef` (brokers, consoles, groups, nodepools, redpandabrokerpools, redpandaroles, schemas, shadowlinks, topics, users). Purely additive validation; existing valid objects are unaffected.

## Testing

- New `tls-disabled` render case + goldens: listeners render, no TLS stanzas, no Certificates. Golden diff is pure addition — no existing case's output changed.
- `go test ./operator/multicluster/ ./operator/api/...` pass; `task generate` zero drift; `golangci-lint` clean.
- Both failure modes were reproduced live on the 3-cloud validation cluster (the second one cost a debugging round-trip precisely because nothing surfaced it).

Draft: both fixes verified by render tests; wants a maintainer sanity-check on the CEL rule's blast radius (all ClusterRef-embedding CRDs) before review.
