### PR TITLE
operator: honor --enable-shadowlinks and cover V1 (vectorized) sources

### DIFF
--- a/operator/chart/deployment.go
+++ b/operator/chart/deployment.go
@@ -369,6 +369,19 @@ func operatorArguments(dot *helmette.Dot) []string {
 	addLicenseFilePathArg(defaults, values)
 	addControllerSyncIntervalArgs(defaults, values)
 
+	// The operator only registers the ShadowLink controller when
+	// --enable-shadowlinks is set, and that controller requires the
+	// ShadowLink CRD. When this chart manages the CRDs it installs that CRD
+	// (it is in the stable set), so enable the controller to match:
+	// otherwise upgrading a release holding live ShadowLink CRs would
+	// silently stop reconciling them, and deletion would hang on the
+	// controller-managed finalizer. Installs that manage CRDs out-of-band
+	// keep the operator's opt-in default; AdditionalCmdFlags overrides both
+	// directions (userProvided wins on merge).
+	if values.CRDs.Enabled {
+		defaults["--enable-shadowlinks"] = "true"
+	}
+
 	if values.Webhook.Enabled {
 		defaults["--webhook-cert-path"] = webhookCertificatePath
 	}

--- a/operator/chart/deployment_test.go
+++ b/operator/chart/deployment_test.go
@@ -112,6 +112,37 @@ func TestAddControllerSyncIntervalArgs(t *testing.T) {
 	})
 }
 
+// TestEnableShadowLinksFlag covers the crds.enabled -> --enable-shadowlinks
+// coupling: when this chart installs the (stable) ShadowLink CRD it must also
+// keep the ShadowLink controller registered, or upgrading a release holding
+// live ShadowLink CRs would silently stop their reconciliation and deletion
+// would hang on the controller-managed finalizer. Installs that manage CRDs
+// out-of-band keep the operator's opt-in default, and additionalCmdFlags wins
+// over the chart-rendered default in both directions.
+func TestEnableShadowLinksFlag(t *testing.T) {
+	t.Run("default render omits the flag", func(t *testing.T) {
+		spec := renderDeployment(t, nil).Spec.Template.Spec
+		for _, arg := range spec.Containers[0].Args {
+			assert.NotContains(t, arg, "--enable-shadowlinks")
+		}
+	})
+
+	t.Run("crds.enabled renders --enable-shadowlinks=true", func(t *testing.T) {
+		spec := renderDeployment(t, map[string]any{
+			"crds": map[string]any{"enabled": true},
+		}).Spec.Template.Spec
+		assert.Contains(t, spec.Containers[0].Args, "--enable-shadowlinks=true")
+	})
+
+	t.Run("additionalCmdFlags wins over the crds.enabled default", func(t *testing.T) {
+		spec := renderDeployment(t, map[string]any{
+			"crds":               map[string]any{"enabled": true},
+			"additionalCmdFlags": []string{"--enable-shadowlinks=false"},
+		}).Spec.Template.Spec
+		assert.Contains(t, spec.Containers[0].Args, "--enable-shadowlinks=false")
+	})
+}
+
 func TestChangeDefaultFlag(t *testing.T) {
 	t.Run("change default enable console flag", func(t *testing.T) {
 		spec := renderDeployment(t, map[string]any{

--- a/operator/chart/templates/_deployment.go.tpl
+++ b/operator/chart/templates/_deployment.go.tpl
@@ -176,6 +176,9 @@
 {{- $defaults := (dict "--health-probe-bind-address" ":8081" "--metrics-bind-address" ":8443" "--leader-elect" "" "--enable-console" "true" "--log-level" $values.logLevel "--webhook-enabled" (printf "%t" $values.webhook.enabled) "--configurator-tag" (get (fromJson (include "operator.containerTag" (dict "a" (list $dot)))) "r") "--configurator-base-image" $values.image.repository "--enable-vectorized-controllers" (printf "%t" $values.vectorizedControllers.enabled)) -}}
 {{- $_ := (get (fromJson (include "operator.addLicenseFilePathArg" (dict "a" (list $defaults $values)))) "r") -}}
 {{- $_ := (get (fromJson (include "operator.addControllerSyncIntervalArgs" (dict "a" (list $defaults $values)))) "r") -}}
+{{- if $values.crds.enabled -}}
+{{- $_ := (set $defaults "--enable-shadowlinks" "true") -}}
+{{- end -}}
 {{- if $values.webhook.enabled -}}
 {{- $_ := (set $defaults "--webhook-cert-path" "/tmp/k8s-webhook-server/serving-certs") -}}
 {{- end -}}

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -5914,6 +5914,7 @@ spec:
         - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
         - --configurator-tag=v26.2.1-beta.3
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=true
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -9463,6 +9464,7 @@ spec:
         - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
         - --configurator-tag=v26.2.1-beta.3
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -11213,6 +11215,7 @@ spec:
         - --configurator-base-image=Fd0
         - --configurator-tag=cOgp6ac
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -48344,6 +48347,7 @@ spec:
         - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
         - --configurator-tag=v26.2.1-beta.3
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=true
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -49707,6 +49711,7 @@ spec:
         - --configurator-base-image=h6rx
         - --configurator-tag=yXNMX
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -51236,6 +51241,7 @@ spec:
         - --configurator-base-image
         - --configurator-tag=vO
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -53023,6 +53029,7 @@ spec:
         - --configurator-base-image=HJ
         - --configurator-tag=0ORIQruw
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -55217,6 +55224,7 @@ spec:
         - --configurator-base-image=JoEOn0Quud0uJ
         - --configurator-tag=Jzj6fJDqK
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -57176,6 +57184,7 @@ spec:
         - --configurator-base-image
         - --configurator-tag=9dFbDt
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -65903,6 +65912,7 @@ spec:
         - --configurator-base-image=95JHcsXy
         - --configurator-tag=YVZ
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -68283,6 +68293,7 @@ spec:
         - --configurator-base-image=gkRs29P
         - --configurator-tag=kgK
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -72268,6 +72279,7 @@ spec:
         - --configurator-base-image=FlBYj
         - --configurator-tag=fS
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -73801,6 +73813,7 @@ spec:
         - --configurator-base-image=Iedc3BYXQ
         - --configurator-tag=UoBs
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=true
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -78536,6 +78549,7 @@ spec:
         - --configurator-base-image=mLw
         - --configurator-tag=5QaeLH
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=true
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -80884,6 +80898,7 @@ spec:
         - --configurator-base-image=ZuVTlT
         - --configurator-tag=J
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect
@@ -86252,6 +86267,7 @@ spec:
         - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
         - --configurator-tag=v26.2.1-beta.3
         - --enable-console=true
+        - --enable-shadowlinks=true
         - --enable-vectorized-controllers=false
         - --health-probe-bind-address=:8081
         - --leader-elect

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -98,6 +98,12 @@ type RunOptions struct {
 	// a different set of cluster CRDs.
 	enableRedpandaControllers bool
 
+	// enableShadowLinks controls whether the ShadowLink controller is
+	// registered. It works in both operator modes: links may reference V1
+	// (vectorized Cluster) or V2 (Redpanda) clusters. Deployments must
+	// install the experimental ShadowLink CRD before enabling this.
+	enableShadowLinks bool
+
 	enableV2NodepoolController  bool
 	enableBrokerController      bool
 	enableConsoleController     bool
@@ -241,7 +247,7 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("force-defluxed-mode", false, "A deprecated and unused flag")
 	cmd.Flags().Bool("allow-pvc-deletion", false, "Deprecated: Ignored if specified")
 	cmd.Flags().Bool("operator-mode", true, "A deprecated and unused flag")
-	cmd.Flags().Bool("enable-shadowlinks", false, "Specifies whether or not to enabled the shadow links controller")
+	cmd.Flags().BoolVar(&o.enableShadowLinks, "enable-shadowlinks", false, "Specifies whether or not to enable the shadow links controller")
 }
 
 func (o *RunOptions) ControllerEnabled(controller Controller) bool {
@@ -540,9 +546,16 @@ func Run(
 		}
 	}
 
-	if err := redpandacontrollers.SetupShadowLinkController(ctx, mcmanager, cloudExpander, v1Controllers, v2Controllers, opts.namespace, opts.shadowLinkSyncInterval); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ShadowLink")
-		return err
+	// The ShadowLink controller is opt-in: it requires the experimental
+	// ShadowLink CRD, which not every deployment installs. It runs in both
+	// operator modes — cloud (V1 mode: --enable-vectorized-controllers with
+	// the Redpanda controllers off) uses it for links between BYOC clusters
+	// and for replicating from external sources such as Confluent.
+	if opts.enableShadowLinks {
+		if err := redpandacontrollers.SetupShadowLinkController(ctx, mcmanager, cloudExpander, v1Controllers, v2Controllers, opts.namespace, opts.shadowLinkSyncInterval); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ShadowLink")
+			return err
+		}
 	}
 
 	if err := redpandacontrollers.SetupTopicController(ctx, mcmanager, cloudExpander, v1Controllers, v2Controllers, opts.namespace, opts.topicSyncInterval); err != nil {

--- a/operator/pkg/client/spec_test.go
+++ b/operator/pkg/client/spec_test.go
@@ -12,6 +12,7 @@ package client
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,8 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testutils"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/labels"
 )
 
 func TestShadowLinkClusterSettings_BootstrapRegression(t *testing.T) {
@@ -172,6 +175,76 @@ func TestShadowLinkClusterSettings_SchemaRegistryCredentials(t *testing.T) {
 		settings, err := factory.RemoteClusterSettings(ctx, link(nil))
 		require.NoError(t, err)
 		require.Nil(t, settings.SchemaRegistry)
+	})
+
+	t.Run("resolves against a V1 (vectorized) source cluster with the same logic", func(t *testing.T) {
+		// Operator V1 mode (cloud/BYOC): the ShadowLink's source is a
+		// vectorized Cluster. Kafka settings resolve from the V1 CR while
+		// the schema registry API credentials resolve through the exact
+		// same secret loading used for the static/V2 paths above.
+		cluster := &vectorizedv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "v1-source",
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: vectorizedv1alpha1.ClusterSpec{
+				Image:    "docker.io/redpandadata/redpanda",
+				Version:  "v24.3.5",
+				Replicas: ptr.To(int32(1)),
+				Configuration: vectorizedv1alpha1.RedpandaConfig{
+					RPCServer:         vectorizedv1alpha1.SocketAddress{Port: 33145},
+					KafkaAPI:          []vectorizedv1alpha1.KafkaAPI{{Port: 9092}},
+					AdminAPI:          []vectorizedv1alpha1.AdminAPI{{Port: 9644}},
+					SchemaRegistryAPI: []vectorizedv1alpha1.SchemaRegistryAPI{{Port: 8081}},
+					DeveloperMode:     true,
+				},
+			},
+		}
+		require.NoError(t, c.Create(ctx, cluster))
+		require.NoError(t, c.Create(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "v1-source-0",
+				Namespace: metav1.NamespaceDefault,
+				Labels:    labels.ForCluster(cluster),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "redpanda", Image: "redpanda"}},
+			},
+		}))
+
+		l := link(&redpandav1alpha2.ShadowLinkSchemaRegistryAPIOptions{
+			SourceURL: "https://registry.example.com",
+			Authentication: &redpandav1alpha2.ShadowLinkSchemaRegistryAuthentication{
+				Basic: &redpandav1alpha2.ShadowLinkSchemaRegistryBasicAuthentication{
+					Username: secretRef("api-key"),
+					Password: secretRef("api-secret"),
+				},
+			},
+		})
+		l.Spec.SourceCluster = &redpandav1alpha2.ClusterSource{
+			ClusterRef: &redpandav1alpha2.ClusterRef{
+				Name:  "v1-source",
+				Group: ptr.To("redpanda.vectorized.io"),
+				Kind:  ptr.To("Cluster"),
+			},
+		}
+
+		settings, err := factory.RemoteClusterSettings(ctx, l)
+		require.NoError(t, err)
+
+		// Kafka side came from the V1 cluster: one bootstrap URL per pod,
+		// addressed through the headless service on the internal port.
+		require.Len(t, settings.BootstrapServers, 1)
+		require.True(t, strings.HasPrefix(settings.BootstrapServers[0], "v1-source-0.v1-source."), "unexpected bootstrap %q", settings.BootstrapServers[0])
+		require.True(t, strings.HasSuffix(settings.BootstrapServers[0], ":9092"), "unexpected bootstrap %q", settings.BootstrapServers[0])
+		require.Nil(t, settings.Authentication)
+		require.Nil(t, settings.TLSSettings)
+
+		// Schema registry side is the shared secret-resolution path.
+		require.NotNil(t, settings.SchemaRegistry)
+		require.NotNil(t, settings.SchemaRegistry.BasicAuthentication)
+		require.Equal(t, "the-key", settings.SchemaRegistry.BasicAuthentication.Username)
+		require.Equal(t, "the-secret", settings.SchemaRegistry.BasicAuthentication.Password)
 	})
 
 	t.Run("errors when the referenced secret does not exist", func(t *testing.T) {


### PR DESCRIPTION
Follow-up to #1661. Enables ShadowLink role and schema replication for **Operator V1 mode** deployments (cloud/BYOC) with the same underlying code as V2 — no forked logic.

## What

- **Wire the dead `--enable-shadowlinks` flag.** It was declared but never read; the ShadowLink controller registered unconditionally, which crash-loops any deployment that doesn't install the experimental ShadowLink CRD. cloudv2 already passes this flag in both its deploy paths (raw manifest and helm, see `terraform/provisioners/kubernetes-redpanda-{aws,gcp}`) with `--enable-vectorized-controllers --enable-redpanda-controllers=false`, expecting it to gate the controller. Now it does.
- **Prove the V1 path shares the common logic.** Roles/schemas conversion (#1661) operates on the ShadowLink CRD and is cluster-generation-agnostic; the client factory already resolves `vectorized.Cluster` refs into the same `shadow.RemoteClusterSettings`. New envtest case: a ShadowLink whose `sourceCluster.clusterRef` targets a V1 Cluster resolves per-pod Kafka bootstrap from the V1 CR while `shadowSchemaRegistryAPI` basic-auth credentials resolve through the shared Secret-loading path — the **Confluent Cloud → BYOC** shape on AWS/GCP.

## cloudv2 consumption notes

- BYOC → Redpanda links (V1 `Cluster` clusterRefs) and Confluent → BYOC links (staticConfiguration + `shadowSchemaRegistryAPI`) both work with the operator in V1 mode; the controller watches `vectorized.Cluster` sources when `--enable-vectorized-controllers` is set.
- cloudv2's vendored CRD types (`pkg/redpandaoperator/api/redpanda/v1alpha2/shadow_link_types.go`) must be re-synced to pick up `roleSyncOptions` and `schemaRegistrySyncOptions.shadowSchemaRegistryAPI` from #1661.
- For non-Redpanda sources (Confluent), set `roleSyncOptions: {enabled: false}`: role sync degrades gracefully to a task-level `LINK_UNAVAILABLE` but is noise (validated e2e against Confluent Cloud dedicated + CFK).

## Testing

- `TestShadowLinkClusterSettings_SchemaRegistryCredentials/resolves_against_a_V1_(vectorized)_source_cluster_with_the_same_logic` (new, envtest)
- `operator/pkg/client/shadow` conversion suite and `operator/api/redpanda/v1alpha2` suite pass (`TestSyncer` requires a testcontainers Docker provider unavailable in this environment; unchanged by this diff)
