### PR TITLE
operator: fix StretchCluster SASL with the default SCRAM mechanism

### DIFF
--- a/.changes/unreleased/operator-Changed-20260715-130000.yaml
+++ b/.changes/unreleased/operator-Changed-20260715-130000.yaml
@@ -1,0 +1,17 @@
+project: operator
+kind: Changed
+body: |
+  The SASL mechanism fields on the Redpanda and StretchCluster CRDs
+  (`auth.sasl.mechanism`, `auth.sasl.bootstrapUser.mechanism`, and
+  `auth.sasl.users[].mechanism`) now have enum validation restricting them to
+  `SCRAM-SHA-256` or `SCRAM-SHA-512`, matching the chart's values schema.
+  Previously an invalid or misspelled mechanism was admitted and then surfaced
+  only later as recurring Kafka-API reconcile errors; it is now rejected at
+  apply time. Note: this is a stricter CRD. Kubernetes validates enums only on
+  write, so existing objects are not re-checked at upgrade, but the next
+  `kubectl apply`/update of an object whose mechanism holds a non-canonical
+  value — including an explicit empty string (`mechanism: ""`), which the
+  operator previously treated as "use the default" — will be rejected. Audit
+  and correct such values (or omit the field to get the default) before or
+  after upgrading.
+time: 2026-07-15T13:00:00.000000-08:00

--- a/.changes/unreleased/operator-Fixed-20260715-120000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260715-120000.yaml
@@ -1,0 +1,15 @@
+project: operator
+kind: Fixed
+body: |
+  Fixed SASL authentication on StretchClusters using the default SCRAM
+  mechanism. The operator's internal Kafka client hardcoded SCRAM-SHA-256 while
+  the bootstrap user (kubernetes-controller) is provisioned with the mechanism
+  from spec.auth.sasl.mechanism, which defaults to SCRAM-SHA-512. This caused
+  every operator operation going through the Kafka API (User CRs, ACL sync) to
+  fail with SASL_AUTHENTICATION_FAILED. The client now derives its SCRAM
+  mechanism from the cluster spec. Note: the bootstrap user's SCRAM credential
+  is created once at first boot, so `auth.sasl.mechanism` is effectively
+  immutable — changing it on an already-bootstrapped cluster leaves the stored
+  credential under the old mechanism and re-triggers the same authentication
+  failure.
+time: 2026-07-15T12:00:00.000000-08:00

--- a/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go
@@ -399,6 +399,7 @@ type SASL struct {
 	// Enables SASL authentication. If you enable SASL authentication, you must provide a Secret name in `secretRef`.
 	Enabled *bool `json:"enabled,omitempty"`
 	// Specifies the default authentication mechanism to use for superusers. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+	// +kubebuilder:validation:Enum=SCRAM-SHA-256;SCRAM-SHA-512
 	Mechanism *string `json:"mechanism,omitempty"`
 	// If `users` is empty, `secretRef` specifies the name of the Secret that contains your superuser credentials in the format <username>:<password>:<optional-authentication-mechanism>. Otherwise, `secretRef` specifies the name of the Secret that the chart creates to store the credentials in `users`.
 	SecretRef *string `json:"secretRef,omitempty"`
@@ -435,12 +436,14 @@ type BootstrapUser struct {
 	// Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
 	// NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
 	// taken from sasl.mechanism.
+	// +kubebuilder:validation:Enum=SCRAM-SHA-256;SCRAM-SHA-512
 	Mechanism *string `json:"mechanism,omitempty"`
 }
 
 // UsersItems configures a list of superusers in the Helm values.
 type UsersItems struct {
 	// Specifies the authentication mechanism to use for superusers. Overrides the default in `SASL`. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+	// +kubebuilder:validation:Enum=SCRAM-SHA-256;SCRAM-SHA-512
 	Mechanism *string `json:"mechanism,omitempty"`
 	// Specifies the name of the superuser.
 	Name *string `json:"name,omitempty"`

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_helpers.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_helpers.go
@@ -130,6 +130,13 @@ func (s *SASL) IsEnabled() bool {
 }
 
 // GetMechanism returns the SASL mechanism, defaulting to SCRAM-SHA-512.
+//
+// New and updated objects are admission-validated against the canonical
+// upper-case SCRAM-SHA-256/SCRAM-SHA-512 enum. Objects persisted by an older
+// operator (before that enum existed) may still hold a non-canonical value;
+// the stretch Kafka client tolerates that via scramMechanismForStretch's
+// case-folding (operator/pkg/client/stretch_cluster.go), so this getter returns
+// the stored value unchanged.
 func (s *SASL) GetMechanism() string {
 	if s != nil && s.Mechanism != nil && *s.Mechanism != "" {
 		return *s.Mechanism

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_helpers_test.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_helpers_test.go
@@ -129,7 +129,7 @@ func TestSASL(t *testing.T) {
 		}{
 			{"nil receiver", nil, redpandav1alpha2.DefaultSASLMechanism},
 			{"zero value", &redpandav1alpha2.SASL{}, redpandav1alpha2.DefaultSASLMechanism},
-			{"custom mechanism", &redpandav1alpha2.SASL{Mechanism: ptr.To("PLAIN")}, "PLAIN"},
+			{"configured mechanism passes through", &redpandav1alpha2.SASL{Mechanism: ptr.To("SCRAM-SHA-256")}, "SCRAM-SHA-256"},
 			{"empty string falls back to default", &redpandav1alpha2.SASL{Mechanism: ptr.To("")}, redpandav1alpha2.DefaultSASLMechanism},
 		}
 		for _, tt := range tests {

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -463,7 +463,8 @@ makes the operator and brokers authenticate with a credential the cluster never 
 Rotate the bootstrap user out of band (via the admin API) instead. + |  | 
 | *`mechanism`* __string__ | Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. +
 NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is +
-taken from sasl.mechanism. + |  | 
+taken from sasl.mechanism. + |  | Enum: [SCRAM-SHA-256 SCRAM-SHA-512] +
+
 |===
 
 
@@ -4329,7 +4330,8 @@ SASL configures SASL authentication in the Helm values.
 |===
 | Field | Description | Default | Validation
 | *`enabled`* __boolean__ | Enables SASL authentication. If you enable SASL authentication, you must provide a Secret name in `secretRef`. + |  | 
-| *`mechanism`* __string__ | Specifies the default authentication mechanism to use for superusers. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. + |  | 
+| *`mechanism`* __string__ | Specifies the default authentication mechanism to use for superusers. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. + |  | Enum: [SCRAM-SHA-256 SCRAM-SHA-512] +
+
 | *`secretRef`* __string__ | If `users` is empty, `secretRef` specifies the name of the Secret that contains your superuser credentials in the format <username>:<password>:<optional-authentication-mechanism>. Otherwise, `secretRef` specifies the name of the Secret that the chart creates to store the credentials in `users`. + |  | 
 | *`users`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-usersitems[$$UsersItems$$] array__ | Specifies a list of superuser credentials. + |  | 
 | *`bootstrapUser`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-bootstrapuser[$$BootstrapUser$$]__ | Specifies configuration about the bootstrap user. + |  | 
@@ -6324,7 +6326,8 @@ UsersItems configures a list of superusers in the Helm values.
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`mechanism`* __string__ | Specifies the authentication mechanism to use for superusers. Overrides the default in `SASL`. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. + |  | 
+| *`mechanism`* __string__ | Specifies the authentication mechanism to use for superusers. Overrides the default in `SASL`. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`. + |  | Enum: [SCRAM-SHA-256 SCRAM-SHA-512] +
+
 | *`name`* __string__ | Specifies the name of the superuser. + |  | 
 | *`password`* __string__ | Specifies the superuser password. + |  | 
 |===

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -1083,6 +1083,9 @@ spec:
                                   Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
                                   NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
                                   taken from sasl.mechanism.
+                                enum:
+                                - SCRAM-SHA-256
+                                - SCRAM-SHA-512
                                 type: string
                               name:
                                 description: |-
@@ -1141,6 +1144,9 @@ spec:
                             description: Specifies the default authentication mechanism
                               to use for superusers. Options are `SCRAM-SHA-256` and
                               `SCRAM-SHA-512`.
+                            enum:
+                            - SCRAM-SHA-256
+                            - SCRAM-SHA-512
                             type: string
                           secretRef:
                             description: If `users` is empty, `secretRef` specifies
@@ -1159,6 +1165,9 @@ spec:
                                   description: Specifies the authentication mechanism
                                     to use for superusers. Overrides the default in
                                     `SASL`. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                                  enum:
+                                  - SCRAM-SHA-256
+                                  - SCRAM-SHA-512
                                   type: string
                                 name:
                                   description: Specifies the name of the superuser.
@@ -35083,6 +35092,9 @@ spec:
                                   Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
                                   NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
                                   taken from sasl.mechanism.
+                                enum:
+                                - SCRAM-SHA-256
+                                - SCRAM-SHA-512
                                 type: string
                               name:
                                 description: |-
@@ -35141,6 +35153,9 @@ spec:
                             description: Specifies the default authentication mechanism
                               to use for superusers. Options are `SCRAM-SHA-256` and
                               `SCRAM-SHA-512`.
+                            enum:
+                            - SCRAM-SHA-256
+                            - SCRAM-SHA-512
                             type: string
                           secretRef:
                             description: If `users` is empty, `secretRef` specifies
@@ -35159,6 +35174,9 @@ spec:
                                   description: Specifies the authentication mechanism
                                     to use for superusers. Overrides the default in
                                     `SASL`. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                                  enum:
+                                  - SCRAM-SHA-256
+                                  - SCRAM-SHA-512
                                   type: string
                                 name:
                                   description: Specifies the name of the superuser.

--- a/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
@@ -109,6 +109,9 @@ spec:
                               Specifies the authentication mechanism to use for the bootstrap user. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
                               NOTE: for the StretchCluster kind this field is currently ignored; the mechanism is
                               taken from sasl.mechanism.
+                            enum:
+                            - SCRAM-SHA-256
+                            - SCRAM-SHA-512
                             type: string
                           name:
                             description: |-
@@ -165,6 +168,9 @@ spec:
                       mechanism:
                         description: Specifies the default authentication mechanism
                           to use for superusers. Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                        enum:
+                        - SCRAM-SHA-256
+                        - SCRAM-SHA-512
                         type: string
                       secretRef:
                         description: If `users` is empty, `secretRef` specifies the
@@ -183,6 +189,9 @@ spec:
                               description: Specifies the authentication mechanism
                                 to use for superusers. Overrides the default in `SASL`.
                                 Options are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+                              enum:
+                              - SCRAM-SHA-256
+                              - SCRAM-SHA-512
                               type: string
                             name:
                               description: Specifies the name of the superuser.

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -15,10 +15,12 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
 	corev1 "k8s.io/api/core/v1"
@@ -155,7 +157,9 @@ func (c *Factory) stretchAdminClientForEndpoints(ctx context.Context, sc *redpan
 		return nil, errors.Wrap(err, "building TLS config")
 	}
 
-	username, password, err := c.stretchClusterAuth(ctx, sc, k8sClient)
+	// The admin API authenticates with HTTP Basic Auth (rpadmin.BasicAuth),
+	// which is mechanism-agnostic, so the SCRAM mechanism is not needed here.
+	username, password, _, err := c.stretchClusterAuth(ctx, sc, k8sClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading auth credentials")
 	}
@@ -211,15 +215,19 @@ func (c *Factory) kafkaForStretchCluster(ctx context.Context, sc *redpandav1alph
 		clientOpts = append(clientOpts, kgo.DialTLSConfig(tlsConfig))
 	}
 
-	username, password, err := c.stretchClusterAuth(ctx, sc, k8sClient)
+	username, password, mechanism, err := c.stretchClusterAuth(ctx, sc, k8sClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading auth credentials")
 	}
 	if username != "" {
-		clientOpts = append(clientOpts, kgo.SASL(scram.Auth{
+		saslMechanism, err := scramMechanismForStretch(scram.Auth{
 			User: username,
 			Pass: password,
-		}.AsSha256Mechanism()))
+		}, mechanism)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolving SASL mechanism")
+		}
+		clientOpts = append(clientOpts, kgo.SASL(saslMechanism))
 	}
 
 	return kgo.NewClient(clientOpts...)
@@ -275,7 +283,9 @@ func (c *Factory) schemaRegistryForStretchCluster(ctx context.Context, sc *redpa
 
 	srOpts := []sr.ClientOpt{sr.URLs(urls...), sr.HTTPClient(&http.Client{Transport: transport})}
 
-	username, password, err := c.stretchClusterAuth(ctx, sc, k8sClient)
+	// Schema Registry authenticates with HTTP Basic Auth, which is
+	// mechanism-agnostic, so the SCRAM mechanism is not needed here.
+	username, password, _, err := c.stretchClusterAuth(ctx, sc, k8sClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading auth credentials")
 	}
@@ -423,10 +433,15 @@ func (c *Factory) stretchClusterListenerTLSConfig(ctx context.Context, sc *redpa
 }
 
 // stretchClusterAuth reads the bootstrap user credentials from the bootstrap
-// user secret if SASL is enabled.
-func (c *Factory) stretchClusterAuth(ctx context.Context, sc *redpandav1alpha2.StretchCluster, k8sClient client.Client) (username, password string, _ error) {
+// user secret if SASL is enabled. The returned mechanism is the SASL mechanism
+// configured on the cluster (defaulting to SCRAM-SHA-512) — it matches the
+// mechanism Redpanda used to create the bootstrap user's SCRAM credential (see
+// bootstrapUserEnvVars in operator/multicluster/statefulset_redpanda.go) and
+// must be honored by SCRAM clients. When SASL is disabled all returns are
+// empty.
+func (c *Factory) stretchClusterAuth(ctx context.Context, sc *redpandav1alpha2.StretchCluster, k8sClient client.Client) (username, password, mechanism string, _ error) {
 	if !sc.Spec.Auth.IsSASLEnabled() {
-		return "", "", nil
+		return "", "", "", nil
 	}
 
 	// Resolve via the shared helper so the operator's own admin/Kafka/SR clients
@@ -436,13 +451,29 @@ func (c *Factory) stretchClusterAuth(ctx context.Context, sc *redpandav1alpha2.S
 	secretName, passwordKey := sc.BootstrapUserPasswordLocation()
 	var secret corev1.Secret
 	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sc.Namespace, Name: secretName}, &secret); err != nil {
-		return "", "", errors.Wrapf(err, "reading bootstrap user secret %q", secretName)
+		return "", "", "", errors.Wrapf(err, "reading bootstrap user secret %q", secretName)
 	}
 
 	pw, ok := secret.Data[passwordKey]
 	if !ok || len(pw) == 0 {
-		return "", "", fmt.Errorf("bootstrap user secret %q has no password", secretName)
+		return "", "", "", fmt.Errorf("bootstrap user secret %q has no password", secretName)
 	}
 
-	return redpandav1alpha2.StretchClusterBootstrapUsername, string(pw), nil
+	return redpandav1alpha2.StretchClusterBootstrapUsername, string(pw), sc.Spec.Auth.SASL.GetMechanism(), nil
+}
+
+// scramMechanismForStretch maps a StretchCluster's configured SASL mechanism to
+// the corresponding franz-go SCRAM mechanism for the given credentials. The
+// bootstrap user is always provisioned with a SCRAM mechanism
+// (SCRAM-SHA-256/512); hardcoding one silently breaks SASL whenever the
+// configured mechanism differs — e.g. the SCRAM-SHA-512 default (K8S-899).
+func scramMechanismForStretch(auth scram.Auth, mechanism string) (sasl.Mechanism, error) {
+	switch strings.ToUpper(mechanism) {
+	case "SCRAM-SHA-256":
+		return auth.AsSha256Mechanism(), nil
+	case "SCRAM-SHA-512":
+		return auth.AsSha512Mechanism(), nil
+	default:
+		return nil, fmt.Errorf("unsupported SASL mechanism %q for StretchCluster bootstrap user, supported: [SCRAM-SHA-256, SCRAM-SHA-512]", mechanism)
+	}
 }

--- a/operator/pkg/client/stretch_cluster_auth_test.go
+++ b/operator/pkg/client/stretch_cluster_auth_test.go
@@ -58,7 +58,7 @@ func TestStretchClusterAuth_HonorsSecretKeyRef(t *testing.T) {
 			WithObjects(secret(sc.BootstrapUserSecretName(), redpandav1alpha2.StretchClusterBootstrapPasswordKey, "op-managed-pw")).
 			Build()
 
-		user, pw, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
+		user, pw, _, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
 		require.NoError(t, err)
 		require.Equal(t, redpandav1alpha2.StretchClusterBootstrapUsername, user)
 		require.Equal(t, "op-managed-pw", pw)
@@ -77,7 +77,7 @@ func TestStretchClusterAuth_HonorsSecretKeyRef(t *testing.T) {
 			WithObjects(secret("custom-bootstrap", "custom-key", "user-pw")).
 			Build()
 
-		user, pw, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
+		user, pw, _, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
 		require.NoError(t, err)
 		require.Equal(t, redpandav1alpha2.StretchClusterBootstrapUsername, user)
 		require.Equal(t, "user-pw", pw)
@@ -87,9 +87,114 @@ func TestStretchClusterAuth_HonorsSecretKeyRef(t *testing.T) {
 		sc := &redpandav1alpha2.StretchCluster{ObjectMeta: metav1.ObjectMeta{Name: "stretch", Namespace: "default"}}
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		user, pw, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
+		user, pw, _, err := (&Factory{}).stretchClusterAuth(context.Background(), sc, fakeClient)
 		require.NoError(t, err)
 		require.Empty(t, user)
 		require.Empty(t, pw)
 	})
+}
+
+// TestStretchClusterAuth guards the plumbing that regressed in K8S-899: the
+// SASL mechanism that kafkaForStretchCluster passes to the SCRAM client comes
+// from stretchClusterAuth's third return value, which must reflect
+// spec.auth.sasl.mechanism (defaulting to SCRAM-SHA-512), not a hardcoded
+// mechanism. It also covers the SASL-disabled path (all empty).
+func TestStretchClusterAuth(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	newSC := func(sasl *redpandav1alpha2.SASL) *redpandav1alpha2.StretchCluster {
+		return &redpandav1alpha2.StretchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "sc", Namespace: "ns"},
+			Spec: redpandav1alpha2.StretchClusterSpec{
+				Auth: &redpandav1alpha2.Auth{SASL: sasl},
+			},
+		}
+	}
+
+	bootstrapSecret := func(sc *redpandav1alpha2.StretchCluster) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sc.BootstrapUserSecretName(),
+				Namespace: sc.Namespace,
+			},
+			Data: map[string][]byte{
+				redpandav1alpha2.StretchClusterBootstrapPasswordKey: []byte("bootstrap-pw"),
+			},
+		}
+	}
+
+	testCases := []struct {
+		name          string
+		sasl          *redpandav1alpha2.SASL
+		injectSecret  bool // add the bootstrap-user secret to the fake client
+		emptyPassword bool // if injected, omit the password key
+		wantUser      string
+		wantPass      string
+		wantMechanism string
+		wantErr       string // expected error substring; empty means no error
+	}{
+		{
+			name:          "default mechanism is SCRAM-SHA-512",
+			sasl:          &redpandav1alpha2.SASL{Enabled: ptr.To(true)},
+			injectSecret:  true,
+			wantUser:      redpandav1alpha2.StretchClusterBootstrapUsername,
+			wantPass:      "bootstrap-pw",
+			wantMechanism: "SCRAM-SHA-512",
+		},
+		{
+			name:          "explicit SCRAM-SHA-256 is returned",
+			sasl:          &redpandav1alpha2.SASL{Enabled: ptr.To(true), Mechanism: ptr.To("SCRAM-SHA-256")},
+			injectSecret:  true,
+			wantUser:      redpandav1alpha2.StretchClusterBootstrapUsername,
+			wantPass:      "bootstrap-pw",
+			wantMechanism: "SCRAM-SHA-256",
+		},
+		{
+			// No secret is injected: stretchClusterAuth returns early on
+			// !IsSASLEnabled() before reading the bootstrap-user secret.
+			name:         "SASL disabled returns all empty",
+			sasl:         &redpandav1alpha2.SASL{Enabled: ptr.To(false)},
+			injectSecret: false,
+		},
+		{
+			name:         "missing bootstrap secret is an error",
+			sasl:         &redpandav1alpha2.SASL{Enabled: ptr.To(true)},
+			injectSecret: false,
+			wantErr:      "reading bootstrap user secret",
+		},
+		{
+			name:          "bootstrap secret without a password is an error",
+			sasl:          &redpandav1alpha2.SASL{Enabled: ptr.To(true)},
+			injectSecret:  true,
+			emptyPassword: true,
+			wantErr:       "has no password",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := newSC(tc.sasl)
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.injectSecret {
+				secret := bootstrapSecret(sc)
+				if tc.emptyPassword {
+					secret.Data = nil
+				}
+				builder = builder.WithObjects(secret)
+			}
+			k8sClient := builder.Build()
+
+			c := &Factory{}
+			user, pass, mechanism, err := c.stretchClusterAuth(context.Background(), sc, k8sClient)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantUser, user)
+			require.Equal(t, tc.wantPass, pass)
+			require.Equal(t, tc.wantMechanism, mechanism)
+		})
+	}
 }

--- a/operator/pkg/client/stretch_cluster_mechanism_test.go
+++ b/operator/pkg/client/stretch_cluster_mechanism_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
+)
+
+// TestScramMechanismForStretch guards against K8S-899: the operator's stretch
+// Kafka client must authenticate with the SASL mechanism configured on the
+// StretchCluster (matching the mechanism Redpanda used to create the bootstrap
+// user), not a hardcoded one. The default mechanism is SCRAM-SHA-512.
+func TestScramMechanismForStretch(t *testing.T) {
+	auth := scram.Auth{User: "kubernetes-controller", Pass: "secret"}
+
+	testCases := []struct {
+		name      string
+		mechanism string
+		wantName  string
+		wantErr   bool
+	}{
+		{
+			name:      "default mechanism is SCRAM-SHA-512",
+			mechanism: "SCRAM-SHA-512",
+			wantName:  "SCRAM-SHA-512",
+		},
+		{
+			name:      "SCRAM-SHA-256 is honored",
+			mechanism: "SCRAM-SHA-256",
+			wantName:  "SCRAM-SHA-256",
+		},
+		{
+			name:      "mechanism is case-insensitive",
+			mechanism: "scram-sha-512",
+			wantName:  "SCRAM-SHA-512",
+		},
+		{
+			name:      "unsupported mechanism is rejected",
+			mechanism: "PLAIN",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mechanism, err := scramMechanismForStretch(auth, tc.mechanism)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantName, mechanism.Name())
+		})
+	}
+}


### PR DESCRIPTION
Fixes [K8S-899](https://redpandadata.atlassian.net/browse/K8S-899).

## Problem

On a StretchCluster with SASL enabled, the operator provisions the `kubernetes-controller` bootstrap user with the mechanism from `spec.auth.sasl.mechanism` (default **SCRAM-SHA-512**), but the operator's own Kafka client always authenticated with hardcoded **SCRAM-SHA-256**. The default SASL configuration therefore broke every operator operation going through the Kafka API (User CRs, ACL sync) with `SASL_AUTHENTICATION_FAILED`, even though the cluster itself looked healthy.

## Changes

- **`kafkaForStretchCluster`** now derives its SCRAM mechanism from the cluster spec (via a new `scramMechanismForStretch` helper) instead of hardcoding `AsSha256Mechanism`. `stretchClusterAuth` returns the configured mechanism alongside the credentials. The admin and schema-registry paths use HTTP Basic Auth (mechanism-agnostic) and are unchanged.
- **CRD enum validation**: the SASL mechanism fields (`auth.sasl.mechanism`, `auth.sasl.bootstrapUser.mechanism`, `auth.sasl.users[].mechanism`) now carry a kubebuilder `Enum` restricting them to the canonical `SCRAM-SHA-256`/`SCRAM-SHA-512`, matching the redpanda chart's `values.schema.json`. Invalid mechanisms are rejected at apply time rather than surfacing as recurring reconcile errors. Applies to both the Redpanda and StretchCluster CRDs.
- **Unit tests** cover the mechanism mapping helper and `stretchClusterAuth` (default and explicit mechanisms, SASL-disabled, and the missing-secret / empty-password error paths).

## Compatibility note

Because Kubernetes validates enums only on write, existing objects holding a non-canonical mechanism value (including an explicit empty string `mechanism: ""`, which was previously treated as "use the default") are rejected on their next `kubectl apply`/update. Audit and correct such values (or omit the field to get the default) when upgrading. Note also that the bootstrap user's SCRAM credential is created once at first boot, so `auth.sasl.mechanism` is effectively immutable on an already-bootstrapped cluster.

## Testing

- `go build ./operator/...`, `go vet`, and the `TestScramMechanismForStretch` / `TestStretchClusterAuth` / `TestSASL` suites pass.
- `nix develop -c task generate lint-fix` produces no diff (CRDs, crd-docs, and formatting are CI-consistent); `golangci-lint`, `helm lint --strict`, and `actionlint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[K8S-899]: https://redpandadata.atlassian.net/browse/K8S-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ