### PR TITLE
operator: name unresolvable cluster-config values on conditions and events

### DIFF
--- a/.changes/unreleased/operator-Changed-20260731-114717.yaml
+++ b/.changes/unreleased/operator-Changed-20260731-114717.yaml
@@ -1,0 +1,12 @@
+project: operator
+kind: Changed
+body: |
+  Unresolvable external secrets referenced from cluster config now surface
+  with the affected property named (e.g. `could not resolve property
+  "iceberg_rest_catalog_client_secret": ...`). The reconcile still fails
+  before pushing config; in addition, the v1 Cluster CR's ClusterConfigured
+  condition is now set to the warning text (previously the failure was only
+  visible as a reconcile error), the v2 Redpanda CR's ConfigurationApplied
+  condition carries the same message, and the v2 controller emits a Warning
+  event per unresolvable property.
+time: 2026-07-31T11:47:17.000000+00:00

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -889,16 +889,19 @@ func (r *RedpandaReconciler) reconcileClusterConfig(ctx context.Context, state *
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 	// If any fixups produced warnings (typically `errorToWarning`-wrapped
-	// failed external secret lookups on Optional secrets), the
-	// corresponding entries in `config` still hold their unexpanded
-	// `${secrets.X}` placeholders. Pushing that to PatchClusterConfig
-	// would surface Redpanda's downstream validation error (e.g. "Must
-	// set both of iceberg_rest_catalog_client_id ...") instead of the
-	// actual root cause (e.g. an AccessDeniedException from the secret
-	// store). Fail the reconcile with the warning text so the user sees
-	// the actionable cause directly in the status condition. See K8S-858.
+	// failed external secret lookups on Optional secrets), the affected
+	// properties are missing from `config`. Pushing that to the admin API
+	// would surface Redpanda's downstream validation error (e.g. "Must set
+	// both of iceberg_rest_catalog_client_id ...") instead of the actual
+	// root cause (e.g. an AccessDeniedException from the secret store).
+	// Emit a Warning event per unresolvable property and fail the
+	// reconcile before pushing; the deferred SetConfigurationApplied puts
+	// the warning text on the ConfigurationApplied condition. See K8S-858.
 	if msg := clusterconfiguration.FormatWarnings(warnings); msg != "" {
-		err := errors.Newf("cluster config has unresolved external secret references: %s", msg)
+		for _, w := range warnings {
+			cluster.GetEventRecorderFor("RedpandaReconciler").Eventf(state.cluster.Redpanda, "Warning", redpandav1alpha2.EventSeverityError, "unresolvable cluster configuration value: %s", w.Error()) //nolint:staticcheck // TODO: migrate to GetEventRecorder (new events API)
+		}
+		err := errors.Newf("cluster configuration contains unresolvable values: %s", msg)
 		logger.Error(err, "fetching cluster config")
 		return ctrl.Result{}, err
 	}

--- a/operator/internal/controller/vectorized/cluster_controller_configuration.go
+++ b/operator/internal/controller/vectorized/cluster_controller_configuration.go
@@ -81,21 +81,28 @@ func (r *ClusterReconciler) reconcileConfiguration(
 		return 0, errorWithContext(err, "error while creating the concrete configuration")
 	}
 	// If any fixups produced warnings (typically `errorToWarning`-wrapped
-	// failed external secret lookups on Optional secrets), the
-	// corresponding entries in `config` still hold their unexpanded
-	// `${secrets.X}` placeholders. Pushing that to PatchClusterConfig
-	// would surface Redpanda's downstream validation error (e.g. "Must
-	// set both of iceberg_rest_catalog_client_id ...") instead of the
-	// actual root cause (e.g. an AccessDeniedException from the secret
-	// store). Bail out of the reconcile with the warning text so it
-	// shows up as the actionable cause in the Cluster CR's
-	// ClusterConfiguredConditionType status condition. Shares the same
-	// helper as the v2 path. See K8S-858.
+	// failed external secret lookups on Optional secrets), the affected
+	// properties are missing from `config`. Pushing that to
+	// PatchClusterConfig would surface Redpanda's downstream validation
+	// error (e.g. "Must set both of iceberg_rest_catalog_client_id ...")
+	// instead of the actual root cause (e.g. an AccessDeniedException from
+	// the secret store). Record the warnings on the ClusterConfigured
+	// condition and fail the reconcile before pushing, so the CR carries
+	// the actionable cause and we retry with backoff until the values
+	// resolve. See K8S-858.
 	if msg := clusterconfiguration.FormatWarnings(cfg.ClusterConfigWarnings()); msg != "" {
-		return 0, errorWithContext(
-			fmt.Errorf("cluster config has unresolved external secret references: %s", msg),
-			"unresolved external secret references",
-		)
+		err := fmt.Errorf("cluster configuration contains unresolvable values: %s", msg)
+		if redpandaCluster.Status.SetCondition(
+			vectorizedv1alpha1.ClusterConfiguredConditionType,
+			corev1.ConditionFalse,
+			vectorizedv1alpha1.ClusterConfiguredReasonError,
+			err.Error(),
+		) {
+			if updateErr := r.Status().Update(ctx, redpandaCluster); updateErr != nil {
+				return 0, errorWithContext(updateErr, "could not update condition on cluster")
+			}
+		}
+		return 0, errorWithContext(err, "reifying cluster configuration")
 	}
 
 	// Checking if the feature is active because in the initial stages of cluster creation, it takes time for the feature to be activated

--- a/pkg/clusterconfiguration/cel_patcher.go
+++ b/pkg/clusterconfiguration/cel_patcher.go
@@ -91,7 +91,7 @@ func (t *Template[T]) Fixup(engine func(reflect.Value) (*cel.Env, error)) error 
 		if err != nil {
 			var w Warning
 			if errors.As(err, &w) {
-				t.Warnings = append(t.Warnings, err)
+				t.Warnings = append(t.Warnings, errors.Wrapf(err, "could not resolve property %q", f.Field))
 				continue
 			}
 			errs = append(errs, errors.Newf("problem running CEL expression for field %q: %w", f.Field, err))

--- a/pkg/clusterconfiguration/configuration_cluster.go
+++ b/pkg/clusterconfiguration/configuration_cluster.go
@@ -46,11 +46,11 @@ type clusterCfg struct {
 
 	// warnings captures non-fatal fixup failures from the last Reify call,
 	// most commonly an `errorToWarning`-wrapped external secret lookup that
-	// could not be resolved. The fixup's templated value remains in
-	// `concrete` (unexpanded), so any caller passing the result to the
-	// Redpanda admin API needs to surface these warnings to the user —
-	// otherwise the only signal will be Redpanda's downstream validation
-	// error on the unexpanded placeholder, which obscures the root cause.
+	// could not be resolved. The affected property is omitted from
+	// `concrete`, so any caller passing the result to the Redpanda admin
+	// API needs to surface these warnings to the user — otherwise the only
+	// signal will be Redpanda's downstream validation error complaining
+	// about the missing property, which obscures the root cause.
 	// See K8S-858.
 	warnings []error
 }
@@ -254,11 +254,11 @@ func (c *clusterCfg) Reify(ctx context.Context, reader k8sclient.Reader, cloudEx
 		return nil, errors.WithStack(err)
 	}
 	// Fixup emits non-fatal warnings (typically `errorToWarning`-wrapped
-	// failed secret expansions on Optional secrets) without aborting.
-	// Snapshot them so callers can surface them in a status condition
-	// before passing the partially-rendered config to the Redpanda admin
-	// API. Without this, the caller would only see Redpanda's downstream
-	// "Must set both of …" validation error on the unexpanded placeholder.
+	// failed secret expansions on Optional secrets) without aborting; the
+	// affected properties are omitted from the result. Snapshot the
+	// warnings so callers can surface them in status conditions or events.
+	// Without this, the only downstream signal would be Redpanda's
+	// "Must set both of …" validation error about the missing property.
 	c.warnings = append([]error(nil), t.Warnings...)
 
 	// Finally, use the schema to turn those representations into concrete values

--- a/pkg/clusterconfiguration/configuration_node.go
+++ b/pkg/clusterconfiguration/configuration_node.go
@@ -134,6 +134,11 @@ func (n *nodeCfg) Reify(ctx context.Context, reader k8sclient.Reader, cloudExpan
 	if err := t.Fixup(factory); err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// TODO(follow-up): t.Warnings is dropped here, the same latent pattern
+	// clusterCfg.Reify used to have (see K8S-858). It is unreachable today
+	// because node-config fixups never wrap values in errorToWarning, but if
+	// that changes these warnings should be stored and surfaced like
+	// clusterCfg's.
 	n.concrete = cfg
 	return n.concrete, nil
 }

--- a/pkg/clusterconfiguration/warnings_test.go
+++ b/pkg/clusterconfiguration/warnings_test.go
@@ -41,12 +41,11 @@ func TestFormatWarnings(t *testing.T) {
 }
 
 // TestClusterCfg_Warnings_FromOptionalSecretFailure asserts that
-// errorToWarning-wrapped failed expansions (the contract used for
-// Optional external secrets, configuration_cluster.go:181-183) are
-// surfaced through the new Warnings accessor so the v1 and v2
-// controllers can lift them into a status condition before pushing the
-// partially-rendered config to Redpanda. Regression coverage for
-// K8S-858.
+// errorToWarning-wrapped failed expansions (the contract clusterCfg.compile
+// emits for Optional external secret refs) are
+// surfaced through the Warnings accessor so the v1 and v2 controllers
+// can lift them into a status condition (and, on v2, Warning events)
+// before failing the reconcile. Regression coverage for K8S-858.
 func TestClusterCfg_Warnings_FromOptionalSecretFailure(t *testing.T) {
 	cfg := clusterconfiguration.NewClusterCfg(clusterconfiguration.NewPodContext("namespace"))
 	cfg.SetAdditionalConfiguration("iceberg_rest_catalog_client_secret", `""`)
@@ -63,11 +62,14 @@ func TestClusterCfg_Warnings_FromOptionalSecretFailure(t *testing.T) {
 	)
 
 	_, err := cfg.Reify(context.TODO(), nil, nil, nil)
-	require.NoError(t, err, "Reify itself must not fail for a Warning; the field is left unexpanded")
+	require.NoError(t, err, "Reify itself must not fail for a Warning; the property is omitted from the result")
 
 	warnings := cfg.Warnings()
 	require.Len(t, warnings, 1, "expected one Warning for the simulated optional-secret failure")
 	assert.Contains(t, warnings[0].Error(), "DATABRICKS_CLIENT_SECRET")
+	// The warning must name the affected property, not just the underlying
+	// secret failure, so the user can tell which config value is missing.
+	assert.Contains(t, warnings[0].Error(), `could not resolve property "iceberg_rest_catalog_client_secret"`)
 
 	// And the shared formatter should produce a user-facing summary that
 	// the controller can drop straight into a status condition message.


### PR DESCRIPTION
## What

When an external secret referenced from cluster config cannot be resolved,
surface the failure with the affected property named — on the Cluster CR's
`ClusterConfigured` condition (v1), on the Redpanda CR's
`ConfigurationApplied` condition plus a Warning event per property (v2) —
while keeping the existing fail-before-push reconcile behaviour.

## Why

#1530 (K8S-858 / sev-3-inc-2775) fixed the original silent failure — an
unresolvable iceberg REST catalog client secret surfaced only as Redpanda's
misleading "Must set both of iceberg_rest_catalog_client_id and ..." broker
error — by failing the reconcile before pushing config. But the failure was
only visible as a reconcile error: the warning didn't name the affected
config property, v1 never wrote it to a status condition, and there were no
events. Someone looking at the CR still couldn't tell what was wrong.

## Notable behavior

- `cel_patcher.go` wraps each warning with the property name:
  `could not resolve property "iceberg_rest_catalog_client_secret": ...`.
- v1 (vectorized) sets `ClusterConfigured=False/Error` with the warning text
  before returning the reconcile error (previously the condition was left
  untouched).
- v2 emits a Warning event per unresolvable property, then fails the
  reconcile; the deferred `SetConfigurationApplied` writes the same message
  onto the `ConfigurationApplied` condition.
- Reconcile semantics are unchanged from #1530: nothing is pushed to the
  admin API while values are unresolvable; the reconcile retries with
  backoff until the secret resolves.

`nodeCfg.Reify` has the same latent warning-dropping pattern; it is
unreachable today (node-config fixups never use `errorToWarning`) and is
marked with a follow-up TODO rather than changed here.

## Tests

The K8S-858 regression test now asserts the warning names the affected
property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)