### PR TITLE
docs: treat CRD and Helm doc comments as documentation

### DIFF
--- a/.claude/skills/doc-strings/SKILL.md
+++ b/.claude/skills/doc-strings/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: doc-strings
+description: Writing standards for user-facing doc strings in this repo — Go doc comments on CRD fields (operator/api/redpanda/v1alpha2/) and helm-docs comments in chart values.yaml files. Apply when adding or editing those comments, or reviewing a diff that touches them. They are published documentation, generated verbatim into the CRD reference, kubectl explain output, Helm chart docs, and docs.redpanda.com.
+---
+
+# Doc strings
+
+CRD field doc comments and `values.yaml` helm-docs comments in this repo are
+not code comments. Generators publish them verbatim: `crd-ref-docs` and
+`controller-gen` turn field comments into the CRD reference on
+docs.redpanda.com AND the OpenAPI schema descriptions behind
+`kubectl explain`; `helm-docs` turns `# --` comments into the chart README
+and the Helm reference pages. Write them for the operator running the
+cluster, not for the maintainer reading the Go.
+
+The authoritative standard is `resources/writing-style/embedded-reference-strings.md`
+in redpanda-data/docs-team-standards (private; fetch it, never vendor a
+copy). The rules below are the local summary.
+
+## CRD field comments (operator/api/redpanda/v1alpha2/)
+
+- Describe the YAML key the user types (the `json:` tag), never the Go
+  field name. "ClusterSource is a reference to..." documents the wrong
+  identifier; the user writes `cluster:`.
+- Enumerate legal values in prose even when a
+  `+kubebuilder:validation:Enum` marker exists: the marker validates, the
+  prose is what users read in `kubectl explain`.
+- State defaults ("Defaults to ...") and what happens when the field is
+  absent. `+kubebuilder:default` markers are stripped, not rendered.
+- Every user-facing struct and field gets a comment. An undocumented
+  struct ships as an empty reference table. `operator/crd-ref-docs-config.yaml`
+  (`hidefromdoc`, ignoreTypes) defines what is user-facing.
+- Marker lines (`+kubebuilder:...`, `+optional`, `+required`) are stripped
+  by the generator; everything else in the comment block is published.
+
+## Helm values comments (charts/*/chart/values.yaml)
+
+- Document a key with `# -- description` immediately above it;
+  continuation lines keep `#` without `--`.
+- `# @default -- <text>` when the YAML default is empty or computed;
+  `# @raw` for verbatim blocks; `# @ignored` to exclude.
+- Never leave `# --` markers inside commented-out example blocks:
+  helm-docs cannot attach them and the text silently disappears.
+- Every user-visible key gets a description; cross-reference sibling keys
+  with their full path (`listeners.<listener-name>.tls.cert`).
+
+## Quality bar (both surfaces)
+
+State the effect and when to change the setting; never restate the name;
+give defaults and units; no internal jargon; describe current behavior,
+not roadmap. After editing, run `task generate` so the generated docs
+(README.md, CRD YAML) stay in sync — CI diffs them.
+
+## Check published content
+
+Changing a default, unit, or behavior, removing or renaming a surface, or
+adding a new one can make published docs wrong or leave a gap. Search
+docs.redpanda.com for the surface name before finalizing the change (the
+public docs MCP at https://docs.redpanda.com/mcp exposes search and Q&A
+tools; plain web search works too). If a published page states the old
+behavior, say so in the PR description and update the doc string in the
+same diff; the PR review automation routes high-impact cases to the docs
+team's Jira intake (comments on the existing DOC ticket or files one).
+
+## What NOT to flag in review
+
+Subjective wording on a comment that already states effect, default, and
+legal values; internal code comments; anything outside the two surfaces
+above.

--- a/.github/workflows/doc-strings-review.yml
+++ b/.github/workflows/doc-strings-review.yml
@@ -1,0 +1,53 @@
+---
+# Suggest-only review of user-facing doc strings (CRD field comments and
+# helm-docs values.yaml comments) — published to the CRD reference,
+# kubectl explain, chart READMEs, and docs.redpanda.com.
+#
+# All review logic lives in the shared reusable workflow in
+# redpanda-data/docs-extensions-and-macros so it cannot drift between
+# repos; this shim owns only the trigger paths and the secrets.
+#
+# The ref tracks main deliberately. docs-extensions-and-macros is a
+# first-party repo owned by the docs team, and pinning a SHA meant every
+# fix to the shared review needed a manual bump here before it took
+# effect. Tracking main means fixes land automatically; the tradeoff is
+# that a merge there ships straight into this repo's CI. The review is
+# suggest-only and fails open, so the blast radius of a bad change is a
+# missing review rather than a blocked PR.
+name: doc-strings-review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - "operator/api/redpanda/**"
+      - "charts/*/chart/values.yaml"
+      - "charts/*/values.yaml"
+concurrency:
+  group: doc-strings-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  review:
+    # Same-repo PRs only. A fork PR carries no secrets, and the reusable
+    # workflow declares anthropic_api_key as required, so a fork PR would
+    # FAIL the job rather than skip it. A suggest-only review must never
+    # redden an external contributor's PR.
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: redpanda-data/docs-extensions-and-macros/.github/workflows/doc-strings-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    with:
+      # The AWS inputs let the reusable workflow assume this repo's OIDC role
+      # and read the org bot token from Secrets Manager, the same way the
+      # repo's other workflows do. The token is not a GitHub Actions secret
+      # here. Requires docs-extensions-and-macros#294.
+      aws_region: ${{ vars.RP_AWS_CRED_REGION }}
+      aws_role_name_prefix: ${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}
+      surfaces: helm,crd
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      aws_cred_account_id: ${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}
+      actions_bot_token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/doc-strings-review.yml
+++ b/.github/workflows/doc-strings-review.yml
@@ -27,10 +27,12 @@ concurrency:
   cancel-in-progress: true
 jobs:
   review:
-    # Same-repo PRs only. A fork PR carries no secrets, and the reusable
-    # workflow declares anthropic_api_key as required, so a fork PR would
-    # FAIL the job rather than skip it. A suggest-only review must never
-    # redden an external contributor's PR.
+    # Same-repo PRs only. A fork PR is issued a read-only token whatever the
+    # permissions block below asks for, and carries neither the OIDC role nor
+    # the Secrets Manager access the model auth needs — so the review has
+    # nothing to authenticate with and nothing to post with. Skipping it
+    # outright is the honest outcome: a suggest-only review must never redden
+    # an external contributor's PR.
     if: >-
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -47,7 +49,28 @@ jobs:
       aws_region: ${{ vars.RP_AWS_CRED_REGION }}
       aws_role_name_prefix: ${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}
       surfaces: helm,crd
+      # Model traffic goes through the ADP AI Gateway (DEVPROD-4735) rather
+      # than a direct Anthropic key, matching streaming-enterprise's shim.
+      # Not a cost saving: it is what makes this review's spend attributable.
+      # Cost and usage attributes by agent and by an agent's tags, so the
+      # reusable workflow's default credential is the doc-strings-review
+      # self-managed agent's, and this repo's share of that review now groups
+      # under that agent and its team=docs tag. On a direct key it was outside
+      # ADP altogether and appeared in no report at all.
+      #
+      # The same OIDC role assumed above reads the credential, so the only
+      # other requirement is the Secrets Manager grant:
+      # sdlc/prod/github/docs_doc_strings_client, added for this repo in
+      # devprod-infra#802. Without it the mint cannot happen — and because
+      # every step in that chain is continue-on-error, the symptom is a review
+      # that silently does not appear rather than a failing check. Read the
+      # job log, not the check colour.
+      use_adp_gateway: true
     secrets:
+      # Inert while use_adp_gateway is on: the reusable workflow passes the key
+      # through only on the non-gateway path and blanks it otherwise, so it
+      # never reaches the model step. Kept so that turning the gateway off
+      # leaves a working review rather than a lint-only one.
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       aws_cred_account_id: ${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}
       actions_bot_token: ${{ secrets.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
CRD field doc comments ship to the CRD reference on docs.redpanda.com AND `kubectl explain`; `values.yaml` helm-docs comments ship to chart READMEs and the Helm reference. The existing `task :generate` + diff gate enforces freshness of generated docs — nothing checks quality of the source comments (e.g. `SchemaSpec`'s comments document the Go field names rather than the YAML keys users type; `SchemaReference` is entirely undocumented).

Suggest-only, zero new required checks:

- **`.claude/skills/doc-strings`**: writing standards for both surfaces
- **`doc-strings-review.yml`**: a 33-line shim calling the shared reusable workflow in docs-extensions-and-macros — deterministic lint on the diff, then (only on findings) one Claude review with one-click suggestion blocks citing the docs-team standard, plus routing of published-content impact to the docs team's Jira intake. Hardened, fails open, never blocks.

**Draft until**: docs-extensions-and-macros#264 merges and releases, and this repo has `ANTHROPIC_API_KEY` + `ACTIONS_BOT_TOKEN` available to Actions (fails open to lint-only without them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)