### PR TITLE
operator: fix StretchCluster bootstrap-user Secret race and honor secretKeyRef (K8S-900)

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-migration.yaml
+++ b/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-migration.yaml
@@ -1,0 +1,13 @@
+project: operator
+kind: Fixed
+body: |
+  StretchClusters bootstrapped before `bootstrapUser.secretKeyRef` was honored no
+  longer break operator authentication when a secretKeyRef is added later. Such a
+  cluster was bootstrapped with the operator-managed `<name>-bootstrap-user`
+  Secret, and the bootstrap password cannot be changed by editing a Secret. The
+  reconciler now detects the legacy Secret, keeps using the password the cluster
+  was actually bootstrapped with, and seeds the referenced secretKeyRef location
+  from it. If the referenced location already holds a different password it
+  refuses with a terminal condition instead of writing divergent copies across
+  member clusters.
+time: 2026-07-15T13:30:00.000000+00:00

--- a/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-missing-key.yaml
+++ b/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-missing-key.yaml
@@ -1,0 +1,11 @@
+project: operator
+kind: Fixed
+body: |
+  StretchCluster bootstrap-user sync now fails loudly instead of silently
+  diverging when a user-provided `bootstrapUser.secretKeyRef` points at a Secret
+  that exists but has no data under the referenced key. Previously the reconciler
+  ignored the empty key, generated a fresh password, and wrote it only to the
+  member clusters that lacked the Secret — splitting credentials across the
+  stretch. It now sets a terminal `BootstrapUserSynced` error condition asking
+  the operator to populate the referenced key.
+time: 2026-07-15T13:00:00.000000+00:00

--- a/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-race.yaml
+++ b/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-race.yaml
@@ -1,0 +1,14 @@
+project: operator
+kind: Fixed
+body: |
+  Fixed a StretchCluster deadlock where applying the same manifest to every
+  member cluster at once (a scripted loop or a GitOps controller such as Argo or
+  Flux) could persist divergent bootstrap-user passwords across clusters,
+  tripping the leader's consistency check and permanently halting reconciliation
+  with `Cluster has no desired brokers`. Because the Secret is immutable the
+  cluster could not self-heal. The multicluster renderer no longer generates its
+  own bootstrap-user password; creation and cross-cluster synchronization of the
+  Secret is now owned exclusively by the reconciler's single-writer
+  `syncBootstrapUser` path. The password-mismatch error message now also reports
+  the local cluster by its canonical name instead of an empty string.
+time: 2026-07-15T12:00:00.000000+00:00

--- a/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-secretkeyref.yaml
+++ b/.changes/unreleased/operator-Fixed-20260715-stretch-bootstrap-user-secretkeyref.yaml
@@ -1,0 +1,12 @@
+project: operator
+kind: Fixed
+body: |
+  StretchCluster now honors `spec.auth.sasl.bootstrapUser.secretKeyRef`.
+  Previously the field was silently ignored: the operator always created and
+  read its own generated `<name>-bootstrap-user` Secret, so automation that
+  supplied a password via the documented `secretKeyRef` failed to authenticate.
+  The reconciler now reads a pre-existing password from the referenced
+  Secret/key (or writes a generated one there) and replicates it to every member
+  cluster, and the broker StatefulSet, admin/Kafka client, and static-config
+  conversion all resolve the credential from the same location.
+time: 2026-07-15T12:30:00.000000+00:00

--- a/operator/api/redpanda/v1alpha2/conversion/stretch_to_static_config.go
+++ b/operator/api/redpanda/v1alpha2/conversion/stretch_to_static_config.go
@@ -170,13 +170,16 @@ func stretchListenerTLS(sc *redpandav1alpha2.StretchCluster, poolSpec *redpandav
 // stretchBootstrapPasswordSource returns the ValueSource pointing at the
 // per-cluster bootstrap user secret.
 func stretchBootstrapPasswordSource(sc *redpandav1alpha2.StretchCluster) *ir.ValueSource {
+	// Resolve via the shared helper so the generated static config points at a
+	// user-pinned bootstrapUser.secretKeyRef location when set (K8S-900).
+	secretName, passwordKey := sc.BootstrapUserPasswordLocation()
 	return &ir.ValueSource{
 		Namespace: sc.Namespace,
 		SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: sc.BootstrapUserSecretName(),
+				Name: secretName,
 			},
-			Key: redpandav1alpha2.StretchClusterBootstrapPasswordKey,
+			Key: passwordKey,
 		},
 	}
 }

--- a/operator/api/redpanda/v1alpha2/conversion/stretch_to_static_config_test.go
+++ b/operator/api/redpanda/v1alpha2/conversion/stretch_to_static_config_test.go
@@ -166,6 +166,30 @@ func TestConvertStretchClusterToStaticConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "SASL enabled with bootstrapUser.secretKeyRef",
+			mutate: func(sc *redpandav1alpha2.StretchCluster, _ *redpandav1alpha2.RedpandaBrokerPool) {
+				sc.Spec.Auth = &redpandav1alpha2.Auth{
+					SASL: &redpandav1alpha2.SASL{
+						Enabled: ptr.To(true),
+						BootstrapUser: &redpandav1alpha2.BootstrapUser{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+								Key:                  "custom-key",
+							},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, cfg *ir.StaticConfigurationSource) {
+				// The generated static config must point Kafka and Admin auth at
+				// the user-pinned secret/key, not the operator-managed default.
+				require.Equal(t, "custom-bootstrap", cfg.Kafka.SASL.Password.SecretKeyRef.Name)
+				require.Equal(t, "custom-key", cfg.Kafka.SASL.Password.SecretKeyRef.Key)
+				require.Equal(t, "custom-bootstrap", cfg.Admin.Auth.Password.SecretKeyRef.Name)
+				require.Equal(t, "custom-key", cfg.Admin.Auth.Password.SecretKeyRef.Key)
+			},
+		},
+		{
 			name: "TLS + SASL together",
 			mutate: func(sc *redpandav1alpha2.StretchCluster, pool *redpandav1alpha2.RedpandaBrokerPool) {
 				pool.Spec.TLS = &redpandav1alpha2.TLS{Enabled: ptr.To(true)}

--- a/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
@@ -412,11 +412,29 @@ type SASL struct {
 type BootstrapUser struct {
 	// Name specifies the name of the bootstrap user created for the cluster, if unspecified
 	// defaults to "kubernetes-controller".
+	// NOTE: for the StretchCluster kind this field is currently ignored; the bootstrap
+	// username is fixed to "kubernetes-controller". Only secretKeyRef is honored there.
 	Name *string `json:"name,omitempty"`
 	// Specifies the location where the generated password will be written or a pre-existing
-	// password will be read from.
+	// password will be read from. For the StretchCluster kind the referenced key is required
+	// (there is no default key at the CRD level).
+	//
+	// For the StretchCluster kind the referenced Secret is read and replicated by the
+	// operator to every member cluster in the same namespace, so whoever can set this field
+	// is trusted to name a Secret whose contents may be copied across all member clusters of
+	// the mesh. The operator never overwrites an existing Secret of that name on a member
+	// cluster.
+	//
+	// IMPORTANT: for the StretchCluster kind the bootstrap password is consumed only when the
+	// cluster is first bootstrapped and cannot be rotated afterwards by editing this Secret,
+	// changing secretKeyRef to a different location, or removing secretKeyRef. Redpanda keeps
+	// the SCRAM credential it was bootstrapped with, so changing the source after bootstrap
+	// makes the operator and brokers authenticate with a credential the cluster never learned.
+	// Rotate the bootstrap user out of band (via the admin API) instead.
 	SecretKeyRef *corev1.SecretKeySelector `json:"secretKeyRef,omitempty"`
 	// Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+	// NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
+	// taken from sasl.mechanism.
 	Mechanism *string `json:"mechanism,omitempty"`
 }
 

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_helpers.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_helpers.go
@@ -813,6 +813,47 @@ func (sc *StretchCluster) BootstrapUserSecretName() string {
 	return fmt.Sprintf("%s-bootstrap-user", sc.Name)
 }
 
+// BootstrapUserPasswordLocation resolves the Secret name and data key that hold
+// the bootstrap user's SCRAM password.
+//
+// When the user pins a location via spec.auth.sasl.bootstrapUser.secretKeyRef,
+// that name and key are honored: the operator reads a pre-existing password from
+// it or writes a generated one to it, and replicates the Secret to every member
+// cluster. When no secretKeyRef is given it falls back to the operator-managed
+// <name>-bootstrap-user Secret and the [StretchClusterBootstrapPasswordKey] data
+// key.
+//
+// Note that the StretchCluster CRD marks secretKeyRef.key as required, so in
+// practice a user-pinned ref always carries a key; the key fallback below is
+// defense-in-depth for callers that construct a ref programmatically. Only
+// secretKeyRef is honored for StretchCluster — bootstrapUser.name and
+// bootstrapUser.mechanism are ignored (see their field docs).
+//
+// Every bootstrap-user consumer MUST resolve the location through this method so
+// the reconciler's syncBootstrapUser, the StatefulSet RPK_PASS env var, the
+// admin/Kafka client factory, and the static-config conversion always agree on
+// where the password lives (see the note on [StretchCluster.BootstrapUserSecretName]).
+func (sc *StretchCluster) BootstrapUserPasswordLocation() (secretName, passwordKey string) {
+	secretName = sc.BootstrapUserSecretName()
+	passwordKey = StretchClusterBootstrapPasswordKey
+
+	if sc.Spec.Auth == nil || sc.Spec.Auth.SASL == nil {
+		return secretName, passwordKey
+	}
+	bootstrapUser := sc.Spec.Auth.SASL.BootstrapUser
+	if bootstrapUser == nil || bootstrapUser.SecretKeyRef == nil {
+		return secretName, passwordKey
+	}
+
+	if bootstrapUser.SecretKeyRef.Name != "" {
+		secretName = bootstrapUser.SecretKeyRef.Name
+	}
+	if bootstrapUser.SecretKeyRef.Key != "" {
+		passwordKey = bootstrapUser.SecretKeyRef.Key
+	}
+	return secretName, passwordKey
+}
+
 // --- StretchClusterSpec convenience methods ---
 
 // GetResourceRequirements returns the Kubernetes resource requirements from the spec.

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_helpers_test.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_helpers_test.go
@@ -2053,3 +2053,57 @@ func TestPoolFSValidator(t *testing.T) {
 		}
 	})
 }
+
+func TestBootstrapUserPasswordLocation(t *testing.T) {
+	sc := &redpandav1alpha2.StretchCluster{}
+	sc.Name = "stretch"
+
+	withSASL := func(bu *redpandav1alpha2.BootstrapUser) *redpandav1alpha2.StretchCluster {
+		out := sc.DeepCopy()
+		out.Spec.Auth = &redpandav1alpha2.Auth{
+			SASL: &redpandav1alpha2.SASL{Enabled: ptr.To(true), BootstrapUser: bu},
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		cluster  *redpandav1alpha2.StretchCluster
+		wantName string
+		wantKey  string
+	}{
+		{"no auth falls back to operator-managed", sc, "stretch-bootstrap-user", "password"},
+		{"SASL without bootstrapUser falls back", withSASL(nil), "stretch-bootstrap-user", "password"},
+		{"bootstrapUser without secretKeyRef falls back", withSASL(&redpandav1alpha2.BootstrapUser{}), "stretch-bootstrap-user", "password"},
+		{
+			"secretKeyRef name and key are honored",
+			withSASL(&redpandav1alpha2.BootstrapUser{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "user-secret"},
+				Key:                  "user-key",
+			}}),
+			"user-secret", "user-key",
+		},
+		{
+			"secretKeyRef name only defaults the key",
+			withSASL(&redpandav1alpha2.BootstrapUser{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "user-secret"},
+			}}),
+			"user-secret", "password",
+		},
+		{
+			"secretKeyRef key only defaults the name",
+			withSASL(&redpandav1alpha2.BootstrapUser{SecretKeyRef: &corev1.SecretKeySelector{
+				Key: "user-key",
+			}}),
+			"stretch-bootstrap-user", "user-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotKey := tt.cluster.BootstrapUserPasswordLocation()
+			assert.Equal(t, tt.wantName, gotName)
+			assert.Equal(t, tt.wantKey, gotKey)
+		})
+	}
+}

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -441,10 +441,28 @@ BootstrapUser configures the user used to bootstrap Redpanda when SASL is enable
 |===
 | Field | Description | Default | Validation
 | *`name`* __string__ | Name specifies the name of the bootstrap user created for the cluster, if unspecified +
-defaults to "kubernetes-controller". + |  | 
+defaults to "kubernetes-controller". +
+NOTE: for the StretchCluster kind this field is currently ignored; the bootstrap +
+username is fixed to "kubernetes-controller". Only secretKeyRef is honored there. + |  | 
 | *`secretKeyRef`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core[$$SecretKeySelector$$]__ | Specifies the location where the generated password will be written or a pre-existing +
-password will be read from. + |  | 
-| *`mechanism`* __string__ | Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. + |  | 
+password will be read from. For the StretchCluster kind the referenced key is required +
+(there is no default key at the CRD level). +
+
+For the StretchCluster kind the referenced Secret is read and replicated by the +
+operator to every member cluster in the same namespace, so whoever can set this field +
+is trusted to name a Secret whose contents may be copied across all member clusters of +
+the mesh. The operator never overwrites an existing Secret of that name on a member +
+cluster. +
+
+IMPORTANT: for the StretchCluster kind the bootstrap password is consumed only when the +
+cluster is first bootstrapped and cannot be rotated afterwards by editing this Secret, +
+changing secretKeyRef to a different location, or removing secretKeyRef. Redpanda keeps +
+the SCRAM credential it was bootstrapped with, so changing the source after bootstrap +
+makes the operator and brokers authenticate with a credential the cluster never learned. +
+Rotate the bootstrap user out of band (via the admin API) instead. + |  | 
+| *`mechanism`* __string__ | Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. +
+NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is +
+taken from sasl.mechanism. + |  | 
 |===
 
 

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -1079,19 +1079,36 @@ spec:
                               user.
                             properties:
                               mechanism:
-                                description: Specifies the authentication mechanism
-                                  to use for the bootstrap user. Options are `SCRAM-SHA-256`
-                                  and `SCRAM-SHA-512`.
+                                description: |-
+                                  Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                                  NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
+                                  taken from sasl.mechanism.
                                 type: string
                               name:
                                 description: |-
                                   Name specifies the name of the bootstrap user created for the cluster, if unspecified
                                   defaults to "kubernetes-controller".
+                                  NOTE: for the StretchCluster kind this field is currently ignored; the bootstrap
+                                  username is fixed to "kubernetes-controller". Only secretKeyRef is honored there.
                                 type: string
                               secretKeyRef:
                                 description: |-
                                   Specifies the location where the generated password will be written or a pre-existing
-                                  password will be read from.
+                                  password will be read from. For the StretchCluster kind the referenced key is required
+                                  (there is no default key at the CRD level).
+
+                                  For the StretchCluster kind the referenced Secret is read and replicated by the
+                                  operator to every member cluster in the same namespace, so whoever can set this field
+                                  is trusted to name a Secret whose contents may be copied across all member clusters of
+                                  the mesh. The operator never overwrites an existing Secret of that name on a member
+                                  cluster.
+
+                                  IMPORTANT: for the StretchCluster kind the bootstrap password is consumed only when the
+                                  cluster is first bootstrapped and cannot be rotated afterwards by editing this Secret,
+                                  changing secretKeyRef to a different location, or removing secretKeyRef. Redpanda keeps
+                                  the SCRAM credential it was bootstrapped with, so changing the source after bootstrap
+                                  makes the operator and brokers authenticate with a credential the cluster never learned.
+                                  Rotate the bootstrap user out of band (via the admin API) instead.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -35062,19 +35079,36 @@ spec:
                               user.
                             properties:
                               mechanism:
-                                description: Specifies the authentication mechanism
-                                  to use for the bootstrap user. Options are `SCRAM-SHA-256`
-                                  and `SCRAM-SHA-512`.
+                                description: |-
+                                  Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                                  NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
+                                  taken from sasl.mechanism.
                                 type: string
                               name:
                                 description: |-
                                   Name specifies the name of the bootstrap user created for the cluster, if unspecified
                                   defaults to "kubernetes-controller".
+                                  NOTE: for the StretchCluster kind this field is currently ignored; the bootstrap
+                                  username is fixed to "kubernetes-controller". Only secretKeyRef is honored there.
                                 type: string
                               secretKeyRef:
                                 description: |-
                                   Specifies the location where the generated password will be written or a pre-existing
-                                  password will be read from.
+                                  password will be read from. For the StretchCluster kind the referenced key is required
+                                  (there is no default key at the CRD level).
+
+                                  For the StretchCluster kind the referenced Secret is read and replicated by the
+                                  operator to every member cluster in the same namespace, so whoever can set this field
+                                  is trusted to name a Secret whose contents may be copied across all member clusters of
+                                  the mesh. The operator never overwrites an existing Secret of that name on a member
+                                  cluster.
+
+                                  IMPORTANT: for the StretchCluster kind the bootstrap password is consumed only when the
+                                  cluster is first bootstrapped and cannot be rotated afterwards by editing this Secret,
+                                  changing secretKeyRef to a different location, or removing secretKeyRef. Redpanda keeps
+                                  the SCRAM credential it was bootstrapped with, so changing the source after bootstrap
+                                  makes the operator and brokers authenticate with a credential the cluster never learned.
+                                  Rotate the bootstrap user out of band (via the admin API) instead.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must

--- a/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
@@ -105,19 +105,36 @@ spec:
                         description: Specifies configuration about the bootstrap user.
                         properties:
                           mechanism:
-                            description: Specifies the authentication mechanism to
-                              use for the bootstrap user. Options are `SCRAM-SHA-256`
-                              and `SCRAM-SHA-512`.
+                            description: |-
+                              Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                              NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
+                              taken from sasl.mechanism.
                             type: string
                           name:
                             description: |-
                               Name specifies the name of the bootstrap user created for the cluster, if unspecified
                               defaults to "kubernetes-controller".
+                              NOTE: for the StretchCluster kind this field is currently ignored; the bootstrap
+                              username is fixed to "kubernetes-controller". Only secretKeyRef is honored there.
                             type: string
                           secretKeyRef:
                             description: |-
                               Specifies the location where the generated password will be written or a pre-existing
-                              password will be read from.
+                              password will be read from. For the StretchCluster kind the referenced key is required
+                              (there is no default key at the CRD level).
+
+                              For the StretchCluster kind the referenced Secret is read and replicated by the
+                              operator to every member cluster in the same namespace, so whoever can set this field
+                              is trusted to name a Secret whose contents may be copied across all member clusters of
+                              the mesh. The operator never overwrites an existing Secret of that name on a member
+                              cluster.
+
+                              IMPORTANT: for the StretchCluster kind the bootstrap password is consumed only when the
+                              cluster is first bootstrapped and cannot be rotated afterwards by editing this Secret,
+                              changing secretKeyRef to a different location, or removing secretKeyRef. Redpanda keeps
+                              the SCRAM credential it was bootstrapped with, so changing the source after bootstrap
+                              makes the operator and brokers authenticate with a credential the cluster never learned.
+                              Rotate the bootstrap user out of band (via the admin API) instead.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -685,6 +685,18 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 	}
 	clusterNames := r.Manager.GetClusterNames()
 
+	// Resolve where the password lives. When the user pins a location via
+	// spec.auth.sasl.bootstrapUser.secretKeyRef we read/generate/replicate there
+	// instead of the operator-managed <name>-bootstrap-user Secret. This is the
+	// single writer for that Secret regardless of who named it, which is what
+	// keeps concurrent multi-cluster applies from diverging (K8S-900).
+	secretName, passwordKey := sc.BootstrapUserPasswordLocation()
+
+	// Whether the location above came from a user-provided secretKeyRef (as
+	// opposed to the operator-managed default). SASL is enabled here, so SASL is
+	// non-nil; only BootstrapUser/SecretKeyRef can be absent.
+	userPinnedSecret := sc.Spec.Auth.SASL.BootstrapUser != nil && sc.Spec.Auth.SASL.BootstrapUser.SecretKeyRef != nil
+
 	// Phase 1: scan all clusters for existing bootstrap user secrets.
 	// If multiple secrets exist, verify they all have the same password.
 	//
@@ -714,7 +726,6 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 			return ctrl.Result{}, errors.Wrapf(err, "getting cluster %s", clusterName)
 		}
 
-		secretName := bootstrapSecretName(sc)
 		var existing corev1.Secret
 		getCtx, getCancel := context.WithTimeout(ctx, lifecycle.CallTimeoutFor(clusterName))
 		err = cl.GetClient().Get(getCtx, client.ObjectKey{
@@ -731,20 +742,82 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 			// Phase 3 will recreate the secret if missing.
 			continue
 		}
-		if pw, ok := existing.Data[bootstrapUserPasswordKey]; ok && len(pw) > 0 {
-			password := string(pw)
-			if canonicalPassword == "" {
-				canonicalPassword = password
-				canonicalCluster = clusterName
-				logger.V(log.TraceLevel).Info("found existing bootstrap user secret", "cluster", clusterName, "secret", secretName)
-			} else if canonicalPassword != password {
+		pw, ok := existing.Data[passwordKey]
+		if !ok || len(pw) == 0 {
+			// The Secret object exists but carries no password under the resolved
+			// key. For a user-pinned secretKeyRef this is a misconfiguration we must
+			// surface: silently falling through would generate a fresh password and
+			// write it only to the *other* clusters (Phase 3 skips this one because
+			// the object already exists), splitting credentials across the stretch —
+			// the exact K8S-900 failure mode. For the operator-managed Secret this
+			// cannot normally happen, so leave Phase 3 to (re)create it.
+			if userPinnedSecret {
+				pinnedCluster := lifecycle.CanonicalClusterName(clusterName, r.Manager.GetLocalClusterName)
 				msg := fmt.Sprintf(
-					"bootstrap user password mismatch: secret %q in cluster %q differs from cluster %q; "+
-						"manual intervention required — delete the incorrect secret(s) and let the controller recreate them",
-					secretName, clusterName, canonicalCluster,
+					"bootstrap user secret %q in cluster %q has no data under key %q; "+
+						"populate the referenced secret's key or remove spec.auth.sasl.bootstrapUser.secretKeyRef",
+					secretName, pinnedCluster, passwordKey,
 				)
-				state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonPasswordMismatch, msg)
+				state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonTerminalError, msg)
 				return ctrl.Result{}, errors.New(msg)
+			}
+			continue
+		}
+
+		password := string(pw)
+		if canonicalPassword == "" {
+			canonicalPassword = password
+			canonicalCluster = clusterName
+			logger.V(log.TraceLevel).Info("found existing bootstrap user secret", "cluster", clusterName, "secret", secretName)
+		} else if canonicalPassword != password {
+			// Canonicalise both names so a secret found on the local cluster —
+			// which GetClusterNames() reports as the empty-string sentinel
+			// (mcmanager.LocalCluster) — is surfaced by its human-readable peer
+			// name rather than an empty "" in the operator-facing error (K8S-900).
+			mismatchCluster := lifecycle.CanonicalClusterName(clusterName, r.Manager.GetLocalClusterName)
+			sourceCluster := lifecycle.CanonicalClusterName(canonicalCluster, r.Manager.GetLocalClusterName)
+			msg := fmt.Sprintf(
+				"bootstrap user password mismatch: secret %q in cluster %q differs from cluster %q; "+
+					"manual intervention required — delete the incorrect secret(s) and let the controller recreate them",
+				secretName, mismatchCluster, sourceCluster,
+			)
+			state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonPasswordMismatch, msg)
+			return ctrl.Result{}, errors.New(msg)
+		}
+	}
+
+	// Phase 1b — migration (K8S-900): a StretchCluster created before secretKeyRef
+	// was honored was bootstrapped from the operator-managed <name>-bootstrap-user
+	// Secret. If the user has since added a secretKeyRef pointing elsewhere, the
+	// password Redpanda actually knows is the one in that legacy Secret — switching
+	// to the referenced location would break authentication (the bootstrap password
+	// cannot be changed by editing a Secret). When the legacy Secret still exists we
+	// treat it as authoritative: seed the referenced location from it so every
+	// consumer keeps using the bootstrapped password. If the referenced location
+	// already holds a *different* password we refuse rather than write divergent
+	// copies, since we cannot silently honor a password the cluster was not
+	// bootstrapped with.
+	if userPinnedSecret {
+		legacyName := sc.BootstrapUserSecretName()
+		if secretName != legacyName {
+			if legacyPassword, legacyCluster := r.findExistingBootstrapPassword(ctx, sc, clusterNames, legacyName, bootstrapUserPasswordKey); legacyPassword != "" {
+				switch {
+				case canonicalPassword == "":
+					canonicalPassword = legacyPassword
+					canonicalCluster = legacyCluster
+					logger.Info("migrating bootstrap password from operator-managed secret to the referenced secretKeyRef location",
+						"legacySecret", legacyName, "referencedSecret", secretName)
+				case canonicalPassword != legacyPassword:
+					msg := fmt.Sprintf(
+						"StretchCluster was bootstrapped with the operator-managed secret %q, but the "+
+							"referenced secret %q holds a different password; the bootstrap password cannot be "+
+							"changed by editing the secret. Set %q to the existing password or remove "+
+							"spec.auth.sasl.bootstrapUser.secretKeyRef.",
+						legacyName, secretName, secretName,
+					)
+					state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonTerminalError, msg)
+					return ctrl.Result{}, errors.New(msg)
+				}
 			}
 		}
 	}
@@ -769,7 +842,6 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 			continue
 		}
 
-		secretName := bootstrapSecretName(sc)
 		k8sClient := cl.GetClient()
 
 		var existing corev1.Secret
@@ -777,7 +849,12 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 			Namespace: sc.Namespace,
 			Name:      secretName,
 		}, &existing); err == nil {
-			// Secret already exists — nothing to do for this cluster.
+			// Secret already exists — nothing to do for this cluster. We never
+			// overwrite: this bounds the blast radius of a user-supplied
+			// secretKeyRef.Name (a StretchCluster editor names the Secret the
+			// operator reads and replicates across member clusters) to creating a
+			// same-named Secret only where one is absent, never clobbering a
+			// colliding one. See the SecretKeyRef field doc for the trust boundary.
 			continue
 		}
 
@@ -812,7 +889,7 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 			Immutable: ptr.To(true),
 			Type:      corev1.SecretTypeOpaque,
 			Data: map[string][]byte{
-				bootstrapUserPasswordKey: []byte(canonicalPassword),
+				passwordKey: []byte(canonicalPassword),
 			},
 		}
 
@@ -826,13 +903,49 @@ func (r *MulticlusterReconciler) syncBootstrapUser(ctx context.Context, state *s
 	if generated {
 		state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonSynced, fmt.Sprintf("Bootstrap user secret created and synced across %d cluster(s)", len(clusterNames)))
 	} else {
-		state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonExistingReused, fmt.Sprintf("Using existing bootstrap user secret from cluster %q", canonicalCluster))
+		// Canonicalise for the same reason as the mismatch error above: the
+		// reused secret may have been found on the local cluster, which
+		// GetClusterNames() reports as the empty-string sentinel (K8S-900).
+		sourceCluster := lifecycle.CanonicalClusterName(canonicalCluster, r.Manager.GetLocalClusterName)
+		state.status.StretchClusterStatus.SetBootstrapUserSynced(statuses.StretchClusterBootstrapUserSyncedReasonExistingReused, fmt.Sprintf("Using existing bootstrap user secret from cluster %q", sourceCluster))
 	}
 
 	state.bootstrapUser = defaultBootstrapUsername
 	state.bootstrapPassword = canonicalPassword
 
 	return ctrl.Result{}, nil
+}
+
+// findExistingBootstrapPassword scans reachable clusters for a Secret named
+// `name` carrying a non-empty password under `key`, returning the first one found
+// and the cluster it came from (canonicalised for display), or ("", "") if none.
+// Used during secretKeyRef migration to locate the legacy operator-managed
+// bootstrap password a pre-existing cluster was actually bootstrapped with. Scan
+// order follows GetClusterNames, mirroring the Phase-1 reachability/timeout
+// handling so a partitioned peer cannot stall the reconcile.
+func (r *MulticlusterReconciler) findExistingBootstrapPassword(ctx context.Context, sc *redpandav1alpha2.StretchCluster, clusterNames []string, name, key string) (password, clusterCanonical string) {
+	logger := log.FromContext(ctx)
+	for _, clusterName := range clusterNames {
+		if clusterName != mcmanager.LocalCluster && !r.Manager.IsClusterReachable(clusterName) {
+			continue
+		}
+		cl, err := r.Manager.GetCluster(ctx, clusterName)
+		if err != nil {
+			continue
+		}
+		var existing corev1.Secret
+		getCtx, getCancel := context.WithTimeout(ctx, lifecycle.CallTimeoutFor(clusterName))
+		err = cl.GetClient().Get(getCtx, client.ObjectKey{Namespace: sc.Namespace, Name: name}, &existing)
+		getCancel()
+		if err != nil {
+			continue
+		}
+		if pw, ok := existing.Data[key]; ok && len(pw) > 0 {
+			logger.V(log.TraceLevel).Info("found legacy bootstrap user secret for migration", "cluster", clusterName, "secret", name)
+			return string(pw), lifecycle.CanonicalClusterName(clusterName, r.Manager.GetLocalClusterName)
+		}
+	}
+	return "", ""
 }
 
 // syncCA ensures that a shared root CA Secret exists for each operator-managed

--- a/operator/internal/controller/redpanda/sync_bootstrap_user_test.go
+++ b/operator/internal/controller/redpanda/sync_bootstrap_user_test.go
@@ -47,6 +47,11 @@ type mockManager struct {
 	multicluster.Manager
 	clusters map[string]*mockCluster
 	names    []string
+	// localName, when non-empty, is returned by GetLocalClusterName. It lets a
+	// test model the production convention where GetClusterNames() carries the
+	// empty-string local sentinel (mcmanager.LocalCluster) while the manager
+	// still knows the canonical peer name. Falls back to names[0] when unset.
+	localName string
 }
 
 func (m *mockManager) GetClusterNames() []string { return m.names }
@@ -57,8 +62,14 @@ func (m *mockManager) GetCluster(_ context.Context, name string) (cluster.Cluste
 	}
 	return cl, nil
 }
-func (m *mockManager) GetLeader() string           { return m.names[0] }
-func (m *mockManager) GetLocalClusterName() string { return m.names[0] }
+func (m *mockManager) GetLeader() string { return m.names[0] }
+func (m *mockManager) GetLocalClusterName() string {
+	if m.localName != "" {
+		return m.localName
+	}
+	return m.names[0]
+}
+
 func (m *mockManager) AddOrReplaceCluster(_ context.Context, _ string, _ cluster.Cluster) error {
 	return nil
 }
@@ -307,6 +318,339 @@ func TestSyncBootstrapUser_PasswordMismatchAcrossClusters(t *testing.T) {
 	require.Equal(t, metav1.ConditionFalse, cond.Status)
 	require.Equal(t, string(statuses.StretchClusterBootstrapUserSyncedReasonPasswordMismatch), cond.Reason)
 	require.Contains(t, cond.Message, "manual intervention")
+}
+
+// TestSyncBootstrapUser_MismatchMessageCanonicalizesLocalCluster covers the
+// K8S-900 cosmetic sub-bug: when the canonical (first-found) secret lives on the
+// local cluster, GetClusterNames() reports it as the empty-string sentinel
+// (mcmanager.LocalCluster). The mismatch error must surface the human-readable
+// peer name (GetLocalClusterName) rather than an empty cluster name.
+func TestSyncBootstrapUser_MismatchMessageCanonicalizesLocalCluster(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	// "" is mcmanager.LocalCluster — the local cluster sentinel that
+	// GetClusterNames() returns in production.
+	clusterNames := []string{"", "cluster-b"}
+	sc := testStretchCluster()
+
+	clients := map[string]client.Client{
+		"": newFakeClient(stretchClusterForCluster(sc, "local"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bootstrapSecretName(sc),
+				Namespace: sc.Namespace,
+			},
+			Data: map[string][]byte{
+				bootstrapUserPasswordKey: []byte("password-one-aaaaaaaaaaaaaaaaaaa"),
+			},
+			Type: corev1.SecretTypeOpaque,
+		}),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bootstrapSecretName(sc),
+				Namespace: sc.Namespace,
+			},
+			Data: map[string][]byte{
+				bootstrapUserPasswordKey: []byte("password-two-bbbbbbbbbbbbbbbbbbb"),
+			},
+			Type: corev1.SecretTypeOpaque,
+		}),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	mgr.localName = "kind-rp-1"
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{Manager: mgr}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "password mismatch")
+	// The canonical cluster (first found, on the local sentinel "") must be
+	// reported by its human-readable name, not as an empty string.
+	require.Contains(t, err.Error(), "kind-rp-1")
+	require.NotContains(t, err.Error(), `cluster ""`)
+}
+
+// TestSyncBootstrapUser_ReusedMessageCanonicalizesLocalCluster is the success-path
+// counterpart to the mismatch test: when the reused secret is found on the local
+// cluster (the empty-string sentinel), the ExistingReused status message must name
+// the canonical peer, not an empty cluster (K8S-900).
+func TestSyncBootstrapUser_ReusedMessageCanonicalizesLocalCluster(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"", "cluster-b"}
+	sc := testStretchCluster()
+	password := "shared-password-across-all-12345"
+
+	clients := map[string]client.Client{
+		"": newFakeClient(stretchClusterForCluster(sc, "local"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapSecretName(sc), Namespace: sc.Namespace},
+			Data:       map[string][]byte{bootstrapUserPasswordKey: []byte(password)},
+			Type:       corev1.SecretTypeOpaque,
+		}),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapSecretName(sc), Namespace: sc.Namespace},
+			Data:       map[string][]byte{bootstrapUserPasswordKey: []byte(password)},
+			Type:       corev1.SecretTypeOpaque,
+		}),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	mgr.localName = "kind-rp-1"
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.NoError(t, err)
+
+	state.status.StretchClusterStatus.UpdateConditions(sc)
+	cond := apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterBootstrapUserSynced)
+	require.NotNil(t, cond)
+	require.Equal(t, string(statuses.StretchClusterBootstrapUserSyncedReasonExistingReused), cond.Reason)
+	require.Contains(t, cond.Message, "kind-rp-1")
+	require.NotContains(t, cond.Message, `cluster ""`)
+}
+
+// TestSyncBootstrapUser_HonorsSecretKeyRefExisting: when the user pins the
+// bootstrap password to a custom Secret/key via bootstrapUser.secretKeyRef and
+// pre-creates it on one cluster, syncBootstrapUser must read that Secret (not the
+// operator-managed <name>-bootstrap-user), reuse its password, and replicate it
+// to the other clusters under the same custom name/key (K8S-900 follow-up).
+func TestSyncBootstrapUser_HonorsSecretKeyRefExisting(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"cluster-a", "cluster-b"}
+	sc := testStretchCluster()
+	sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+			Key:                  "custom-key",
+		},
+	}
+	userPassword := "user-supplied-password-abcdefghij"
+
+	clients := map[string]client.Client{
+		"cluster-a": newFakeClient(stretchClusterForCluster(sc, "cluster-a"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "custom-bootstrap", Namespace: sc.Namespace},
+			Data:       map[string][]byte{"custom-key": []byte(userPassword)},
+			Type:       corev1.SecretTypeOpaque,
+		}),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b")),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.NoError(t, err)
+
+	// The user-supplied password is reused.
+	require.Equal(t, userPassword, state.bootstrapPassword)
+
+	// The custom secret is replicated to cluster-b under the same name/key.
+	var replicated corev1.Secret
+	require.NoError(t, clients["cluster-b"].Get(ctx, types.NamespacedName{Namespace: sc.Namespace, Name: "custom-bootstrap"}, &replicated))
+	require.Equal(t, userPassword, string(replicated.Data["custom-key"]))
+
+	// The operator-managed secret name must NOT be created anywhere.
+	var operatorManaged corev1.Secret
+	err = clients["cluster-b"].Get(ctx, types.NamespacedName{Namespace: sc.Namespace, Name: bootstrapSecretName(sc)}, &operatorManaged)
+	require.True(t, k8sapierrors.IsNotFound(err), "operator-managed secret must not be created when secretKeyRef is set")
+}
+
+// TestSyncBootstrapUser_HonorsSecretKeyRefGenerate: when secretKeyRef is set but
+// no Secret exists yet, syncBootstrapUser generates a password and writes it to
+// the referenced Secret/key (the field is documented as "where the generated
+// password will be written").
+func TestSyncBootstrapUser_HonorsSecretKeyRefGenerate(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"cluster-a", "cluster-b"}
+	sc := testStretchCluster()
+	sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+			Key:                  "custom-key",
+		},
+	}
+
+	clients := map[string]client.Client{
+		"cluster-a": newFakeClient(stretchClusterForCluster(sc, "cluster-a")),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b")),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.NoError(t, err)
+	require.Len(t, state.bootstrapPassword, 32)
+
+	for _, clusterName := range clusterNames {
+		var secret corev1.Secret
+		require.NoError(t, clients[clusterName].Get(ctx, types.NamespacedName{Namespace: sc.Namespace, Name: "custom-bootstrap"}, &secret),
+			"generated secret should exist under the referenced name in %s", clusterName)
+		require.Equal(t, state.bootstrapPassword, string(secret.Data["custom-key"]))
+	}
+}
+
+// TestSyncBootstrapUser_SecretKeyRefExistingButMissingKey: when secretKeyRef
+// points at a Secret that exists but has no data under the referenced key, the
+// operator must fail loudly (terminal condition) rather than silently generate a
+// divergent password that gets written only to the other clusters (K8S-900).
+func TestSyncBootstrapUser_SecretKeyRefExistingButMissingKey(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"cluster-a", "cluster-b"}
+	sc := testStretchCluster()
+	sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+			Key:                  "custom-key",
+		},
+	}
+
+	clients := map[string]client.Client{
+		// The referenced Secret exists but stores the password under the wrong key.
+		"cluster-a": newFakeClient(stretchClusterForCluster(sc, "cluster-a"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "custom-bootstrap", Namespace: sc.Namespace},
+			Data:       map[string][]byte{"wrong-key": []byte("whatever")},
+			Type:       corev1.SecretTypeOpaque,
+		}),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b")),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no data under key")
+	require.Contains(t, err.Error(), "custom-key")
+
+	// Must NOT have written a divergent password to cluster-b.
+	var replicated corev1.Secret
+	getErr := clients["cluster-b"].Get(ctx, types.NamespacedName{Namespace: sc.Namespace, Name: "custom-bootstrap"}, &replicated)
+	require.True(t, k8sapierrors.IsNotFound(getErr), "must not create a divergent secret when the referenced key is missing")
+
+	state.status.StretchClusterStatus.UpdateConditions(sc)
+	cond := apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterBootstrapUserSynced)
+	require.NotNil(t, cond)
+	require.Equal(t, string(statuses.StretchClusterBootstrapUserSyncedReasonTerminalError), cond.Reason)
+}
+
+// TestSyncBootstrapUser_MigratesLegacyPasswordToSecretKeyRef: a cluster
+// bootstrapped before secretKeyRef was honored holds the operator-managed
+// <name>-bootstrap-user Secret. When the user later adds a secretKeyRef, the
+// operator must keep using the password the cluster was actually bootstrapped
+// with (the legacy one) and seed the referenced location from it — not generate
+// a new password that Redpanda never saw (K8S-900).
+func TestSyncBootstrapUser_MigratesLegacyPasswordToSecretKeyRef(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"cluster-a", "cluster-b"}
+	sc := testStretchCluster()
+	sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+			Key:                  "custom-key",
+		},
+	}
+	legacyPassword := "legacy-bootstrapped-password-123"
+
+	clients := map[string]client.Client{
+		// cluster-a still carries the legacy operator-managed secret; the
+		// referenced custom secret does not exist yet.
+		"cluster-a": newFakeClient(stretchClusterForCluster(sc, "cluster-a"), &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapSecretName(sc), Namespace: sc.Namespace},
+			Data:       map[string][]byte{bootstrapUserPasswordKey: []byte(legacyPassword)},
+			Type:       corev1.SecretTypeOpaque,
+		}),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b")),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.NoError(t, err)
+
+	// The legacy (bootstrapped) password is retained, not regenerated.
+	require.Equal(t, legacyPassword, state.bootstrapPassword)
+
+	// The referenced location is seeded with the legacy password on every cluster.
+	for _, clusterName := range clusterNames {
+		var ref corev1.Secret
+		require.NoError(t, clients[clusterName].Get(ctx, types.NamespacedName{Namespace: sc.Namespace, Name: "custom-bootstrap"}, &ref),
+			"referenced secret should be seeded in %s", clusterName)
+		require.Equal(t, legacyPassword, string(ref.Data["custom-key"]))
+	}
+}
+
+// TestSyncBootstrapUser_MigrationConflictRefusesDivergence: if the referenced
+// secret holds a *different* password than the one the cluster was bootstrapped
+// with, the operator refuses (terminal condition) rather than write divergent
+// copies to the other clusters.
+func TestSyncBootstrapUser_MigrationConflictRefusesDivergence(t *testing.T) {
+	ctx := ctrllog.IntoContext(context.Background(), logr.Discard())
+
+	clusterNames := []string{"cluster-a", "cluster-b"}
+	sc := testStretchCluster()
+	sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+			Key:                  "custom-key",
+		},
+	}
+
+	clients := map[string]client.Client{
+		"cluster-a": newFakeClient(stretchClusterForCluster(sc, "cluster-a"),
+			// legacy operator-managed (bootstrapped) password
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: bootstrapSecretName(sc), Namespace: sc.Namespace},
+				Data:       map[string][]byte{bootstrapUserPasswordKey: []byte("legacy-password-aaaaaaaaaaaaaaa")},
+				Type:       corev1.SecretTypeOpaque,
+			},
+			// referenced location holds a DIFFERENT password
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom-bootstrap", Namespace: sc.Namespace},
+				Data:       map[string][]byte{"custom-key": []byte("user-password-bbbbbbbbbbbbbbbb")},
+				Type:       corev1.SecretTypeOpaque,
+			}),
+		"cluster-b": newFakeClient(stretchClusterForCluster(sc, "cluster-b")),
+	}
+	mgr := newMockManager(clusterNames, clients)
+	state := newTestState(sc, clusterNames)
+
+	r := &MulticlusterReconciler{
+		Manager:         mgr,
+		LifecycleClient: lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(lifecycle.Image{}, lifecycle.Image{}, lifecycle.CloudSecretsFlags{})),
+	}
+	_, err := r.syncBootstrapUser(ctx, state, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "different password")
+
+	// Must not have written a divergent copy to cluster-b.
+	var ref corev1.Secret
+	getErr := clients["cluster-b"].Get(ctx, types.NamespacedName{Namespace: sc.Namespace, Name: "custom-bootstrap"}, &ref)
+	require.True(t, k8sapierrors.IsNotFound(getErr))
+
+	state.status.StretchClusterStatus.UpdateConditions(sc)
+	cond := apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterBootstrapUserSynced)
+	require.NotNil(t, cond)
+	require.Equal(t, string(statuses.StretchClusterBootstrapUserSyncedReasonTerminalError), cond.Reason)
 }
 
 func TestSyncBootstrapUser_ClusterUnreachable(t *testing.T) {

--- a/operator/multicluster/render_state.go
+++ b/operator/multicluster/render_state.go
@@ -353,7 +353,8 @@ func (r *RenderState) podOrdinalOffset(pool *redpandav1alpha2.RedpandaBrokerPool
 // fetchBootstrapUser looks up an existing bootstrap user secret so that we
 // re-emit it with the same password rather than generating a new random one
 // on every reconciliation. If the secret doesn't exist yet, secretBootstrapUser()
-// will create one with a fresh random password.
+// emits nothing: the secret is created and synced across clusters exclusively by
+// the MulticlusterReconciler's syncBootstrapUser() single writer (K8S-900).
 func (r *RenderState) fetchBootstrapUser() error {
 	if r.client == nil || !r.Spec().Auth.IsSASLEnabled() {
 		return nil

--- a/operator/multicluster/secrets.go
+++ b/operator/multicluster/secrets.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
-	"github.com/redpanda-data/redpanda-operator/operator/pkg/tplutil"
 )
 
 // secrets returns all Secrets for the given RenderState. Object order matches
@@ -148,10 +147,20 @@ func secretSASLUsers(state *RenderState) (*corev1.Secret, error) {
 
 // secretBootstrapUser returns the bootstrap user Secret. If an existing secret
 // was found during state construction (fetchBootstrapUser), it's returned as-is
-// to preserve the password across reconciliations. Otherwise a new secret with a
-// random 32-char password is created. The secret is marked Immutable so that
-// Kubernetes rejects any future mutations — password rotation requires deleting
-// and re-creating the secret.
+// to preserve the password across reconciliations. Otherwise it returns nil.
+//
+// The renderer is deliberately NOT a password generator. Creation and
+// cross-cluster synchronization of the immutable bootstrap-user Secret is owned
+// exclusively by the MulticlusterReconciler's syncBootstrapUser(), which runs as
+// a Phase-1 syncer before any resource rendering. Generating a second,
+// independent random password here races that single writer: when the same
+// StretchCluster manifest is applied to every member cluster at once (a scripted
+// loop or a GitOps controller), the two uncoordinated RandAlphaNum(32) calls can
+// persist divergent passwords into the immutable Secret on different clusters.
+// The leader's consistency check then hard-errors and all reconciliation stops
+// with no way to self-heal (K8S-900). Treating a missing Secret as "not ready
+// yet" keeps syncBootstrapUser the sole source of truth; the Secret it created
+// is picked up on this or the next reconcile via fetchBootstrapUser.
 func secretBootstrapUser(state *RenderState) *corev1.Secret {
 	if !state.Spec().Auth.IsSASLEnabled() {
 		return nil
@@ -162,29 +171,10 @@ func secretBootstrapUser(state *RenderState) *corev1.Secret {
 		return nil
 	}
 
-	// Re-emit the existing secret to preserve the password.
-	if state.bootstrapUserSecret != nil {
-		return state.bootstrapUserSecret
-	}
-
-	password := tplutil.RandAlphaNum(32)
-
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      state.cluster.BootstrapUserSecretName(),
-			Namespace: state.namespace,
-			Labels:    state.commonLabels(),
-		},
-		Immutable: ptr.To(true),
-		Type:      corev1.SecretTypeOpaque,
-		StringData: map[string]string{
-			redpandav1alpha2.StretchClusterBootstrapPasswordKey: password,
-		},
-	}
+	// Re-emit the existing secret to preserve the password. A nil secret means
+	// syncBootstrapUser hasn't created it yet — emit nothing rather than racing
+	// it with a freshly generated password (see doc comment above).
+	return state.bootstrapUserSecret
 }
 
 // secretFSValidator returns the filesystem validator Secret for a pool.

--- a/operator/multicluster/secrets_test.go
+++ b/operator/multicluster/secrets_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package multicluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+func saslStretchCluster() *redpandav1alpha2.StretchCluster {
+	return &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "stretch", Namespace: "ns"},
+		Spec: redpandav1alpha2.StretchClusterSpec{
+			Auth: &redpandav1alpha2.Auth{
+				SASL: &redpandav1alpha2.SASL{Enabled: ptr.To(true)},
+			},
+		},
+	}
+}
+
+// K8S-900: the renderer must NOT generate its own bootstrap-user password when
+// no secret exists yet. syncBootstrapUser() is the single writer that creates
+// and synchronizes the immutable secret across all member clusters. A second,
+// independent RandAlphaNum(32) generator here races that path — when the
+// manifest is applied to all clusters at once, the two generators can persist
+// divergent immutable passwords on different clusters, tripping the leader's
+// consistency check and permanently halting reconciliation. The renderer must
+// therefore treat a missing secret as "not ready yet" and emit nothing.
+func TestSecretBootstrapUser_DoesNotSelfGenerate(t *testing.T) {
+	sc := saslStretchCluster()
+	state, err := NewRenderState(nil, sc, nil, nil, "test")
+	require.NoError(t, err)
+	require.Nil(t, state.bootstrapUserSecret, "no existing secret should be discovered with a nil client")
+
+	require.Nil(t, secretBootstrapUser(state),
+		"renderer must treat a missing bootstrap-user secret as not-ready, not generate its own")
+}
+
+// When the secret already exists it must be re-emitted verbatim so the password
+// is preserved across reconciliations.
+func TestSecretBootstrapUser_ReEmitsExisting(t *testing.T) {
+	sc := saslStretchCluster()
+	state, err := NewRenderState(nil, sc, nil, nil, "test")
+	require.NoError(t, err)
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sc.BootstrapUserSecretName(),
+			Namespace: sc.Namespace,
+		},
+		Immutable: ptr.To(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			redpandav1alpha2.StretchClusterBootstrapPasswordKey: []byte("preserved-password"),
+		},
+	}
+	state.bootstrapUserSecret = existing
+
+	require.Same(t, existing, secretBootstrapUser(state),
+		"an existing bootstrap-user secret must be re-emitted unchanged")
+}
+
+// When the user owns the secret via an explicit SecretKeyRef, the renderer
+// emits nothing regardless of discovery state (the reconciler's
+// syncBootstrapUser is the single writer of that Secret).
+func TestSecretBootstrapUser_UserOwnedSecretKeyRef(t *testing.T) {
+	sc := saslStretchCluster()
+	sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "user-owned"},
+			Key:                  "password",
+		},
+	}
+	state, err := NewRenderState(nil, sc, nil, nil, "test")
+	require.NoError(t, err)
+
+	require.Nil(t, secretBootstrapUser(state),
+		"a user-provided SecretKeyRef must suppress operator-managed secret emission")
+}
+
+// The StatefulSet's RPK_PASS env var must source from the user-pinned
+// bootstrapUser.secretKeyRef location so the pod authenticates with the same
+// credential the reconciler created/synced (K8S-900).
+func TestBootstrapUserEnvVars_HonorsSecretKeyRef(t *testing.T) {
+	findRPKPass := func(vars []corev1.EnvVar) *corev1.EnvVar {
+		for i := range vars {
+			if vars[i].Name == "RPK_PASS" {
+				return &vars[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("default operator-managed location", func(t *testing.T) {
+		sc := saslStretchCluster()
+		state, err := NewRenderState(nil, sc, nil, nil, "test")
+		require.NoError(t, err)
+
+		rpkPass := findRPKPass(bootstrapUserEnvVars(state))
+		require.NotNil(t, rpkPass)
+		require.Equal(t, sc.BootstrapUserSecretName(), rpkPass.ValueFrom.SecretKeyRef.Name)
+		require.Equal(t, redpandav1alpha2.StretchClusterBootstrapPasswordKey, rpkPass.ValueFrom.SecretKeyRef.Key)
+	})
+
+	t.Run("user-pinned secretKeyRef", func(t *testing.T) {
+		sc := saslStretchCluster()
+		sc.Spec.Auth.SASL.BootstrapUser = &redpandav1alpha2.BootstrapUser{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+				Key:                  "custom-key",
+			},
+		}
+		state, err := NewRenderState(nil, sc, nil, nil, "test")
+		require.NoError(t, err)
+
+		rpkPass := findRPKPass(bootstrapUserEnvVars(state))
+		require.NotNil(t, rpkPass)
+		require.Equal(t, "custom-bootstrap", rpkPass.ValueFrom.SecretKeyRef.Name)
+		require.Equal(t, "custom-key", rpkPass.ValueFrom.SecretKeyRef.Key)
+	})
+}

--- a/operator/multicluster/statefulset_redpanda.go
+++ b/operator/multicluster/statefulset_redpanda.go
@@ -148,7 +148,10 @@ func bootstrapUserEnvVars(state *RenderState) []corev1.EnvVar {
 	}
 
 	mechanism := state.Spec().Auth.SASL.GetMechanism()
-	secretName := state.cluster.BootstrapUserSecretName()
+	// Resolve via the shared helper so the pod reads from a user-pinned
+	// bootstrapUser.secretKeyRef location when set, matching what the reconciler
+	// creates/syncs (K8S-900).
+	secretName, passwordKey := state.cluster.BootstrapUserPasswordLocation()
 
 	return []corev1.EnvVar{
 		{
@@ -162,7 +165,7 @@ func bootstrapUserEnvVars(state *RenderState) []corev1.EnvVar {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: secretName,
 					},
-					Key: redpandav1alpha2.StretchClusterBootstrapPasswordKey,
+					Key: passwordKey,
 				},
 			},
 		},

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -429,13 +429,17 @@ func (c *Factory) stretchClusterAuth(ctx context.Context, sc *redpandav1alpha2.S
 		return "", "", nil
 	}
 
-	secretName := sc.BootstrapUserSecretName()
+	// Resolve via the shared helper so the operator's own admin/Kafka/SR clients
+	// read from the same location the reconciler wrote to — the user-pinned
+	// bootstrapUser.secretKeyRef when set, otherwise the operator-managed
+	// <name>-bootstrap-user Secret (K8S-900).
+	secretName, passwordKey := sc.BootstrapUserPasswordLocation()
 	var secret corev1.Secret
 	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sc.Namespace, Name: secretName}, &secret); err != nil {
 		return "", "", errors.Wrapf(err, "reading bootstrap user secret %q", secretName)
 	}
 
-	pw, ok := secret.Data[redpandav1alpha2.StretchClusterBootstrapPasswordKey]
+	pw, ok := secret.Data[passwordKey]
 	if !ok || len(pw) == 0 {
 		return "", "", fmt.Errorf("bootstrap user secret %q has no password", secretName)
 	}

--- a/operator/pkg/client/stretch_cluster_auth_test.go
+++ b/operator/pkg/client/stretch_cluster_auth_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+// TestStretchClusterAuth_HonorsSecretKeyRef ensures the operator's own
+// admin/Kafka/schema-registry client factory reads the bootstrap password from
+// the same location the reconciler writes to, including a user-pinned
+// bootstrapUser.secretKeyRef. Without this the operator authenticates against a
+// non-existent operator-managed secret when secretKeyRef is set (K8S-900).
+func TestStretchClusterAuth_HonorsSecretKeyRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+
+	newSC := func(bu *redpandav1alpha2.BootstrapUser) *redpandav1alpha2.StretchCluster {
+		return &redpandav1alpha2.StretchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "stretch", Namespace: "default"},
+			Spec: redpandav1alpha2.StretchClusterSpec{
+				Auth: &redpandav1alpha2.Auth{
+					SASL: &redpandav1alpha2.SASL{Enabled: ptr.To(true), BootstrapUser: bu},
+				},
+			},
+		}
+	}
+
+	secret := func(name, key, value string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Data:       map[string][]byte{key: []byte(value)},
+			Type:       corev1.SecretTypeOpaque,
+		}
+	}
+
+	t.Run("default operator-managed location", func(t *testing.T) {
+		sc := newSC(nil)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(secret(sc.BootstrapUserSecretName(), redpandav1alpha2.StretchClusterBootstrapPasswordKey, "op-managed-pw")).
+			Build()
+
+		user, pw, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
+		require.NoError(t, err)
+		require.Equal(t, redpandav1alpha2.StretchClusterBootstrapUsername, user)
+		require.Equal(t, "op-managed-pw", pw)
+	})
+
+	t.Run("user-pinned secretKeyRef", func(t *testing.T) {
+		sc := newSC(&redpandav1alpha2.BootstrapUser{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "custom-bootstrap"},
+				Key:                  "custom-key",
+			},
+		})
+		// Only the referenced secret exists — the operator-managed name is absent,
+		// as the reconciler would leave it when secretKeyRef is set.
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(secret("custom-bootstrap", "custom-key", "user-pw")).
+			Build()
+
+		user, pw, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
+		require.NoError(t, err)
+		require.Equal(t, redpandav1alpha2.StretchClusterBootstrapUsername, user)
+		require.Equal(t, "user-pw", pw)
+	})
+
+	t.Run("SASL disabled returns empty", func(t *testing.T) {
+		sc := &redpandav1alpha2.StretchCluster{ObjectMeta: metav1.ObjectMeta{Name: "stretch", Namespace: "default"}}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		user, pw, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
+		require.NoError(t, err)
+		require.Empty(t, user)
+		require.Empty(t, pw)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes [K8S-900](https://redpandadata.atlassian.net/browse/K8S-900): a StretchCluster deadlock where applying the same manifest to every member cluster at once (a scripted loop or a GitOps controller such as Argo/Flux) could persist **divergent bootstrap-user passwords** across clusters. Two uncoordinated code paths each generated their own `RandAlphaNum(32)` password for the immutable `<stretchcluster>-bootstrap-user` Secret; the leader's consistency check then hard-errored and all reconciliation stopped (`Cluster has no desired brokers`), with no way to self-heal because the Secret is immutable. Reproduced 3/3 on 3× kind.

While fixing the race, this also makes the operator actually honor the documented `spec.auth.sasl.bootstrapUser.secretKeyRef`, which was silently ignored on the StretchCluster path.

## What changed

**Race fix (single writer)**
- The multicluster renderer no longer generates a bootstrap password — a missing Secret is treated as "not ready yet". `syncBootstrapUser()` (a Phase-1 syncer that runs before rendering) is the sole creator/synchronizer.
- Cluster names are canonicalized in the password-mismatch error and the existing-reused status message, so a Secret found on the local cluster is reported by its peer name instead of an empty `""` sentinel.

**Honor `bootstrapUser.secretKeyRef`** via a single shared resolver (`BootstrapUserPasswordLocation`) so every consumer agrees on where the password lives: `syncBootstrapUser`, the StatefulSet `RPK_PASS` env, the operator's admin/Kafka/schema-registry client factory, and the static-config conversion.

**Robustness & safety of the referenced-secret path**
- Fail loudly (terminal `BootstrapUserSynced` condition) when the referenced Secret exists but lacks the referenced key, instead of silently generating a password and writing it only to the other clusters.
- Migration: a cluster bootstrapped before `secretKeyRef` was honored keeps the password it was actually bootstrapped with; the operator seeds the referenced location from the legacy Secret, and refuses (terminal) rather than write divergent copies if the referenced location already holds a different password.

**Documentation**
- Only `secretKeyRef` is honored for the StretchCluster kind (`name`/`mechanism` are ignored); the CRD requires `secretKeyRef.key`.
- The bootstrap password is consumed only at first bootstrap and **cannot be rotated** afterwards by editing the Secret, changing `secretKeyRef`, or removing it.
- The cross-cluster trust boundary of a user-named replicated Secret.

## Testing

- `go build ./operator/...` clean; `golangci-lint` clean on all touched packages.
- Unit tests across `api/redpanda/v1alpha2` (+ `conversion`), `multicluster`, `pkg/client`, and `internal/controller/redpanda` cover: renderer no-self-generate/re-emit, the resolver, StatefulSet env, client factory, static-config conversion, canonical-name messages, the missing-key guard, and the migration adopt/refuse behavior.
- CRDs and `crd-docs.adoc` regenerated via `task k8s:generate`.
- Integration suites requiring Docker/testcontainers (`pkg/client` stretch suite) were not runnable locally; new logic is covered by fast unit tests.

## Notes / intentional design decisions

- Changing or removing `secretKeyRef` after bootstrap is **unsupported** (Redpanda keeps the SCRAM credential from genesis); documented rather than blocked, with best-effort auto-migration for the one recoverable direction.
- Honoring `secretKeyRef.Name` means the operator replicates a user-named in-namespace Secret across member clusters (bounded: same namespace, requires CR-edit, never overwrites); documented as a trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[K8S-900]: https://redpandadata.atlassian.net/browse/K8S-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ