### PR TITLE
operator: fix two stacked testenv bugs that hard-fail integration retries

### DIFF
--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -29,8 +29,10 @@ import (
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	goclientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -135,18 +137,29 @@ func New(t *testing.T, options Options) *Env {
 	}
 
 	if len(options.CRDs) > 0 {
-		crds, err := envtest.InstallCRDs(config, envtest.CRDInstallOptions{
-			CRDs:               dupCRDs(options.CRDs),
-			ErrorIfPathMissing: false,
-		})
-		// Tolerate "already exists" errors when running with -p=N, since
-		// multiple test packages may install CRDs into the same shared cluster.
-		if err != nil && !k8sapierrors.IsAlreadyExists(err) && !strings.Contains(err.Error(), "already exists") {
-			require.NoError(t, err)
-		}
-		if err == nil {
-			require.Equal(t, len(options.CRDs), len(crds))
-		}
+		// When running with -p=N, multiple test packages install CRDs into the
+		// same shared cluster concurrently. envtest.InstallCRDs aborts at the
+		// first create/update conflict without touching the CRDs later in the
+		// list, so a single tolerated failure can leave those CRDs missing for
+		// the rest of the run. Retry until a full pass installs and waits for
+		// every CRD.
+		var crds []*apiextensionsv1.CustomResourceDefinition
+		err := retry.OnError(
+			wait.Backoff{Steps: 10, Duration: 500 * time.Millisecond, Factor: 1.5, Cap: 5 * time.Second},
+			func(err error) bool {
+				return k8sapierrors.IsAlreadyExists(err) || k8sapierrors.IsConflict(err) || strings.Contains(err.Error(), "already exists")
+			},
+			func() error {
+				var err error
+				crds, err = envtest.InstallCRDs(config, envtest.CRDInstallOptions{
+					CRDs:               dupCRDs(options.CRDs),
+					ErrorIfPathMissing: false,
+				})
+				return err
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, len(options.CRDs), len(crds))
 	}
 
 	c, err := client.New(config, client.Options{Scheme: options.Scheme})

--- a/operator/pkg/client/factory_test.go
+++ b/operator/pkg/client/factory_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -145,7 +146,11 @@ func TestIntegrationFactoryOperatorV1(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = c.Create(context.Background(), &rbacv1.ClusterRoleBinding{
+	// The ClusterRoleBinding is cluster-scoped, so the testenv namespace
+	// cleanup can't remove it and its subject references a namespace unique to
+	// this run. Delete any instance leaked by a previous run and clean up on
+	// exit so gotestsum re-runs against the same cluster don't collide.
+	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: env.Namespace(),
@@ -158,8 +163,17 @@ func TestIntegrationFactoryOperatorV1(t *testing.T) {
 			Kind:     "ClusterRole",
 			Name:     "cluster-admin",
 		},
-	})
+	}
+	if err := c.Delete(context.Background(), crb); err != nil && !k8sapierrors.IsNotFound(err) {
+		require.NoError(t, err)
+	}
+	err = c.Create(context.Background(), crb)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := c.Delete(context.Background(), crb); err != nil && !k8sapierrors.IsNotFound(err) {
+			t.Logf("failed to clean up ClusterRoleBinding %q: %v", crb.Name, err)
+		}
+	})
 
 	env.SetupManager("test", func(mgr multicluster.Manager) error {
 		dialer := kube.NewPodDialer(mgr.GetLocalManager().GetConfig())


### PR DESCRIPTION
## What

Fixes the two stacked test-infrastructure bugs that failed all three attempts of the integration step on build 14752 (#1676) — a failure mode that looks deterministic but is unrelated to the code under test.

**1. Shared-cluster CRD install race leaves trailing CRDs uninstalled.**
`testenv.New` installs `crds.All()` via `envtest.InstallCRDs` against the shared k3d cluster, and every `SkipVCluster: true` test package does this concurrently under `-p=N`. `InstallCRDs` aborts at the first create/update conflict without touching the CRDs later in the list, and testenv tolerated that error and proceeded. Since CRDs install in sorted order, the trailing `redpanda.vectorized.io` CRDs could end up missing for the whole run, failing `TestIntegrationFactoryOperatorV1` with `no matches for kind "Cluster" in version "redpanda.vectorized.io/v1alpha1"`. The install is now retried on already-exists/conflict errors until a full pass installs and waits for every CRD, and the CRD count is always asserted.

**2. Leaked ClusterRoleBinding poisons every gotestsum re-run.**
`TestIntegrationFactoryOperatorV1` creates a cluster-scoped `ClusterRoleBinding` named `test`; namespace cleanup can't remove it, and its subject points at the run-unique test namespace. Once a first run failed after creating it, every `--rerun-fails` attempt in the same job died instantly with `clusterrolebindings "test" already exists`, so in-job retries could never pass. The test now deletes any leaked instance before creating and removes it on cleanup.

## Why this matters

With both bugs stacked, a single lost CRD-install race turns into a hard job failure: the first run fails on the missing CRD, and the leaked CRB guarantees both re-runs fail in ~8s. This is exactly the 3-for-3 signature on build 14752.

## Testing

- `go vet` + `golangci-lint run` clean on both packages; compile-checked the test binaries.
- The fixes are only exercised meaningfully by CI's concurrent integration runs (the race needs multiple packages installing CRDs into a shared cluster simultaneously).

Test-only changes, no user-facing behavior — labeled `no-changelog`.
