### PR TITLE
ci: dispatch rpk k8s plugin docs regeneration on operator releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,3 +173,25 @@ jobs:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/helm-charts
           event-type: sync-operator-repo-releases
+
+      # Regenerate the rpk k8s plugin docs in redpanda-data/docs. The docs
+      # workflow (update-rpk-plugin-docs.yml) refreshes only the k8s subtree
+      # of its rpk command snapshot and opens a PR against each docs branch
+      # whose rpk version has the k8s command. The version pin is required:
+      # pre-GA plugin releases are not promoted to latest in the manifest,
+      # so an unpinned `rpk k8s install` resolves nothing.
+      - name: Compute rpk k8s plugin version
+        if: ${{ startsWith(steps.get_ref.outputs.ref_name, 'operator/v') }}
+        id: k8s_version
+        run: |
+          tag="${{ steps.get_ref.outputs.ref_name }}"
+          version="$(basename "$tag")"
+          echo "version=${version#v}" >> "$GITHUB_OUTPUT"
+      - name: Trigger rpk k8s plugin docs update in redpanda-data/docs
+        if: ${{ startsWith(steps.get_ref.outputs.ref_name, 'operator/v') }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          repository: redpanda-data/docs
+          event-type: update-rpk-plugin-docs
+          client-payload: '{"plugin": "k8s", "version": "${{ steps.k8s_version.outputs.version }}"}'


### PR DESCRIPTION
## Summary

The rpk k8s plugin publishes to the rpk plugin manifest on `operator/v*` tags, independent of Redpanda releases, so its docs in redpanda-data/docs go stale between full rpk doc regenerations (and pre-GA they get deleted outright: redpanda-data/docs#1831 lost the five `rpk k8s multicluster` pages because `rpk k8s install` resolves nothing until a stable version is promoted to latest).

After the plugin publish, this sends an `update-rpk-plugin-docs` repository dispatch to redpanda-data/docs. The docs workflow ([docs#1834](https://github.com/redpanda-data/docs/pull/1834)) installs the pinned plugin version against an rpk binary matching its committed command snapshot, refreshes only the k8s subtree, and opens a docs PR against each branch whose rpk version has the `k8s` command (beta only, until 26.2 GA).

## Details

- Reuses the `ACTIONS_BOT_TOKEN` already fetched for the helm-charts dispatch in the same job, and the same `startsWith(ref, 'operator/v')` guard as the plugin publish steps.
- The version pin in the payload is what makes pre-GA k8s docs generable at all: unpinned installs resolve nothing until GA.
- Receiving side is validated: a local run against the docs beta snapshot with `--plugin k8s --plugin-version 26.2.1-beta.3` restored the five multicluster pages.

No effect on non-operator tags or the release itself: the dispatch is the last step and only fires for `operator/v*`.