### PR TITLE
Update github and backport configuration files after removing 25.2.x branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -4,7 +4,7 @@
   "commitConflicts": true,
   "repoOwner": "redpanda-data",
   "repoName": "redpanda-operator",
-  "targetBranchChoices": ["release/v26.2.x","release/v26.1.x", "release/v25.3.x", "release/v25.2.x"],
+  "targetBranchChoices": ["release/v26.2.x","release/v26.1.x", "release/v25.3.x"],
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v(\\d+).(\\d+).x$": "release/v$1.$2.x"

--- a/.github/branches.yml
+++ b/.github/branches.yml
@@ -1,1 +1,1 @@
-active: ["main", "release/v26.2.x", "release/v26.1.x", "release/v25.3.x", "release/v25.2.x"]
+active: ["main", "release/v26.2.x", "release/v26.1.x", "release/v25.3.x"]


### PR DESCRIPTION
After https://github.com/redpanda-data/redpanda-operator/pull/1728 PR the lint test failed. This change removes unsupported release branch. 