### PR TITLE
[release/v25.3.x] Bump Go toolchain to 1.25.13 to address Snyk stdlib findings

### DIFF
--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/acceptance
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/alias/go.mod
+++ b/alias/go.mod
@@ -1,3 +1,3 @@
 module github.com/redpanda-data/redpanda-operator/alias
 
-go 1.25.12
+go 1.25.13

--- a/charts/connectors/go.mod
+++ b/charts/connectors/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/connectors
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/charts/console/go.mod
+++ b/charts/console/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/console/v3
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cloudhut/common v0.11.0

--- a/charts/redpanda/go.mod
+++ b/charts/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/charts/redpanda/v25
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cert-manager/cert-manager v1.14.5

--- a/gen/go.mod
+++ b/gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gen
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	// As gen schema generates a schema for a chart via reflect, we

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.12
+go 1.25.13
 
 use (
 	./acceptance

--- a/gotohelm/go.mod
+++ b/gotohelm/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/gotohelm
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/Masterminds/goutils v1.1.1

--- a/gotohelm/testdata/src/example/go.mod
+++ b/gotohelm/testdata/src/example/go.mod
@@ -1,6 +1,6 @@
 module example.com/example
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/redpanda-data/redpanda-operator/gotohelm v0.0.0-00010101000000-000000000000

--- a/harpoon/go.mod
+++ b/harpoon/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/harpoon
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/licensereport/go.mod
+++ b/licensereport/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licensereport
 
-go 1.25.12
+go 1.25.13
 
 require github.com/google/licenseclassifier/v2 v2.0.0
 

--- a/licenseupdater/go.mod
+++ b/licenseupdater/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/licenseupdater
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/operator
 
-go 1.25.12
+go 1.25.13
 
 require (
 	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.11-20260108182238-df92733e0119.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/redpanda-operator/pkg
 
-go 1.25.12
+go 1.25.13
 
 replace pgregory.net/rapid => github.com/chrisseto/rapid v0.0.0-20240815210052-cdeef406c65c
 

--- a/pkg/lint/testdata/tool-versions.txtar
+++ b/pkg/lint/testdata/tool-versions.txtar
@@ -8,7 +8,7 @@ changie version v1.24.0
 
 -- go --
 # go version | cut -d ' ' -f 1-3
-go version go1.25.12
+go version go1.25.13
 
 -- helm --
 # helm version


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda-operator/pull/1740 to `release/v25.3.x`. This branch tracks Go 1.25.x, so the bump is 1.25.12 → 1.25.13 (the corresponding fix release for that line; the auto-backport bot is not used for dep/toolchain bumps).

Addresses HIGH severity Go stdlib vulnerabilities: CVE-2026-56853 (std/net/http DoS, GO-2026-6089), CVE-2026-56860 (std/net/url DoS, GO-2026-6218), CVE-2026-56862 (std/crypto/tls DoS, GO-2026-6090), CVE-2026-33818 (std/encoding/asn1 recursion, GO-2026-5972), CVE-2026-56859 (std/encoding/xml recursion, GO-2026-6088), plus MEDIUM CVE-2026-56858 (std/html/template XSS, GO-2026-6091). CVE-2026-46600 (std/net) affects only Go 1.26.x and does not apply to this branch. Full vulnerability details and reference links in #1740.

`go mod tidy` across all workspace modules and `go work sync` produced no further changes; `go build ./operator/... ./pkg/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)