### PR TITLE
fix(operator): WithNodePool now creates a new map to prevent nodepool label corruption

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260804-193002.yaml
+++ b/.changes/unreleased/operator-Fixed-20260804-193002.yaml
@@ -1,0 +1,18 @@
+project: operator
+kind: Fixed
+body: |-
+    All nodepools after the first no longer inherit the first nodepool's cluster.redpanda.com/nodepool label.
+
+      The internal label-union helper mutated its first argument in place and
+      returned that same map by reference instead of a copy. ForCluster passed the
+      Cluster CR's own Labels map through it as that first argument, so every call
+      to ForCluster for a given cluster handed back that identical live map. Once
+      Helm's app.kubernetes.io/managed-by: Helm label made the map non-nil, the
+      first nodepool to derive its labels from it stamped
+      cluster.redpanda.com/nodepool directly into the shared map, and the union
+      helper's "existing key wins" rule then made every subsequent nodepool
+      silently inherit that same stale value instead of its own — so all of a
+      later nodepool's pods carried an earlier nodepool's label. The union helper
+      now always allocates and returns a new map and never touches either input,
+      so no caller can observe or propagate a mutation through it.
+time: 2026-08-04T19:30:02.000000+03:00

--- a/operator/pkg/labels/labels.go
+++ b/operator/pkg/labels/labels.go
@@ -53,7 +53,7 @@ type CommonLabels map[string]string
 // recommended by the kubernetes documentation https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 func ForCluster(cluster *vectorizedv1alpha1.Cluster) CommonLabels {
 	dl := defaultClusterLabels(cluster)
-	labels := merge(cluster.Labels, dl)
+	labels := union(cluster.Labels, dl)
 
 	return labels
 }
@@ -108,27 +108,31 @@ func (cl CommonLabels) nodePoolSelectorLabels() k8slabels.Set {
 }
 
 func (cl CommonLabels) WithNodePool(nodePool string) CommonLabels {
-	return merge(cl, map[string]string{
-		"cluster.redpanda.com/nodepool": nodePool,
-	})
+	// union(cl, nil) hands back a fresh copy of cl, so mutating the result
+	// below can never corrupt cl itself or any other CommonLabels derived
+	// from the same underlying map (see the regression test). NodePoolKey is
+	// set unconditionally, rather than through union()'s "existing key wins"
+	// rule, since cl may already carry a (possibly different) nodepool value.
+	result := CommonLabels(union(cl, nil))
+	result[NodePoolKey] = nodePool
+	return result
 }
 
-// merge merges two sets of labels
-// if label is set in mainLabels, it won't be overwritten by newLabels
-func merge(
+// union returns a new map containing the union of mainLabels and newLabels;
+// neither input is mutated. If a key is set in mainLabels, that value wins
+// over newLabels.
+func union(
 	mainLabels map[string]string, newLabels map[string]string,
 ) map[string]string {
-	if mainLabels == nil {
-		mainLabels = make(map[string]string)
-	}
-
+	merged := make(map[string]string, len(mainLabels)+len(newLabels))
 	for k, v := range newLabels {
-		if _, ok := mainLabels[k]; !ok {
-			mainLabels[k] = v
-		}
+		merged[k] = v
+	}
+	for k, v := range mainLabels {
+		merged[k] = v
 	}
 
-	return mainLabels
+	return merged
 }
 
 func defaultClusterLabels(cluster *vectorizedv1alpha1.Cluster) map[string]string {

--- a/operator/pkg/labels/labels_test.go
+++ b/operator/pkg/labels/labels_test.go
@@ -69,3 +69,26 @@ func TestLabels(t *testing.T) {
 		}
 	}
 }
+
+// TestWithNodePoolDoesNotCorruptSecondPool is a regression test for the mutation bug where
+// Helm adds app.kubernetes.io/managed-by: Helm to the Cluster CR, making cluster.Labels
+// non-nil. WithNodePool must produce independent labels for each nodepool.
+func TestWithNodePoolDoesNotCorruptSecondPool(t *testing.T) {
+	cluster := &vectorizedv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "default",
+			Labels:    map[string]string{"app.kubernetes.io/managed-by": "Helm"},
+		},
+	}
+
+	pool1Labels := labels.ForCluster(cluster).WithNodePool("blue-a")
+	pool2Labels := labels.ForCluster(cluster).WithNodePool("green-a")
+
+	if pool1Labels[labels.NodePoolKey] != "blue-a" {
+		t.Errorf("pool1 nodepool label: want blue-a, got %s", pool1Labels[labels.NodePoolKey])
+	}
+	if pool2Labels[labels.NodePoolKey] != "green-a" {
+		t.Errorf("pool2 nodepool label: want green-a, got %s (mutation bug)", pool2Labels[labels.NodePoolKey])
+	}
+}


### PR DESCRIPTION
When Helm manages the Cluster CR it stamps app.kubernetes.io/managed-by: Helm onto cluster.Labels, making it a non-nil map. WithNodePool previously called merge(), which both mutates its first argument in-place and never overrides existing keys. This caused the second nodepool's StatefulSet to inherit the first pool's NodePoolKey value instead of its own, because:
  1. ForCluster(cluster) returns cluster.Labels directly (same pointer)
  2. WithNodePool("blue-a") writes NodePoolKey into cluster.Labels via merge
  3. WithNodePool("green-a") sees NodePoolKey already present and skips it

The result was all green-a pods carrying cluster.redpanda.com/nodepool=blue-a, causing the operator to count them toward blue-a's readyReplicas and never set OperatorQuiescent=True, stalling tier migrations indefinitely.

Fix: create a fresh map in WithNodePool and unconditionally set NodePoolKey. Regression test added.