### PR TITLE
operator: implement NP -> BP conversion

### DIFF
--- a/operator/api/redpanda/v1alpha2/broker_pool_types.go
+++ b/operator/api/redpanda/v1alpha2/broker_pool_types.go
@@ -45,7 +45,7 @@ func (s *RedpandaBrokerPoolList) GetItems() []*RedpandaBrokerPool {
 	return functional.MapFn(ptr.To, s.Items)
 }
 
-// NodePoolSpec contains the node pool spec for the given node pool.
+// BrokerPoolSpec contains the node pool spec for the given node pool.
 // Note that the defaulting behavior comes from the underlying Redpanda
 // chart renderer, the attributes specified here will get merged in and
 // override the defaults.

--- a/operator/api/redpanda/v1alpha2/conversion.go
+++ b/operator/api/redpanda/v1alpha2/conversion.go
@@ -50,6 +50,14 @@ var (
 	// goverter:context namespace
 	ConvertSchemaRegistrySpecToIR func(namespace string, src *SchemaRegistrySpec) *ir.SchemaRegistrySpec
 
+	// goverter:ignore ClusterDomain TLS External Listeners RBAC ServiceAccount
+	// goverter:ignore Monitoring Storage Resources ImagePullSecrets RackAwareness Logging
+	// A v2 NodePool carries no cluster-level configuration: the ignored fields
+	// exist only on EmbeddedBrokerPoolSpec (they migrated off StretchClusterSpec
+	// onto the pool) and stay nil here. On the v2 path their values come from the
+	// Redpanda CR through the chart render pipeline instead.
+	ConvertEmbeddedNodePoolSpecToEmbeddedBrokerPoolSpec func(EmbeddedNodePoolSpec) (*EmbeddedBrokerPoolSpec, error)
+
 	// Private conversions for tuning / customizing conversions.
 	// Naming convention: `autoconv_<Type>_To_<pkg>_<Type>`
 
@@ -315,9 +323,10 @@ var (
 
 	// LivenessProbe/ReadinessProbe conversions (RedpandaConsole -> Console)
 
-	conv_LivenessProbe_To_ProbeApplyConfiguration           = convertViaMarshaling[*LivenessProbe, *ProbeApplyConfiguration]
-	conv_ReadinessProbe_To_ProbeApplyConfiguration          = convertViaMarshaling[*ReadinessProbe, *ProbeApplyConfiguration]
-	conv_ProbeApplyConfiguration_To_ProbeApplyConfiguration = convertViaMarshaling[*ProbeApplyConfiguration, *applycorev1.ProbeApplyConfiguration]
+	conv_LivenessProbe_To_ProbeApplyConfiguration                                       = convertViaMarshaling[*LivenessProbe, *ProbeApplyConfiguration]
+	conv_ReadinessProbe_To_ProbeApplyConfiguration                                      = convertViaMarshaling[*ReadinessProbe, *ProbeApplyConfiguration]
+	conv_ProbeApplyConfiguration_To_ProbeApplyConfiguration                             = convertViaMarshaling[*ProbeApplyConfiguration, *applycorev1.ProbeApplyConfiguration]
+	conv_applycorev1_PodSpecApplyConfiguration_To_applycorev1_PodSpecApplyConfiguration = convertViaMarshaling[*applycorev1.PodSpecApplyConfiguration, *applycorev1.PodSpecApplyConfiguration]
 )
 
 type deepCopier[T any] interface {

--- a/operator/api/redpanda/v1alpha2/conversion/to_render.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render.go
@@ -32,8 +32,8 @@ type V2Defaulters struct {
 	ConfiguratorArgs []string
 }
 
-// ConvertV2ToRenderState converts a v2 Redpanda CRD to a redpanda chart RenderState.
-func ConvertV2ToRenderState(config *kube.RESTConfig, defaulters *V2Defaulters, cluster *redpandav1alpha2.Redpanda, pools []*redpandav1alpha2.NodePool) (*redpanda.RenderState, error) {
+// ConvertV2ToRenderState converts a v2 Redpanda CRD and any [redpandav1alpha2.RedpandaBrokerPool]s to a redpanda chart RenderState.
+func ConvertV2ToRenderState(config *kube.RESTConfig, defaulters *V2Defaulters, cluster *redpandav1alpha2.Redpanda, pools []*redpandav1alpha2.RedpandaBrokerPool) (*redpanda.RenderState, error) {
 	spec := defaultV2Spec(defaulters, cluster)
 
 	dot, err := redpanda.Chart.Dot(config, helmette.Release{
@@ -53,7 +53,7 @@ func ConvertV2ToRenderState(config *kube.RESTConfig, defaulters *V2Defaulters, c
 		if err := convertV2Fields(state, &state.Values, spec); err != nil {
 			return err
 		}
-		renderedPools, err := convertV2NodepoolsToPools(state.Values, pools, defaulters)
+		renderedPools, err := convertBrokerPoolsToPools(state.Values, pools, defaulters)
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func convertStatefulsetV2Fields(state *redpanda.RenderState, values *redpanda.Va
 		values.Statefulset.PodTemplate.Spec.PriorityClassName = spec.PriorityClassName
 	}
 	if spec.TerminationGracePeriodSeconds != nil {
-		values.Statefulset.PodTemplate.Spec.TerminationGracePeriodSeconds = ptr.To(int64(*spec.TerminationGracePeriodSeconds))
+		values.Statefulset.PodTemplate.Spec.TerminationGracePeriodSeconds = new(int64(*spec.TerminationGracePeriodSeconds))
 	}
 
 	// Only materialize probe overrides the CR actually sets; unconditionally
@@ -336,10 +336,10 @@ func convertStatefulsetSidecarV2Fields(state *redpanda.RenderState, values *redp
 	return nil
 }
 
-func convertV2NodepoolsToPools(values redpanda.Values, pools []*redpandav1alpha2.NodePool, defaulters *V2Defaulters) ([]redpanda.Pool, error) {
+func convertBrokerPoolsToPools(values redpanda.Values, pools []*redpandav1alpha2.RedpandaBrokerPool, defaulters *V2Defaulters) ([]redpanda.Pool, error) {
 	converted := make([]redpanda.Pool, len(pools))
 	for i, pool := range pools {
-		set, err := convertV2NodepoolToPool(values, pool, defaulters)
+		set, err := convertBrokerPoolToPool(values, pool, defaulters)
 		if err != nil {
 			return nil, err
 		}
@@ -348,7 +348,16 @@ func convertV2NodepoolsToPools(values redpanda.Values, pools []*redpandav1alpha2
 	return converted, nil
 }
 
-func convertV2NodepoolToPool(clusterValues redpanda.Values, pool *redpandav1alpha2.NodePool, defaulters *V2Defaulters) (_ redpanda.Pool, err error) {
+// convertBrokerPoolToPool merges a single BrokerPool over the chart's default
+// Statefulset values to produce a renderable [redpanda.Pool].
+//
+// The merge at the bottom is JSON-based, so the BrokerPool-only fields
+// (clusterDomain, tls, external, listeners, rbac, serviceAccount, monitoring,
+// storage, resources, imagePullSecrets, rackAwareness, logging) are simply
+// absent from redpanda.Statefulset and get dropped. None of them collides with
+// a Statefulset key, so a BrokerPool merges exactly as the equivalent NodePool
+// did. On the v2 path those settings come from the Redpanda CR.
+func convertBrokerPoolToPool(clusterValues redpanda.Values, pool *redpandav1alpha2.RedpandaBrokerPool, defaulters *V2Defaulters) (_ redpanda.Pool, err error) {
 	// we grab *just* the default values here
 	v, err := redpanda.Chart.LoadValues(map[string]any{})
 	if err != nil {
@@ -366,7 +375,7 @@ func convertV2NodepoolToPool(clusterValues redpanda.Values, pool *redpandav1alph
 
 	values := helmette.Unwrap[redpanda.Values](v)
 	defaultSet := values.Statefulset
-	// we adjust some of the defaults that need to be changed in the nodepool context
+	// we adjust some of the defaults that need to be changed in the brokerpool context
 	defaultSet.PodTemplate.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels = map[string]string{
 		`app.kubernetes.io/component`: fmt.Sprintf(`{{ include "redpanda.name" . }}-%s-statefulset`, pool.Name),
 		`app.kubernetes.io/instance`:  `{{ .Release.Name }}`,
@@ -377,8 +386,8 @@ func convertV2NodepoolToPool(clusterValues redpanda.Values, pool *redpandav1alph
 		`app.kubernetes.io/instance`:  `{{ .Release.Name }}`,
 		`app.kubernetes.io/name`:      `{{ include "redpanda.name" . }}`,
 	}
-	// Inherit cluster-level PVC retention policy as the pool default. A NodePool whose
-	// own EmbeddedNodePoolSpec.PersistentVolumeClaimRetentionPolicy is set will override
+	// Inherit cluster-level PVC retention policy as the pool default. A BrokerPool whose
+	// own EmbeddedBrokerPoolSpec.PersistentVolumeClaimRetentionPolicy is set will override
 	// this via the convertJSON merge below.
 	if clusterValues.Statefulset.PersistentVolumeClaimRetentionPolicy != nil {
 		defaultSet.PersistentVolumeClaimRetentionPolicy = clusterValues.Statefulset.PersistentVolumeClaimRetentionPolicy.DeepCopy()
@@ -414,17 +423,17 @@ func convertV2NodepoolToPool(clusterValues redpanda.Values, pool *redpandav1alph
 			container := containerOrInit(&values.Statefulset.PodTemplate.Spec.Containers, redpanda.RedpandaContainerName)
 			configurator := containerOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, redpanda.RedpandaConfiguratorContainerName)
 
-			container.Image = ptr.To(image)
-			configurator.Image = ptr.To(image)
+			container.Image = new(image)
+			configurator.Image = new(image)
 
 			// here we use clusterValues since we need to look at the cluster-level context
 			if clusterValues.Tuning.TuneAIOEvents {
 				tuning := containerOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, redpanda.RedpandaTuningContainerName)
-				tuning.Image = ptr.To(image)
+				tuning.Image = new(image)
 			}
 			if values.Statefulset.InitContainers.FSValidator.Enabled {
 				validator := containerOrInit(&values.Statefulset.PodTemplate.Spec.InitContainers, redpanda.FSValidatorContainerName)
-				validator.Image = ptr.To(image)
+				validator.Image = new(image)
 			}
 		}
 	}

--- a/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
+++ b/operator/api/redpanda/v1alpha2/conversion/to_render_test.go
@@ -11,12 +11,14 @@ package conversion
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
 	"pgregory.net/rapid"
@@ -29,11 +31,21 @@ import (
 	"github.com/redpanda-data/redpanda-operator/pkg/rapidutil"
 )
 
-func TestNodepoolConversion(t *testing.T) {
+func TestBrokerPoolConversion(t *testing.T) {
+	cfg := rapidutil.Merge(rapidutil.KubernetesTypes, rapid.MakeConfig{
+		Types: map[reflect.Type]*rapid.Generator[any]{
+			reflect.TypeFor[*runtime.RawExtension](): rapid.Just[any](nil),
+		},
+	})
+
 	rapid.Check(t, func(t *rapid.T) {
-		values := rapid.MakeCustom[redpanda.Values](rapidutil.KubernetesTypes).Draw(t, "values")
-		pools := rapid.SliceOf(rapid.MakeCustom[redpandav1alpha2.NodePool](rapidutil.KubernetesTypes)).Draw(t, "pools")
-		_, err := convertV2NodepoolsToPools(values, functional.MapFn(ptr.To, pools), &V2Defaulters{})
+		values := rapid.MakeCustom[redpanda.Values](cfg).Draw(t, "values")
+		pools := rapid.SliceOf(rapid.MakeCustom[*redpandav1alpha2.RedpandaBrokerPool](cfg).Filter(func(bp *redpandav1alpha2.RedpandaBrokerPool) bool {
+			// Force rapid to only select non-nil pools.
+			return bp != nil
+		})).Draw(t, "pools")
+
+		_, err := convertBrokerPoolsToPools(values, pools, &V2Defaulters{})
 		require.NoError(t, err)
 	})
 }
@@ -100,14 +112,14 @@ func TestPersistentVolumeClaimRetentionPolicyPrecedence(t *testing.T) {
 			state := &redpanda.RenderState{Values: values}
 			require.NoError(t, convertV2Fields(state, &state.Values, clusterSpec))
 
-			pool := &redpandav1alpha2.NodePool{
-				Spec: redpandav1alpha2.NodePoolSpec{
-					EmbeddedNodePoolSpec: redpandav1alpha2.EmbeddedNodePoolSpec{
+			pool := &redpandav1alpha2.RedpandaBrokerPool{
+				Spec: redpandav1alpha2.BrokerPoolSpec{
+					EmbeddedBrokerPoolSpec: redpandav1alpha2.EmbeddedBrokerPoolSpec{
 						PersistentVolumeClaimRetentionPolicy: tc.poolSet,
 					},
 				},
 			}
-			converted, err := convertV2NodepoolToPool(state.Values, pool, &V2Defaulters{})
+			converted, err := convertBrokerPoolToPool(state.Values, pool, &V2Defaulters{})
 			require.NoError(t, err)
 			got := converted.Statefulset.PersistentVolumeClaimRetentionPolicy
 			require.NotNil(t, got, "rendered pool should always carry a policy (chart default ensures this)")

--- a/operator/api/redpanda/v1alpha2/zz_generated.conversion.go
+++ b/operator/api/redpanda/v1alpha2/zz_generated.conversion.go
@@ -173,6 +173,37 @@ func init() {
 		}
 		return pConsolePartialRenderValues, nil
 	}
+	ConvertEmbeddedNodePoolSpecToEmbeddedBrokerPoolSpec = func(source EmbeddedNodePoolSpec) (*EmbeddedBrokerPoolSpec, error) {
+		var v1alpha2EmbeddedBrokerPoolSpec EmbeddedBrokerPoolSpec
+		if source.AdditionalSelectorLabels != nil {
+			v1alpha2EmbeddedBrokerPoolSpec.AdditionalSelectorLabels = make(map[string]string, len(source.AdditionalSelectorLabels))
+			for key, value := range source.AdditionalSelectorLabels {
+				v1alpha2EmbeddedBrokerPoolSpec.AdditionalSelectorLabels[key] = value
+			}
+		}
+		if source.Replicas != nil {
+			xint32 := *source.Replicas
+			v1alpha2EmbeddedBrokerPoolSpec.Replicas = &xint32
+		}
+		if source.AdditionalRedpandaCmdFlags != nil {
+			v1alpha2EmbeddedBrokerPoolSpec.AdditionalRedpandaCmdFlags = make([]string, len(source.AdditionalRedpandaCmdFlags))
+			for i := 0; i < len(source.AdditionalRedpandaCmdFlags); i++ {
+				v1alpha2EmbeddedBrokerPoolSpec.AdditionalRedpandaCmdFlags[i] = source.AdditionalRedpandaCmdFlags[i]
+			}
+		}
+		pV1alpha2PodTemplate, err := pV1alpha2PodTemplateToPV1alpha2PodTemplate(source.PodTemplate)
+		if err != nil {
+			return nil, err
+		}
+		v1alpha2EmbeddedBrokerPoolSpec.PodTemplate = pV1alpha2PodTemplate
+		v1alpha2EmbeddedBrokerPoolSpec.Services = pV1alpha2NodePoolServicesToPV1alpha2NodePoolServices(source.Services)
+		v1alpha2EmbeddedBrokerPoolSpec.InitContainers = pV1alpha2PoolInitContainersToPV1alpha2PoolInitContainers(source.InitContainers)
+		v1alpha2EmbeddedBrokerPoolSpec.Image = pV1alpha2RedpandaImageToPV1alpha2RedpandaImage(source.Image)
+		v1alpha2EmbeddedBrokerPoolSpec.SidecarImage = pV1alpha2RedpandaImageToPV1alpha2RedpandaImage(source.SidecarImage)
+		v1alpha2EmbeddedBrokerPoolSpec.InitContainerImage = pV1alpha2InitContainerImageToPV1alpha2InitContainerImage(source.InitContainerImage)
+		v1alpha2EmbeddedBrokerPoolSpec.PersistentVolumeClaimRetentionPolicy = pV1StatefulSetPersistentVolumeClaimRetentionPolicyToPV1StatefulSetPersistentVolumeClaimRetentionPolicy(source.PersistentVolumeClaimRetentionPolicy)
+		return &v1alpha2EmbeddedBrokerPoolSpec, nil
+	}
 	ConvertKafkaAPISpecToIR = func(context string, source *KafkaAPISpec) *ir.KafkaAPISpec {
 		var pIrKafkaAPISpec *ir.KafkaAPISpec
 		if source != nil {
@@ -579,6 +610,18 @@ func pV1CapabilitiesToPV1CapabilitiesApplyConfiguration(source *v1.Capabilities)
 		pV1CapabilitiesApplyConfiguration = &v1CapabilitiesApplyConfiguration
 	}
 	return pV1CapabilitiesApplyConfiguration
+}
+func pV1ClientIPConfigApplyConfigurationToPV1ClientIPConfigApplyConfiguration(source *v11.ClientIPConfigApplyConfiguration) *v11.ClientIPConfigApplyConfiguration {
+	var pV1ClientIPConfigApplyConfiguration *v11.ClientIPConfigApplyConfiguration
+	if source != nil {
+		var v1ClientIPConfigApplyConfiguration v11.ClientIPConfigApplyConfiguration
+		if (*source).TimeoutSeconds != nil {
+			xint32 := *(*source).TimeoutSeconds
+			v1ClientIPConfigApplyConfiguration.TimeoutSeconds = &xint32
+		}
+		pV1ClientIPConfigApplyConfiguration = &v1ClientIPConfigApplyConfiguration
+	}
+	return pV1ClientIPConfigApplyConfiguration
 }
 func pV1ConfigMapEnvSourceToPV1ConfigMapEnvSource(source *v1.ConfigMapEnvSource) *v1.ConfigMapEnvSource {
 	var pV1ConfigMapEnvSource *v1.ConfigMapEnvSource
@@ -1044,6 +1087,112 @@ func pV1SecurityContextToPV1SecurityContextApplyConfiguration(source *v1.Securit
 	}
 	return pV1SecurityContextApplyConfiguration
 }
+func pV1ServiceSpecApplyConfigurationToPV1ServiceSpecApplyConfiguration(source *v11.ServiceSpecApplyConfiguration) *v11.ServiceSpecApplyConfiguration {
+	var pV1ServiceSpecApplyConfiguration *v11.ServiceSpecApplyConfiguration
+	if source != nil {
+		var v1ServiceSpecApplyConfiguration v11.ServiceSpecApplyConfiguration
+		if (*source).Ports != nil {
+			v1ServiceSpecApplyConfiguration.Ports = make([]v11.ServicePortApplyConfiguration, len((*source).Ports))
+			for i := 0; i < len((*source).Ports); i++ {
+				v1ServiceSpecApplyConfiguration.Ports[i] = v1ServicePortApplyConfigurationToV1ServicePortApplyConfiguration((*source).Ports[i])
+			}
+		}
+		if (*source).Selector != nil {
+			v1ServiceSpecApplyConfiguration.Selector = make(map[string]string, len((*source).Selector))
+			for key, value := range (*source).Selector {
+				v1ServiceSpecApplyConfiguration.Selector[key] = value
+			}
+		}
+		if (*source).ClusterIP != nil {
+			xstring := *(*source).ClusterIP
+			v1ServiceSpecApplyConfiguration.ClusterIP = &xstring
+		}
+		if (*source).ClusterIPs != nil {
+			v1ServiceSpecApplyConfiguration.ClusterIPs = make([]string, len((*source).ClusterIPs))
+			for j := 0; j < len((*source).ClusterIPs); j++ {
+				v1ServiceSpecApplyConfiguration.ClusterIPs[j] = (*source).ClusterIPs[j]
+			}
+		}
+		if (*source).Type != nil {
+			v1ServiceType := v1.ServiceType(*(*source).Type)
+			v1ServiceSpecApplyConfiguration.Type = &v1ServiceType
+		}
+		if (*source).ExternalIPs != nil {
+			v1ServiceSpecApplyConfiguration.ExternalIPs = make([]string, len((*source).ExternalIPs))
+			for k := 0; k < len((*source).ExternalIPs); k++ {
+				v1ServiceSpecApplyConfiguration.ExternalIPs[k] = (*source).ExternalIPs[k]
+			}
+		}
+		if (*source).SessionAffinity != nil {
+			v1ServiceAffinity := v1.ServiceAffinity(*(*source).SessionAffinity)
+			v1ServiceSpecApplyConfiguration.SessionAffinity = &v1ServiceAffinity
+		}
+		if (*source).LoadBalancerIP != nil {
+			xstring2 := *(*source).LoadBalancerIP
+			v1ServiceSpecApplyConfiguration.LoadBalancerIP = &xstring2
+		}
+		if (*source).LoadBalancerSourceRanges != nil {
+			v1ServiceSpecApplyConfiguration.LoadBalancerSourceRanges = make([]string, len((*source).LoadBalancerSourceRanges))
+			for l := 0; l < len((*source).LoadBalancerSourceRanges); l++ {
+				v1ServiceSpecApplyConfiguration.LoadBalancerSourceRanges[l] = (*source).LoadBalancerSourceRanges[l]
+			}
+		}
+		if (*source).ExternalName != nil {
+			xstring3 := *(*source).ExternalName
+			v1ServiceSpecApplyConfiguration.ExternalName = &xstring3
+		}
+		if (*source).ExternalTrafficPolicy != nil {
+			v1ServiceExternalTrafficPolicy := v1.ServiceExternalTrafficPolicy(*(*source).ExternalTrafficPolicy)
+			v1ServiceSpecApplyConfiguration.ExternalTrafficPolicy = &v1ServiceExternalTrafficPolicy
+		}
+		if (*source).HealthCheckNodePort != nil {
+			xint32 := *(*source).HealthCheckNodePort
+			v1ServiceSpecApplyConfiguration.HealthCheckNodePort = &xint32
+		}
+		if (*source).PublishNotReadyAddresses != nil {
+			xbool := *(*source).PublishNotReadyAddresses
+			v1ServiceSpecApplyConfiguration.PublishNotReadyAddresses = &xbool
+		}
+		v1ServiceSpecApplyConfiguration.SessionAffinityConfig = pV1SessionAffinityConfigApplyConfigurationToPV1SessionAffinityConfigApplyConfiguration((*source).SessionAffinityConfig)
+		if (*source).IPFamilies != nil {
+			v1ServiceSpecApplyConfiguration.IPFamilies = make([]v1.IPFamily, len((*source).IPFamilies))
+			for m := 0; m < len((*source).IPFamilies); m++ {
+				v1ServiceSpecApplyConfiguration.IPFamilies[m] = v1.IPFamily((*source).IPFamilies[m])
+			}
+		}
+		if (*source).IPFamilyPolicy != nil {
+			v1IPFamilyPolicy := v1.IPFamilyPolicy(*(*source).IPFamilyPolicy)
+			v1ServiceSpecApplyConfiguration.IPFamilyPolicy = &v1IPFamilyPolicy
+		}
+		if (*source).AllocateLoadBalancerNodePorts != nil {
+			xbool2 := *(*source).AllocateLoadBalancerNodePorts
+			v1ServiceSpecApplyConfiguration.AllocateLoadBalancerNodePorts = &xbool2
+		}
+		if (*source).LoadBalancerClass != nil {
+			xstring4 := *(*source).LoadBalancerClass
+			v1ServiceSpecApplyConfiguration.LoadBalancerClass = &xstring4
+		}
+		if (*source).InternalTrafficPolicy != nil {
+			v1ServiceInternalTrafficPolicy := v1.ServiceInternalTrafficPolicy(*(*source).InternalTrafficPolicy)
+			v1ServiceSpecApplyConfiguration.InternalTrafficPolicy = &v1ServiceInternalTrafficPolicy
+		}
+		if (*source).TrafficDistribution != nil {
+			xstring5 := *(*source).TrafficDistribution
+			v1ServiceSpecApplyConfiguration.TrafficDistribution = &xstring5
+		}
+		pV1ServiceSpecApplyConfiguration = &v1ServiceSpecApplyConfiguration
+	}
+	return pV1ServiceSpecApplyConfiguration
+}
+func pV1SessionAffinityConfigApplyConfigurationToPV1SessionAffinityConfigApplyConfiguration(source *v11.SessionAffinityConfigApplyConfiguration) *v11.SessionAffinityConfigApplyConfiguration {
+	var pV1SessionAffinityConfigApplyConfiguration *v11.SessionAffinityConfigApplyConfiguration
+	if source != nil {
+		var v1SessionAffinityConfigApplyConfiguration v11.SessionAffinityConfigApplyConfiguration
+		v1SessionAffinityConfigApplyConfiguration.ClientIP = pV1ClientIPConfigApplyConfigurationToPV1ClientIPConfigApplyConfiguration((*source).ClientIP)
+		pV1SessionAffinityConfigApplyConfiguration = &v1SessionAffinityConfigApplyConfiguration
+	}
+	return pV1SessionAffinityConfigApplyConfiguration
+}
 func pV1SleepActionToPV1SleepAction(source *v1.SleepAction) *v1.SleepAction {
 	var pV1SleepAction *v1.SleepAction
 	if source != nil {
@@ -1052,6 +1201,16 @@ func pV1SleepActionToPV1SleepAction(source *v1.SleepAction) *v1.SleepAction {
 		pV1SleepAction = &v1SleepAction
 	}
 	return pV1SleepAction
+}
+func pV1StatefulSetPersistentVolumeClaimRetentionPolicyToPV1StatefulSetPersistentVolumeClaimRetentionPolicy(source *v12.StatefulSetPersistentVolumeClaimRetentionPolicy) *v12.StatefulSetPersistentVolumeClaimRetentionPolicy {
+	var pV1StatefulSetPersistentVolumeClaimRetentionPolicy *v12.StatefulSetPersistentVolumeClaimRetentionPolicy
+	if source != nil {
+		var v1StatefulSetPersistentVolumeClaimRetentionPolicy v12.StatefulSetPersistentVolumeClaimRetentionPolicy
+		v1StatefulSetPersistentVolumeClaimRetentionPolicy.WhenDeleted = v1PersistentVolumeClaimRetentionPolicyTypeToV1PersistentVolumeClaimRetentionPolicyType((*source).WhenDeleted)
+		v1StatefulSetPersistentVolumeClaimRetentionPolicy.WhenScaled = v1PersistentVolumeClaimRetentionPolicyTypeToV1PersistentVolumeClaimRetentionPolicyType((*source).WhenScaled)
+		pV1StatefulSetPersistentVolumeClaimRetentionPolicy = &v1StatefulSetPersistentVolumeClaimRetentionPolicy
+	}
+	return pV1StatefulSetPersistentVolumeClaimRetentionPolicy
 }
 func pV1TCPSocketActionToPV1TCPSocketAction(source *v1.TCPSocketAction) *v1.TCPSocketAction {
 	var pV1TCPSocketAction *v1.TCPSocketAction
@@ -1257,6 +1416,22 @@ func pV1alpha2IngressConfigToPConsolePartialIngressConfig(source *IngressConfig)
 	}
 	return pConsolePartialIngressConfig
 }
+func pV1alpha2InitContainerImageToPV1alpha2InitContainerImage(source *InitContainerImage) *InitContainerImage {
+	var pV1alpha2InitContainerImage *InitContainerImage
+	if source != nil {
+		var v1alpha2InitContainerImage InitContainerImage
+		if (*source).Repository != nil {
+			xstring := *(*source).Repository
+			v1alpha2InitContainerImage.Repository = &xstring
+		}
+		if (*source).Tag != nil {
+			xstring2 := *(*source).Tag
+			v1alpha2InitContainerImage.Tag = &xstring2
+		}
+		pV1alpha2InitContainerImage = &v1alpha2InitContainerImage
+	}
+	return pV1alpha2InitContainerImage
+}
 func pV1alpha2KafkaSecretsToPConsolePartialKafkaSecrets(source *KafkaSecrets) *v3.PartialKafkaSecrets {
 	var pConsolePartialKafkaSecrets *v3.PartialKafkaSecrets
 	if source != nil {
@@ -1333,6 +1508,15 @@ func pV1alpha2MonitoringConfigToPV1alpha2MonitoringConfig(source *MonitoringConf
 	}
 	return pV1alpha2MonitoringConfig
 }
+func pV1alpha2NodePoolServicesToPV1alpha2NodePoolServices(source *NodePoolServices) *NodePoolServices {
+	var pV1alpha2NodePoolServices *NodePoolServices
+	if source != nil {
+		var v1alpha2NodePoolServices NodePoolServices
+		v1alpha2NodePoolServices.PerPod = pV1alpha2PerPodServicesToPV1alpha2PerPodServices((*source).PerPod)
+		pV1alpha2NodePoolServices = &v1alpha2NodePoolServices
+	}
+	return pV1alpha2NodePoolServices
+}
 func pV1alpha2OIDCLoginSecretsToPConsolePartialOIDCLoginSecrets(source *OIDCLoginSecrets) *v3.PartialOIDCLoginSecrets {
 	var pConsolePartialOIDCLoginSecrets *v3.PartialOIDCLoginSecrets
 	if source != nil {
@@ -1344,6 +1528,119 @@ func pV1alpha2OIDCLoginSecretsToPConsolePartialOIDCLoginSecrets(source *OIDCLogi
 		pConsolePartialOIDCLoginSecrets = &consolePartialOIDCLoginSecrets
 	}
 	return pConsolePartialOIDCLoginSecrets
+}
+func pV1alpha2PerPodServiceOverrideToPV1alpha2PerPodServiceOverride(source *PerPodServiceOverride) *PerPodServiceOverride {
+	var pV1alpha2PerPodServiceOverride *PerPodServiceOverride
+	if source != nil {
+		var v1alpha2PerPodServiceOverride PerPodServiceOverride
+		if (*source).Enabled != nil {
+			xbool := *(*source).Enabled
+			v1alpha2PerPodServiceOverride.Enabled = &xbool
+		}
+		if (*source).Labels != nil {
+			v1alpha2PerPodServiceOverride.Labels = make(map[string]string, len((*source).Labels))
+			for key, value := range (*source).Labels {
+				v1alpha2PerPodServiceOverride.Labels[key] = value
+			}
+		}
+		if (*source).Annotations != nil {
+			v1alpha2PerPodServiceOverride.Annotations = make(map[string]string, len((*source).Annotations))
+			for key2, value2 := range (*source).Annotations {
+				v1alpha2PerPodServiceOverride.Annotations[key2] = value2
+			}
+		}
+		v1alpha2PerPodServiceOverride.Spec = pV1ServiceSpecApplyConfigurationToPV1ServiceSpecApplyConfiguration((*source).Spec)
+		pV1alpha2PerPodServiceOverride = &v1alpha2PerPodServiceOverride
+	}
+	return pV1alpha2PerPodServiceOverride
+}
+func pV1alpha2PerPodServicesToPV1alpha2PerPodServices(source *PerPodServices) *PerPodServices {
+	var pV1alpha2PerPodServices *PerPodServices
+	if source != nil {
+		var v1alpha2PerPodServices PerPodServices
+		v1alpha2PerPodServices.Local = pV1alpha2PerPodServiceOverrideToPV1alpha2PerPodServiceOverride((*source).Local)
+		v1alpha2PerPodServices.Remote = pV1alpha2PerPodServiceOverrideToPV1alpha2PerPodServiceOverride((*source).Remote)
+		pV1alpha2PerPodServices = &v1alpha2PerPodServices
+	}
+	return pV1alpha2PerPodServices
+}
+func pV1alpha2PodTemplateToPV1alpha2PodTemplate(source *PodTemplate) (*PodTemplate, error) {
+	var pV1alpha2PodTemplate *PodTemplate
+	if source != nil {
+		var v1alpha2PodTemplate PodTemplate
+		if (*source).Labels != nil {
+			v1alpha2PodTemplate.Labels = make(map[string]string, len((*source).Labels))
+			for key, value := range (*source).Labels {
+				v1alpha2PodTemplate.Labels[key] = value
+			}
+		}
+		if (*source).Annotations != nil {
+			v1alpha2PodTemplate.Annotations = make(map[string]string, len((*source).Annotations))
+			for key2, value2 := range (*source).Annotations {
+				v1alpha2PodTemplate.Annotations[key2] = value2
+			}
+		}
+		pV1PodSpecApplyConfiguration, err := conv_applycorev1_PodSpecApplyConfiguration_To_applycorev1_PodSpecApplyConfiguration((*source).Spec)
+		if err != nil {
+			return nil, err
+		}
+		v1alpha2PodTemplate.Spec = pV1PodSpecApplyConfiguration
+		pV1alpha2PodTemplate = &v1alpha2PodTemplate
+	}
+	return pV1alpha2PodTemplate, nil
+}
+func pV1alpha2PoolConfiguratorToPV1alpha2PoolConfigurator(source *PoolConfigurator) *PoolConfigurator {
+	var pV1alpha2PoolConfigurator *PoolConfigurator
+	if source != nil {
+		var v1alpha2PoolConfigurator PoolConfigurator
+		if (*source).AdditionalCLIArgs != nil {
+			v1alpha2PoolConfigurator.AdditionalCLIArgs = make([]string, len((*source).AdditionalCLIArgs))
+			for i := 0; i < len((*source).AdditionalCLIArgs); i++ {
+				v1alpha2PoolConfigurator.AdditionalCLIArgs[i] = (*source).AdditionalCLIArgs[i]
+			}
+		}
+		pV1alpha2PoolConfigurator = &v1alpha2PoolConfigurator
+	}
+	return pV1alpha2PoolConfigurator
+}
+func pV1alpha2PoolFSValidatorToPV1alpha2PoolFSValidator(source *PoolFSValidator) *PoolFSValidator {
+	var pV1alpha2PoolFSValidator *PoolFSValidator
+	if source != nil {
+		var v1alpha2PoolFSValidator PoolFSValidator
+		if (*source).Enabled != nil {
+			xbool := *(*source).Enabled
+			v1alpha2PoolFSValidator.Enabled = &xbool
+		}
+		if (*source).ExpectedFS != nil {
+			xstring := *(*source).ExpectedFS
+			v1alpha2PoolFSValidator.ExpectedFS = &xstring
+		}
+		pV1alpha2PoolFSValidator = &v1alpha2PoolFSValidator
+	}
+	return pV1alpha2PoolFSValidator
+}
+func pV1alpha2PoolInitContainersToPV1alpha2PoolInitContainers(source *PoolInitContainers) *PoolInitContainers {
+	var pV1alpha2PoolInitContainers *PoolInitContainers
+	if source != nil {
+		var v1alpha2PoolInitContainers PoolInitContainers
+		v1alpha2PoolInitContainers.FSValidator = pV1alpha2PoolFSValidatorToPV1alpha2PoolFSValidator((*source).FSValidator)
+		v1alpha2PoolInitContainers.SetDataDirOwnership = pV1alpha2PoolSetDataDirOwnershipToPV1alpha2PoolSetDataDirOwnership((*source).SetDataDirOwnership)
+		v1alpha2PoolInitContainers.Configurator = pV1alpha2PoolConfiguratorToPV1alpha2PoolConfigurator((*source).Configurator)
+		pV1alpha2PoolInitContainers = &v1alpha2PoolInitContainers
+	}
+	return pV1alpha2PoolInitContainers
+}
+func pV1alpha2PoolSetDataDirOwnershipToPV1alpha2PoolSetDataDirOwnership(source *PoolSetDataDirOwnership) *PoolSetDataDirOwnership {
+	var pV1alpha2PoolSetDataDirOwnership *PoolSetDataDirOwnership
+	if source != nil {
+		var v1alpha2PoolSetDataDirOwnership PoolSetDataDirOwnership
+		if (*source).Enabled != nil {
+			xbool := *(*source).Enabled
+			v1alpha2PoolSetDataDirOwnership.Enabled = &xbool
+		}
+		pV1alpha2PoolSetDataDirOwnership = &v1alpha2PoolSetDataDirOwnership
+	}
+	return pV1alpha2PoolSetDataDirOwnership
 }
 func pV1alpha2RedpandaAdminAPISecretsToPConsolePartialRedpandaAdminAPISecrets(source *RedpandaAdminAPISecrets) *v3.PartialRedpandaAdminAPISecrets {
 	var pConsolePartialRedpandaAdminAPISecrets *v3.PartialRedpandaAdminAPISecrets
@@ -1368,6 +1665,26 @@ func pV1alpha2RedpandaAdminAPISecretsToPConsolePartialRedpandaAdminAPISecrets(so
 		pConsolePartialRedpandaAdminAPISecrets = &consolePartialRedpandaAdminAPISecrets
 	}
 	return pConsolePartialRedpandaAdminAPISecrets
+}
+func pV1alpha2RedpandaImageToPV1alpha2RedpandaImage(source *RedpandaImage) *RedpandaImage {
+	var pV1alpha2RedpandaImage *RedpandaImage
+	if source != nil {
+		var v1alpha2RedpandaImage RedpandaImage
+		if (*source).Repository != nil {
+			xstring := *(*source).Repository
+			v1alpha2RedpandaImage.Repository = &xstring
+		}
+		if (*source).Tag != nil {
+			xstring2 := *(*source).Tag
+			v1alpha2RedpandaImage.Tag = &xstring2
+		}
+		if (*source).PullPolicy != nil {
+			xstring3 := *(*source).PullPolicy
+			v1alpha2RedpandaImage.PullPolicy = &xstring3
+		}
+		pV1alpha2RedpandaImage = &v1alpha2RedpandaImage
+	}
+	return pV1alpha2RedpandaImage
 }
 func pV1alpha2RedpandaSecretsToPConsolePartialRedpandaSecrets(source *RedpandaSecrets) *v3.PartialRedpandaSecrets {
 	var pConsolePartialRedpandaSecrets *v3.PartialRedpandaSecrets
@@ -1624,6 +1941,9 @@ func v1NodeSelectorTermToV1NodeSelectorTerm(source v1.NodeSelectorTerm) v1.NodeS
 	}
 	return v1NodeSelectorTerm
 }
+func v1PersistentVolumeClaimRetentionPolicyTypeToV1PersistentVolumeClaimRetentionPolicyType(source v12.PersistentVolumeClaimRetentionPolicyType) v12.PersistentVolumeClaimRetentionPolicyType {
+	return v12.PersistentVolumeClaimRetentionPolicyType(source)
+}
 func v1PodAffinityTermToV1PodAffinityTerm(source v1.PodAffinityTerm) v1.PodAffinityTerm {
 	var v1PodAffinityTerm v1.PodAffinityTerm
 	v1PodAffinityTerm.LabelSelector = pV1LabelSelectorToPV1LabelSelector(source.LabelSelector)
@@ -1665,6 +1985,31 @@ func v1ProbeHandlerToV1ProbeHandler(source v1.ProbeHandler) v1.ProbeHandler {
 }
 func v1SeccompProfileTypeToV1SeccompProfileType(source v1.SeccompProfileType) v1.SeccompProfileType {
 	return v1.SeccompProfileType(source)
+}
+func v1ServicePortApplyConfigurationToV1ServicePortApplyConfiguration(source v11.ServicePortApplyConfiguration) v11.ServicePortApplyConfiguration {
+	var v1ServicePortApplyConfiguration v11.ServicePortApplyConfiguration
+	if source.Name != nil {
+		xstring := *source.Name
+		v1ServicePortApplyConfiguration.Name = &xstring
+	}
+	if source.Protocol != nil {
+		v1Protocol := v1.Protocol(*source.Protocol)
+		v1ServicePortApplyConfiguration.Protocol = &v1Protocol
+	}
+	if source.AppProtocol != nil {
+		xstring2 := *source.AppProtocol
+		v1ServicePortApplyConfiguration.AppProtocol = &xstring2
+	}
+	if source.Port != nil {
+		xint32 := *source.Port
+		v1ServicePortApplyConfiguration.Port = &xint32
+	}
+	v1ServicePortApplyConfiguration.TargetPort = pIntstrIntOrStringToPIntstrIntOrString(source.TargetPort)
+	if source.NodePort != nil {
+		xint322 := *source.NodePort
+		v1ServicePortApplyConfiguration.NodePort = &xint322
+	}
+	return v1ServicePortApplyConfiguration
 }
 func v1SysctlToV1SysctlApplyConfiguration(source v1.Sysctl) v11.SysctlApplyConfiguration {
 	var v1SysctlApplyConfiguration v11.SysctlApplyConfiguration

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
@@ -46,7 +46,7 @@ spec:
             type: object
           spec:
             description: |-
-              NodePoolSpec contains the node pool spec for the given node pool.
+              BrokerPoolSpec contains the node pool spec for the given node pool.
               Note that the defaulting behavior comes from the underlying Redpanda
               chart renderer, the attributes specified here will get merged in and
               override the defaults.

--- a/operator/internal/lifecycle/v2_node_pools.go
+++ b/operator/internal/lifecycle/v2_node_pools.go
@@ -57,11 +57,46 @@ func (m *V2NodePoolRenderer) Render(ctx context.Context, cluster *ClusterWithPoo
 }
 
 func (m *V2NodePoolRenderer) convertToRender(cluster *ClusterWithPools) (*redpanda.RenderState, error) {
+	brokerPools, err := nodePoolsToBrokerPools(cluster.NodePools)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
 	return conversion.ConvertV2ToRenderState(m.kubeConfig, &conversion.V2Defaulters{
 		RedpandaImage:    defaultImage(m.redpandaImage),
 		SidecarImage:     defaultImage(m.sideCarImage),
 		ConfiguratorArgs: m.cloudSecrets.AdditionalConfiguratorArgs(),
-	}, cluster.Redpanda, cluster.NodePools)
+	}, cluster.Redpanda, brokerPools)
+}
+
+// nodePoolsToBrokerPools converts v2 NodePools into the equivalent
+// RedpandaBrokerPools to allow access to [redpanda.RenderState].
+//
+// The resultant [redpandav1alpha2.RedpandaBrokerPools] spec will have a handful of
+// nil fields as [redpandav1alpha2.NodePool] is subset of broker pools. See
+// [redpandav1alpha2.ConvertEmbeddedNodePoolSpecToEmbeddedBrokerPoolSpec] for
+// details.
+func nodePoolsToBrokerPools(pools []*redpandav1alpha2.NodePool) ([]*redpandav1alpha2.RedpandaBrokerPool, error) {
+	converted := make([]*redpandav1alpha2.RedpandaBrokerPool, 0, len(pools))
+	for _, pool := range pools {
+		if pool == nil {
+			continue
+		}
+
+		spec, err := redpandav1alpha2.ConvertEmbeddedNodePoolSpecToEmbeddedBrokerPoolSpec(pool.Spec.EmbeddedNodePoolSpec)
+		if err != nil {
+			return nil, errors.Wrapf(err, "converting NodePool %q to a RedpandaBrokerPool", pool.Name)
+		}
+
+		converted = append(converted, &redpandav1alpha2.RedpandaBrokerPool{
+			ObjectMeta: *pool.ObjectMeta.DeepCopy(),
+			Spec: redpandav1alpha2.BrokerPoolSpec{
+				EmbeddedBrokerPoolSpec: *spec,
+				ClusterRef:             *pool.Spec.ClusterRef.DeepCopy(),
+			},
+		})
+	}
+	return converted, nil
 }
 
 func isNodePool(object client.Object) bool {

--- a/operator/internal/lifecycle/v2_node_pools_test.go
+++ b/operator/internal/lifecycle/v2_node_pools_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package lifecycle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+func TestNodePoolsToBrokerPools(t *testing.T) {
+	np := testNodePool()
+
+	converted, err := nodePoolsToBrokerPools([]*redpandav1alpha2.NodePool{np})
+	require.NoError(t, err)
+	require.Len(t, converted, 1)
+
+	bp := converted[0]
+
+	// ObjectMeta carries over verbatim: Name and Generation drive the rendered
+	// StatefulSet name, identity labels, and pool-scoped affinity selectors.
+	require.Equal(t, np.ObjectMeta, bp.ObjectMeta)
+	require.Equal(t, np.Spec.ClusterRef, bp.Spec.ClusterRef)
+
+	// The pool spec is carried across onto the widened type. Shared
+	// types/values are cloned not copied.
+	require.Equal(t, np.Spec.Replicas, bp.Spec.Replicas)
+	require.Equal(t, np.Spec.AdditionalSelectorLabels, bp.Spec.AdditionalSelectorLabels)
+	require.NotSame(t, &np.Spec.AdditionalSelectorLabels, &bp.Spec.AdditionalSelectorLabels)
+	require.Equal(t, np.Spec.AdditionalRedpandaCmdFlags, bp.Spec.AdditionalRedpandaCmdFlags)
+	require.NotSame(t, &np.Spec.AdditionalRedpandaCmdFlags, &bp.Spec.AdditionalRedpandaCmdFlags)
+	require.Equal(t, np.Spec.Image, bp.Spec.Image)
+	require.NotSame(t, np.Spec.Image, bp.Spec.Image)
+}
+
+// testNodePool returns a NodePool whose every mutable field is reachable through
+// a pointer, map, or slice, so the aliasing assertions below have something to
+// bite on.
+func testNodePool() *redpandav1alpha2.NodePool {
+	return &redpandav1alpha2.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pool-a",
+			Namespace:  "ns",
+			Generation: 42,
+			Labels:     map[string]string{"owner": "rp"},
+		},
+		Spec: redpandav1alpha2.NodePoolSpec{
+			EmbeddedNodePoolSpec: redpandav1alpha2.EmbeddedNodePoolSpec{
+				Replicas:                   new(int32(3)),
+				AdditionalSelectorLabels:   map[string]string{"selector": "label"},
+				AdditionalRedpandaCmdFlags: []string{"--smp=2"},
+				Image:                      &redpandav1alpha2.RedpandaImage{Repository: new("original"), Tag: new("v1")},
+			},
+			ClusterRef: redpandav1alpha2.ClusterRef{
+				Group:     new("cluster.redpanda.com"),
+				Kind:      new("Redpanda"),
+				Name:      "rp",
+				Namespace: new("ns"),
+			},
+		},
+	}
+}

--- a/operator/internal/lifecycle/v2_simple_resources.go
+++ b/operator/internal/lifecycle/v2_simple_resources.go
@@ -53,10 +53,15 @@ func (m *V2SimpleResourceRenderer) Render(ctx context.Context, cluster *ClusterW
 		spec = &redpandav1alpha2.RedpandaClusterSpec{}
 	}
 
+	brokerPools, err := nodePoolsToBrokerPools(cluster.NodePools)
+	if err != nil {
+		return nil, err
+	}
+
 	// NB: No need for real defaults here as the defaults are leveraged only in the stateful set
 	// images and pod command-line args, neither of which are looked at for rendering simple
 	// resources.
-	state, err := conversion.ConvertV2ToRenderState(m.kubeConfig, &conversion.V2Defaulters{}, cluster.Redpanda, cluster.NodePools)
+	state, err := conversion.ConvertV2ToRenderState(m.kubeConfig, &conversion.V2Defaulters{}, cluster.Redpanda, brokerPools)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +147,12 @@ func (m *V2SimpleResourceRenderer) MigratingResources() []client.Object {
 // admin port); a conversion failure returns nil and callers treat a missing
 // endpoint as "cannot verify, do nothing".
 func (m *V2SimpleResourceRenderer) GetAdminAPIEndpoints(cluster *ClusterWithPools) []string {
-	state, err := conversion.ConvertV2ToRenderState(m.kubeConfig, &conversion.V2Defaulters{}, cluster.Redpanda, cluster.NodePools)
+	brokerPools, err := nodePoolsToBrokerPools(cluster.NodePools)
+	if err != nil {
+		return nil
+	}
+
+	state, err := conversion.ConvertV2ToRenderState(m.kubeConfig, &conversion.V2Defaulters{}, cluster.Redpanda, brokerPools)
 	if err != nil {
 		return nil
 	}

--- a/pkg/rapidutil/rapidutil.go
+++ b/pkg/rapidutil/rapidutil.go
@@ -16,6 +16,7 @@
 package rapidutil
 
 import (
+	"maps"
 	"reflect"
 	"time"
 
@@ -66,3 +67,24 @@ var (
 		},
 	}
 )
+
+// Merge merges the provided [rapid.MakeConfig]s into one. Priority is given to
+// the right most configs.
+func Merge(cfgs ...rapid.MakeConfig) rapid.MakeConfig {
+	out := rapid.MakeConfig{
+		Types:  map[reflect.Type]*rapid.Generator[any]{},
+		Fields: map[reflect.Type]map[string]*rapid.Generator[any]{},
+	}
+
+	for _, cfg := range cfgs {
+		if cfg.Types != nil {
+			maps.Copy(out.Types, cfg.Types)
+		}
+
+		if cfg.Fields != nil {
+			maps.Copy(out.Fields, cfg.Fields)
+		}
+	}
+
+	return out
+}


### PR DESCRIPTION
As the initial step to unifying NodePools and BrokerPools, this commit begins plumbing BrokerPools into the RedpandaClusterController from the bottom up. It implements a basic conversion routine and refactors the resource rendering pipeline to rely on BrokerPools instead of NodePools.

Notable: The new fields available on BrokerPools are not currently respected as there is no legitimate way for said fields to be set.