### PR TITLE
nix: correct go install to 1.26.5

### DIFF
--- a/ci/helm.nix
+++ b/ci/helm.nix
@@ -1,27 +1,24 @@
 { pkgs
 , stdenv
-, fetchzip
+}:
+{ version
+, src
+  # When true, the binary is installed as `helm-${version}` instead of `helm` so
+  # that multiple versions may coexist on $PATH.
+, versionSuffix ? false
 }:
 let
   pname = "helm";
-  version = "3.10.3";
-  src = {
-    aarch64-darwin = fetchzip {
-      url = "https://get.helm.sh/helm-v${version}-darwin-arm64.tar.gz";
-      hash = "sha256-3W/piPZvkyrGOLCgghn7j9CgNxAVvWn1kwFb8Von9Ko=";
-    };
-    x86_64-linux = fetchzip {
-      url = "https://get.helm.sh/helm-v${version}-linux-amd64.tar.gz";
-      hash = "sha256-XAtiT7vaSBrfrj03gbcQUmUMQSZ9+5nymxfVSOnQ+sM=";
-    };
-  }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+  binary = if versionSuffix then "helm-${version}" else "helm";
 in
 stdenv.mkDerivation {
-  inherit pname version src;
+  inherit pname version;
+
+  src = src.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
 
   installPhase = ''
     mkdir -p "$out/bin"
-    cp "$src/helm" "$out/bin/helm-${version}"
-    chmod 755 "$out/bin/helm-${version}"
+    cp "$src/helm" "$out/bin/${binary}"
+    chmod 755 "$out/bin/${binary}"
   '';
 }

--- a/ci/overlay.nix
+++ b/ci/overlay.nix
@@ -1,5 +1,9 @@
 { pkgs
-}: (final: prev: {
+}:
+let
+  mkHelm = pkgs.callPackage ./helm.nix { };
+in
+(final: prev: {
   backport = pkgs.callPackage ./backport.nix { };
   bk = pkgs.callPackage ./bk.nix { };
   code-generator = pkgs.callPackage ./code-generator.nix { };
@@ -7,10 +11,43 @@
   crd-ref-docs = pkgs.callPackage ./crd-ref-docs.nix { };
   docker-tag-list = pkgs.callPackage ./docker-tag-list.nix { };
   goverter = pkgs.callPackage ./goverter.nix { };
-  helm-3-10-3 = pkgs.callPackage ./helm.nix { };
   kuttl = pkgs.callPackage ./kuttl.nix { };
   licenseupdater = pkgs.callPackage ./licenseupdater.nix { };
   rp-controller-gen = pkgs.callPackage ./rp-controller-gen.nix { };
   setup-envtest = pkgs.callPackage ./setup-envtest.nix { };
   vcluster = pkgs.callPackage ./vcluster.nix { };
+  # The hashes below are the unpacked (NAR) hashes of the release tarballs, as
+  # required by fetchzip. To compute one for a new version/platform:
+  #
+  #   nix hash convert --hash-algo sha256 --to sri \
+  #     "$(nix-prefetch-url --unpack --type sha256 https://get.helm.sh/helm-v<VERSION>-<PLATFORM>.tar.gz)"
+  #
+  # Where <PLATFORM> is one of darwin-arm64 or linux-amd64.
+  helm-3-10-3 = mkHelm {
+    version = "3.10.3";
+    versionSuffix = true;
+    src = {
+      aarch64-darwin = pkgs.fetchzip {
+        url = "https://get.helm.sh/helm-v3.10.3-darwin-arm64.tar.gz";
+        hash = "sha256-3W/piPZvkyrGOLCgghn7j9CgNxAVvWn1kwFb8Von9Ko=";
+      };
+      x86_64-linux = pkgs.fetchzip {
+        url = "https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz";
+        hash = "sha256-XAtiT7vaSBrfrj03gbcQUmUMQSZ9+5nymxfVSOnQ+sM=";
+      };
+    };
+  };
+  helm-3-19-1 = mkHelm {
+    version = "3.19.1";
+    src = {
+      aarch64-darwin = pkgs.fetchzip {
+        url = "https://get.helm.sh/helm-v3.19.1-darwin-arm64.tar.gz";
+        hash = "sha256-MrWws7eObrZUpP/xU1hElbSloa8GZFwI4rwENNP9ez8=";
+      };
+      x86_64-linux = pkgs.fetchzip {
+        url = "https://get.helm.sh/helm-v3.19.1-linux-amd64.tar.gz";
+        hash = "sha256-8feTouvv+I89Lqsg732jQZBxUcwVqr/c8RuDUYpoUK4=";
+      };
+    };
+  };
 })

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773646010,
-        "narHash": "sha256-iYrs97hS7p5u4lQzuNWzuALGIOdkPXvjz7bviiBjUu8=",
+        "lastModified": 1784872115,
+        "narHash": "sha256-THPEF2po0fsoH8gNtp+Ae0XFDJH3N/ol7xO3v6VMTJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b2c2d84341b2afb5647081c1386a80d7a8d8605",
+        "rev": "335f0738cb2fa9708f3f428e39d2eae975d1338d",
         "type": "github"
       },
       "original": {
@@ -86,26 +86,12 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "otel-tui": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1773034977,

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,21 @@
 {
   inputs = {
+    # Picking an arbitrary SHA of nixpkgs can result in having to build from
+    # source if the hydra build failed or it wasn't included in a build until a
+    # later batch. Instead:
+    # 1. Find the commit with the change you want.
+    # 2. Find the nearest PASSING build on https://hydra.nixos.org/job/nixpkgs/unstable/unstable/all
+    # 3. Run:  nix flake update nixpkgs --override-input nixpkgs nixpkgs/<SHA FROM ABOVE>
     nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    otel-tui.url = "github:ymtdzzz/otel-tui";
+    otel-tui = {
+      url = "github:ymtdzzz/otel-tui";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -44,6 +53,9 @@
             env = [
               { name = "CGO_ENABLED"; value = "0"; }
               { name = "GOROOT"; value = "${pkgs.go_1_26}/share/go"; }
+              # Prevent go from downloading toolchains other than the one pinned by nix.
+              # See https://go.dev/doc/toolchain#select
+              { name = "GOTOOLCHAIN"; value = "local"; }
               { name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.33.x)"; }
               { name = "PATH"; eval = "$(pwd)/.build:$PATH"; }
               { name = "TEST_CERTMANAGER_VERSION"; eval = "v1.14.2"; }
@@ -91,12 +103,12 @@
               pkgs.goverter
               pkgs.grpc-tools
               pkgs.helm-3-10-3
+              pkgs.helm-3-19-1
               pkgs.helm-docs
               pkgs.jq
               pkgs.k3d # Kind alternative that allows adding/removing Nodes.
               pkgs.kind
               pkgs.kubectl
-              pkgs.kubernetes-helm
               pkgs.kustomize
               pkgs.kuttl
               pkgs.licenseupdater

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -1,10 +1,10 @@
 -- aws --
 # aws --version | cut -d ' ' -f 1-2
-aws-cli/2.33.2 Python/3.13.12
+aws-cli/2.35.11 Python/3.14.6
 
 -- changie --
 # changie --version
-changie version v1.24.0
+changie version v1.25.1
 
 -- go --
 # go version | cut -d ' ' -f 1-3
@@ -12,7 +12,7 @@ go version go1.26.5
 
 -- helm --
 # helm version
-version.BuildInfo{Version:"v3.19.1", GitCommit:"v3.19.1", GitTreeState:"", GoVersion:"go1.25.7"}
+version.BuildInfo{Version:"v3.19.1", GitCommit:"4f953c223ba21103268e0b664c64240bc69fced7", GitTreeState:"clean", GoVersion:"go1.24.9"}
 
 -- helm-docs --
 # helm-docs -v
@@ -20,17 +20,17 @@ helm-docs version 1.14.2
 
 -- k3d --
 # k3d version
-k3d version v5.8.3
-k3s version v1.21.7-k3s1 (default)
+k3d version v5.9.0
+k3s version v1.32.5-k3s1 (default)
 
 -- kind --
 # kind version | cut -d ' ' -f 1-3
-kind v0.31.0 go1.25.7
+kind v0.32.0 go1.26.5
 
 -- kubectl --
 # kubectl version --client=true
-Client Version: v1.35.2
-Kustomize Version: v5.7.1
+Client Version: v1.36.2
+Kustomize Version: v5.8.1
 
 -- kustomize --
 # kustomize version
@@ -46,5 +46,5 @@ KUTTL Version: version.Info{GitVersion:"0.25.0", GitCommit:"ca80cff", BuildDate:
 
 -- yq --
 # yq --version
-yq (https://github.com/mikefarah/yq/) version v4.52.4
+yq (https://github.com/mikefarah/yq/) version v4.53.3
 


### PR DESCRIPTION
The go package installed by nix was 1.26.1, not 1.26.5 as reported by go.work/go.mod. This was due to the default value of `GOTOOLCHAIN` being set to `auto` which causes go to fetch the listed toolchain version.

This was discovered because we manually set `GOROOT` which causes a subtle mismatch between the go binary version and GOROOT's version.

Correct the installed version to go 1.26.1 by bumping nixpkg's sha. This incidentally upgraded a handful of other packages. Most notably was `helm`, which upgraded to v4. As we're not currently working with v4, additionally pin to the previously installed version.