### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,3 @@
 | [`release/v26.2.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v26.2.x) |    v26.2.x     |                                              Apr 1, 2027 (est)                                              |
 | [`release/v26.1.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v26.1.x) |    v26.1.x     |                                              Apr 1, 2027 (est)                                              |
 | [`release/v25.3.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.3.x) |    v25.3.x     |                                             Nov 19, 2026 (est)                                              |
-| [`release/v25.2.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.2.x) |    v25.2.x     |                                             Jul 31, 2026 (est)                                              |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@
 |                                            Branch                                            | Release Series | [End of Support](https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions) |
 |:--------------------------------------------------------------------------------------------:|:--------------:|:-----------------------------------------------------------------------------------------------------------:|
 |            [`main`](https://github.com/redpanda-data/redpanda-operator/tree/main)            |    v26.3.x     |                                                     TBD                                                     |
-| [`release/v26.2.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v26.2.x) |    v26.2.x     |                                              Apr 1, 2027 (est)                                              |
+| [`release/v26.2.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v26.2.x) |    v26.2.x     |                                              July 28, 2027 (est)                                              |
 | [`release/v26.1.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v26.1.x) |    v26.1.x     |                                              Apr 1, 2027 (est)                                              |
 | [`release/v25.3.x`](https://github.com/redpanda-data/redpanda-operator/tree/release/v25.3.x) |    v25.3.x     |                                             Nov 19, 2026 (est)                                              |


### PR DESCRIPTION
- Remove 25.2.x from readme as no longer supported. 
- Update 26.2.x EOL date as described in https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions