### PR TITLE
charts/redpanda: add doc comments for optional external values

### DIFF
--- a/.changes/unreleased/charts-redpanda-Fixed-20260806-142659.yaml
+++ b/.changes/unreleased/charts-redpanda-Fixed-20260806-142659.yaml
@@ -1,0 +1,5 @@
+project: charts/redpanda
+kind: Fixed
+body: |-
+    Machine-readable doc comments for the optional external values (addresses, annotations, externalDns.enabled, prefixTemplate, sourceRanges) so the published Helm spec reference documents them. Comment-only change: no keys, no schema, no rendered output changes.
+time: 2026-08-06T14:26:59.201704+01:00

--- a/charts/redpanda/chart/values.yaml
+++ b/charts/redpanda/chart/values.yaml
@@ -272,6 +272,7 @@ external:
   # NodePort is recommended in cases where latency is a priority.
   type: NodePort
   # Optional source range for external access. Only applicable when external.type is LoadBalancer
+  # @doc external.sourceRanges -- Optional source IP ranges for external access. Only applicable when `external.type` is `LoadBalancer`.
   # sourceRanges: []
   # -- Optional domain advertised to external clients
   # If specified, then it will be appended to the `external.addresses` values as each broker's advertised address
@@ -283,11 +284,13 @@ external:
   # If external.domain is set, the domain is appended to these values.
   # There is an option to define a single external address for all brokers and leverage
   # prefixTemplate as it will be calculated during initContainer execution.
+  # @doc external.addresses -- Optional list of addresses that the Redpanda brokers advertise, with one entry for each broker in order of StatefulSet replicas. The number of brokers is defined in `statefulset.replicas`. The values can be IP addresses or DNS names. If `external.domain` is set, the domain is appended to these values. To use a single external address for all brokers, define one entry and use `external.prefixTemplate` so that each broker's address is calculated during initContainer execution.
   # addresses:
   # - redpanda-0
   # - redpanda-1
   # - redpanda-2
   #
+  # @doc external.annotations -- Optional annotations to add to the external Service instances, for example `cloud.google.com/load-balancer-type: "Internal"` or `service.beta.kubernetes.io/aws-load-balancer-type: nlb`.
   # annotations:
     # For example:
     # cloud.google.com/load-balancer-type: "Internal"
@@ -295,8 +298,11 @@ external:
   # If you enable externalDns, each LoadBalancer service instance
   # will be annotated with external-dns hostname
   # matching external.addresses + external.domain
+  # @doc external.externalDns.enabled -- If you enable externalDns, each LoadBalancer Service instance is annotated with the external-dns hostname, matching `external.addresses` plus `external.domain`.
   # externalDns:
   #   enabled: true
+  # @doc external.prefixTemplate -- Optional Go template for the prefix of each broker's advertised address. The result is prepended to `external.domain` during initContainer execution. Only used when `external.addresses` contains a single entry that serves all brokers.
+  # @default -- `""`
   # prefixTemplate: ""
   # -- Gateway API TLSRoute-based external access (alternative to NodePort/LoadBalancer).
   # The chart creates a bootstrap TLSRoute plus one per-broker TLSRoute, routed by SNI


### PR DESCRIPTION
Comment-only half of [K8S-125](https://redpandadata.atlassian.net/browse/K8S-125): `external.addresses`, `external.annotations`, `external.externalDns.enabled`, `external.prefixTemplate`, and `external.sourceRanges` ship commented out in `values.yaml`, so helm-docs never renders them and they are missing from the published [Helm spec reference](https://docs.redpanda.com/current/reference/k-redpanda-helm-spec/#external).

This adds `# @doc <path> -- <description>` comment annotations next to the existing comments. The docs pipeline ([docs-extensions-and-macros#248](https://github.com/redpanda-data/docs-extensions-and-macros/pull/248)) extracts these when generating the reference, so the values become documented without making them real keys (an explicit `domain: null` is currently rejected by the values schema, and real keys were ruled out in review).

## Zero-impact verification

- **Comment-only**: no keys, no schema, no Go changes.
- `helm-docs` output (chart README) is byte-identical - the annotations are invisible to it.
- `helm template` output is byte-identical.
- End-to-end through the docs pipeline with #248: the generated reference gains sections for all five values (plus 15 more that already had `# --` markers), each verified against the chart's `Values` struct.

An upstream helm-docs feature request for native support is tracked in norwoodj/helm-docs#175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[K8S-125]: https://redpandadata.atlassian.net/browse/K8S-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ