### PR TITLE
ci: forward TELEMETRY_PRIVATE_KEY into the nix build container

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260814-104743.yaml
+++ b/.changes/unreleased/operator-Fixed-20260814-104743.yaml
@@ -1,0 +1,12 @@
+project: operator
+kind: Fixed
+body: |-
+    Official release images now embed the telemetry signing key, enabling operator telemetry.
+
+      The release pipeline fetched `TELEMETRY_PRIVATE_KEY` on the Buildkite agent
+      but never forwarded it into the containerized build
+      (`ci/scripts/run-in-nix-docker.sh` forwards env vars by explicit allowlist),
+      so the key-injection step silently no-op'd, `key.pem` stayed empty, and the
+      telemetry client was compiled out (a disabled no-op) of every published
+      image, including v26.2.1 and its betas.
+time: 2026-08-14T10:47:43+02:00

--- a/ci/scripts/run-in-nix-docker.sh
+++ b/ci/scripts/run-in-nix-docker.sh
@@ -67,6 +67,7 @@ docker run --rm -it \
 	-e ACCEPTANCE_ARTIFACTS_DIR \
 	-e INTEGRATION_ARTIFACTS_DIR \
 	-e REDPANDA_SAMPLE_LICENSE \
+	-e TELEMETRY_PRIVATE_KEY \
 	--user 0:$(id -g) \
 	--privileged \
 	--net=host \


### PR DESCRIPTION
## Problem

Operator telemetry is compiled out of every official build. No data has landed in BigQuery since telemetry shipped (K8S-914, [Slack thread](https://redpandadata.slack.com/archives/C04K2N6S2A3/p1786402396070119)).

Root cause: the `operator-release` Buildkite step pulls the `sdlc/prod/buildkite/telemetry_private_key` secret and sets `TELEMETRY_PRIVATE_KEY` **on the agent**, but the build runs inside a container started by `ci/scripts/run-in-nix-docker.sh`, which forwards env vars by explicit allowlist — and `TELEMETRY_PRIVATE_KEY` was not on it. The injection step in `taskfiles/build.yml` is guarded by `if [ -n "${TELEMETRY_PRIVATE_KEY:-}" ]`, so it silently no-op'd, `operator/internal/telemetry/key.pem` stayed empty, and `telemetry.Enabled()` returned false in the shipped binary.

Verified against the v26.2.1 release (Buildkite build 14959):
- The release log shows `TELEMETRY_PRIVATE_KEY` being set by the aws-sm plugin on the agent, but the logged `docker run` command has no `-e TELEMETRY_PRIVATE_KEY`, and the `Injecting telemetry signing key` echo never executed.
- The published `redpandadata/redpanda-operator:v26.2.1` image binary (digest `sha256:0656f2ee…`, linux/amd64) contains no private-key PEM block — the key was not embedded.

## Fix

Add `TELEMETRY_PRIVATE_KEY` to the `docker run` env allowlist so the key reaches the containerized build and the injection step in `taskfiles/build.yml` actually runs on release builds. Dev/PR builds are unaffected: the variable is only set on release pipelines, and an empty `key.pem` keeps telemetry disabled.

## Verification after the next release build

- `strings` the shipped binary for a `PRIVATE KEY` PEM header, or
- watch `vectorized.callhome_layer_1.kubernetes_telemetry` — a fresh install reports ~5 minutes after startup (note: ingestion also requires analytics-metrics#18 to be merged/deployed, which is tracked separately in K8S-914).

Fixes K8S-914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)