### PR TITLE
rpk-k8s: frame multicluster help text around Stretch Clusters

### DIFF
--- a/operator/cmd/rpk-k8s/k8s/multicluster/bootstrap.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/bootstrap.go
@@ -437,9 +437,10 @@ func bootstrapCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
-		Short: "Bootstrap a multicluster Redpanda deployment",
-		Long: `Bootstrap TLS certificates and kubeconfig secrets across multiple
-Kubernetes clusters for a Redpanda multicluster deployment.
+		Short: "Bootstrap TLS certificates and peer configuration for a Redpanda Stretch Cluster",
+		Long: `Bootstrap the TLS certificates and kubeconfig secrets that the multicluster
+operators of a Redpanda Stretch Cluster need to communicate across Kubernetes
+clusters.
 
 This command connects to each specified Kubernetes context, generates a shared
 CA certificate, and distributes per-cluster TLS certificates and kubeconfig
@@ -457,7 +458,7 @@ to learn each cluster's external IP/hostname. The resulting peer list is
 printed on success for pasting into helm values.
 
 --output=yaml skips applying anything and writes manifests as YAML. No
-cluster contact or kubeconfig is needed — cluster names are derived from
+cluster contact or kubeconfig is needed: cluster names are derived from
 --context flags (LB mode) or --dns-override keys (bootstrap mode).
 
 When --output-dir <dir> is set, one file per cluster is written into the

--- a/operator/cmd/rpk-k8s/k8s/multicluster/bundle.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/bundle.go
@@ -466,9 +466,9 @@ func bundleCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "bundle",
-		Short: "Collect a diagnostics bundle from a multicluster operator deployment",
-		Long: `Collects environment data from each Kubernetes cluster running the
-Redpanda multicluster operator and packages it into a ZIP file for support.
+		Short: "Collect a diagnostics bundle from the operators of a Redpanda Stretch Cluster",
+		Long: `Collects environment data from each Kubernetes cluster in a Redpanda Stretch
+Cluster deployment and packages it into a ZIP file for support.
 This is the operator-side counterpart to 'rpk debug bundle', which collects
 data from the Redpanda brokers themselves.
 
@@ -477,7 +477,7 @@ discovers peer clusters from labelled cache Secrets stored by the operator's
 raft-bootstrap flow on the starting cluster, so the tool stays useful when
 one of the peer clusters is down. Pass multiple --context flags to bypass
 discovery and diagnose exactly that set.`,
-		Example: `  # Single context — discover peers from the starting cluster
+		Example: `  # Single context: discover peers from the starting cluster
   rpk k8s multicluster bundle --kubeconfig /path/to/kubeconfig
 
   # Specific starting cluster from the default kubeconfig

--- a/operator/cmd/rpk-k8s/k8s/multicluster/multicluster.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/multicluster.go
@@ -16,8 +16,12 @@ import (
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "multicluster",
-		Short: "Manage Redpanda multicluster deployments on Kubernetes",
-		Long:  "Commands for bootstrapping and managing Redpanda multicluster deployments across multiple Kubernetes clusters.",
+		Short: "Manage the multicluster operators that run a Redpanda Stretch Cluster",
+		Long: `Commands for bootstrapping and managing the multicluster operators that run
+a Redpanda Stretch Cluster: a single logical Redpanda cluster distributed
+across multiple Kubernetes clusters. One operator runs in each Kubernetes
+cluster, and the operators coordinate through Raft consensus to manage the
+Stretch Cluster as a single unit.`,
 	}
 
 	cmd.AddCommand(

--- a/operator/cmd/rpk-k8s/k8s/multicluster/status.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/status.go
@@ -95,9 +95,10 @@ func statusCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Check the health of a multicluster operator deployment",
-		Long: `Checks each cluster's operator pod health, raft consensus state,
-TLS certificate validity, and cross-cluster consistency.
+		Short: "Check the health of the operators that run a Redpanda Stretch Cluster",
+		Long: `Checks the health of the multicluster operators that run a Redpanda Stretch
+Cluster: each cluster's operator pod health, raft consensus state, TLS
+certificate validity, and cross-cluster consistency.
 
 Connects to each specified Kubernetes context, finds the multicluster operator
 pod, port-forwards to its gRPC transport, and queries raft status. Also


### PR DESCRIPTION
## What

Rewords the `rpk k8s multicluster` help text (parent + `bootstrap`, `status`, `bundle`) to say explicitly that these commands manage the operators that run a **Stretch Cluster**. Also replaces two em dashes in user-facing help/example strings.

## Why

The multicluster operator plane exists solely to run Stretch Clusters — the layered CR controllers registered in multicluster mode (`operator/cmd/multicluster/multicluster.go`) reconcile resources whose `clusterRef` targets a StretchCluster. But the help text only said "Redpanda multicluster deployments", which doesn't tell users what the commands are for, and collides with the docs' use of "multi-cluster deployment" for independent clusters with async replication (Shadowing).

The docs pipeline also generates the `rpk k8s` reference pages from this help output (see redpanda-data/docs#1681), so aligning the source text keeps the CLI and published docs consistent without doc-side overrides. Em dashes are banned by the docs style guide, hence the two punctuation fixes.

Before/after (parent command Short):
- Before: `Manage Redpanda multicluster deployments on Kubernetes`
- After: `Manage the multicluster operators that run a Redpanda Stretch Cluster`

## Testing

- `go build ./cmd/rpk-k8s/...` and `go test ./cmd/rpk-k8s/...` pass.
- Built the plugin and verified the rendered `--help` output for all four commands.

Please backport to the v26.2.x release line so the GA plugin ships with this text.
