### PR TITLE
operator: skip-and-warn on Forbidden in the migration job's sweep

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,7 +4,7 @@
   "commitConflicts": true,
   "repoOwner": "redpanda-data",
   "repoName": "redpanda-operator",
-  "targetBranchChoices": ["release/v26.2.x","release/v26.1.x", "release/v25.3.x", "release/v25.2.x"],
+  "targetBranchChoices": ["release/v26.2.x","release/v26.1.x", "release/v25.3.x"],
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v(\\d+).(\\d+).x$": "release/v$1.$2.x"

--- a/.changes/unreleased/operator-Fixed-20260813-090000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260813-090000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: 'Fixed the post-upgrade migration job failing the whole upgrade when its ServiceAccount lacks permissions for optional resource types swept during field-manager migration — e.g. Gateway API `tlsroutes`/`httproutes` on clusters that have the Gateway API CRDs installed but manage RBAC manually (`rbac.create=false`). `Forbidden` errors during the sweep are now logged as warnings and the affected type or resource is skipped (and re-swept on the next upgrade); failing to list the `Redpanda`/`Console` custom resources themselves remains fatal.'
+time: 2026-08-13T09:00:00.000000-07:00

--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -1,1 +1,1 @@
-active: ["main", "release/v26.2.x", "release/v26.1.x", "release/v25.3.x", "release/v25.2.x"]
+active: ["main", "release/v26.2.x", "release/v26.1.x", "release/v25.3.x"]

--- a/operator/chart/files/rbac/v2-manager.ClusterRole.yaml
+++ b/operator/chart/files/rbac/v2-manager.ClusterRole.yaml
@@ -41,7 +41,6 @@ rules:
       - ""
     resources:
       - nodes
-      - pods/log
     verbs:
       - get
       - list
@@ -53,6 +52,12 @@ rules:
       - get
       - list
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -366,7 +366,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -378,6 +377,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -1297,7 +1302,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -1309,6 +1313,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -1998,7 +2008,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -2010,6 +2019,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -2956,7 +2971,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -2968,6 +2982,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -3677,7 +3697,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -3689,6 +3708,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -4621,7 +4646,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -4633,6 +4657,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -5504,7 +5534,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -5516,6 +5545,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -6670,7 +6705,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -6682,6 +6716,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -7476,7 +7516,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -7488,6 +7527,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -8421,7 +8466,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -8433,6 +8477,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -9126,7 +9176,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -9138,6 +9187,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -10110,7 +10165,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -10122,6 +10176,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -10903,7 +10963,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -10915,6 +10974,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -11933,7 +11998,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -11945,6 +12009,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -12759,7 +12829,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -12771,6 +12840,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -13721,7 +13796,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -13733,6 +13807,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -14429,7 +14509,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -14441,6 +14520,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -15379,7 +15464,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -15391,6 +15475,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -16089,7 +16179,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -16101,6 +16190,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -17071,7 +17166,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -17083,6 +17177,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -17779,7 +17879,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -17791,6 +17890,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -18562,7 +18667,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -18574,6 +18678,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -19284,7 +19394,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -19296,6 +19405,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -20241,7 +20356,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -20253,6 +20367,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -21143,7 +21263,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -21155,6 +21274,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -22325,7 +22450,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -22337,6 +22461,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -23042,7 +23172,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -23054,6 +23183,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -23871,7 +24006,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -23883,6 +24017,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -24567,7 +24707,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -24579,6 +24718,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -25526,7 +25671,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -25538,6 +25682,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -26242,7 +26392,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -26254,6 +26403,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -27193,7 +27348,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -27205,6 +27359,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -28278,7 +28438,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -28290,6 +28449,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -29446,7 +29611,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -29458,6 +29622,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -30163,7 +30333,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -30175,6 +30344,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -31153,7 +31328,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -31165,6 +31339,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -32037,7 +32217,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -32049,6 +32228,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -33162,7 +33347,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -33174,6 +33358,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -34251,7 +34441,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -34263,6 +34452,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -35357,7 +35552,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -35369,6 +35563,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -36243,7 +36443,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -36255,6 +36454,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -37607,7 +37812,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -37619,6 +37823,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -38323,7 +38533,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -38335,6 +38544,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -39286,7 +39501,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -39298,6 +39512,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -40187,7 +40407,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -40199,6 +40418,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -41470,7 +41695,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -41482,6 +41706,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -42541,7 +42771,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -42553,6 +42782,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -43688,7 +43923,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -43700,6 +43934,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -44826,7 +45066,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -44838,6 +45077,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -46004,7 +46249,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -46016,6 +46260,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -46731,7 +46981,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -46743,6 +46992,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -47895,7 +48150,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -47907,6 +48161,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -48789,7 +49049,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -48801,6 +49060,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -49994,7 +50259,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -50006,6 +50270,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -51403,7 +51673,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -51415,6 +51684,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -52752,7 +53027,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -52764,6 +53038,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -53579,7 +53859,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -53591,6 +53870,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -54558,7 +54843,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -54570,6 +54854,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -55428,7 +55718,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -55440,6 +55729,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -56846,7 +57141,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -56858,6 +57152,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -59316,7 +59616,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -59328,6 +59627,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -60848,7 +61153,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -60860,6 +61164,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -62530,7 +62840,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -62542,6 +62851,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -63780,7 +64095,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -63792,6 +64106,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -66198,7 +66518,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -66210,6 +66529,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -67694,7 +68019,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -67706,6 +68030,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -68520,7 +68850,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -68532,6 +68861,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -70053,7 +70388,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -70065,6 +70399,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -71553,7 +71893,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -71565,6 +71904,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -72797,7 +73142,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -72809,6 +73153,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -74400,7 +74750,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -74412,6 +74761,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -75900,7 +76255,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -75912,6 +76266,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -76747,7 +77107,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -76759,6 +77118,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -78042,7 +78407,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -78054,6 +78418,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -79075,7 +79445,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -79087,6 +79456,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -80636,7 +81011,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -80648,6 +81022,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -81462,7 +81842,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -81474,6 +81853,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -82908,7 +83293,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -82920,6 +83304,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -83737,7 +84127,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -83749,6 +84138,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -84668,7 +85063,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -84680,6 +85074,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -85459,7 +85859,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -85471,6 +85870,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -86479,7 +86884,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -86491,6 +86895,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -87270,7 +87680,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -87282,6 +87691,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -88298,7 +88713,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -88310,6 +88724,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -89089,7 +89509,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -89101,6 +89520,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -90111,7 +90536,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -90123,6 +90547,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -90812,7 +91242,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -90824,6 +91253,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -91744,7 +92179,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -91756,6 +92190,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -92445,7 +92885,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -92457,6 +92896,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -93419,7 +93864,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -93431,6 +93875,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -94211,7 +94661,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -94223,6 +94672,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -95186,7 +95641,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -95198,6 +95652,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -95977,7 +96437,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -95989,6 +96448,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -96907,7 +97372,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -96919,6 +97383,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -97608,7 +98078,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -97620,6 +98089,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -98555,7 +99030,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -98567,6 +99041,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -99256,7 +99736,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -99268,6 +99747,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -100186,7 +100671,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -100198,6 +100682,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -100887,7 +101377,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -100899,6 +101388,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -101817,7 +102312,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -101829,6 +102323,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -102518,7 +103018,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -102530,6 +103029,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -103448,7 +103953,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -103460,6 +103964,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -104149,7 +104659,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -104161,6 +104670,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -105087,7 +105602,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -105099,6 +105613,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -105788,7 +106308,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -105800,6 +106319,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -106726,7 +107251,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -106738,6 +107262,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -107427,7 +107957,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -107439,6 +107968,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -108391,7 +108926,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -108403,6 +108937,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -109092,7 +109632,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -109104,6 +109643,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -110146,7 +110691,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -110158,6 +110702,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -110847,7 +111397,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -110859,6 +111408,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -111813,7 +112368,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -111825,6 +112379,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -112514,7 +113074,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -112526,6 +113085,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -113480,7 +114045,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -113492,6 +114056,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -114181,7 +114751,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -114193,6 +114762,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -115146,7 +115721,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -115158,6 +115732,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -115863,7 +116443,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -115875,6 +116454,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -116904,7 +117489,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -116916,6 +117500,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -117712,7 +118302,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -117724,6 +118313,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -118808,7 +119403,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -118820,6 +119414,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -119616,7 +120216,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -119628,6 +120227,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -120706,7 +121311,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -120718,6 +121322,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -121514,7 +122124,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -121526,6 +122135,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -122537,7 +123152,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -122549,6 +123163,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -123345,7 +123965,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -123357,6 +123976,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -124360,7 +124985,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -124372,6 +124996,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -125152,7 +125782,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -125164,6 +125793,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -126213,7 +126848,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -126225,6 +126859,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -126914,7 +127554,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -126926,6 +127565,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -127851,7 +128496,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -127863,6 +128507,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -128552,7 +129202,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -128564,6 +129213,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:
@@ -129483,7 +130138,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -129495,6 +130149,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:

--- a/operator/cmd/migration/fieldmanagers.go
+++ b/operator/cmd/migration/fieldmanagers.go
@@ -11,12 +11,15 @@ package migration
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"slices"
 
 	"github.com/redpanda-data/common-go/kube"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,9 +55,22 @@ func migrateFieldManagers(ctx context.Context, ctl *kube.Ctl, k8sClient client.C
 	consoleTypes := consolechart.Types()
 	ownershipResolver := lifecycle.NewV2OwnershipResolver()
 
+	// Forbidden errors below this point are non-fatal. Installs that manage
+	// RBAC by hand (rbac.create=false) often lack permissions for optional
+	// resource types they don't use — e.g. Gateway API TLSRoutes, swept only
+	// because the CRDs happen to be installed — and failing the post-upgrade
+	// hook over them wedges every subsequent upgrade. Anything skipped here
+	// is re-swept on the next upgrade once the permission is granted. Only
+	// the Redpanda/Console lists above stay fatal: if we can't see the CRs
+	// this job exists to serve, something is fundamentally broken.
+	warnedTypes := map[string]bool{}
+
 	for _, rp := range redpandas.Items {
 		if err := maybeUpdate(ctx, undesiredFieldManagers, ctl, k8sClient, &rp); err != nil {
-			return err
+			if !apierrors.IsForbidden(err) {
+				return err
+			}
+			warnForbiddenUpdate(k8sClient.Scheme(), &rp, err)
 		}
 
 		// get the ownership labels for Redpanda-owned resources
@@ -64,11 +80,18 @@ func migrateFieldManagers(ctx context.Context, ctl *kube.Ctl, k8sClient client.C
 		for _, rt := range redpandaTypes {
 			resources, err := listIfResourceExists(ctx, k8sClient, labels, &rp, rt)
 			if err != nil {
-				return err
+				if !apierrors.IsForbidden(err) {
+					return err
+				}
+				warnForbiddenList(k8sClient.Scheme(), warnedTypes, rt, err)
+				continue
 			}
 			for _, resource := range resources {
 				if err := maybeUpdate(ctx, undesiredFieldManagers, ctl, k8sClient, resource); err != nil {
-					return err
+					if !apierrors.IsForbidden(err) {
+						return err
+					}
+					warnForbiddenUpdate(k8sClient.Scheme(), resource, err)
 				}
 			}
 		}
@@ -76,7 +99,10 @@ func migrateFieldManagers(ctx context.Context, ctl *kube.Ctl, k8sClient client.C
 
 	for _, console := range consoles.Items {
 		if err := maybeUpdate(ctx, undesiredFieldManagers, ctl, k8sClient, &console); err != nil {
-			return err
+			if !apierrors.IsForbidden(err) {
+				return err
+			}
+			warnForbiddenUpdate(k8sClient.Scheme(), &console, err)
 		}
 
 		// get ownership labels for the Console controller
@@ -84,17 +110,53 @@ func migrateFieldManagers(ctx context.Context, ctl *kube.Ctl, k8sClient client.C
 		for _, rt := range consoleTypes {
 			resources, err := listIfResourceExists(ctx, k8sClient, labels, &console, rt)
 			if err != nil {
-				return err
+				if !apierrors.IsForbidden(err) {
+					return err
+				}
+				warnForbiddenList(k8sClient.Scheme(), warnedTypes, rt, err)
+				continue
 			}
 			for _, resource := range resources {
 				if err := maybeUpdate(ctx, undesiredFieldManagers, ctl, k8sClient, resource); err != nil {
-					return err
+					if !apierrors.IsForbidden(err) {
+						return err
+					}
+					warnForbiddenUpdate(k8sClient.Scheme(), resource, err)
 				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// warnForbiddenList records that the sweep is skipping a resource type the
+// migration job's ServiceAccount cannot list. Logged once per type: one
+// missing rule would otherwise repeat for every Redpanda/Console CR. The
+// sweep still runs for each CR's namespace, so namespace-scoped grants that
+// cover only some namespaces migrate what they can.
+func warnForbiddenList(scheme *runtime.Scheme, warned map[string]bool, objectType client.Object, err error) {
+	name := typeName(scheme, objectType)
+	if warned[name] {
+		return
+	}
+	warned[name] = true
+	log.Printf("WARNING: skipping %s: %v — grant the missing permission to the migration job's ServiceAccount, or ignore this warning if you don't use this resource type", name, err)
+}
+
+// warnForbiddenUpdate records that a resource keeps its current field
+// managers because the migration job's ServiceAccount may not update it.
+// Logged per resource rather than per type: unlike a skipped list, these are
+// resources the operator actively manages.
+func warnForbiddenUpdate(scheme *runtime.Scheme, obj client.Object, err error) {
+	log.Printf("WARNING: cannot migrate field managers of %s %s: %v — the resource keeps its current field managers until the next upgrade after the migration job's ServiceAccount is granted the missing permission", typeName(scheme, obj), client.ObjectKeyFromObject(obj), err)
+}
+
+func typeName(scheme *runtime.Scheme, obj client.Object) string {
+	if gvk, err := kube.GVKFor(scheme, obj); err == nil {
+		return gvk.GroupKind().String()
+	}
+	return fmt.Sprintf("%T", obj)
 }
 
 // copied from operator/internal/controller/console/controller.go

--- a/operator/cmd/migration/fieldmanagers_test.go
+++ b/operator/cmd/migration/fieldmanagers_test.go
@@ -10,7 +10,13 @@
 package migration
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/redpanda-data/common-go/kube"
@@ -19,10 +25,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
@@ -469,6 +478,277 @@ func TestFieldManagersRegression(t *testing.T) {
 	require.Nil(t, probe.Exec, "exec probe should be gone after migration + re-apply")
 	require.NotNil(t, probe.TCPSocket, "tcp probe should be the only one remaining")
 	require.Equal(t, intstr.FromInt32(9644), probe.TCPSocket.Port)
+}
+
+// TestFieldManagersSkipsForbiddenListTypes verifies that a Forbidden error
+// while listing a swept resource type skips that type (warning once) instead
+// of failing the migration, and that the sweep continues on to later types.
+func TestFieldManagersSkipsForbiddenListTypes(t *testing.T) {
+	scheme := controller.UnifiedScheme
+	config := kubetest.NewEnv(t).RestConfig()
+
+	oldctl, err := kube.FromRESTConfig(config, kube.Options{
+		Options: client.Options{
+			Scheme: scheme,
+		},
+		FieldManager: "*kube.Ctl",
+	})
+	require.NoError(t, err)
+
+	newctl, err := kube.FromRESTConfig(config, kube.Options{
+		Options: client.Options{
+			Scheme: scheme,
+		},
+		FieldManager: "new",
+	})
+	require.NoError(t, err)
+
+	k8sClient, err := client.NewWithWatch(config, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	installCRDs(t, oldctl)
+
+	// Two clusters so the forbidden type is swept twice, proving the warning
+	// dedupes to one line per type.
+	clusterA := newTestCluster(t, k8sClient, "forbidden-list-a")
+	newTestCluster(t, k8sClient, "forbidden-list-b")
+
+	// A StatefulSet owned by clusterA carrying an undesired field manager
+	// alongside the new one (a resource whose only manager is the undesired
+	// one can't be cleared by the migration's update: the server ignores an
+	// empty managedFields list in update requests). Deployments sort before
+	// StatefulSets in the swept type list, so a migrated StatefulSet proves
+	// the sweep continued past the denial.
+	set := newTestStatefulSet(clusterA)
+	require.NoError(t, oldctl.Apply(t.Context(), set))
+	require.NoError(t, newctl.Apply(t.Context(), newTestStatefulSet(clusterA)))
+
+	denied := interceptor.NewClient(k8sClient, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*appsv1.DeploymentList); ok {
+				return apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "deployments"}, "", errors.New("test denies listing deployments"))
+			}
+			return c.List(ctx, list, opts...)
+		},
+	})
+
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	require.NoError(t, migrateFieldManagers(t.Context(), newctl, denied))
+	log.SetOutput(os.Stderr)
+
+	// The sweep continued past the forbidden Deployment list: the
+	// StatefulSet's undesired manager was migrated.
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(set), set))
+	managers := getFieldManagers(set)
+	require.False(t, slices.Contains(managers, "*kube.Ctl"))
+	require.True(t, slices.Contains(managers, "new"))
+
+	// Two clusters swept the denied type; the warning fired exactly once.
+	require.Equal(t, 1, strings.Count(logs.String(), "skipping Deployment.apps"), "logs:\n%s", logs.String())
+}
+
+// TestFieldManagersForbiddenCRListIsFatal verifies that Forbidden while
+// listing the Redpanda CRs themselves still fails the migration.
+func TestFieldManagersForbiddenCRListIsFatal(t *testing.T) {
+	scheme := controller.UnifiedScheme
+	config := kubetest.NewEnv(t).RestConfig()
+
+	newctl, err := kube.FromRESTConfig(config, kube.Options{
+		Options: client.Options{
+			Scheme: scheme,
+		},
+		FieldManager: "new",
+	})
+	require.NoError(t, err)
+
+	k8sClient, err := client.NewWithWatch(config, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	denied := interceptor.NewClient(k8sClient, interceptor.Funcs{
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*redpandav1alpha2.RedpandaList); ok {
+				return apierrors.NewForbidden(schema.GroupResource{Group: "cluster.redpanda.com", Resource: "redpandas"}, "", errors.New("test denies listing redpandas"))
+			}
+			return c.List(ctx, list, opts...)
+		},
+	})
+
+	err = migrateFieldManagers(t.Context(), newctl, denied)
+	require.Error(t, err)
+	require.True(t, apierrors.IsForbidden(err))
+}
+
+// TestFieldManagersForbiddenUpdateContinues verifies that a Forbidden error
+// while updating a found resource warns and moves on to the remaining
+// resources instead of failing the migration.
+func TestFieldManagersForbiddenUpdateContinues(t *testing.T) {
+	scheme := controller.UnifiedScheme
+	config := kubetest.NewEnv(t).RestConfig()
+
+	oldctl, err := kube.FromRESTConfig(config, kube.Options{
+		Options: client.Options{
+			Scheme: scheme,
+		},
+		FieldManager: "*kube.Ctl",
+	})
+	require.NoError(t, err)
+
+	newctl, err := kube.FromRESTConfig(config, kube.Options{
+		Options: client.Options{
+			Scheme: scheme,
+		},
+		FieldManager: "new",
+	})
+	require.NoError(t, err)
+
+	k8sClient, err := client.NewWithWatch(config, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	installCRDs(t, oldctl)
+
+	cluster := newTestCluster(t, k8sClient, "forbidden-update")
+
+	// A Deployment and a StatefulSet, both owned by the cluster and both
+	// carrying an undesired field manager. Deployments are swept first, so a
+	// migrated StatefulSet proves the sweep continued past the denied update.
+	// Apply with the old manager, then co-own with the new manager — the
+	// state migration acts on. (A resource whose only manager is the
+	// undesired one can't be cleared by the migration's update: the server
+	// ignores an empty managedFields list in update requests.)
+	deploy := newTestDeployment(cluster)
+	require.NoError(t, oldctl.Apply(t.Context(), deploy))
+	require.NoError(t, newctl.Apply(t.Context(), newTestDeployment(cluster)))
+	set := newTestStatefulSet(cluster)
+	require.NoError(t, oldctl.Apply(t.Context(), set))
+	require.NoError(t, newctl.Apply(t.Context(), newTestStatefulSet(cluster)))
+
+	denied := interceptor.NewClient(k8sClient, interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*appsv1.Deployment); ok {
+				return apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "deployments"}, obj.GetName(), errors.New("test denies updating deployments"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	})
+
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	require.NoError(t, migrateFieldManagers(t.Context(), newctl, denied))
+	log.SetOutput(os.Stderr)
+
+	// The denied Deployment keeps its managers.
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(deploy), deploy))
+	require.True(t, slices.Contains(getFieldManagers(deploy), "*kube.Ctl"))
+
+	// The sweep continued: the StatefulSet was migrated.
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(set), set))
+	managers := getFieldManagers(set)
+	require.False(t, slices.Contains(managers, "*kube.Ctl"))
+	require.True(t, slices.Contains(managers, "new"))
+
+	require.Contains(t, logs.String(), "cannot migrate field managers of Deployment.apps")
+}
+
+func installCRDs(t *testing.T, ctl *kube.Ctl) {
+	t.Helper()
+	require.NoError(t, kube.ApplyAll(t.Context(), ctl, crds.All()...))
+	for _, crd := range crds.All() {
+		require.NoError(t, kube.WaitFor(t.Context(), ctl, crd.DeepCopy(), func(ext *apiextensionsv1.CustomResourceDefinition, err error) (bool, error) {
+			for _, cond := range ext.Status.Conditions {
+				if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+					return true, nil
+				}
+			}
+			return false, nil
+		}))
+	}
+}
+
+func newTestCluster(t *testing.T, k8sClient client.Client, name string) *redpandav1alpha2.Redpanda {
+	t.Helper()
+	cluster := &redpandav1alpha2.Redpanda{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+				Statefulset: &redpandav1alpha2.Statefulset{
+					Replicas: ptr.To(1),
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(t.Context(), cluster))
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(cluster), cluster))
+	return cluster
+}
+
+func newTestStatefulSet(cluster *redpandav1alpha2.Redpanda) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: testOwnedObjectMeta(cluster, cluster.Name+"-sts"),
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: testPodTemplate(),
+		},
+	}
+}
+
+func newTestDeployment(cluster *redpandav1alpha2.Redpanda) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: testOwnedObjectMeta(cluster, cluster.Name+"-deploy"),
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: testPodTemplate(),
+		},
+	}
+}
+
+func testOwnedObjectMeta(cluster *redpandav1alpha2.Redpanda, name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: cluster.Namespace,
+		Labels:    lifecycle.NewV2OwnershipResolver().GetOwnerLabels(&lifecycle.ClusterWithPools{Redpanda: cluster}),
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: redpandav1alpha2.GroupVersion.String(),
+			Kind:       "Redpanda",
+			Name:       cluster.Name,
+			UID:        cluster.UID,
+		}},
+	}
+}
+
+func testPodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app": "test",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test",
+					Image: "test",
+				},
+			},
+		},
+	}
 }
 
 func getFieldManagers(o client.Object) []string {

--- a/operator/config/rbac/itemized/v2-manager.yaml
+++ b/operator/config/rbac/itemized/v2-manager.yaml
@@ -41,7 +41,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -53,6 +52,12 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:

--- a/operator/internal/controller/redpanda/testdata/role.yaml
+++ b/operator/internal/controller/redpanda/testdata/role.yaml
@@ -41,7 +41,6 @@ rules:
   - ""
   resources:
   - nodes
-  - pods/log
   verbs:
   - get
   - list
@@ -55,6 +54,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
Implements [K8S-918](https://redpandadata.atlassian.net/browse/K8S-918).

## What

The post-upgrade migration job sweeps every renderable chart type per Redpanda/Console CR to strip legacy field managers (`helm`, `helm-controller`, old operator manager names). Today any error in that sweep is fatal, which fails the helm post-upgrade hook and wedges the release.

This PR makes `Forbidden` during the sweep non-fatal, per the scoping in K8S-918:

| Path | Behavior on Forbidden |
|---|---|
| Listing `RedpandaList` / `ConsoleList` | **stays fatal** — if the job can't see the CRs it exists to serve, something is fundamentally broken |
| Per-type list in the sweep | **skip the type + warn once per type**; the sweep still runs per namespace, so partial namespace-scoped grants migrate what they can |
| Update / force-apply of a found resource | **warn per resource and continue** — retried on the next upgrade |

All other errors remain fatal.

## Why

Installs that manage RBAC by hand (`rbac.create=false`) often lack permissions for optional types they don't use. v26.2 added Gateway API `TLSRoute` to the sweep, so upgrading v26.1.10 → v26.2.1 hard-fails on any cluster that merely has the Gateway API CRDs installed (they ship with many meshes/ingress controllers):

```
unable to update field managers: tlsroutes.gateway.networking.k8s.io is forbidden:
User "system:serviceaccount:...:redpanda-operator-migration-job" cannot list resource "tlsroutes" ...
```

Skipping is safe: types added after the SSA migration (like TLSRoute) can never carry legacy field managers, so the sweep over them is provably a no-op; for pre-existing types a skip is bounded (stale managers keep removed fields from pruning) and self-heals on the next upgrade once the permission is granted. The job already skips types whose CRDs aren't installed (`meta.IsNoMatchError`) — this is the RBAC-flavored sibling of that condition.

With default `rbac.create=true` the mechanism is dormant: the chart recreates the migration-job ClusterRole with rules for every swept type on each upgrade, so no `Forbidden` occurs and behavior is unchanged.

## Testing

New envtest coverage in `fieldmanagers_test.go`:

- `TestFieldManagersSkipsForbiddenListTypes` — denied Deployment list: migration succeeds, later types still migrate, warning dedupes to one line per type across multiple CRs
- `TestFieldManagersForbiddenCRListIsFatal` — denied Redpanda list: migration still fails
- `TestFieldManagersForbiddenUpdateContinues` — denied Deployment update: migration succeeds, denied resource keeps its managers, later resources still migrate, per-resource warning logged

`go test ./operator/cmd/migration/ -count=1` — all 5 tests pass. `golangci-lint run ./operator/cmd/migration/...` — 0 issues.

Test note: the fixtures co-own objects with the new manager before migrating because a resource whose *only* manager is the undesired one can't be cleared by the migration's update — the API server ignores an empty `managedFields` list in update requests. That pre-existing quirk is unchanged by this PR (such resources self-heal once the operator applies with its own manager).

## Follow-ups

- Backport to `release/v26.2.x` once merged (the 26.1 → 26.2 path is where restricted-RBAC users hit this).
- Release-note the per-release RBAC delta for manual-RBAC users (tracked in K8S-918): skip-and-warn unblocks the upgrade, but the operator SA still needs the new permissions at runtime where those CRDs are present.


[K8S-918]: https://redpandadata.atlassian.net/browse/K8S-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
