### PR TITLE
prevent etcd + kube-apiserver from leaking in tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,20 @@
           # nix commands. e.g. nix copy .#devshell.
           packages.devshell = self'.devShells.default;
 
+          packages.envtest-shim = pkgs.buildGoModule {
+            name = "envtest-shim";
+
+            src = ./reaper;
+            vendorHash = "sha256-at1aAaxyk07gdZpFnyhTIQS0qtiLHkQK839F6PC06EQ=";
+
+            postInstall = ''
+              mkdir -p $out/shims/
+              ln -s $out/bin/reaper $out/shims/etcd
+              ln -s $out/bin/reaper $out/shims/kube-apiserver
+            '';
+          };
+
+
           devshells.default = {
             env = [
               { name = "CGO_ENABLED"; value = "0"; }
@@ -56,6 +70,10 @@
               # Prevent go from downloading toolchains other than the one pinned by nix.
               # See https://go.dev/doc/toolchain#select
               { name = "GOTOOLCHAIN"; value = "local"; }
+              # Force KUBEBUILDER_ASSETS to run through a shim that ensures
+              # long running processes are terminated rather than orphaned.
+              { name = "TEST_ASSET_ETCD"; value = "${self'.packages.envtest-shim}/shims/etcd"; }
+              { name = "TEST_ASSET_KUBE_APISERVER"; value = "${self'.packages.envtest-shim}/shims/kube-apiserver"; }
               { name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.33.x)"; }
               { name = "PATH"; eval = "$(pwd)/.build:$PATH"; }
               { name = "TEST_CERTMANAGER_VERSION"; eval = "v1.14.2"; }
@@ -78,6 +96,7 @@
             # If the version of the installed binary is important make sure to
             # update TestToolVersions.
             packages = [
+              self'.packages.envtest-shim
               pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               pkgs.awscli2
               pkgs.backport

--- a/go.work
+++ b/go.work
@@ -13,5 +13,6 @@ use (
 	./licensereport
 	./operator
 	./pkg
+	./reaper
 	./rpk-k8s-publish
 )

--- a/reaper/README.md
+++ b/reaper/README.md
@@ -1,0 +1,25 @@
+# (envtest) Reaper
+
+A shim that wraps the `envtest` binaries (`etcd`, `kube-apiserver`) so they don't
+outlive the test process that started them.
+
+`reaper` is symlinked as `shims/etcd` and `shims/kube-apiserver` (see
+`packages.envtest-shim` in `flake.nix`) and pointed at by `TEST_ASSET_ETCD` /
+`TEST_ASSET_KUBE_APISERVER`. When run, it execs the identically named binary
+from `$KUBEBUILDER_ASSETS`, forwarding stdio and its own exit code, and kills
+that child once its own parent exits. Without it, a `go test` run that dies
+without cleaning up (`SIGKILL`, a panic in the wrong place, `^C` in some
+harnesses) leaves `etcd` and `kube-apiserver` processes behind.
+
+Watching the parent is OS specific, so each `watch_$GOOS.go` implements
+`watchParent`. Both block, without polling, until the parent exits or the
+context is canceled:
+
+- darwin: `kqueue` with `EVFILT_PROC` / `NOTE_EXIT`.
+- linux: `pidfd_open` (Linux 5.3+), which yields an fd that becomes readable
+  when the process exits, plus an `eventfd` to break out of `poll` on
+  cancellation.
+
+Note that `PR_SET_PDEATHSIG` is deliberately not used on linux: its notion of
+"parent" is the *thread* that created the process, and Go's runtime retires
+threads at will, which would kill the child while the test is still running.

--- a/reaper/go.mod
+++ b/reaper/go.mod
@@ -1,0 +1,8 @@
+module github.com/redpanda-data/redpanda-operator/reaper
+
+go 1.26.5
+
+require (
+	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
+)

--- a/reaper/go.sum
+++ b/reaper/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/reaper/main.go
+++ b/reaper/main.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGPIPE)
+	defer cancel()
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	binary := filepath.Join(os.Getenv("KUBEBUILDER_ASSETS"), filepath.Base(os.Args[0]))
+	args := os.Args[1:]
+
+	//nolint:gosec // This is a development tool and the binary itself MUST be in
+	//KUBEBUILDER_ASSETS. There's no real concern about command injection here.
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+
+	group.Go(func() error {
+		// Ensure that the watcher get shutdown even if Run exits without error.
+		defer cancel()
+
+		return cmd.Run()
+	})
+
+	group.Go(func() error {
+		defer cancel()
+
+		return watchParent(ctx)
+	})
+
+	err := group.Wait()
+
+	if err, ok := errors.AsType[*exec.ExitError](err); ok {
+		os.Exit(err.ExitCode())
+	}
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/reaper/watch_darwin.go
+++ b/reaper/watch_darwin.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func watchParent(ctx context.Context) error {
+	// Getppid returns 1 if the parent process is already dead.
+	ppid := os.Getppid()
+	if ppid == 1 {
+		return nil
+	}
+	return watchPID(ctx, ppid)
+}
+
+func watchPID(ctx context.Context, pid int) error {
+	fd, err := unix.Kqueue()
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+
+	watches := make([]unix.Kevent_t, 2)
+
+	// Thanks to https://stackoverflow.com/questions/24689728/detect-process-exit-on-osx
+	unix.SetKevent(&watches[0], pid, unix.EVFILT_PROC, unix.EV_ADD|unix.EV_RECEIPT)
+	watches[0].Fflags = unix.NOTE_EXIT
+
+	// Listen for USER events as well so we can handle context cancellations.
+	unix.SetKevent(&watches[1], 1, unix.EVFILT_USER, unix.EV_ADD)
+
+	if _, err := unix.Kevent(fd, watches, nil, nil); err != nil {
+		return err
+	}
+
+	// Wake kqueue poll when context is canceled.
+	go func() {
+		<-ctx.Done()
+
+		var ev unix.Kevent_t
+		unix.SetKevent(&ev, 1, unix.EVFILT_USER, 0)
+		ev.Fflags = unix.NOTE_TRIGGER
+		_, _ = unix.Kevent(fd, []unix.Kevent_t{ev}, nil, nil)
+	}()
+
+	// Wait until something wakes us.
+	events := make([]unix.Kevent_t, 1)
+	_, err = unix.Kevent(fd, nil, events, nil)
+	return err
+}

--- a/reaper/watch_linux.go
+++ b/reaper/watch_linux.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func watchParent(ctx context.Context) error {
+	ppid := os.Getppid()
+	if ppid == 1 {
+		return nil
+	}
+	return watchPID(ctx, ppid)
+}
+
+func watchPID(ctx context.Context, pid int) error {
+	// A pidfd becomes readable once the process it refers to exits, so we can
+	// wait for pid without polling and without being its parent.
+	// Requires Linux 5.3+. pidfd_open always sets O_CLOEXEC.
+	pidfd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		// pid is already gone and reaped, nothing to wait for.
+		if errors.Is(err, unix.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	defer unix.Close(pidfd)
+
+	// Used to wake the poll below when the context is canceled.
+	eventfd, err := unix.Eventfd(0, unix.EFD_CLOEXEC)
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{})
+	waiterExited := make(chan struct{})
+
+	go func() {
+		defer close(waiterExited)
+
+		select {
+		case <-ctx.Done():
+			var buf [8]byte
+			binary.NativeEndian.PutUint64(buf[:], 1)
+			_, _ = unix.Write(eventfd, buf[:])
+		case <-done:
+		}
+	}()
+
+	// Ensure the waiter is finished with eventfd before closing it, otherwise
+	// it could write to an unrelated fd that has since reused the number.
+	defer func() {
+		close(done)
+		<-waiterExited
+		_ = unix.Close(eventfd)
+	}()
+
+	fds := []unix.PollFd{
+		{Fd: int32(pidfd), Events: unix.POLLIN},
+		{Fd: int32(eventfd), Events: unix.POLLIN},
+	}
+
+	for {
+		// Any signal delivered to this thread, including the runtime's own
+		// preemption signals, will interrupt poll. Just resume waiting.
+		if _, err := unix.Poll(fds, -1); errors.Is(err, unix.EINTR) {
+			continue
+		} else if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
etcd and kube-apiserver would leak whenever running go tests. This commit introduces a wrapper process that kills its children when the parent exists to prevent any leaks.