### PR TITLE
operator: make User password.valueFrom optional so value-only works

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260709-user-password-value.yaml
+++ b/.changes/unreleased/operator-Fixed-20260709-user-password-value.yaml
@@ -1,0 +1,10 @@
+project: operator
+kind: Fixed
+body: |-
+    The User CRD now accepts `spec.authentication.password.value` on its
+    own, as documented. The schema previously marked
+    `password.valueFrom` as unconditionally required, so the structural
+    check rejected value-only manifests before the either/or validation
+    rule could run. Providing neither `value` nor `valueFrom` is still
+    rejected, now with the rule's own message.
+time: 2026-07-09T09:35:00.000000-07:00

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -2764,7 +2764,12 @@ Password specifies a password for the user.
 | Field | Description | Default | Validation
 | *`value`* __string__ | Value is a hardcoded value to use for the given password. It should only be used for testing purposes. +
 In production, use ValueFrom. + |  | 
-| *`valueFrom`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-passwordsource[$$PasswordSource$$]__ | ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials. + |  | 
+| *`valueFrom`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-passwordsource[$$PasswordSource$$]__ | ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials. +
+Optional when value is set: the type-level validation rule enforces +
+that at least one of the two is present. (This field being marked +
+required in the schema used to make the documented value-only form +
+impossible to apply — https://github.com/redpanda-data/redpanda-operator/issues/1290.) + |  | Optional: \{} +
+
 | *`noGenerate`* __boolean__ | NoGenerate when set to true does not create kubernetes secret when ValueFrom points to none-existent secret. + |  | 
 |===
 

--- a/operator/api/redpanda/v1alpha2/user_types.go
+++ b/operator/api/redpanda/v1alpha2/user_types.go
@@ -156,13 +156,18 @@ type UserAuthenticationSpec struct {
 }
 
 // Password specifies a password for the user.
-// +kubebuilder:validation:XValidation:message="valueFrom must not be empty if no value supplied",rule=`self.value != "" || has(self.valueFrom)`
+// +kubebuilder:validation:XValidation:message="valueFrom must not be empty if no value supplied",rule=`(has(self.value) && self.value != "") || has(self.valueFrom)`
 type Password struct {
 	// Value is a hardcoded value to use for the given password. It should only be used for testing purposes.
 	// In production, use ValueFrom.
 	Value string `json:"value,omitempty"`
 	// ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials.
-	ValueFrom *PasswordSource `json:"valueFrom"`
+	// Optional when value is set: the type-level validation rule enforces
+	// that at least one of the two is present. (This field being marked
+	// required in the schema used to make the documented value-only form
+	// impossible to apply — https://github.com/redpanda-data/redpanda-operator/issues/1290.)
+	// +optional
+	ValueFrom *PasswordSource `json:"valueFrom,omitempty"`
 	// NoGenerate when set to true does not create kubernetes secret when ValueFrom points to none-existent secret.
 	NoGenerate bool `json:"noGenerate,omitempty"`
 }
@@ -171,6 +176,13 @@ type Password struct {
 func (p *Password) Fetch(ctx context.Context, c client.Client, namespace string) (string, error) {
 	if p.Value != "" {
 		return p.Value, nil
+	}
+
+	// The CRD's validation rule guarantees value or valueFrom is set on
+	// admitted objects; guard anyway for hand-constructed values now that
+	// valueFrom is optional in the schema.
+	if p.ValueFrom == nil || p.ValueFrom.SecretKeyRef == nil {
+		return "", errors.New("password has neither a value nor a valueFrom.secretKeyRef")
 	}
 
 	name := p.ValueFrom.SecretKeyRef.LocalObjectReference.Name

--- a/operator/api/redpanda/v1alpha2/user_types_test.go
+++ b/operator/api/redpanda/v1alpha2/user_types_test.go
@@ -225,7 +225,7 @@ func TestUserValidation(t *testing.T) {
 			mutate: func(user *User) {
 				user.Spec.Authentication = &UserAuthenticationSpec{}
 			},
-			errors: []string{`spec.authentication.password.valueFrom: Required value`},
+			errors: []string{`spec.authentication.password: Invalid value`, `valueFrom must not be empty if no value supplied`},
 		},
 		"authentication - no secret key ref": {
 			mutate: func(user *User) {

--- a/operator/config/crd/bases/cluster.redpanda.com_users.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_users.yaml
@@ -70,8 +70,12 @@ spec:
                           In production, use ValueFrom.
                         type: string
                       valueFrom:
-                        description: ValueFrom specifies a source for a password to
-                          be fetched from when specifying or generating user credentials.
+                        description: |-
+                          ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials.
+                          Optional when value is set: the type-level validation rule enforces
+                          that at least one of the two is present. (This field being marked
+                          required in the schema used to make the documented value-only form
+                          impossible to apply — https://github.com/redpanda-data/redpanda-operator/issues/1290.)
                         properties:
                           secretKeyRef:
                             description: |-
@@ -104,12 +108,10 @@ spec:
                         required:
                         - secretKeyRef
                         type: object
-                    required:
-                    - valueFrom
                     type: object
                     x-kubernetes-validations:
                     - message: valueFrom must not be empty if no value supplied
-                      rule: self.value != "" || has(self.valueFrom)
+                      rule: (has(self.value) && self.value != "") || has(self.valueFrom)
                   syncCredentials:
                     description: |-
                       SyncCredentials when set to true causes the operator to re-read the

--- a/operator/internal/controller/redpanda/user_controller_test.go
+++ b/operator/internal/controller/redpanda/user_controller_test.go
@@ -23,12 +23,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
 )
 
 // TestUserAdoptExisting verifies that a User CR applied for an already-existing
@@ -651,4 +653,60 @@ func TestUserReconcile(t *testing.T) { // nolint:funlen // These tests have clea
 			require.True(t, apierrors.IsNotFound(k8sClient.Get(ctx, key, user)))
 		})
 	}
+}
+
+// TestUserPasswordSchemaValidation verifies the CRD-level contract of
+// spec.authentication.password: providing only `value` must be admitted, and
+// providing neither `value` nor `valueFrom` must be rejected by the type's
+// validation rule. The schema used to mark valueFrom as unconditionally
+// required, which made the documented value-only form impossible to apply
+// (the structural check fired before the either/or rule could run).
+// Regression test for
+// https://github.com/redpanda-data/redpanda-operator/issues/1290.
+func TestUserPasswordSchemaValidation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	testEnv := testutils.RedpandaTestEnv{}
+	cfg, err := testEnv.StartRedpandaTestEnv(false)
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	user := func(name string, password redpandav1alpha2.Password) *redpandav1alpha2.User {
+		return &redpandav1alpha2.User{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: redpandav1alpha2.UserSpec{
+				ClusterSource: &redpandav1alpha2.ClusterSource{
+					ClusterRef: &redpandav1alpha2.ClusterRef{Name: "redpanda"},
+				},
+				Authentication: &redpandav1alpha2.UserAuthenticationSpec{
+					Password: password,
+				},
+			},
+		}
+	}
+
+	// The documented value-only form is admitted.
+	require.NoError(t, c.Create(ctx, user("value-only", redpandav1alpha2.Password{
+		Value: "value-only-password",
+	})))
+
+	// valueFrom-only (the common production form) still works.
+	require.NoError(t, c.Create(ctx, user("valuefrom-only", redpandav1alpha2.Password{
+		ValueFrom: &redpandav1alpha2.PasswordSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "some-secret"},
+			},
+		},
+	})))
+
+	// Neither is rejected by the either/or rule with its message, not a
+	// structural-schema error.
+	err = c.Create(ctx, user("neither", redpandav1alpha2.Password{}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "valueFrom must not be empty if no value supplied")
 }


### PR DESCRIPTION
## Summary

Fixes #1290.

The [docs](https://docs.redpanda.com/current/manage/kubernetes/security/authentication/k-user-controller/#manage-user-secrets) describe two ways to provide a User password — a direct `spec.authentication.password.value`, or a Secret via `valueFrom.secretKeyRef` — but the value-only form was impossible to apply: `Password.ValueFrom` had no `omitempty`/`+optional`, so controller-gen marked it **required** in the OpenAPI schema, and structural validation rejected the manifest before the type's either/or CEL rule (which was written to permit exactly this) ever ran. That's the reported error verbatim:

```
* spec.authentication.password.valueFrom: Required value
* <nil>: Invalid value: null: some validation rules were not checked because the object was invalid
```

The reconcile path has always supported value-only (`getExistingPassword` returns `password.value` when `valueFrom` is nil) — only the schema forbade it.

## What changes

- `Password.ValueFrom` is `+optional` with `omitempty`; the users CRD no longer lists it under `required`.
- The either/or CEL rule gains a `has()` guard (`(has(self.value) && self.value != "") || has(self.valueFrom)`) so the neither-field case now fails with the rule's own message — previously that combination was unreachable, and without the guard it would have surfaced as a CEL evaluation error rather than the intended message.
- `Password.Fetch` gains a nil guard for hand-constructed values now that the schema permits nil `ValueFrom` (admitted objects are already protected by the rule).
- Generated: users CRD, crd-docs.

## Testing

- New `TestUserPasswordSchemaValidation` (envtest against the repo's embedded CRDs) asserts all three quadrants: **value-only admitted** (the #1290 repro — fails before this change with `valueFrom: Required value`), valueFrom-only admitted, neither rejected with `valueFrom must not be empty if no value supplied`.
- `go test ./operator/pkg/client/users/` (testcontainers, real Redpanda) passes — the package consuming `Password` end to end.
- `task generate` zero drift; `golangci-lint` clean.

Note for reviewers: `value` remains documented as testing-only; production guidance stays `valueFrom`. Existing manifests are unaffected — this only widens what is accepted.
