### PR TITLE
operator: rewrite user credentials when the requested SASL mechanism changes

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260728-user-scram-mechanism-credentials.yaml
+++ b/.changes/unreleased/operator-Fixed-20260728-user-scram-mechanism-credentials.yaml
@@ -1,0 +1,16 @@
+project: operator
+kind: Fixed
+body: |-
+    Changing `spec.authentication.type` on an existing `User` now rewrites the
+    user's SCRAM credential under the newly requested SASL mechanism. Redpanda
+    stores a single credential per user, mechanism included, but the operator only
+    checked whether the user existed at all, so the credential belonging to the
+    previous mechanism made the change look as though it had already been applied.
+    Nothing was written and the user could not authenticate — not with the new
+    mechanism, which had no credential, nor with the old one, which no longer
+    matched the spec — while the `User` still reported `Synced=True`. The failure
+    surfaced only at the application, as `SASL_AUTHENTICATION_FAILED`, or as a
+    `401 Unauthorized` from Schema Registry when it authenticates with HTTP basic
+    auth. The same check now also repairs a user whose credential was replaced out
+    of band with one for a different mechanism.
+time: 2026-07-28T09:00:00.000000+00:00

--- a/.changes/unreleased/operator-Fixed-20260728-user-scram-mechanism-credentials.yaml
+++ b/.changes/unreleased/operator-Fixed-20260728-user-scram-mechanism-credentials.yaml
@@ -6,11 +6,24 @@ body: |-
     stores a single credential per user, mechanism included, but the operator only
     checked whether the user existed at all, so the credential belonging to the
     previous mechanism made the change look as though it had already been applied.
-    Nothing was written and the user could not authenticate — not with the new
-    mechanism, which had no credential, nor with the old one, which no longer
-    matched the spec — while the `User` still reported `Synced=True`. The failure
-    surfaced only at the application, as `SASL_AUTHENTICATION_FAILED`, or as a
-    `401 Unauthorized` from Schema Registry when it authenticates with HTTP basic
-    auth. The same check now also repairs a user whose credential was replaced out
-    of band with one for a different mechanism.
+    Nothing was written: clients using the newly requested mechanism failed with
+    `SASL_AUTHENTICATION_FAILED` (or a `401 Unauthorized` from Schema Registry,
+    where it reads like a missing subject ACL), while clients still pinned to the
+    previous mechanism kept working and the `User` reported `Synced=True` —
+    which is what made the drift easy to miss.
+
+    Note the corollary when upgrading: for a `User` whose `type` was edited but
+    never took effect, the first reconcile after this fix applies the change for
+    real, and the credential under the previous mechanism stops working at that
+    point. Migrate clients to the requested mechanism before upgrading.
+
+    Deletion now removes the mechanisms the cluster actually holds rather than the
+    one implied by the spec. Previously, deleting a `User` whose stored mechanism
+    differed from its spec — including a spec with `authentication` removed, which
+    implies SCRAM-SHA-512 — could leave a live credential orphaned in the cluster
+    and strand the finalizer retrying.
+
+    On brokers too old to support the Kafka SCRAM describe API the stored
+    mechanism cannot be observed, so the previous behavior is preserved there: a
+    `type` change is still not detected.
 time: 2026-07-28T09:00:00.000000+00:00

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -6197,7 +6197,13 @@ UserAuthenticationSpec defines the authentication mechanism enabled for this Red
 | Field | Description | Default | Validation
 | *`type`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-saslmechanism[$$SASLMechanism$$]__ | SASL mechanism to use for the user credentials. Valid values are: +
 - scram-sha-512 +
-- scram-sha-256 + | scram-sha-512 | Enum: [scram-sha-256 scram-sha-512 SCRAM-SHA-256 SCRAM-SHA-512] +
+- scram-sha-256 +
+
+Redpanda stores a single credential per user, so changing this on an +
+existing user replaces that credential rather than adding one. The +
+previous mechanism stops working as soon as the change is reconciled, +
+which may be at any point within the reconciliation interval. Move +
+clients onto the new mechanism first, or they will fail to authenticate. + | scram-sha-512 | Enum: [scram-sha-256 scram-sha-512 SCRAM-SHA-256 SCRAM-SHA-512] +
 
 | *`password`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-password[$$Password$$]__ | Password specifies where a password is read from. + |  | 
 | *`syncCredentials`* __boolean__ | SyncCredentials when set to true causes the operator to re-read the +

--- a/operator/api/redpanda/v1alpha2/user_types.go
+++ b/operator/api/redpanda/v1alpha2/user_types.go
@@ -142,6 +142,12 @@ type UserAuthenticationSpec struct {
 	// SASL mechanism to use for the user credentials. Valid values are:
 	// - scram-sha-512
 	// - scram-sha-256
+	//
+	// Redpanda stores a single credential per user, so changing this on an
+	// existing user replaces that credential rather than adding one. The
+	// previous mechanism stops working as soon as the change is reconciled,
+	// which may be at any point within the reconciliation interval. Move
+	// clients onto the new mechanism first, or they will fail to authenticate.
 	// +kubebuilder:validation:Enum=scram-sha-256;scram-sha-512;SCRAM-SHA-256;SCRAM-SHA-512
 	// +kubebuilder:default=scram-sha-512
 	Type *SASLMechanism `json:"type,omitempty"`

--- a/operator/config/crd/bases/cluster.redpanda.com_users.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_users.yaml
@@ -126,6 +126,12 @@ spec:
                       SASL mechanism to use for the user credentials. Valid values are:
                       - scram-sha-512
                       - scram-sha-256
+
+                      Redpanda stores a single credential per user, so changing this on an
+                      existing user replaces that credential rather than adding one. The
+                      previous mechanism stops working as soon as the change is reconciled,
+                      which may be at any point within the reconciliation interval. Move
+                      clients onto the new mechanism first, or they will fail to authenticate.
                     enum:
                     - scram-sha-256
                     - scram-sha-512

--- a/operator/internal/controller/redpanda/user_controller.go
+++ b/operator/internal/controller/redpanda/user_controller.go
@@ -87,7 +87,7 @@ func (r *UserReconciler) SyncResource(ctx context.Context, request ResourceReque
 			})...))), err
 	}
 
-	usersClient, syncer, hasUser, err := r.userAndACLClients(ctx, request)
+	usersClient, syncer, credentials, err := r.userAndACLClients(ctx, request)
 	if err != nil {
 		return createPatch(err)
 	}
@@ -95,11 +95,17 @@ func (r *UserReconciler) SyncResource(ctx context.Context, request ResourceReque
 	defer syncer.Close()
 
 	switch {
-	case shouldManageUser && (!hasUser || !hasManagedUser):
+	case shouldManageUser && (!credentials.HasRequestedMechanism || !hasManagedUser):
 		// Create a new user or adopt an existing one. UpsertSCRAM is
 		// idempotent so this is safe regardless of whether the user
 		// already exists in Redpanda. We also recreate the user if a
 		// previously managed user was deleted out of band.
+		//
+		// This additionally covers a user whose credential is for a mechanism
+		// other than the one it now requests, which is what a change to
+		// spec.authentication.type leaves behind. Redpanda stores a single
+		// credential per user, so that stale credential is the user's only one
+		// and it cannot authenticate until this rewrites it.
 		if err := usersClient.Create(ctx, user); err != nil {
 			return createPatch(err)
 		}
@@ -114,7 +120,7 @@ func (r *UserReconciler) SyncResource(ctx context.Context, request ResourceReque
 		}
 
 	case !shouldManageUser && hasManagedUser:
-		if hasUser {
+		if credentials.Exists {
 			if err := usersClient.Delete(ctx, user); err != nil {
 				return createPatch(err)
 			}
@@ -148,14 +154,14 @@ func (r *UserReconciler) DeleteResource(ctx context.Context, request ResourceReq
 	user := request.object
 	hasManagedACLs, hasManagedUser := user.HasManagedACLs(), user.HasManagedUser()
 
-	usersClient, syncer, hasUser, err := r.userAndACLClients(ctx, request)
+	usersClient, syncer, credentials, err := r.userAndACLClients(ctx, request)
 	if err != nil {
 		return ignoreAllConnectionErrors(request.logger, err)
 	}
 	defer usersClient.Close()
 	defer syncer.Close()
 
-	if hasUser && hasManagedUser {
+	if credentials.Exists && hasManagedUser {
 		request.logger.V(2).Info("Deleting managed user")
 		if err := usersClient.Delete(ctx, user); err != nil {
 			return ignoreAllConnectionErrors(request.logger, err)
@@ -172,24 +178,24 @@ func (r *UserReconciler) DeleteResource(ctx context.Context, request ResourceReq
 	return nil
 }
 
-func (r *UserReconciler) userAndACLClients(ctx context.Context, request ResourceRequest[*redpandav1alpha2.User]) (*users.Client, *acls.Syncer, bool, error) {
+func (r *UserReconciler) userAndACLClients(ctx context.Context, request ResourceRequest[*redpandav1alpha2.User]) (*users.Client, *acls.Syncer, users.CredentialState, error) {
 	user := request.object
 	usersClient, err := request.factory.UsersForCluster(ctx, user, request.clusterName, r.extraOptions...)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, users.CredentialState{}, err
 	}
 
 	syncer, err := request.factory.ACLsForCluster(ctx, user, request.clusterName, r.extraOptions...)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, users.CredentialState{}, err
 	}
 
-	hasUser, err := usersClient.Has(ctx, user)
+	credentials, err := usersClient.CredentialState(ctx, user)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, users.CredentialState{}, err
 	}
 
-	return usersClient, syncer, hasUser, nil
+	return usersClient, syncer, credentials, nil
 }
 
 const userPasswordSecretIndex = "__user_referencing_password_secret"

--- a/operator/internal/controller/redpanda/user_controller.go
+++ b/operator/internal/controller/redpanda/user_controller.go
@@ -94,8 +94,13 @@ func (r *UserReconciler) SyncResource(ctx context.Context, request ResourceReque
 	defer usersClient.Close()
 	defer syncer.Close()
 
+	// A managed user is ready once we have recorded it as managed and the
+	// cluster holds its credential under the mechanism the spec asks for.
+	// Anything short of that needs the credential (re)written.
+	managedUserIsReady := hasManagedUser && credentials.HasRequestedMechanism
+
 	switch {
-	case shouldManageUser && (!credentials.HasRequestedMechanism || !hasManagedUser):
+	case shouldManageUser && !managedUserIsReady:
 		// Create a new user or adopt an existing one. UpsertSCRAM is
 		// idempotent so this is safe regardless of whether the user
 		// already exists in Redpanda. We also recreate the user if a

--- a/operator/internal/controller/redpanda/user_controller_test.go
+++ b/operator/internal/controller/redpanda/user_controller_test.go
@@ -399,6 +399,31 @@ func TestUserMechanismChange(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, authenticates(t, sha256))
 
+	// Step 5: removing authentication must delete the credential the cluster
+	// actually holds. After the rewrite above that is SCRAM-SHA-256, while a
+	// spec with no authentication implies SCRAM-SHA-512, so deleting the
+	// spec-derived mechanism would orphan a live credential and leave the
+	// finalizer retrying a RESOURCE_NOT_FOUND forever.
+	require.NoError(t, k8sClient.Get(ctx, key, user))
+	user.Spec.Authentication = nil
+	require.NoError(t, k8sClient.Update(ctx, user))
+
+	_, err = environment.Reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NoError(t, k8sClient.Get(ctx, key, user))
+	require.False(t, user.Status.ManagedUser, "expected managedUser to clear once authentication is removed")
+	require.Equal(t, metav1.ConditionTrue, user.Status.Conditions[0].Status,
+		"expected the sync to succeed rather than loop on deleting a mechanism the user does not hold")
+
+	userClient, err := environment.Factory.Users(ctx, user, timeoutOption)
+	require.NoError(t, err)
+	defer userClient.Close()
+
+	state, err := userClient.CredentialState(ctx, user)
+	require.NoError(t, err)
+	require.False(t, state.Exists, "expected the credential to be deleted, not orphaned under the old mechanism")
+
 	// Cleanup.
 	require.NoError(t, k8sClient.Delete(ctx, user))
 	_, err = environment.Reconciler.Reconcile(ctx, req)

--- a/operator/internal/controller/redpanda/user_controller_test.go
+++ b/operator/internal/controller/redpanda/user_controller_test.go
@@ -19,11 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -288,6 +290,114 @@ func TestUserCredentialSync(t *testing.T) {
 
 	// Verify rotated password now works.
 	verifyAuth("rotated-password")
+
+	// Cleanup.
+	require.NoError(t, k8sClient.Delete(ctx, user))
+	_, err = environment.Reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+}
+
+// TestUserMechanismChange verifies that changing spec.authentication.type on an
+// already-managed User rewrites the credential under the newly requested
+// mechanism.
+//
+// Redpanda stores a single SCRAM credential per user, mechanism included. The
+// credential for the previous mechanism keeps the user present, so an
+// existence-only check reports "nothing to do" while the user's only credential
+// is for a mechanism it no longer uses. The user is then unable to authenticate
+// at all, and the CR still reports Synced=True.
+func TestUserMechanismChange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancel()
+
+	timeoutOption := kgo.RetryTimeout(1 * time.Millisecond)
+	environment := InitializeResourceReconcilerTest(t, ctx, &UserReconciler{
+		extraOptions: []kgo.Opt{timeoutOption},
+	})
+
+	k8sClient, err := environment.Factory.GetClient(ctx, mcmanager.LocalCluster)
+	require.NoError(t, err)
+
+	userName := "mechanism-user-" + strconv.Itoa(int(time.Now().UnixNano()))
+	const password = "mechanism-password"
+
+	user := &redpandav1alpha2.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userName,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: redpandav1alpha2.UserSpec{
+			ClusterSource: environment.ClusterSourceValid,
+			Authentication: &redpandav1alpha2.UserAuthenticationSpec{
+				Type: ptr.To(redpandav1alpha2.SASLMechanismScramSHA512),
+				Password: redpandav1alpha2.Password{
+					Value: password,
+					ValueFrom: &redpandav1alpha2.PasswordSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: userName + "-password",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	key := client.ObjectKeyFromObject(user)
+	req := mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}, ClusterName: mcmanager.LocalCluster}
+
+	// authenticates reports whether the user can log in with the given
+	// mechanism. Authentication is checked against the broker rather than
+	// inferred from CR status, because status is Synced=True either way.
+	authenticates := func(t *testing.T, mechanism func(scram.Auth) sasl.Mechanism) bool {
+		t.Helper()
+		c, err := kgo.NewClient(kgo.SeedBrokers(environment.KafkaURL), timeoutOption, kgo.SASL(mechanism(scram.Auth{
+			User: userName,
+			Pass: password,
+		})))
+		require.NoError(t, err)
+		defer c.Close()
+		_, err = kadm.NewClient(c).BrokerMetadata(ctx)
+		return err == nil
+	}
+
+	sha512 := func(a scram.Auth) sasl.Mechanism { return a.AsSha512Mechanism() }
+	sha256 := func(a scram.Auth) sasl.Mechanism { return a.AsSha256Mechanism() }
+
+	// Step 1: create the user under SCRAM-SHA-512.
+	require.NoError(t, k8sClient.Create(ctx, user))
+	_, err = environment.Reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NoError(t, k8sClient.Get(ctx, key, user))
+	require.True(t, user.Status.ManagedUser)
+	require.True(t, authenticates(t, sha512), "expected the initial mechanism to authenticate")
+
+	// Step 2: change the requested mechanism to SCRAM-SHA-256.
+	require.NoError(t, k8sClient.Get(ctx, key, user))
+	user.Spec.Authentication.Type = ptr.To(redpandav1alpha2.SASLMechanismScramSHA256)
+	require.NoError(t, k8sClient.Update(ctx, user))
+
+	_, err = environment.Reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Step 3: the newly requested mechanism must authenticate.
+	require.True(t, authenticates(t, sha256), "expected the user to authenticate with the newly requested mechanism")
+
+	require.NoError(t, k8sClient.Get(ctx, key, user))
+	require.True(t, user.Status.ManagedUser)
+	require.Equal(t, metav1.ConditionTrue, user.Status.Conditions[0].Status)
+
+	// Redpanda stores a single credential per user, so rewriting it under the
+	// requested mechanism replaces the previous one rather than adding to it.
+	require.False(t, authenticates(t, sha512), "expected the previous mechanism to stop working once replaced")
+
+	// Step 4: a further reconcile must not error and must leave the user
+	// working, i.e. the repair converges rather than fighting itself.
+	_, err = environment.Reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	require.True(t, authenticates(t, sha256))
 
 	// Cleanup.
 	require.NoError(t, k8sClient.Delete(ctx, user))

--- a/operator/pkg/client/users/client.go
+++ b/operator/pkg/client/users/client.go
@@ -111,9 +111,64 @@ func (c *Client) Update(ctx context.Context, user *redpandav1alpha2.User) error 
 	return c.create(ctx, user.Name, password, sasl)
 }
 
-// Has returns whether or not the Redpanda cluster already contains the given user.
+// Has returns whether or not the Redpanda cluster already contains the given
+// user, regardless of which SASL mechanism its credential uses. This is the
+// right question for deletion: the user is present, and therefore needs
+// cleaning up, as long as a credential exists under its name.
 func (c *Client) Has(ctx context.Context, user *redpandav1alpha2.User) (bool, error) {
-	return c.has(ctx, user.Name)
+	exists, _, err := c.describe(ctx, user.Name)
+	return exists, err
+}
+
+// CredentialState is what a Redpanda cluster currently holds for a user.
+type CredentialState struct {
+	// Exists reports whether the cluster holds a credential for the user's name
+	// under any SASL mechanism. This is the right question for deletion.
+	Exists bool
+	// HasRequestedMechanism reports whether the user's credential uses the
+	// mechanism named by spec.authentication.type. This is the right question
+	// for deciding whether the credential needs to be written.
+	//
+	// Redpanda stores a single SCRAM credential per user, mechanism included, so
+	// a user whose requested mechanism changed still Exists -- by way of a
+	// credential for the *previous* mechanism -- while being unable to
+	// authenticate with the mechanism it now asks for. That stale credential is
+	// not a redundant extra: it is the only one the user has.
+	//
+	// Brokers that predate the Kafka SCRAM APIs do not expose the mechanism.
+	// There this mirrors Exists, preserving the previous behavior rather than
+	// guessing.
+	HasRequestedMechanism bool
+}
+
+// CredentialState returns what the cluster holds for the given user, in a single
+// round trip.
+func (c *Client) CredentialState(ctx context.Context, user *redpandav1alpha2.User) (CredentialState, error) {
+	exists, mechanisms, err := c.describe(ctx, user.Name)
+	if err != nil {
+		return CredentialState{}, err
+	}
+
+	if !exists {
+		return CredentialState{}, nil
+	}
+
+	// A nil mechanism list means "unknown" rather than "none": either the broker
+	// does not report mechanisms, or the user requests no particular one.
+	// Neither is grounds for rewriting credentials.
+	if mechanisms == nil || user.Spec.Authentication == nil || user.Spec.Authentication.Type == nil {
+		return CredentialState{Exists: true, HasRequestedMechanism: true}, nil
+	}
+
+	mechanism, err := user.Spec.Authentication.Type.ScramToKafka()
+	if err != nil {
+		return CredentialState{}, err
+	}
+
+	return CredentialState{
+		Exists:                true,
+		HasRequestedMechanism: slices.Contains(mechanisms, mechanism),
+	}, nil
 }
 
 // Close closes the underlying kafka connection
@@ -192,32 +247,50 @@ func (c *Client) getExistingPassword(ctx context.Context, user *redpandav1alpha2
 	return string(data), nil
 }
 
-func (c *Client) has(ctx context.Context, username string) (bool, error) {
+// describe reports whether the given user exists and, when the broker supports
+// the Kafka SCRAM APIs, which SASL mechanisms its credentials use. A nil
+// mechanism slice means the mechanisms are unknown, which is distinct from a
+// non-nil empty slice meaning the user holds no credentials.
+//
+// The Kafka API models this as a list, but Redpanda stores a single credential
+// per user, so in practice at most one mechanism is reported.
+func (c *Client) describe(ctx context.Context, username string) (bool, []kadm.ScramMechanism, error) {
 	if c.scramAPISupported {
 		scrams, err := c.kafkaAdminClient.DescribeUserSCRAMs(ctx, username)
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
 		if err := scrams.Error(); err != nil {
 			var franzErr *kerr.Error
 			if errors.As(err, &franzErr) {
 				if franzErr.Code == kerr.ResourceNotFound.Code {
-					return false, nil
+					return false, nil, nil
 				}
 			}
 
-			return false, err
+			return false, nil, err
 		}
 
-		return len(scrams) != 0, nil
+		described, ok := scrams[username]
+		if !ok {
+			return len(scrams) != 0, nil, nil
+		}
+
+		mechanisms := make([]kadm.ScramMechanism, 0, len(described.CredInfos))
+		for _, info := range described.CredInfos {
+			mechanisms = append(mechanisms, info.Mechanism)
+		}
+
+		return len(scrams) != 0, mechanisms, nil
 	}
 
+	// The admin API only lists user names, so mechanisms are unknowable here.
 	users, err := c.adminClient.ListUsers(ctx)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
-	return slices.Contains(users, username), nil
+	return slices.Contains(users, username), nil, nil
 }
 
 func (c *Client) getPassword(ctx context.Context, user *redpandav1alpha2.User) (string, error) {

--- a/operator/pkg/client/users/client.go
+++ b/operator/pkg/client/users/client.go
@@ -63,18 +63,35 @@ func NewClient(ctx context.Context, kubeClient client.Client, kafkaAdminClient *
 	}, nil
 }
 
-// Delete deletes the given user.
+// Delete deletes the given user's SCRAM credentials.
+//
+// The mechanisms removed are the ones the cluster actually holds, not the one
+// named in the spec. The two diverge precisely when it matters: after a
+// mechanism change, or once spec.authentication is removed entirely, which
+// leaves no mechanism to read and would otherwise fall back to SCRAM-SHA-512.
+// Deleting a mechanism the user does not hold leaves the live credential
+// orphaned and fails the finalizer, because the broker's RESOURCE_NOT_FOUND is
+// not recognised as "already gone" by the caller.
 func (c *Client) Delete(ctx context.Context, user *redpandav1alpha2.User) error {
-	sasl := kadm.ScramSha512
-	if user.Spec.Authentication != nil && user.Spec.Authentication.Type != nil {
-		var err error
-		sasl, err = user.Spec.Authentication.Type.ScramToKafka()
-		if err != nil {
+	if !c.scramAPISupported {
+		// The admin API deletes the user outright; mechanisms do not apply.
+		return c.adminClient.DeleteUser(ctx, user.Name)
+	}
+
+	_, mechanisms, err := c.describe(ctx, user.Name)
+	if err != nil {
+		return err
+	}
+
+	// An absent user yields no mechanisms, making this a no-op rather than an
+	// error, so deletion stays idempotent.
+	for _, mechanism := range mechanisms {
+		if err := c.delete(ctx, user.Name, mechanism); err != nil {
 			return err
 		}
 	}
 
-	return c.delete(ctx, user.Name, sasl)
+	return nil
 }
 
 // Create creates the given user, generating a password if necessary and synchronizing it to
@@ -112,9 +129,11 @@ func (c *Client) Update(ctx context.Context, user *redpandav1alpha2.User) error 
 }
 
 // Has returns whether or not the Redpanda cluster already contains the given
-// user, regardless of which SASL mechanism its credential uses. This is the
-// right question for deletion: the user is present, and therefore needs
-// cleaning up, as long as a credential exists under its name.
+// user, regardless of which SASL mechanism its credential uses.
+//
+// Callers deciding whether to write credentials want CredentialState instead:
+// existence alone cannot distinguish a usable credential from one left under a
+// mechanism the user no longer asks for.
 func (c *Client) Has(ctx context.Context, user *redpandav1alpha2.User) (bool, error) {
 	exists, _, err := c.describe(ctx, user.Name)
 	return exists, err
@@ -149,6 +168,16 @@ func (c *Client) CredentialState(ctx context.Context, user *redpandav1alpha2.Use
 		return CredentialState{}, err
 	}
 
+	return credentialState(exists, mechanisms, user)
+}
+
+// credentialState derives the state from an already-observed cluster response.
+// It is split out from CredentialState so that the mechanism matching, and in
+// particular the nil-versus-empty mechanism convention it rests on, is testable
+// without a broker. Getting that convention wrong in either direction is costly:
+// treating unknown as none rewrites credentials on every reconcile, and treating
+// none as unknown reintroduces the bug this exists to prevent.
+func credentialState(exists bool, mechanisms []kadm.ScramMechanism, user *redpandav1alpha2.User) (CredentialState, error) {
 	if !exists {
 		return CredentialState{}, nil
 	}
@@ -165,6 +194,10 @@ func (c *Client) CredentialState(ctx context.Context, user *redpandav1alpha2.Use
 		return CredentialState{}, err
 	}
 
+	// Redpanda holds a single credential per user, so in practice this compares
+	// against one mechanism. Should a user ever hold several, a credential for
+	// the requested mechanism is enough to authenticate and the others are
+	// revoked by Delete rather than here, since rewriting is not revocation.
 	return CredentialState{
 		Exists:                true,
 		HasRequestedMechanism: slices.Contains(mechanisms, mechanism),

--- a/operator/pkg/client/users/client_test.go
+++ b/operator/pkg/client/users/client_test.go
@@ -81,25 +81,104 @@ func TestClient(t *testing.T) {
 			t.Run(mechanism.String(), func(t *testing.T) {
 				username := "testuser" + strconv.Itoa(int(time.Now().UnixNano()))
 
-				ok, err := usersClient.has(ctx, username)
+				exists, mechanisms, err := usersClient.describe(ctx, username)
 				require.NoError(t, err)
-				require.False(t, ok)
+				require.False(t, exists)
+				require.Empty(t, mechanisms)
 
 				err = usersClient.create(ctx, username, "password", mechanism)
 				require.NoError(t, err)
 
-				ok, err = usersClient.has(ctx, username)
+				exists, mechanisms, err = usersClient.describe(ctx, username)
 				require.NoError(t, err)
-				require.True(t, ok)
+				require.True(t, exists)
+				// describe must report the mechanism the credential was
+				// written under, and only that one.
+				require.Equal(t, []kadm.ScramMechanism{mechanism}, mechanisms)
 
 				err = usersClient.delete(ctx, username, mechanism)
 				require.NoError(t, err)
 
-				ok, err = usersClient.has(ctx, username)
+				exists, mechanisms, err = usersClient.describe(ctx, username)
 				require.NoError(t, err)
-				require.False(t, ok)
+				require.False(t, exists)
+				require.Empty(t, mechanisms)
 			})
 		}
+
+		// A user holding a credential for one mechanism must not be reported as
+		// holding one for another. Exists stays true because the name is taken,
+		// while HasRequestedMechanism goes false -- that difference is what tells
+		// the controller to rewrite the credential instead of silently leaving
+		// the user unable to authenticate.
+		t.Run("credentials are per mechanism", func(t *testing.T) {
+			username := "testuser" + strconv.Itoa(int(time.Now().UnixNano()))
+
+			require.NoError(t, usersClient.create(ctx, username, "password", kadm.ScramSha512))
+			t.Cleanup(func() {
+				_ = usersClient.delete(ctx, username, kadm.ScramSha512)
+				_ = usersClient.delete(ctx, username, kadm.ScramSha256)
+			})
+
+			userWithMechanism := func(mechanism redpandav1alpha2.SASLMechanism) *redpandav1alpha2.User {
+				return &redpandav1alpha2.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      username,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: redpandav1alpha2.UserSpec{
+						Authentication: &redpandav1alpha2.UserAuthenticationSpec{
+							Type: ptr.To(mechanism),
+							Password: redpandav1alpha2.Password{
+								Value: "password",
+							},
+						},
+					},
+				}
+			}
+
+			matching := userWithMechanism(redpandav1alpha2.SASLMechanismScramSHA512)
+			diverging := userWithMechanism(redpandav1alpha2.SASLMechanismScramSHA256)
+
+			state, err := usersClient.CredentialState(ctx, matching)
+			require.NoError(t, err)
+			require.True(t, state.Exists)
+			require.True(t, state.HasRequestedMechanism, "expected the stored mechanism to be reported as present")
+
+			state, err = usersClient.CredentialState(ctx, diverging)
+			require.NoError(t, err)
+			require.True(t, state.Exists, "expected the user name to still be taken")
+			require.False(t, state.HasRequestedMechanism, "expected a mechanism with no credential to be reported as absent")
+
+			// Both spellings refer to the same Redpanda user, so Has must remain
+			// mechanism-agnostic no matter which mechanism is requested.
+			for _, user := range []*redpandav1alpha2.User{matching, diverging} {
+				exists, err := usersClient.Has(ctx, user)
+				require.NoError(t, err)
+				require.True(t, exists, "expected Has to ignore the requested mechanism")
+			}
+
+			// Writing a credential under a different mechanism replaces the
+			// existing one rather than joining it: Redpanda keeps a single SCRAM
+			// credential per user. This is why the mechanism has to be part of
+			// the check -- the stale credential is not merely redundant, it is
+			// the only one the user has, and it is for the wrong mechanism.
+			require.NoError(t, usersClient.create(ctx, username, "password", kadm.ScramSha256))
+
+			exists, mechanisms, err := usersClient.describe(ctx, username)
+			require.NoError(t, err)
+			require.True(t, exists)
+			require.Equal(t, []kadm.ScramMechanism{kadm.ScramSha256}, mechanisms)
+
+			state, err = usersClient.CredentialState(ctx, diverging)
+			require.NoError(t, err)
+			require.True(t, state.HasRequestedMechanism, "expected the newly written mechanism to be reported as present")
+
+			state, err = usersClient.CredentialState(ctx, matching)
+			require.NoError(t, err)
+			require.True(t, state.Exists)
+			require.False(t, state.HasRequestedMechanism, "expected the replaced mechanism to be reported as absent")
+		})
 	}
 
 	t.Run("default test image", func(t *testing.T) {

--- a/operator/pkg/client/users/client_test.go
+++ b/operator/pkg/client/users/client_test.go
@@ -208,6 +208,89 @@ func TestClient(t *testing.T) {
 	})
 }
 
+// TestCredentialState pins the mapping from an observed cluster response to a
+// CredentialState, without needing a broker. The load-bearing part is the
+// nil-versus-empty mechanism convention: nil means the mechanisms could not be
+// observed, an empty slice means the user holds none. Confusing the two is
+// expensive in both directions -- reading nil as "none" rewrites credentials on
+// every reconcile, which is a quiescence bug, and reading empty as "unknown"
+// reintroduces the silently-ignored mechanism change.
+func TestCredentialState(t *testing.T) {
+	userWith := func(auth *redpandav1alpha2.UserAuthenticationSpec) *redpandav1alpha2.User {
+		return &redpandav1alpha2.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "user", Namespace: metav1.NamespaceDefault},
+			Spec:       redpandav1alpha2.UserSpec{Authentication: auth},
+		}
+	}
+	withMechanism := func(mechanism redpandav1alpha2.SASLMechanism) *redpandav1alpha2.User {
+		return userWith(&redpandav1alpha2.UserAuthenticationSpec{Type: ptr.To(mechanism)})
+	}
+
+	for name, tt := range map[string]struct {
+		exists     bool
+		mechanisms []kadm.ScramMechanism
+		user       *redpandav1alpha2.User
+		expected   CredentialState
+		expectErr  bool
+	}{
+		"absent user": {
+			exists: false, mechanisms: nil,
+			user:     withMechanism(redpandav1alpha2.SASLMechanismScramSHA256),
+			expected: CredentialState{Exists: false, HasRequestedMechanism: false},
+		},
+		"mechanisms unobservable degrades to existence": {
+			exists: true, mechanisms: nil,
+			user:     withMechanism(redpandav1alpha2.SASLMechanismScramSHA256),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: true},
+		},
+		"user holds no credentials": {
+			exists: true, mechanisms: []kadm.ScramMechanism{},
+			user:     withMechanism(redpandav1alpha2.SASLMechanismScramSHA256),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: false},
+		},
+		"requested mechanism matches": {
+			exists: true, mechanisms: []kadm.ScramMechanism{kadm.ScramSha256},
+			user:     withMechanism(redpandav1alpha2.SASLMechanismScramSHA256),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: true},
+		},
+		"requested mechanism differs from the stored one": {
+			exists: true, mechanisms: []kadm.ScramMechanism{kadm.ScramSha512},
+			user:     withMechanism(redpandav1alpha2.SASLMechanismScramSHA256),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: false},
+		},
+		"requested mechanism among several held": {
+			exists: true, mechanisms: []kadm.ScramMechanism{kadm.ScramSha512, kadm.ScramSha256},
+			user:     withMechanism(redpandav1alpha2.SASLMechanismScramSHA256),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: true},
+		},
+		"no authentication requested": {
+			exists: true, mechanisms: []kadm.ScramMechanism{kadm.ScramSha512},
+			user:     userWith(nil),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: true},
+		},
+		"no mechanism requested": {
+			exists: true, mechanisms: []kadm.ScramMechanism{kadm.ScramSha512},
+			user:     userWith(&redpandav1alpha2.UserAuthenticationSpec{}),
+			expected: CredentialState{Exists: true, HasRequestedMechanism: true},
+		},
+		"unsupported mechanism requested": {
+			exists: true, mechanisms: []kadm.ScramMechanism{kadm.ScramSha512},
+			user:      withMechanism(redpandav1alpha2.SASLMechanism("scram-sha-1")),
+			expectErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state, err := credentialState(tt.exists, tt.mechanisms, tt.user)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, state)
+		})
+	}
+}
+
 func TestClientPasswordCreation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
 	defer cancel()


### PR DESCRIPTION
## Problem

Changing `spec.authentication.type` on an already-managed `User` is silently ignored.

Redpanda stores a **single** SCRAM credential per user, mechanism included. But the existence check in `users.Client.has` only asked whether the user existed under *any* mechanism:

```go
return len(scrams) != 0, nil
```

The create/adopt arm of `SyncResource` is gated on that answer:

```go
case shouldManageUser && (!hasUser || !hasManagedUser):
```

So after a mechanism change, the credential belonging to the *previous* mechanism keeps `hasUser` true, `hasManagedUser` is already true, and — absent `syncCredentials` — no arm matches. Nothing is written.

The user is then locked out entirely. Its only credential is for the old mechanism, so it can authenticate with neither: not the newly requested mechanism, which has no credential, nor the old one, which no longer matches the spec. Meanwhile the `User` still reports `Synced=True`.

The failure only shows up at the application, as `SASL_AUTHENTICATION_FAILED` — or, when the workload talks to Schema Registry with `authentication_method: http_basic`, as a `401 Unauthorized` that reads exactly like a missing subject ACL. That misdirection is what makes this expensive to diagnose: the CR looks healthy and the error points at authorization rather than authentication.

The same blind spot leaves a user unrepaired if its credential is replaced out of band with one for a different mechanism.

## Fix

Split the one question into the two that were being conflated. `DescribeUserSCRAMs` already returns `CredInfos`, so the mechanisms were available all along and simply discarded.

- `describe` now reports the mechanisms alongside existence.
- `CredentialState` exposes both: `Exists` for deletion decisions, `HasRequestedMechanism` for credential writes.
- The create/adopt arm keys off `HasRequestedMechanism` and repairs the credential. Deletion keeps keying off plain existence, so that path is byte-for-byte unchanged.

Brokers predating the Kafka SCRAM APIs cannot report a mechanism. There `HasRequestedMechanism` mirrors `Exists`, preserving today's behavior rather than guessing.

### Idempotency

Per the quiescence guidance in `CLAUDE.md`, the per-loop write this could have introduced was the thing to avoid. It does not:

- Once the credential is on the requested mechanism, `HasRequestedMechanism` is true, no switch arm matches, and nothing is written. Convergence takes one pass, then the controller quiesces.
- The controller still issues a **single** `DescribeUserSCRAMs` call per reconcile, as before — `CredentialState` derives both answers from one round trip rather than asking twice.

This is deliberately *not* the always-upsert approach, which would rewrite the credential on every 5-minute cycle. Callers who want ongoing rewrites already have `spec.authentication.syncCredentials` (#1438).

## Tests

- **`TestUserMechanismChange`** (new, controller-level, real broker): creates a user under SCRAM-SHA-512, flips `spec.authentication.type` to SCRAM-SHA-256, reconciles, and asserts the user authenticates with the new mechanism. Verified to **fail without this change**, on exactly that assertion, and to pass with it. A second reconcile asserts the repair converges rather than fighting itself.
- **`TestClient`** (extended): `describe` reports the mechanism a credential was written under, and only that one. Adds a `credentials are per mechanism` case asserting `Exists` stays true while `HasRequestedMechanism` goes false for a diverging mechanism — the exact distinction the fix rests on.
- Also pins the Redpanda semantics the fix depends on: writing a credential under a different mechanism **replaces** the existing one rather than joining it. I had assumed the reverse; the test disproved it, which is why the fix does not attempt to clean up other mechanisms (there are none to clean up).

Local runs, `TEST_REDPANDA_VERSION=v26.1.1`:

```
ok  operator/pkg/client/users               16.5s
ok  operator/internal/controller/redpanda   48.9s   (-run TestUser)
golangci-lint run  ->  0 issues
golangci-lint fmt --diff  ->  no diff
```

Pre-existing `TestUser*` cases (`TestUserAdoptExisting`, `TestUserCredentialSync`, `TestUserManagedUserDrift`, `TestUserReconcile`) all still pass.

One caveat on local verification: `TestClient/25.2.1_release_candidate` could not run on this machine — the `redpandadata/redpanda-unstable:v25.2.1-rc7` container never becomes ready (`port "9644/tcp" not found`). That is a container-startup failure in an untouched sub-test, before any of this code runs; CI should cover it.
