### PR TITLE
[release/v26.2.x] Bump Go toolchain to 1.26.6 to address Snyk stdlib findings

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cert-manager/cert-manager v1.19.3

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,3 +1,3 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.26.5
+go 1.26.6

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console/v3
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cloudhut/common v0.11.0

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda/v25
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cert-manager/cert-manager v1.19.3

--- a/ci/overlay.nix
+++ b/ci/overlay.nix
@@ -16,6 +16,21 @@ in
   rp-controller-gen = pkgs.callPackage ./rp-controller-gen.nix { };
   setup-envtest = pkgs.callPackage ./setup-envtest.nix { };
   vcluster = pkgs.callPackage ./vcluster.nix { };
+  # nixpkgs still ships 1.26.5 as go_1_26; go.mod requires 1.26.6 and the
+  # devshell sets GOTOOLCHAIN=local, so build 1.26.6 from the upstream source
+  # tarball. Scoped to a new attribute (rather than overriding go_1_26) so the
+  # rest of nixpkgs' go-built packages keep their binary-cached builds.
+  #
+  # To compute the hash for a new version:
+  #   curl -sL https://go.dev/dl/go<VERSION>.src.tar.gz | openssl dgst -sha256 -binary | openssl base64 -A
+  # and prepend "sha256-".
+  go_1_26_6 = prev.go_1_26.overrideAttrs (oldAttrs: {
+    version = "1.26.6";
+    src = prev.fetchurl {
+      url = "https://go.dev/dl/go1.26.6.src.tar.gz";
+      hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+    };
+  });
   # The hashes below are the unpacked (NAR) hashes of the release tarballs, as
   # required by fetchzip. To compute one for a new version/platform:
   #

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
           # nix commands. e.g. nix copy .#devshell.
           packages.devshell = self'.devShells.default;
 
-          packages.envtest-shim = pkgs.buildGoModule {
+          packages.envtest-shim = (pkgs.buildGoModule.override { go = pkgs.go_1_26_6; }) {
             name = "envtest-shim";
 
             src = ./reaper;
@@ -66,7 +66,7 @@
           devshells.default = {
             env = [
               { name = "CGO_ENABLED"; value = "0"; }
-              { name = "GOROOT"; value = "${pkgs.go_1_26}/share/go"; }
+              { name = "GOROOT"; value = "${pkgs.go_1_26_6}/share/go"; }
               # Prevent go from downloading toolchains other than the one pinned by nix.
               # See https://go.dev/doc/toolchain#select
               { name = "GOTOOLCHAIN"; value = "local"; }
@@ -115,7 +115,7 @@
               pkgs.gnused # Stream Editor, used by some build scripts.
               pkgs.go-task
               pkgs.go-tools
-              pkgs.go_1_26
+              pkgs.go_1_26_6
               pkgs.gofumpt
               pkgs.golangci-lint
               pkgs.gotestsum

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.26.5
+go 1.26.6
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.5
+go 1.26.6
 
 use (
 	./acceptance

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/goutils v1.1.1

--- a/gotohelm/testdata/src/example/go.mod
+++ b/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/redpanda-data/common-go/kube v0.0.0-20260408144400-efba9928bb27

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cockroachdb/errors v1.12.0

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	buf.build/gen/go/redpandadata/core/connectrpc/go v1.20.0-20260706172830-ee867ae38d23.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.26.5
+go 1.26.6
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -8,7 +8,7 @@ changie version v1.25.1
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.26.5
+go version go1.26.6
 
 -- helm --
 # helm version

--- a/reaper/go.mod
+++ b/reaper/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/reaper
 
-go 1.26.5
+go 1.26.6
 
 require (
 	golang.org/x/sync v0.22.0

--- a/rpk-k8s-publish/go.mod
+++ b/rpk-k8s-publish/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/rpk-k8s-publish
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda-operator/pull/1740 to `release/v26.2.x` (the auto-backport bot is not used for dep/toolchain bumps).

Bumps the `go` directive in all workspace modules from 1.26.5 to 1.26.6, addressing HIGH severity Go stdlib vulnerabilities: CVE-2026-56853 (std/net/http DoS, GO-2026-6089), CVE-2026-56860 (std/net/url DoS, GO-2026-6218), CVE-2026-56862 (std/crypto/tls DoS, GO-2026-6090), CVE-2026-33818 (std/encoding/asn1 recursion, GO-2026-5972), CVE-2026-56859 (std/encoding/xml recursion, GO-2026-6088), CVE-2026-46600 (std/net uncaught exception, GO-2026-5942), plus MEDIUM CVE-2026-56858 (std/html/template XSS, GO-2026-6091). Full vulnerability details and reference links in #1740.

`go mod tidy` across all workspace modules and `go work sync` produced no further changes; `go build ./operator/... ./pkg/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Note on nix:** nixpkgs does not yet ship Go 1.26.6 (its `go_1_26` is 1.26.5) and the devshell pins `GOTOOLCHAIN=local`, so CI initially failed with `go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)`. A second commit adds a scoped `go_1_26_6` overlay attribute built from the upstream source tarball, used only for the devshell (and envtest-shim where present) — overriding `go_1_26` itself would rebuild every Go package in nixpkgs from source. Verified locally: `nix develop -c go version` reports go1.26.6 and TestToolVersions passes.
