### PR TITLE
operator: defer multicluster rendering until broker pool view is complete

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260716-multicluster-seed-servers-split-brain.yaml
+++ b/.changes/unreleased/operator-Fixed-20260716-multicluster-seed-servers-split-brain.yaml
@@ -2,13 +2,18 @@ project: operator
 kind: Fixed
 body: |-
     The multicluster StretchCluster controller no longer renders broker
-    StatefulSets and ConfigMaps when a peer cluster's BrokerPool list wasn't
-    observed this reconcile pass (e.g. a brief post-leader-election window
-    before the health probe's engage cycle completes). Previously the
+    StatefulSets and ConfigMaps when a configured peer cluster's BrokerPool
+    list wasn't observed this reconcile pass — whether the peer was probe-
+    unreachable, its list call failed, or its runtime registration hadn't
+    completed yet (e.g. a brief post-leader-election window before the
+    engage cycle and bootstrap peer registration finish). Previously the
     renderer could compute `seed_servers` from an incomplete cross-cluster
     pool view, producing a self-only seed list for a freshly added
     RedpandaBrokerPool. A broker that bootstraps from a self-only seed list
     forms its own standalone cluster instead of joining the existing
-    StretchCluster, causing a split-brain. The controller now requeues and
-    retries instead of rendering from a partial view.
+    StretchCluster, causing a split-brain. Only the pool-derived steps (CA
+    sync and resource rendering) are deferred and retried; cluster-level
+    recovery — maintenance-mode clearing, stale-disk wipe, decommission
+    hygiene, and license/config sync — keeps running on reachable members
+    during the deferral.
 time: 2026-07-16T09:00:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260716-multicluster-seed-servers-split-brain.yaml
+++ b/.changes/unreleased/operator-Fixed-20260716-multicluster-seed-servers-split-brain.yaml
@@ -1,0 +1,14 @@
+project: operator
+kind: Fixed
+body: |-
+    The multicluster StretchCluster controller no longer renders broker
+    StatefulSets and ConfigMaps when a peer cluster's BrokerPool list wasn't
+    observed this reconcile pass (e.g. a brief post-leader-election window
+    before the health probe's engage cycle completes). Previously the
+    renderer could compute `seed_servers` from an incomplete cross-cluster
+    pool view, producing a self-only seed list for a freshly added
+    RedpandaBrokerPool. A broker that bootstraps from a self-only seed list
+    forms its own standalone cluster instead of joining the existing
+    StretchCluster, causing a split-brain. The controller now requeues and
+    retries instead of rendering from a partial view.
+time: 2026-07-16T09:00:00.000000-07:00

--- a/operator/internal/controller/redpanda/multicluster_broker_pool_view_test.go
+++ b/operator/internal/controller/redpanda/multicluster_broker_pool_view_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
+)
+
+// K8S-891: a leadership change can leave the new leader's health probe not
+// yet reporting a peer cluster reachable. FetchExistingBrokerPoolsFromAllClusters
+// then silently skips that peer, so the fetched BrokerPool union is missing
+// pools. unobservedClusters must surface exactly the clusters missing from
+// the observed set, using canonical (not raw multicluster-runtime) names.
+func TestUnobservedClusters(t *testing.T) {
+	localName := func() string { return "rp-failover" }
+
+	for name, tc := range map[string]struct {
+		allClusters []string
+		observed    map[string]bool
+		want        []string
+	}{
+		"all observed": {
+			allClusters: []string{"", "rp-east", "rp-west"},
+			observed:    map[string]bool{"": true, "rp-east": true, "rp-west": true},
+			want:        nil,
+		},
+		"one peer unobserved": {
+			allClusters: []string{"", "rp-east", "rp-west"},
+			observed:    map[string]bool{"": true, "rp-west": true},
+			want:        []string{"rp-east"},
+		},
+		"local cluster name is canonicalized": {
+			allClusters: []string{"", "rp-east"},
+			observed:    map[string]bool{"rp-east": true},
+			want:        []string{"rp-failover"},
+		},
+		"nothing observed": {
+			allClusters: []string{"", "rp-east", "rp-west"},
+			observed:    map[string]bool{},
+			want:        []string{"rp-failover", "rp-east", "rp-west"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := unobservedClusters(tc.allClusters, tc.observed, localName)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// K8S-891 regression: when a configured cluster's BrokerPool list wasn't
+// observed this pass, checkBrokerPoolViewComplete must report incomplete and
+// set ResourcesSynced to a retryable Error rather than let the caller proceed
+// to render seed_servers from a partial pool view.
+func TestCheckBrokerPoolViewComplete_IncompleteObservationDefers(t *testing.T) {
+	r := &MulticlusterReconciler{}
+	state := &stretchClusterReconciliationState{
+		status:                       lifecycle.NewStretchClusterStatus(),
+		unobservedBrokerPoolClusters: []string{"rp-east", "rp-west"},
+	}
+
+	incomplete, result := r.checkBrokerPoolViewComplete(context.Background(), state)
+	require.True(t, incomplete, "an unobserved peer must defer resource rendering")
+	require.Equal(t, requeueTimeout, result.RequeueAfter)
+
+	sc := &redpandav1alpha2.StretchCluster{}
+	state.status.StretchClusterStatus.UpdateConditions(sc)
+	cond := apimeta.FindStatusCondition(sc.Status.Conditions, statuses.StretchClusterResourcesSynced)
+	require.NotNil(t, cond)
+	require.Equal(t, metav1.ConditionFalse, cond.Status)
+	require.Equal(t, string(statuses.StretchClusterResourcesSyncedReasonError), cond.Reason)
+	require.Contains(t, cond.Message, "rp-east")
+	require.Contains(t, cond.Message, "rp-west")
+}
+
+// Regression guard: once every configured cluster has been observed,
+// checkBrokerPoolViewComplete must not block Phase 2 rendering.
+func TestCheckBrokerPoolViewComplete_FullObservationProceeds(t *testing.T) {
+	r := &MulticlusterReconciler{}
+	state := &stretchClusterReconciliationState{
+		status: lifecycle.NewStretchClusterStatus(),
+	}
+
+	incomplete, result := r.checkBrokerPoolViewComplete(context.Background(), state)
+	require.False(t, incomplete)
+	require.Zero(t, result.RequeueAfter)
+}

--- a/operator/internal/controller/redpanda/multicluster_broker_pool_view_test.go
+++ b/operator/internal/controller/redpanda/multicluster_broker_pool_view_test.go
@@ -20,6 +20,7 @@ import (
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 )
 
 // K8S-891: a leadership change can leave the new leader's health probe not
@@ -99,4 +100,79 @@ func TestCheckBrokerPoolViewComplete_FullObservationProceeds(t *testing.T) {
 	incomplete, result := r.checkBrokerPoolViewComplete(context.Background(), state)
 	require.False(t, incomplete)
 	require.Zero(t, result.RequeueAfter)
+}
+
+// brokerPoolViewManager is a fake multicluster.Manager exposing distinct
+// registered (GetClusterNames) and configured (GetConfiguredClusterNames)
+// sets, mimicking the raft manager's bootstrap mode where a peer appears in
+// the configured set from process start but is registered with the runtime
+// provider only after leadership is acquired and its kubeconfig fetched.
+type brokerPoolViewManager struct {
+	multicluster.Manager
+	local      string
+	registered []string
+	configured []string
+}
+
+func (m *brokerPoolViewManager) GetClusterNames() []string           { return m.registered }
+func (m *brokerPoolViewManager) GetConfiguredClusterNames() []string { return m.configured }
+func (m *brokerPoolViewManager) GetLocalClusterName() string         { return m.local }
+
+func TestUnionClusterNames(t *testing.T) {
+	for name, tc := range map[string]struct {
+		a, b []string
+		want []string
+	}{
+		"identical":            {a: []string{"", "rp-east"}, b: []string{"", "rp-east"}, want: []string{"", "rp-east"}},
+		"configured superset":  {a: []string{""}, b: []string{"", "rp-east", "rp-west"}, want: []string{"", "rp-east", "rp-west"}},
+		"dynamic extra member": {a: []string{"", "rp-dynamic"}, b: []string{"", "rp-east"}, want: []string{"", "rp-dynamic", "rp-east"}},
+		"both empty":           {a: nil, b: nil, want: nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, unionClusterNames(tc.a, tc.b))
+		})
+	}
+}
+
+// K8S-891 regression (PR #1683 review): Manager.GetClusterNames reflects only
+// clusters currently registered with the runtime provider, and bootstrap
+// peers are registered by leader routines that run only after raft
+// leadership is acquired. A reconcile racing that registration sees just the
+// local cluster; its own BrokerPool list succeeds, so an expected set
+// derived from the registered clusters alone reports nothing unobserved and
+// the gate lets a self-only seed list render. The expected set must instead
+// include the manager's configured clusters, so the not-yet-registered peer
+// keeps the gate closed until its registration completes and its BrokerPool
+// list is actually observed.
+func TestBrokerPoolViewGate_ReconcileRacingPeerRegistrationDefers(t *testing.T) {
+	mgr := &brokerPoolViewManager{
+		local:      "rp-central",
+		registered: []string{""},            // peer registration hasn't completed
+		configured: []string{"", "rp-east"}, // static raft peer topology
+	}
+	r := &MulticlusterReconciler{Manager: mgr}
+
+	// Only the local cluster was registered, so only its BrokerPool list was
+	// fetched and observed.
+	observed := map[string]bool{"": true}
+
+	expected := r.expectedBrokerPoolClusters(mgr.GetClusterNames())
+	unobserved := unobservedClusters(expected, observed, mgr.GetLocalClusterName)
+	require.Equal(t, []string{"rp-east"}, unobserved,
+		"a configured-but-unregistered peer must count as unobserved")
+
+	state := &stretchClusterReconciliationState{
+		status:                       lifecycle.NewStretchClusterStatus(),
+		unobservedBrokerPoolClusters: unobserved,
+	}
+	incomplete, result := r.checkBrokerPoolViewComplete(context.Background(), state)
+	require.True(t, incomplete, "reconciliation racing peer registration must defer pool-derived rendering")
+	require.Equal(t, requeueTimeout, result.RequeueAfter)
+
+	// Once the peer's registration completes and its BrokerPool list is
+	// observed, the same computation must open the gate.
+	mgr.registered = []string{"", "rp-east"}
+	observed["rp-east"] = true
+	unobserved = unobservedClusters(r.expectedBrokerPoolClusters(mgr.GetClusterNames()), observed, mgr.GetLocalClusterName)
+	require.Empty(t, unobserved, "a registered and observed peer must not defer rendering")
 }

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -136,6 +136,17 @@ type stretchClusterReconciliationState struct {
 	admin                 *rpadmin.AdminAPI
 	bootstrapUser         string
 	bootstrapPassword     string
+
+	// unobservedBrokerPoolClusters lists the configured clusters whose
+	// RedpandaBrokerPool list could not be fetched this pass (unreachable
+	// probe, transient list error, etc.). When non-empty, cluster.BrokerPools
+	// (and therefore cluster.GetAllBrokerPools()) is a partial view of the
+	// StretchCluster's true broker membership, so rendering seed_servers or
+	// any other pool-derived resource from it risks producing an incomplete
+	// list — e.g. a self-only seed list for a freshly added pool, which makes
+	// that broker bootstrap its own standalone cluster instead of joining
+	// (K8S-891). Callers must defer pool-derived rendering while this is set.
+	unobservedBrokerPoolClusters []string
 }
 
 func (s *stretchClusterReconciliationState) cleanup() {
@@ -292,6 +303,15 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 		}
 	}
 
+	// Both Phase 2 reconcilers below render seed_servers (and other
+	// pool-derived config) from state.cluster.GetAllBrokerPools(), the union
+	// of BrokerPools fetched across every configured cluster. If any cluster
+	// wasn't observed this pass, that union is incomplete — defer rendering
+	// rather than apply a partial view (K8S-891; see checkBrokerPoolViewComplete).
+	if incomplete, result := r.checkBrokerPoolViewComplete(ctx, state); incomplete {
+		return r.syncStatus(ctx, cluster, state, result, nil)
+	}
+
 	// Phase 2: sync Kubernetes resources (simple resources + broker pools).
 	// EndpointSlice sync runs between resource creation and pool readiness
 	// checks so that pods can discover each other before becoming ready.
@@ -400,6 +420,37 @@ func (r *MulticlusterReconciler) findAliveCluster(ctx context.Context, sc *redpa
 		}
 	}
 	return ""
+}
+
+// checkBrokerPoolViewComplete reports whether fetchInitialState observed
+// every configured cluster's BrokerPool list this pass. When a cluster was
+// probe-skipped or its List call failed — most commonly a brief
+// post-leader-election window before the health probe's engage cycle
+// completes — state.cluster.GetAllBrokerPools() is a partial view of the
+// StretchCluster's true broker membership.
+//
+// Rendering seed_servers (or any other pool-derived resource) from a partial
+// view is unsafe: a freshly added pool can render with a self-only seed
+// list, and a broker that bootstraps from a self-only seed list forms its
+// own standalone cluster instead of joining the existing one — a split-brain
+// (K8S-891). Callers must skip Phase 2 rendering and requeue instead of
+// proceeding when this returns incomplete=true; the next pass retries once
+// the peer becomes reachable (health.go's unreachable→reachable transition
+// also wakes the engage loop directly, so this typically resolves within one
+// probe interval).
+func (r *MulticlusterReconciler) checkBrokerPoolViewComplete(ctx context.Context, state *stretchClusterReconciliationState) (incomplete bool, _ ctrl.Result) {
+	if len(state.unobservedBrokerPoolClusters) == 0 {
+		return false, ctrl.Result{}
+	}
+
+	l := log.FromContext(ctx).WithName("checkBrokerPoolViewComplete")
+	msg := fmt.Sprintf(
+		"broker pool view incomplete, clusters not yet observed: %s — deferring resource rendering to avoid an incomplete seed_servers list",
+		strings.Join(state.unobservedBrokerPoolClusters, ", "),
+	)
+	l.Info(msg)
+	state.status.StretchClusterStatus.SetResourcesSynced(statuses.StretchClusterResourcesSyncedReasonError, msg)
+	return true, ctrl.Result{RequeueAfter: requeueTimeout}
 }
 
 // checkSpecConsistency fetches the StretchCluster from every reachable cluster
@@ -561,6 +612,22 @@ func specDiffFields(a, b redpandav1alpha2.StretchClusterSpec) []string {
 	return fields
 }
 
+// unobservedClusters returns the canonical names of every entry in
+// allClusters that observed does not mark true, preserving allClusters'
+// order. Used to detect when FetchExistingBrokerPoolsFromAllClusters'
+// observed set is missing a configured cluster — i.e. its BrokerPool list
+// was probe-skipped or failed to fetch, making the union of BrokerPools an
+// incomplete view of the StretchCluster (K8S-891).
+func unobservedClusters(allClusters []string, observed map[string]bool, getLocalClusterName func() string) []string {
+	var missing []string
+	for _, clusterName := range allClusters {
+		if !observed[clusterName] {
+			missing = append(missing, lifecycle.CanonicalClusterName(clusterName, getLocalClusterName))
+		}
+	}
+	return missing
+}
+
 func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redpandav1alpha2.StretchCluster) (*stretchClusterReconciliationState, error) {
 	logger := log.FromContext(ctx)
 	logger.V(log.DebugLevel).Info("fetchInitialState")
@@ -574,6 +641,13 @@ func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redp
 		return nil, err
 	}
 	sccluster.BrokerPools = brokerPools
+
+	// Any configured cluster missing from brokerPoolsObserved means its
+	// BrokerPool list was probe-skipped or failed to fetch this pass, so
+	// sccluster.BrokerPools (and GetAllBrokerPools()) is an incomplete view.
+	// Recorded here so Reconcile can defer any pool-derived rendering until
+	// every cluster has been observed (K8S-891).
+	unobservedBrokerPoolClusters := unobservedClusters(sccluster.GetClusters(), brokerPoolsObserved, r.Manager.GetLocalClusterName)
 
 	// grab our existing and desired pool resources
 	// so that we can immediately calculate cluster status
@@ -609,10 +683,11 @@ func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redp
 	sccluster.PodEndpoints = pools.PodEndpoints(ctx)
 
 	return &stretchClusterReconciliationState{
-		cluster:               sccluster,
-		pools:                 pools,
-		status:                status,
-		restartOnConfigChange: restartOnConfigChange,
+		cluster:                      sccluster,
+		pools:                        pools,
+		status:                       status,
+		restartOnConfigChange:        restartOnConfigChange,
+		unobservedBrokerPoolClusters: unobservedBrokerPoolClusters,
 	}, nil
 }
 

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -288,11 +288,29 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 		return ctrl.Result{RequeueAfter: finalizerRequeueTimeout}, nil
 	}
 
+	// syncCA (Phase 1) and both Phase 2 reconcilers derive pool-scoped
+	// resources — CA cert names, seed_servers, StatefulSets, ConfigMaps —
+	// from state.cluster.GetAllBrokerPools(), the union of BrokerPools
+	// fetched across every expected cluster. If any cluster wasn't observed
+	// this pass, that union is incomplete — skip exactly those pool-derived
+	// steps rather than apply a partial view (K8S-891; see
+	// checkBrokerPoolViewComplete). Everything else still runs: a peer
+	// outage is precisely when Phase 3's recovery steps (maintenance-mode
+	// clear, stale-disk wipe, decommission hygiene, license/config sync)
+	// are needed on the members we can still reach.
+	poolViewIncomplete, poolViewResult := r.checkBrokerPoolViewComplete(ctx, state)
+
 	// Phase 1: cross-cluster syncers — ensure shared resources exist in all k8s clusters
 	// before any per-cluster reconciliation begins.
 	syncers := []stretchClusterReconciliationFn{
 		r.syncBootstrapUser,
-		r.syncCA,
+	}
+	// syncCA derives the managed-cert names from the BrokerPool union, so it
+	// is deferred alongside Phase 2 while the pool view is incomplete.
+	// syncBootstrapUser is spec-derived and skips unreachable peers itself,
+	// so it always runs.
+	if !poolViewIncomplete {
+		syncers = append(syncers, r.syncCA)
 	}
 
 	for _, syncer := range syncers {
@@ -303,36 +321,36 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 		}
 	}
 
-	// Both Phase 2 reconcilers below render seed_servers (and other
-	// pool-derived config) from state.cluster.GetAllBrokerPools(), the union
-	// of BrokerPools fetched across every configured cluster. If any cluster
-	// wasn't observed this pass, that union is incomplete — defer rendering
-	// rather than apply a partial view (K8S-891; see checkBrokerPoolViewComplete).
-	if incomplete, result := r.checkBrokerPoolViewComplete(ctx, state); incomplete {
-		return r.syncStatus(ctx, cluster, state, result, nil)
-	}
-
 	// Phase 2: sync Kubernetes resources (simple resources + broker pools).
 	// EndpointSlice sync runs between resource creation and pool readiness
 	// checks so that pods can discover each other before becoming ready.
-	resourceReconcilers := []stretchClusterReconciliationFn{
-		r.reconcileResources,
-		r.reconcilePools,
-	}
-	for _, reconciler := range resourceReconcilers {
-		result, err := reconciler(ctx, state, cluster)
-		if err != nil || result.RequeueAfter > 0 {
-			l.V(log.TraceLevel).Info("aborting reconciliation early during resource sync", "error", err, "requeueAfter", result.RequeueAfter)
-			return r.syncStatus(ctx, cluster, state, result, err)
+	// Skipped entirely while the pool view is incomplete:
+	// checkBrokerPoolViewComplete has already set ResourcesSynced to a
+	// retryable error explaining the deferral.
+	if !poolViewIncomplete {
+		resourceReconcilers := []stretchClusterReconciliationFn{
+			r.reconcileResources,
+			r.reconcilePools,
 		}
-	}
+		for _, reconciler := range resourceReconcilers {
+			result, err := reconciler(ctx, state, cluster)
+			if err != nil || result.RequeueAfter > 0 {
+				l.V(log.TraceLevel).Info("aborting reconciliation early during resource sync", "error", err, "requeueAfter", result.RequeueAfter)
+				return r.syncStatus(ctx, cluster, state, result, err)
+			}
+		}
 
-	// All Kubernetes resources are in sync.
-	state.status.StretchClusterStatus.SetResourcesSynced(statuses.StretchClusterResourcesSyncedReasonSynced)
+		// All Kubernetes resources are in sync.
+		state.status.StretchClusterStatus.SetResourcesSynced(statuses.StretchClusterResourcesSyncedReasonSynced)
+	}
 
 	// Phase 3: cluster-level reconciliation (admin API, maintenance mode,
 	// stale-disk wipe, decommission, config, license) — see clusterReconcilers
-	// for ordering.
+	// for ordering. Deliberately NOT gated on the pool view: these steps act
+	// through the admin API and on the pods/pools we can see, and any
+	// "no desired counterpart → drain" decision inside them is separately
+	// guarded by the per-cluster observed set threaded into
+	// FetchExistingAndDesiredPools.
 	for _, reconciler := range r.clusterReconcilers() {
 		result, err := reconciler(ctx, state, cluster)
 		if err != nil || result.RequeueAfter > 0 {
@@ -343,13 +361,18 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 
 	// we're at the end of reconciliation, so sync back our status.
 	// Poll again quickly (faster than the periodic requeue) while the cluster is
-	// not yet settled: either scaled up with no broker Ready yet, or a scale/roll
-	// is still in flight (reconcilePools skipped mutations this pass). This is
-	// applied here — after the Phase-3 cluster reconcilers — rather than aborting
-	// inside reconcilePools, so outage-recovery steps still run while brokers are
-	// unready or churning. See PoolTracker.ScaledUpButNoneReady / CheckScale.
+	// not yet settled: pool-derived rendering was deferred on an incomplete
+	// pool view, the cluster scaled up with no broker Ready yet, or a
+	// scale/roll is still in flight (reconcilePools skipped mutations this
+	// pass). This is applied here — after the Phase-3 cluster reconcilers —
+	// rather than aborting earlier, so outage-recovery steps still run while
+	// a peer is unobserved or brokers are unready or churning. See
+	// PoolTracker.ScaledUpButNoneReady / CheckScale.
 	pollResult := ctrl.Result{}
-	if state.pools.ScaledUpButNoneReady() || !state.pools.CheckScale(ctx) {
+	switch {
+	case poolViewIncomplete:
+		pollResult = poolViewResult
+	case state.pools.ScaledUpButNoneReady() || !state.pools.CheckScale(ctx):
 		l.V(log.DebugLevel).Info("cluster not settled; scheduling fast poll", "requeueAfter", requeueTimeout)
 		pollResult.RequeueAfter = requeueTimeout
 	}
@@ -423,20 +446,26 @@ func (r *MulticlusterReconciler) findAliveCluster(ctx context.Context, sc *redpa
 }
 
 // checkBrokerPoolViewComplete reports whether fetchInitialState observed
-// every configured cluster's BrokerPool list this pass. When a cluster was
-// probe-skipped or its List call failed — most commonly a brief
-// post-leader-election window before the health probe's engage cycle
-// completes — state.cluster.GetAllBrokerPools() is a partial view of the
+// every expected cluster's BrokerPool list this pass. When a cluster was
+// probe-skipped, its List call failed, or its runtime registration hasn't
+// completed yet — most commonly a brief post-leader-election window before
+// the engage cycle and bootstrap peer registration finish —
+// state.cluster.GetAllBrokerPools() is a partial view of the
 // StretchCluster's true broker membership.
 //
-// Rendering seed_servers (or any other pool-derived resource) from a partial
-// view is unsafe: a freshly added pool can render with a self-only seed
-// list, and a broker that bootstraps from a self-only seed list forms its
-// own standalone cluster instead of joining the existing one — a split-brain
-// (K8S-891). Callers must skip Phase 2 rendering and requeue instead of
-// proceeding when this returns incomplete=true; the next pass retries once
-// the peer becomes reachable (health.go's unreachable→reachable transition
-// also wakes the engage loop directly, so this typically resolves within one
+// Rendering seed_servers (or any other pool-derived resource, e.g. syncCA's
+// managed-cert-name derivation) from a partial view is unsafe: a freshly
+// added pool can render with a self-only seed list, and a broker that
+// bootstraps from a self-only seed list forms its own standalone cluster
+// instead of joining the existing one — a split-brain (K8S-891). When this
+// returns incomplete=true, the caller must skip exactly the pool-derived
+// steps (syncCA and the Phase 2 renderers) and requeue with the returned
+// result at the end of the pass — but must still run the steps that don't
+// need the complete pool view (syncBootstrapUser and the Phase 3 cluster
+// reconcilers), since a peer outage is exactly when Phase 3's recovery work
+// is needed on reachable members. The next pass retries once the peer
+// becomes reachable (health.go's unreachable→reachable transition also
+// wakes the engage loop directly, so this typically resolves within one
 // probe interval).
 func (r *MulticlusterReconciler) checkBrokerPoolViewComplete(ctx context.Context, state *stretchClusterReconciliationState) (incomplete bool, _ ctrl.Result) {
 	if len(state.unobservedBrokerPoolClusters) == 0 {
@@ -612,11 +641,45 @@ func specDiffFields(a, b redpandav1alpha2.StretchClusterSpec) []string {
 	return fields
 }
 
+// expectedBrokerPoolClusters returns the set of clusters whose BrokerPool
+// list must be observed before pool-derived rendering is safe: the union of
+// the currently-registered clusters (the caller passes sccluster.GetClusters(),
+// sourced from Manager.GetClusterNames) and the manager's *configured*
+// clusters. The configured set is what closes the K8S-891 startup/failover
+// race: in bootstrap mode a peer is registered with the runtime provider only
+// after raft leadership is acquired and its kubeconfig fetched, so a
+// reconcile racing that registration would otherwise see expected ==
+// observed == {local} and render a self-only seed list anyway. Taking the
+// union (rather than the configured set alone) keeps any dynamically
+// registered cluster in the expected set too.
+func (r *MulticlusterReconciler) expectedBrokerPoolClusters(registered []string) []string {
+	return unionClusterNames(registered, r.Manager.GetConfiguredClusterNames())
+}
+
+// unionClusterNames returns the sorted, deduplicated union of the two
+// cluster-name lists.
+func unionClusterNames(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	var union []string
+	for _, names := range [][]string{a, b} {
+		for _, name := range names {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			union = append(union, name)
+		}
+	}
+	sort.Strings(union)
+	return union
+}
+
 // unobservedClusters returns the canonical names of every entry in
 // allClusters that observed does not mark true, preserving allClusters'
 // order. Used to detect when FetchExistingBrokerPoolsFromAllClusters'
-// observed set is missing a configured cluster — i.e. its BrokerPool list
-// was probe-skipped or failed to fetch, making the union of BrokerPools an
+// observed set is missing an expected cluster — i.e. its BrokerPool list
+// was probe-skipped, failed to fetch, or the cluster isn't even registered
+// with the runtime provider yet, making the union of BrokerPools an
 // incomplete view of the StretchCluster (K8S-891).
 func unobservedClusters(allClusters []string, observed map[string]bool, getLocalClusterName func() string) []string {
 	var missing []string
@@ -642,12 +705,12 @@ func (r *MulticlusterReconciler) fetchInitialState(ctx context.Context, sc *redp
 	}
 	sccluster.BrokerPools = brokerPools
 
-	// Any configured cluster missing from brokerPoolsObserved means its
+	// Any expected cluster missing from brokerPoolsObserved means its
 	// BrokerPool list was probe-skipped or failed to fetch this pass, so
 	// sccluster.BrokerPools (and GetAllBrokerPools()) is an incomplete view.
 	// Recorded here so Reconcile can defer any pool-derived rendering until
 	// every cluster has been observed (K8S-891).
-	unobservedBrokerPoolClusters := unobservedClusters(sccluster.GetClusters(), brokerPoolsObserved, r.Manager.GetLocalClusterName)
+	unobservedBrokerPoolClusters := unobservedClusters(r.expectedBrokerPoolClusters(sccluster.GetClusters()), brokerPoolsObserved, r.Manager.GetLocalClusterName)
 
 	// grab our existing and desired pool resources
 	// so that we can immediately calculate cluster status

--- a/pkg/multicluster/manager.go
+++ b/pkg/multicluster/manager.go
@@ -26,6 +26,16 @@ type Manager interface {
 	GetLeader() string
 	// GetClusterNames returns the names of all clusters known to this manager.
 	GetClusterNames() []string
+	// GetConfiguredClusterNames returns the names of every cluster this
+	// manager is configured to manage, whether or not the cluster has
+	// completed runtime registration yet. For the raft manager this is the
+	// static peer list from its configuration: bootstrap-mode peers appear
+	// here from process start even though they are registered with the
+	// runtime provider (and so appear in GetClusterNames) only after raft
+	// leadership is acquired and their kubeconfig fetched. Use this, not
+	// GetClusterNames, when the caller needs the complete expected cluster
+	// set — e.g. to detect that a cross-cluster view is partial (K8S-891).
+	GetConfiguredClusterNames() []string
 	// GetLocalClusterName returns the canonical name of the local cluster.
 	// In a multicluster setup this is the raft node name (e.g. "cluster-1").
 	// In a single-cluster setup this returns mcmanager.LocalCluster ("").

--- a/pkg/multicluster/raft.go
+++ b/pkg/multicluster/raft.go
@@ -17,6 +17,7 @@ import (
 	"hash/fnv"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -589,7 +590,20 @@ func NewRaftRuntimeManager(config *RaftConfiguration) (Manager, error) {
 		}
 	}
 
-	manager, err := newManager(config.Name, config.LocalLeaderElection != nil, config.Logger.WithName("manager"), restConfig, clusterProvider, broadcaster, func() string {
+	// The full configured cluster set, in the same shape GetClusterNames
+	// produces (local-cluster sentinel + sorted remote peer names). Captured
+	// from the static peer configuration so it is complete from construction
+	// time, before any bootstrap peer's runtime registration has happened.
+	configuredClusterNames := []string{mcmanager.LocalCluster}
+	for _, peer := range config.Peers {
+		if peer.Name == config.Name {
+			continue
+		}
+		configuredClusterNames = append(configuredClusterNames, peer.Name)
+	}
+	sort.Strings(configuredClusterNames)
+
+	manager, err := newManager(config.Name, configuredClusterNames, config.LocalLeaderElection != nil, config.Logger.WithName("manager"), restConfig, clusterProvider, broadcaster, func() string {
 		return idsToNames[currentLeader.Load()]
 	}, func() map[string]cluster.Cluster {
 		clusters := map[string]cluster.Cluster{}
@@ -626,14 +640,22 @@ func NewRaftRuntimeManager(config *RaftConfiguration) (Manager, error) {
 
 type raftManager struct {
 	mcmanager.Manager
-	runnable            *leaderRunnable
-	manager             *leaderelection.LeaderManager
-	logger              logr.Logger
-	localClusterName    string
-	getLeader           func() string
-	getClusters         func() map[string]cluster.Cluster
-	addOrReplaceCluster func(ctx context.Context, clusterName string, cl cluster.Cluster) error
-	clusterHealth       *clusterHealthTracker
+	runnable         *leaderRunnable
+	manager          *leaderelection.LeaderManager
+	logger           logr.Logger
+	localClusterName string
+	// configuredClusterNames is the full set of clusters this manager is
+	// configured to manage — the local-cluster sentinel plus every remote
+	// raft peer — fixed at construction time. Unlike the runtime provider
+	// backing getClusters, it does not depend on peer registration having
+	// completed, so it is authoritative during the window between process
+	// start (or leadership acquisition) and AddOrReplaceCluster finishing
+	// for every bootstrap peer (K8S-891).
+	configuredClusterNames []string
+	getLeader              func() string
+	getClusters            func() map[string]cluster.Cluster
+	addOrReplaceCluster    func(ctx context.Context, clusterName string, cl cluster.Cluster) error
+	clusterHealth          *clusterHealthTracker
 }
 
 func (m *raftManager) AddOrReplaceCluster(ctx context.Context, clusterName string, cl cluster.Cluster) error {
@@ -651,6 +673,10 @@ func (m *raftManager) GetClusterNames() []string {
 	}
 	sort.Strings(clusters)
 	return clusters
+}
+
+func (m *raftManager) GetConfiguredClusterNames() []string {
+	return slices.Clone(m.configuredClusterNames)
 }
 
 func (m *raftManager) GetLocalClusterName() string {
@@ -675,7 +701,7 @@ func (m *raftManager) IsClusterReachable(clusterName string) bool {
 	return m.clusterHealth.IsReachable(clusterName)
 }
 
-func newManager(localClusterName string, localLeaderElection bool, logger logr.Logger, config *rest.Config, provider multicluster.Provider, broadcaster *restartBroadcaster, getLeader func() string, getClusters func() map[string]cluster.Cluster, addOrReplaceCluster func(ctx context.Context, clusterName string, cl cluster.Cluster) error, manager *leaderelection.LeaderManager, opts manager.Options) (Manager, error) {
+func newManager(localClusterName string, configuredClusterNames []string, localLeaderElection bool, logger logr.Logger, config *rest.Config, provider multicluster.Provider, broadcaster *restartBroadcaster, getLeader func() string, getClusters func() map[string]cluster.Cluster, addOrReplaceCluster func(ctx context.Context, clusterName string, cl cluster.Cluster) error, manager *leaderelection.LeaderManager, opts manager.Options) (Manager, error) {
 	mgr, err := mcmanager.New(config, provider, opts)
 	if err != nil {
 		return nil, err
@@ -704,7 +730,7 @@ func newManager(localClusterName string, localLeaderElection bool, logger logr.L
 	})
 	manager.RegisterRoutine(healthTracker.Start)
 
-	return &raftManager{Manager: mgr, manager: manager, runnable: runnable, logger: logger.WithName("raft-manager"), localClusterName: localClusterName, getLeader: getLeader, getClusters: getClusters, addOrReplaceCluster: addOrReplaceCluster, clusterHealth: healthTracker}, nil
+	return &raftManager{Manager: mgr, manager: manager, runnable: runnable, logger: logger.WithName("raft-manager"), localClusterName: localClusterName, configuredClusterNames: configuredClusterNames, getLeader: getLeader, getClusters: getClusters, addOrReplaceCluster: addOrReplaceCluster, clusterHealth: healthTracker}, nil
 }
 
 func (m *raftManager) Add(r mcmanager.Runnable) error {

--- a/pkg/multicluster/raft_configured_clusters_test.go
+++ b/pkg/multicluster/raft_configured_clusters_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package multicluster
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+)
+
+// K8S-891 regression: in bootstrap mode, remote peers are registered with the
+// runtime provider by leader routines that only run after raft leadership is
+// acquired, so GetClusterNames under-reports the cluster set until every
+// AddOrReplaceCluster has completed. GetConfiguredClusterNames must expose
+// the full static peer topology from construction time so callers (e.g. the
+// StretchCluster broker-pool view gate) can tell a genuinely single-cluster
+// view apart from a not-yet-registered peer.
+func TestRaftManagerConfiguredClusterNamesPrecedePeerRegistration(t *testing.T) {
+	mgr, err := NewRaftRuntimeManager(&RaftConfiguration{
+		Name:    "cluster-1",
+		Address: "127.0.0.1:0",
+		Peers: []RaftCluster{
+			// No kubeconfigs: in bootstrap mode these peers are registered
+			// only after leadership is acquired, which never happens in this
+			// test — exactly the pre-registration window being verified.
+			{Name: "cluster-1", Address: "127.0.0.1:0"},
+			{Name: "cluster-3", Address: "127.0.0.1:0"},
+			{Name: "cluster-2", Address: "127.0.0.1:0"},
+		},
+		Bootstrap: true,
+		Insecure:  true,
+		Logger:    logr.Discard(),
+		// Never dialed: the manager is not started in this test.
+		RestConfig: &rest.Config{Host: "https://127.0.0.1:1"},
+	})
+	require.NoError(t, err)
+
+	// The manager was never started and never acquired leadership, so no
+	// peer has been registered: the runtime provider only knows the local
+	// cluster...
+	require.Equal(t, []string{mcmanager.LocalCluster}, mgr.GetClusterNames())
+
+	// ...but the configured set must already be complete (local-cluster
+	// sentinel plus the sorted remote peer names, mirroring
+	// GetClusterNames' shape).
+	require.Equal(t, []string{mcmanager.LocalCluster, "cluster-2", "cluster-3"}, mgr.GetConfiguredClusterNames())
+}

--- a/pkg/multicluster/singlecluster.go
+++ b/pkg/multicluster/singlecluster.go
@@ -33,6 +33,10 @@ func (s *singleClusterManager) GetClusterNames() []string {
 	return []string{mcmanager.LocalCluster}
 }
 
+func (s *singleClusterManager) GetConfiguredClusterNames() []string {
+	return []string{mcmanager.LocalCluster}
+}
+
 func (s *singleClusterManager) GetLocalClusterName() string {
 	return mcmanager.LocalCluster
 }

--- a/pkg/multicluster/static.go
+++ b/pkg/multicluster/static.go
@@ -94,6 +94,13 @@ func (s *staticMulticlusterManager) GetClusterNames() []string {
 	return s.names
 }
 
+// GetConfiguredClusterNames is identical to GetClusterNames for the static
+// manager: its full cluster set is registered at construction time, so there
+// is never a configured-but-unregistered window.
+func (s *staticMulticlusterManager) GetConfiguredClusterNames() []string {
+	return s.names
+}
+
 func (s *staticMulticlusterManager) GetLocalClusterName() string {
 	return s.local
 }


### PR DESCRIPTION
## Summary
- `FetchExistingBrokerPoolsFromAllClusters` silently skips a peer cluster whose health probe hasn't reported it reachable yet (e.g. right after a leadership change, before the engage cycle completes). The renderer used the resulting BrokerPool union unconditionally, so a freshly added pool could render `seed_servers` (and CA cert names) from a partial cross-cluster view — a self-only seed list makes that broker bootstrap its own standalone cluster instead of joining the StretchCluster, causing a split-brain.
- Track which clusters were actually observed (`unobservedClusters` helper) and add `checkBrokerPoolViewComplete`, which defers the pool-derived reconciliation steps — `syncCA` and the Phase 2 StatefulSet/ConfigMap renderers — with a 10s requeue whenever any expected cluster wasn't observed.
- The expected cluster set is the union of the registered clusters and the new `Manager.GetConfiguredClusterNames()` (the static raft peer topology, complete from construction time). This closes the startup/failover race where bootstrap peers aren't registered with the runtime provider yet — registration happens in leader routines only after raft leadership is acquired — so a reconcile racing that registration would otherwise see expected == observed == {local} and still render a self-only seed list.
- The gate defers only the pool-derived steps. `syncBootstrapUser` and the Phase 3 cluster reconcilers (maintenance-mode clearing, stale-disk wipe, decommission hygiene, license/config sync) keep running during the deferral — a peer outage is exactly when that recovery is needed on reachable members — with the gate's fast requeue applied at the end of the pass. Phase 3 scale-down/drain decisions remain safe under a partial view via the observed set already threaded into `FetchExistingAndDesiredPools`.

## Review follow-ups
- **[P1]** (david-yu) The expected set is now derived from the stable configured raft peers (`Manager.GetConfiguredClusterNames()`), union'd with the registered clusters, instead of `GetClusterNames()` alone. Regression tests cover reconciliation racing peer registration: `TestRaftManagerConfiguredClusterNamesPrecedePeerRegistration` (manager-level pre-registration window) and `TestBrokerPoolViewGate_ReconcileRacingPeerRegistrationDefers` (gate-level race, including recovery once the peer registers).
- **[P2]** (david-yu) The gate no longer returns before the whole pipeline: only `syncCA` and Phase 2 rendering are skipped, while `syncBootstrapUser` and the Phase 3 cluster reconcilers continue during outages, restoring the deliberate end-of-pass fast-requeue placement.

## Test plan
- [x] `go build ./operator/... ./pkg/multicluster/...`
- [x] New unit tests: `TestUnobservedClusters`, `TestCheckBrokerPoolViewComplete_IncompleteObservationDefers`, `TestCheckBrokerPoolViewComplete_FullObservationProceeds`, `TestUnionClusterNames`, `TestBrokerPoolViewGate_ReconcileRacingPeerRegistrationDefers`, `TestRaftManagerConfiguredClusterNamesPrecedePeerRegistration`
- [x] Existing `TestCheckSpecConsistency_*` tests still pass
- [x] `golangci-lint run` clean on `./operator/internal/controller/redpanda/...` and `./pkg/multicluster/...`
- [x] Ran a Codex review pass against the fix commit and addressed its finding (moved the gate ahead of `syncCA`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[K8S-891](https://redpandadata.atlassian.net/browse/K8S-891)

[K8S-891]: https://redpandadata.atlassian.net/browse/K8S-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
