### PR TITLE
operator: corroborate node state before the PVCUnbinder's destructive path

### DIFF
--- a/.changes/unreleased/operator-Changed-20260821-120000.yaml
+++ b/.changes/unreleased/operator-Changed-20260821-120000.yaml
@@ -1,0 +1,19 @@
+project: operator
+kind: Changed
+body: |-
+    Improved the PVCUnbinder: it now corroborates node state before deleting anything (a new "node-state" safety gate).
+
+      Previously any total scheduling failure qualified a Pending Pod for
+      remediation once `--unbind-pvcs-after` elapsed — for example a
+      misconfigured broker memory request producing "0/N nodes are available:
+      ... Insufficient memory" while every node stays healthy — after which the
+      unbinder deleted the broker's PVCs and left its Retained
+      PersistentVolumes (and their data) stranded. The unbinder now also
+      requires proof that a Bound claim pins the Pod to a node that is truly
+      unusable: deleted, cordoned, NotReady/unreachable (judged through the
+      Pod's tolerations), or occupied by a pod matching the Pod's required
+      anti-affinity. Without that proof it defers and retries every 30s,
+      visible on the `..._pvc_unbinder_gate_deferred_total{gate="node-state"}`
+      metric and as a `PVCUnbinderDeferred` event on the Pod.
+      `--disable-unbinder-node-corroboration` restores the previous behavior.
+time: 2026-08-21T12:00:00.000000+02:00

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -97,6 +97,7 @@ type MulticlusterOptions struct {
 	UnbindPVCsAfter                    time.Duration
 	AllowPVRebinding                   bool
 	DisablePVCRebindingGateExemption   bool
+	DisableUnbinderNodeCorroboration   bool
 	UnbinderSelector                   pflagutil.LabelSelectorValue
 	BrokerPodNodeUnavailableToleration time.Duration
 
@@ -233,6 +234,7 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.AllowPVRebinding, "allow-pv-rebinding", false, "DEPRECATED. When the PVCUnbinder fires, also clear the freed PV's ClaimRef so the disk can be reused if the node returns. Risks cross-broker disk swap when multiple PVs are cleared concurrently. Leave at false (the default) — the unbinder's pause-annotation, multi-pod auto-detect, and per-cluster serialization gates make this flag unnecessary in practice and unsafe in the cases where it would have been useful.")
 	_ = cmd.Flags().MarkDeprecated("allow-pv-rebinding", "the gating checks added to the PVCUnbinder (pause annotation, multi-pod auto-detect, per-cluster serialization) supersede this flag; see the PVCUnbinder controller godoc")
 	cmd.Flags().BoolVar(&o.DisablePVCRebindingGateExemption, "disable-pvc-rebinding-gate-exemption", false, "Escape hatch: turn off the PVCUnbinder's stuck-claim exemption so its pvc-rebinding gate defers on every unbound claim (the pre-exemption behavior). Use if the exemption's proof chain misfires in your environment; unlike the pause annotation it keeps the rest of the unbinder running.")
+	cmd.Flags().BoolVar(&o.DisableUnbinderNodeCorroboration, "disable-unbinder-node-corroboration", false, "Escape hatch: turn off the PVCUnbinder's node-state gate so unbinds proceed on the scheduling-failure message and timeout alone (the pre-corroboration behavior). Use if the gate's mis-pin proof chain cannot evaluate in your environment (for example, unusual local-PV node-affinity shapes); unlike the pause annotation it keeps the rest of the unbinder running.")
 	cmd.Flags().Var(&o.UnbinderSelector, "unbinder-label-selector", "if provided, a Kubernetes label selector that will filter Pods to be considered by the PVCUnbinder.")
 	cmd.Flags().DurationVar(&o.BrokerPodNodeUnavailableToleration, "broker-pod-node-unavailable-toleration", 0, "Controls injection of node.kubernetes.io/not-ready and node.kubernetes.io/unreachable NoExecute tolerations onto broker pods. 0 (default) = feature off, no tolerations injected. Positive = tolerationSeconds set to this duration. Negative (-1s or any negative value) = tolerate forever, no tolerationSeconds field (appropriate for cloud K8s where Node-object deletion is the authoritative signal of permanent node loss). User-set tolerations for these taint keys are always preserved.")
 	cmd.Flags().DurationVar(&o.ClusterConnectionTimeout, "cluster-connection-timeout", 10*time.Second, "Timeout for internal clients used to connect to Redpanda clusters (admin API in particular)")
@@ -513,6 +515,7 @@ func Run(
 			Selector:                   opts.UnbinderSelector.Selector,
 			AllowRebinding:             opts.AllowPVRebinding,
 			DisableStuckClaimExemption: opts.DisablePVCRebindingGateExemption,
+			DisableNodeCorroboration:   opts.DisableUnbinderNodeCorroboration,
 		}).SetupWithMultiClusterManager(); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PVCUnbinder")
 			return err

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -136,6 +136,7 @@ type RunOptions struct {
 	unbinderSelector                    pflagutil.LabelSelectorValue
 	allowPVRebinding                    bool
 	disablePVCRebindingGateExemption    bool
+	disableUnbinderNodeCorroboration    bool
 	brokerPodNodeUnavailableToleration  time.Duration
 	autoDeletePVCs                      bool
 	webhookCertPath                     string
@@ -228,6 +229,7 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.allowPVRebinding, "allow-pv-rebinding", false, "DEPRECATED. When the PVCUnbinder fires, also clear the freed PV's ClaimRef so the disk can be reused if the node returns. Risks cross-broker disk swap when multiple PVs are cleared concurrently. Leave at false (the default) — the unbinder's pause-annotation, multi-pod auto-detect, and per-cluster serialization gates make this flag unnecessary in practice and unsafe in the cases where it would have been useful.")
 	_ = cmd.Flags().MarkDeprecated("allow-pv-rebinding", "the gating checks added to the PVCUnbinder (pause annotation, multi-pod auto-detect, per-cluster serialization) supersede this flag; see the PVCUnbinder controller godoc")
 	cmd.Flags().BoolVar(&o.disablePVCRebindingGateExemption, "disable-pvc-rebinding-gate-exemption", false, "Escape hatch: turn off the PVCUnbinder's stuck-claim exemption so its pvc-rebinding gate defers on every unbound claim (the pre-exemption behavior). Use if the exemption's proof chain misfires in your environment; unlike the pause annotation it keeps the rest of the unbinder running.")
+	cmd.Flags().BoolVar(&o.disableUnbinderNodeCorroboration, "disable-unbinder-node-corroboration", false, "Escape hatch: turn off the PVCUnbinder's node-state gate so unbinds proceed on the scheduling-failure message and timeout alone (the pre-corroboration behavior). Use if the gate's mis-pin proof chain cannot evaluate in your environment (for example, unusual local-PV node-affinity shapes); unlike the pause annotation it keeps the rest of the unbinder running.")
 	cmd.Flags().Var(&o.unbinderSelector, "unbinder-label-selector", "if provided, a Kubernetes label selector that will filter Pods to be considered by the PVCUnbinder.")
 	cmd.Flags().DurationVar(&o.brokerPodNodeUnavailableToleration, "broker-pod-node-unavailable-toleration", 0, "Controls injection of node.kubernetes.io/not-ready and node.kubernetes.io/unreachable NoExecute tolerations onto broker pods. 0 (default) = feature off, no tolerations injected. Positive = tolerationSeconds set to this duration. Negative (-1s or any negative value) = tolerate forever, no tolerationSeconds field (appropriate for cloud K8s where Node-object deletion is the authoritative signal of permanent node loss). User-set tolerations for these taint keys are always preserved.")
 	cmd.Flags().BoolVar(&o.autoDeletePVCs, "auto-delete-pvcs", false, "Use StatefulSet PersistentVolumeClaimRetentionPolicy to auto delete PVCs on scale down and Cluster resource delete.")
@@ -725,6 +727,7 @@ func Run(
 			Selector:                   opts.unbinderSelector.Selector,
 			AllowRebinding:             opts.allowPVRebinding,
 			DisableStuckClaimExemption: opts.disablePVCRebindingGateExemption,
+			DisableNodeCorroboration:   opts.disableUnbinderNodeCorroboration,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PVCUnbinder")
 			return err

--- a/operator/cmd/sidecar/sidecar.go
+++ b/operator/cmd/sidecar/sidecar.go
@@ -70,6 +70,7 @@ func Command() *cobra.Command {
 		runUnbinder                bool
 		unbinderTimeout            time.Duration
 		unbinderDisableExemption   bool
+		unbinderDisableNodeCorrob  bool
 		selector                   pflagutil.LabelSelectorValue
 		panicAfter                 time.Duration
 	)
@@ -104,6 +105,7 @@ func Command() *cobra.Command {
 				runUnbinder,
 				unbinderTimeout,
 				unbinderDisableExemption,
+				unbinderDisableNodeCorrob,
 				selector.Selector,
 				panicAfter,
 			)
@@ -149,6 +151,7 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&runUnbinder, "run-pvc-unbinder", false, "Specifies if the PVC unbinder should be run.")
 	cmd.Flags().DurationVar(&unbinderTimeout, "pvc-unbinder-timeout", 60*time.Second, "The time period to wait before removing any unbound PVCs.")
 	cmd.Flags().BoolVar(&unbinderDisableExemption, "disable-pvc-rebinding-gate-exemption", false, "Escape hatch: turn off the PVC unbinder's stuck-claim exemption so its pvc-rebinding gate defers on every unbound claim (the pre-exemption behavior).")
+	cmd.Flags().BoolVar(&unbinderDisableNodeCorrob, "disable-unbinder-node-corroboration", false, "Escape hatch: turn off the PVCUnbinder's node-state gate so unbinds proceed on the scheduling-failure message and timeout alone (the pre-corroboration behavior). Use if the gate's mis-pin proof chain cannot evaluate in your environment (for example, unusual local-PV node-affinity shapes); unlike the pause annotation it keeps the rest of the unbinder running.")
 
 	// Internal use flags.
 	cmd.Flags().DurationVar(&panicAfter, "panic-after", 0, "If non-zero, will trigger an unhandled panic after the specified time resulting in a process crash.")
@@ -181,6 +184,7 @@ func Run(
 	runUnbinder bool,
 	unbinderTimeout time.Duration,
 	unbinderDisableExemption bool,
+	unbinderDisableNodeCorrob bool,
 	selector labels.Selector,
 	panicAfter time.Duration,
 ) error {
@@ -278,6 +282,7 @@ func Run(
 			Timeout:                    unbinderTimeout,
 			Selector:                   selector,
 			DisableStuckClaimExemption: unbinderDisableExemption,
+			DisableNodeCorroboration:   unbinderDisableNodeCorrob,
 		}).SetupWithManager(mgr.GetLocalManager()); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PVCUnbinder")
 			return err

--- a/operator/internal/controller/pvcunbinder/pvcunbinder.go
+++ b/operator/internal/controller/pvcunbinder/pvcunbinder.go
@@ -58,7 +58,7 @@ const PauseAnnotation = "operator.redpanda.com/pause-pvc-unbinder"
 // gate defers an unbind.
 const requeueDuringDisruption = 30 * time.Second
 
-// The unbinder runs five safety gates before it deletes anything.
+// The unbinder runs six safety gates before it deletes anything.
 // Each gate can defer (postpone) the unbind. In order:
 //
 //   - Gate 0 "in-flight": a previous unbind in this cluster has not
@@ -73,6 +73,10 @@ const requeueDuringDisruption = 30 * time.Second
 //     [Controller.stuckClaimNames]).
 //   - Gate 4 "freed-pv": a PV freed by --allow-pv-rebinding is still
 //     floating and could pair with the wrong claim. Wait.
+//   - Gate 5 "node-state": no bound claim pins the Pod to a node that
+//     is provably unusable (deleted, cordoned, NotReady, or occupied
+//     by an anti-affinity-conflicting pod). A scheduling failure
+//     message alone is not dead-node evidence. Wait.
 //
 // These names are the label values on the
 // `..._pvc_unbinder_gate_deferred_total` metric and appear in the
@@ -83,6 +87,7 @@ const (
 	gateMultiNode    = "multi-node"
 	gatePVCRebinding = "pvc-rebinding"
 	gateFreedPV      = "freed-pv"
+	gateNodeState    = "node-state"
 )
 
 // The unbinder stores its progress as annotations on the PVs it works
@@ -186,6 +191,14 @@ type Controller struct {
 	// node-affinity shapes). Unlike the pause annotation, it keeps the
 	// rest of the unbinder running.
 	DisableStuckClaimExemption bool
+	// DisableNodeCorroboration turns off Gate 5's node-state
+	// corroboration and restores the pre-gate behavior: unbind on the
+	// scheduling-failure message and timeout alone. It is an escape
+	// hatch for environments where the mis-pin proof chain cannot
+	// evaluate (for example, unusual local-PV node-affinity shapes,
+	// which [pvPinnedHostnames] refuses to interpret). Unlike the
+	// pause annotation, it keeps the rest of the unbinder running.
+	DisableNodeCorroboration bool
 	// ClusterName disambiguates cluster keys in multicluster mode.
 	// Empty for single-cluster operation.
 	ClusterName string
@@ -228,6 +241,7 @@ type MulticlusterController struct {
 	Selector                   labels.Selector
 	AllowRebinding             bool
 	DisableStuckClaimExemption bool
+	DisableNodeCorroboration   bool
 }
 
 // claimListForEvent renders a claim-name list for an Event note,
@@ -301,6 +315,7 @@ func (r *MulticlusterController) Reconcile(ctx context.Context, req mcreconcile.
 		Selector:                   r.Selector,
 		AllowRebinding:             r.AllowRebinding,
 		DisableStuckClaimExemption: r.DisableStuckClaimExemption,
+		DisableNodeCorroboration:   r.DisableNodeCorroboration,
 		ClusterName:                req.ClusterName,
 		Recorder:                   k8sCluster.GetEventRecorder("pvc-unbinder"),
 		Reader:                     k8sCluster.GetAPIReader(),
@@ -474,6 +489,12 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Under --allow-pv-rebinding there is NO exemption: freed PVs
 	// float as binding candidates, and acting while any claim is
 	// unbound could pair it with the wrong disk (INC-2818).
+	// nodeStateProven records whether this reconcile has live-confirmed
+	// the pod's own mis-pin proof. Gate 3's exemption path establishes it
+	// when unbound claims exist; Gate 5 requires it before anything
+	// destructive and computes it itself when Gate 3 never ran the chain.
+	nodeStateProven := false
+
 	clusterPVCsByName, err := r.listClusterPVCsByName(ctx, r.Client, &pod)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -597,6 +618,9 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			r.recordGateDeferred(&pod, gatePVCRebinding, fmt.Sprintf("unbound claims %s are exempted, but the reconciled Pod no longer holds its own mis-pin proof; deferring", claimListForEvent(liveExempted)))
 			return ctrl.Result{RequeueAfter: requeueDuringDisruption}, nil
 		}
+		// The proof above was re-confirmed against the live API server
+		// in this reconcile — exactly the fact Gate 5 needs.
+		nodeStateProven = true
 		// A safety gate is being overridden. Leave the same paper
 		// trail a deferral gets: metric, Event, and log, naming the
 		// exempted claims. Recorded only when the reconcile really
@@ -627,6 +651,40 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		logger.Info(msg, "name", pod.Name)
 		r.recordGateDeferred(&pod, gateFreedPV, msg)
 		return ctrl.Result{RequeueAfter: requeueDuringDisruption}, nil
+	}
+
+	// Gate 5 "node-state": the message check in [Controller.ShouldRemediate]
+	// is deliberately weak — any "0/N nodes are available" total failure
+	// matches, including plain resource pressure (Insufficient memory/cpu)
+	// on a perfectly healthy node. Deleting claims is only justified when
+	// the pod is pinned to a node it can never run on, so require the
+	// pod's own mis-pin proof (see [claimMispinnedForPod]): some Bound
+	// claim's PV pins it to a node that is deleted, cordoned, NotReady
+	// (judged through the pod's tolerations), or occupied by an
+	// anti-affinity-conflicting pod. When Gate 3's exemption path already
+	// live-confirmed that proof this reconcile, it is reused rather than
+	// recomputed. Evidence read failures defer conservatively — the same
+	// fail-safe direction as Gate 3's chain — with context cancellation
+	// surfacing as an error.
+	if !r.DisableNodeCorroboration && !pvGates.ownUnbindInFlight {
+		if !nodeStateProven {
+			proven, err := r.podHasMispinnedBoundClaim(ctx, &pod)
+			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctrl.Result{}, ctxErr
+				}
+				logger.Error(err, "failed to corroborate node state; keeping the conservative deferral", "name", pod.Name)
+				r.recordGateDeferred(&pod, gateNodeState, "node-state evidence read failed; deferring")
+				return ctrl.Result{RequeueAfter: requeueDuringDisruption}, nil
+			}
+			nodeStateProven = proven
+		}
+		if !nodeStateProven {
+			const msg = "no bound claim pins the Pod to an unusable node (deleted, cordoned, NotReady, or occupied by a conflicting pod); the scheduling failure alone is not dead-node evidence; deferring"
+			logger.Info(msg, "name", pod.Name)
+			r.recordGateDeferred(&pod, gateNodeState, msg)
+			return ctrl.Result{RequeueAfter: requeueDuringDisruption}, nil
+		}
 	}
 
 	// NB: We denote PVCs that are deleted as a nil entry within this map. If a
@@ -850,6 +908,14 @@ func (r *Controller) maybeRecyclePersistentVolume(ctx context.Context, pv *corev
 type pvGateState struct {
 	unbindInFlight    bool
 	freedPVUnresolved bool
+	// ownUnbindInFlight reports that the reconciled pod's OWN unbind
+	// is the one in flight (its claims are recorded in the in-flight
+	// annotations). Gate 0 lets such a reconcile proceed so the
+	// idempotent pipeline can finish; Gate 5 must equally stand down —
+	// the claims are already deleted, so no mis-pin proof can exist,
+	// and demanding one would strand the half-done unbind (and with it
+	// Gate 0's hold on the whole cluster) forever.
+	ownUnbindInFlight bool
 }
 
 // checkPVGates evaluates Gates 0 and 4 in one uncached pass over the
@@ -918,6 +984,7 @@ func (r *Controller) checkPVGates(ctx context.Context, clusterKey string, pod *c
 			case r.inFlightClaimOwnedBy(pv, ownClaims):
 				// This pod's own unfinished unbind — let the reconcile
 				// proceed so the idempotent pipeline can complete it.
+				state.ownUnbindInFlight = true
 			default:
 				state.unbindInFlight = true
 			}
@@ -1090,8 +1157,9 @@ func (r *Controller) ShouldRemediate(ctx context.Context, pod *corev1.Pod) (bool
 	// naming volume node affinity in the message somewhere between
 	// K8s 1.21 and 1.28 (exact version never tracked down), so we
 	// accept either an explicit mention or any "0/N nodes are
-	// available" total failure. Stronger proof comes later, from the
-	// exemption evidence chain, not from message text.
+	// available" total failure. Stronger proof comes later, from
+	// Gate 5's node-state corroboration (and Gate 3's exemption
+	// evidence chain), not from message text.
 	if !SchedulingFailureRE.MatchString(cond.Message) {
 		log.FromContext(ctx).Info("scheduling failure does not appear to indicate volume affinity issues; skipping", "name", pod.Name, "condition", cond)
 		return false, 0

--- a/operator/internal/controller/pvcunbinder/pvcunbinder_internal_test.go
+++ b/operator/internal/controller/pvcunbinder/pvcunbinder_internal_test.go
@@ -1507,35 +1507,52 @@ func TestReconcileGate3StuckClaimExemption(t *testing.T) {
 		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "shadow-index-cache-rp-1"}, &gotPVC), "nothing may be deleted when the evidence chain is unavailable")
 	})
 
-	t.Run("evidence reads are skipped entirely when no claim is unbound", func(t *testing.T) {
-		// The unbinder's original scenario — node dead, ALL claims
-		// Bound — must not depend on the exemption evidence chain at
-		// all: with zero unbound claims Gate 3 has nothing to defer
-		// on, so the (broken, per the interceptor) nodes LIST must
-		// never run and remediation must proceed exactly as it did
-		// before the exemption existed.
+	t.Run("all-claims-bound path defers conservatively when the evidence chain is unavailable", func(t *testing.T) {
+		// Historically the all-claims-bound path proceeded without any
+		// node evidence at all — with zero unbound claims Gate 3 had
+		// nothing to defer on, so remediation ran on the scheduling
+		// message and timeout alone. That hole let a healthy node's
+		// "Insufficient memory" failure — a misconfigured broker
+		// memory request is enough — delete data, and
+		// Gate 5 closes it: node corroboration now runs on every
+		// destructive path, so a broken nodes LIST (here: RBAC version
+		// skew, per the interceptor) downgrades to the conservative
+		// deferral instead of proceeding blind.
+		brokenNodeList := interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.NodeList); ok {
+					return apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "", fmt.Errorf("RBAC version skew"))
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}
 		pod := withPVC(podWithVolumeAffinityFailure("rp-1", "ns", "redpanda"), "datadir-rp-1")
 		mispinned := newPVC("datadir-rp-1", "ns", "redpanda", "pv-data-1")
 		pv := boundHostPathPV("pv-data-1", "datadir-rp-1", "node-a")
 		c := fake.NewClientBuilder().WithScheme(s).
 			WithObjects(wffc, pod, mispinned, pv).
-			WithInterceptorFuncs(interceptor.Funcs{
-				List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-					if _, ok := list.(*corev1.NodeList); ok {
-						return apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "", fmt.Errorf("RBAC version skew"))
-					}
-					return cl.List(ctx, list, opts...)
-				},
-			}).Build()
+			WithInterceptorFuncs(brokenNodeList).Build()
 		r := &Controller{Client: c}
 
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
-		require.NoError(t, err, "the all-claims-bound path must not touch the evidence chain")
-		require.Zero(t, res.RequeueAfter)
+		require.NoError(t, err, "an evidence-read failure must not fail the reconcile")
+		require.Equal(t, requeueDuringDisruption, res.RequeueAfter, "Gate 5 must fall back to the conservative deferral")
 
 		var gotPVC corev1.PersistentVolumeClaim
+		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "datadir-rp-1"}, &gotPVC), "nothing may be deleted when the evidence chain is unavailable")
+
+		// The pre-Gate-5 behavior — proceed with zero node evidence —
+		// remains reachable only through the explicit escape hatch.
+		c = fake.NewClientBuilder().WithScheme(s).
+			WithObjects(wffc, withPVC(podWithVolumeAffinityFailure("rp-1", "ns", "redpanda"), "datadir-rp-1"), newPVC("datadir-rp-1", "ns", "redpanda", "pv-data-1"), boundHostPathPV("pv-data-1", "datadir-rp-1", "node-a")).
+			WithInterceptorFuncs(brokenNodeList).Build()
+		r = &Controller{Client: c, DisableNodeCorroboration: true}
+
+		res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err, "with the escape hatch set, the broken evidence chain must not be consulted")
+		require.Zero(t, res.RequeueAfter)
 		err = r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "datadir-rp-1"}, &gotPVC)
-		require.True(t, apierrors.IsNotFound(err), "the mis-pinned bound claim must be deleted despite the broken nodes LIST")
+		require.True(t, apierrors.IsNotFound(err), "the escape hatch must restore the uncorroborated unbind")
 	})
 
 	t.Run("reconciled Pod is re-qualified on the uncached Reader before evidence or destruction", func(t *testing.T) {
@@ -3061,4 +3078,184 @@ func TestLostDiskClaimsResolvesNodeByHostnameLabel(t *testing.T) {
 	lost, err = LostDiskClaims(ctx, c, unbound)
 	require.NoError(t, err)
 	require.Empty(t, lost, "network-attached storage is never disk-loss proof")
+}
+
+// TestReconcileGate5NodeStateCorroboration exercises the node-state
+// gate: before anything destructive, the reconciled Pod must hold its
+// own mis-pin proof — a Bound claim pinned to a node that is deleted,
+// cordoned, NotReady, or occupied by an anti-affinity-conflicting pod.
+// A total scheduling failure alone (e.g. "Insufficient memory" on a
+// perfectly healthy node, as a misconfigured broker memory request
+// produces) matches
+// SchedulingFailureRE but is NOT evidence of a dead node, and must
+// defer instead of deleting data.
+func TestReconcileGate5NodeStateCorroboration(t *testing.T) {
+	ctx := context.Background()
+	s := newScheme(t, false, false, false)
+
+	boundHostPathPV := func(name, claimName, hostname string) *corev1.PersistentVolume {
+		pv := newPVWithAffinity(name, "ns", claimName, hostname)
+		pv.Spec.PersistentVolumeSource = corev1.PersistentVolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: "/data"},
+		}
+		pv.Status.Phase = corev1.VolumeBound
+		return pv
+	}
+
+	// memoryStarvedMsg is the scheduler message a memory-starved pod
+	// gets (e.g. after a misconfigured broker memory request): a
+	// total failure that matches SchedulingFailureRE's "^0/N nodes
+	// are available" alternative without any volume-affinity or
+	// dead-node content.
+	const memoryStarvedMsg = "0/6 nodes are available: 5 node(s) had untolerated taint {redpanda-node: true}, 1 Insufficient memory."
+
+	// boundBroker models a broker whose BOTH claims are Bound to
+	// HostPath PVs pinned to hostname, Pending on a scheduling
+	// failure. Whether the unbind may proceed depends solely on the
+	// pinned node's state.
+	boundBroker := func(name, hostname string) (*corev1.Pod, []client.Object) {
+		pod := withPVC(withPVC(newPod(name, "ns", "redpanda"), "datadir-"+name), "shadow-index-cache-"+name)
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:    corev1.PodScheduled,
+			Status:  corev1.ConditionFalse,
+			Reason:  "Unschedulable",
+			Message: memoryStarvedMsg,
+		}}
+		datadir := newPVC("datadir-"+name, "ns", "redpanda", "pv-data-"+name)
+		shadow := newPVC("shadow-index-cache-"+name, "ns", "redpanda", "pv-shadow-"+name)
+		pvData := boundHostPathPV("pv-data-"+name, "datadir-"+name, hostname)
+		pvShadow := boundHostPathPV("pv-shadow-"+name, "shadow-index-cache-"+name, hostname)
+		return pod, []client.Object{pod, datadir, shadow, pvData, pvShadow}
+	}
+
+	// requireUnbound asserts the full destructive pipeline ran: both
+	// claims deleted, both PVs Retained and annotated in-flight, and
+	// the pod deleted.
+	requireUnbound := func(t *testing.T, r *Controller, name string) {
+		t.Helper()
+		var gotPVC corev1.PersistentVolumeClaim
+		err := r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "datadir-" + name}, &gotPVC)
+		require.True(t, apierrors.IsNotFound(err), "the datadir claim must be deleted")
+		err = r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "shadow-index-cache-" + name}, &gotPVC)
+		require.True(t, apierrors.IsNotFound(err), "the shadow-index-cache claim must be deleted")
+		var gotPV corev1.PersistentVolume
+		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Name: "pv-data-" + name}, &gotPV))
+		require.Equal(t, corev1.PersistentVolumeReclaimRetain, gotPV.Spec.PersistentVolumeReclaimPolicy)
+		require.Equal(t, "/ns/redpanda", gotPV.Annotations[InFlightAnnotation])
+		var gotPod corev1.Pod
+		err = r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: name}, &gotPod)
+		require.True(t, apierrors.IsNotFound(err), "the pod must be deleted to re-trigger PVC creation")
+	}
+
+	t.Run("healthy pinned node defers instead of unbinding", func(t *testing.T) {
+		pod, objs := boundBroker("rp-1", "node-a")
+		recorder := &events.FakeRecorder{Events: make(chan string, 8)}
+		r := newController(t, s, append(objs, newNode("node-a"))...)
+		r.Recorder = recorder
+
+		deferredBefore := promtestutil.ToFloat64(observability.PVCUnbinderGateDeferred.WithLabelValues(gateNodeState))
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err)
+		require.Equal(t, requeueDuringDisruption, res.RequeueAfter, "a healthy pinned node is not dead-node evidence; the gate must defer")
+		require.Equal(t, deferredBefore+1, promtestutil.ToFloat64(observability.PVCUnbinderGateDeferred.WithLabelValues(gateNodeState)), "the deferral must be visible on the gate metric")
+
+		select {
+		case ev := <-recorder.Events:
+			require.Contains(t, ev, eventReasonGateDeferred)
+			require.Contains(t, ev, gateNodeState)
+		default:
+			t.Fatal("expected a PVCUnbinderDeferred event naming the node-state gate")
+		}
+
+		// Nothing destructive happened: claims alive, PV reclaim
+		// policy and annotations untouched, pod alive.
+		var gotPVC corev1.PersistentVolumeClaim
+		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "datadir-rp-1"}, &gotPVC))
+		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "shadow-index-cache-rp-1"}, &gotPVC))
+		var gotPV corev1.PersistentVolume
+		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Name: "pv-data-rp-1"}, &gotPV))
+		require.NotEqual(t, corev1.PersistentVolumeReclaimRetain, gotPV.Spec.PersistentVolumeReclaimPolicy, "the PV reclaim policy must not be flipped when the gate defers")
+		require.NotContains(t, gotPV.Annotations, InFlightAnnotation)
+		var gotPod corev1.Pod
+		require.NoError(t, r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "rp-1"}, &gotPod))
+	})
+
+	t.Run("deleted pinned node proceeds with the unbind", func(t *testing.T) {
+		pod, objs := boundBroker("rp-1", "node-gone")
+		r := newController(t, s, objs...) // no Node object: the node is gone
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err)
+		require.Zero(t, res.RequeueAfter, "a deleted node is the strongest dead-node proof; the unbind must proceed")
+		requireUnbound(t, r, "rp-1")
+	})
+
+	t.Run("cordoned pinned node proceeds with the unbind", func(t *testing.T) {
+		pod, objs := boundBroker("rp-1", "node-a")
+		node := newNode("node-a")
+		node.Spec.Unschedulable = true
+		r := newController(t, s, append(objs, node)...)
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err)
+		require.Zero(t, res.RequeueAfter, "a cordoned node cannot host the pod; the unbind must proceed")
+		requireUnbound(t, r, "rp-1")
+	})
+
+	t.Run("NotReady pinned node proceeds with the unbind", func(t *testing.T) {
+		pod, objs := boundBroker("rp-1", "node-a")
+		node := newNode("node-a")
+		node.Status.Conditions = []corev1.NodeCondition{{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionFalse,
+		}}
+		r := newController(t, s, append(objs, node)...)
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err)
+		require.Zero(t, res.RequeueAfter, "a NotReady node is dead-node evidence (absent an unconditional toleration); the unbind must proceed")
+		requireUnbound(t, r, "rp-1")
+	})
+
+	t.Run("escape hatch restores the uncorroborated behavior", func(t *testing.T) {
+		pod, objs := boundBroker("rp-1", "node-a")
+		r := newController(t, s, append(objs, newNode("node-a"))...)
+		r.DisableNodeCorroboration = true
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err)
+		require.Zero(t, res.RequeueAfter, "with the escape hatch set, the gate must not run")
+		requireUnbound(t, r, "rp-1")
+	})
+
+	t.Run("own in-flight unbind resumes without corroboration", func(t *testing.T) {
+		// Crash-interrupted unbind: the PVCs are already deleted and a
+		// PV carries the in-flight annotations, but the pod delete
+		// never happened. The resume must complete (delete the pod)
+		// even though no bound claim exists to prove anything —
+		// otherwise Gate 0 holds the whole cluster forever.
+		pod := withPVC(withPVC(newPod("rp-1", "ns", "redpanda"), "datadir-rp-1"), "shadow-index-cache-rp-1")
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:    corev1.PodScheduled,
+			Status:  corev1.ConditionFalse,
+			Reason:  "Unschedulable",
+			Message: memoryStarvedMsg,
+		}}
+		pv := boundHostPathPV("pv-data-rp-1", "datadir-rp-1", "node-a")
+		pv.Status.Phase = corev1.VolumeReleased
+		pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimRetain
+		pv.Annotations = map[string]string{
+			InFlightAnnotation:      "/ns/redpanda",
+			InFlightClaimAnnotation: "ns/datadir-rp-1/1111-2222",
+		}
+		r := newController(t, s, pod, pv, newNode("node-a")) // node healthy
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+		require.NoError(t, err)
+		require.Zero(t, res.RequeueAfter, "the pod's own half-done unbind must be allowed to finish")
+
+		var gotPod corev1.Pod
+		err = r.Client.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "rp-1"}, &gotPod)
+		require.True(t, apierrors.IsNotFound(err), "the resume must delete the pod to complete the interrupted unbind")
+	})
 }


### PR DESCRIPTION
## Why

The PVCUnbinder's trigger is deliberately weak by design: `SchedulingFailureRE` accepts any `0/N nodes are available` total scheduling failure, because scheduler message text is unstable across Kubernetes versions. But nothing stronger ever ran on the all-claims-bound path — Gate 3's mis-pin evidence chain only engages when some claim is unbound.

That combination makes plain resource pressure destructive. A user misconfiguring a broker's memory request is enough: the Pod goes `Pending` with `0/N nodes are available: … Insufficient memory` while every node stays healthy, and once `--unbind-pvcs-after` elapses the unbinder deletes the broker's PVCs anyway. The broker restarts empty under a new identity (leaving a ghost broker to decommission and a full re-replication), and the Retained PersistentVolumes strand the old data on the node's disks where nothing ever reclaims it.

## What

**Gate 5 "node-state"**: before anything destructive, the reconciled pod must hold its own mis-pin proof — a Bound claim whose PV pins it to a node that is **deleted**, **cordoned**, **NotReady/unreachable** (judged through the pod's tolerations, preserving the `--broker-pod-node-unavailable-toleration=-1s` contract), or **occupied by an anti-affinity-conflicting pod**. This reuses the existing `claimMispinnedForPod` → `nodeUnavailableForScheduling` evidence chain that Gate 3's exemption path already trusts for the same destructive decision — no new node-health semantics are introduced.

- When Gate 3's exemption path already live-confirmed the proof this reconcile, Gate 5 reuses it rather than recomputing.
- The pod's **own half-done unbind is exempt** (new `pvGateState.ownUnbindInFlight`): its claims are already deleted, so no proof can exist, and demanding one would strand the resume — and Gate 0's hold on the cluster — forever.
- **Evidence read failures defer conservatively** (fail-safe, same direction as Gate 3's chain); deferrals are visible on the existing `…pvc_unbinder_gate_deferred_total{gate="node-state"}` metric and `PVCUnbinderDeferred` pod Event.
- **Escape hatch** `--disable-unbinder-node-corroboration` (all three entry points: `run`, `multicluster`, `sidecar`) restores the pre-gate behavior, mirroring `--disable-pvc-rebinding-gate-exemption` — for environments where the proof chain cannot evaluate (e.g. local-PV node-affinity shapes `pvPinnedHostnames` refuses to interpret).
- Changelog entry included (`.changes/unreleased/`): improvement to the PVCUnbinder.

Behavior check: the memory-starved-pod shape now defers every 30s (alertable inaction) until the pod schedules; genuinely dead/cordoned/NotReady nodes and the fresh-cluster deadlock case Gate 3's exemption exists for proceed exactly as before.

## Testing

TDD — the healthy-node test was written first and failed against main (unbind proceeded where a deferral is required):

- `TestReconcileGate5NodeStateCorroboration`: healthy pinned node defers (nothing deleted, no Retain flip, metric + event fired); deleted / cordoned / NotReady node proceeds through the full pipeline; escape hatch restores the uncorroborated unbind; own in-flight unbind resumes without corroboration.
- The one existing test pinning the old invariant ("evidence reads are skipped entirely when no claim is unbound") asserted exactly the hole described above; rewritten to the new contract: broken evidence chain ⇒ conservative deferral, with the old proceed-blind behavior reachable only via the escape hatch.
- `go build ./...`, `go vet`, and the full `internal/controller/pvcunbinder` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)