### PR TITLE
operator: serve multicluster metrics over HTTPS so the ServiceMonitor can scrape

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260825-140000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260825-140000.yaml
@@ -1,0 +1,27 @@
+project: operator
+kind: Fixed
+body: |-
+    The `multicluster` command now serves its metrics endpoint over HTTPS by default, so the operator chart's ServiceMonitor can actually scrape a multicluster deployment.
+
+      The chart renders the ServiceMonitor with `scheme: https` and
+      `insecureSkipVerify: true`, which is what the `run` command's
+      `--metrics-secure` default (true) produces — controller-runtime terminates
+      TLS with a self-signed certificate when no certificate path is given. The
+      `multicluster` command had no such flag and enabled secure serving only when
+      `--metrics-cert-path`/`--metrics-key-path` were passed, which the chart never
+      does, so it listened for plain HTTP on the metrics port and every scrape
+      failed in the TLS handshake. Operator metrics from a multicluster
+      installation were therefore never collected. `multicluster` now takes the
+      same `--metrics-secure` flag, defaulting to true; the metrics endpoint stays
+      behind bearer-token authn/authz either way.
+
+      If you worked around this by overriding the rendered ServiceMonitor to
+      `scheme: http`, drop that override — the scrape now needs `https`. To keep
+      the old plain-HTTP endpoint instead, pass `--metrics-secure=false` to the
+      operator.
+
+      Relatedly, `rpk k8s multicluster bundle` now expects HTTPS unless
+      `--metrics-secure=false` is present in the deployment's arguments, and
+      retries a failed scrape with the other scheme so bundles still collect
+      metrics from operators predating this change.
+time: 2026-08-25T14:00:00-07:00

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/go-logr/logr"
 	"github.com/redpanda-data/common-go/kube"
 	"github.com/redpanda-data/common-go/license"
 	"github.com/redpanda-data/common-go/otelutil/log"
@@ -79,6 +80,7 @@ type MulticlusterOptions struct {
 	BaseTag                string
 	HealthProbeBindAddress string
 	MetricsBindAddress     string
+	MetricsSecure          bool
 	MetricsCertPath        string
 	MetricsKeyPath         string
 	WebhookCertPath        string
@@ -203,6 +205,69 @@ func peerFromFlag(value string) (RaftCluster, error) {
 	}, nil
 }
 
+// disableHTTP2 prevents us from being vulnerable to the HTTP/2 Stream
+// Cancellation and Rapid Reset CVEs. For more information see:
+// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+// - https://github.com/advisories/GHSA-4374-p667-p6c8
+func disableHTTP2(c *tls.Config) {
+	c.NextProtos = []string{"http/1.1"}
+}
+
+// metricsOptions builds the metrics server configuration, or nil when
+// --metrics-bind-address wasn't given (no metrics server).
+//
+// Secure serving defaults to on, matching the `run` command: the chart's
+// ServiceMonitor scrapes the metrics port over https with
+// insecureSkipVerify, and controller-runtime generates a self-signed
+// certificate when no --metrics-cert-path is supplied. Serving plain HTTP
+// here — which is what happened before secure serving got a default — meant
+// every scrape died in the TLS handshake, so the metrics of a multicluster
+// deployment were simply never collected.
+func (o *MulticlusterOptions) metricsOptions(ctx context.Context, setupLog logr.Logger) (*metricsserver.Options, error) {
+	if o.MetricsBindAddress == "" {
+		return nil, nil
+	}
+
+	options := &metricsserver.Options{
+		BindAddress: o.MetricsBindAddress,
+		// FilterProvider is used to protect the metrics endpoint with authn/authz.
+		// These configurations ensure that only authorized users and service accounts
+		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
+		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.4/pkg/metrics/filters#WithAuthenticationAndAuthorization
+		//
+		// NB: unlike `run`, the filter stays on even with
+		// --metrics-secure=false. Opting out of TLS shouldn't also opt out
+		// of authentication.
+		FilterProvider: filters.WithAuthenticationAndAuthorization,
+		// An explicit certificate implies secure serving, as the flag help says.
+		SecureServing: o.MetricsSecure || o.MetricsCertPath != "" || o.MetricsKeyPath != "",
+	}
+
+	if !options.SecureServing {
+		return options, nil
+	}
+
+	options.TLSOpts = []func(*tls.Config){disableHTTP2}
+
+	if o.MetricsCertPath != "" || o.MetricsKeyPath != "" {
+		// Set up all of the certificate watching code
+		metricsCertWatcher, err := certwatcher.New(o.MetricsCertPath, o.MetricsKeyPath)
+		if err != nil {
+			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
+			return nil, err
+		}
+		go func() {
+			setupLog.Error(metricsCertWatcher.Start(ctx), "metrics cert watcher exited")
+		}()
+
+		options.TLSOpts = append(options.TLSOpts, func(config *tls.Config) {
+			config.GetCertificate = metricsCertWatcher.GetCertificate
+		})
+	}
+
+	return options, nil
+}
+
 func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Name, "name", "", "raft node name")
 	cmd.Flags().StringVar(&o.Address, "raft-address", "", "raft node address")
@@ -221,6 +286,7 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "address for binding health check endpoint")
 	cmd.Flags().StringVar(&o.BaseImage, "base-image", "", "base image for sidecars and init containers")
 	cmd.Flags().StringVar(&o.BaseTag, "base-tag", "", "base image tag for sidecars and init containers")
+	cmd.Flags().BoolVar(&o.MetricsSecure, "metrics-secure", true, "If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	cmd.Flags().StringVar(&o.MetricsCertPath, "metrics-cert-path", "", "The path to the metrics server certificate file, implies secure serving of metrics")
 	cmd.Flags().StringVar(&o.MetricsKeyPath, "metrics-key-path", "", "The path to the metrics server key file, implies secure serving of metrics.")
 	cmd.Flags().StringVar(&o.LicenseFilePath, "license-file-path", "", "The path to the Redpanda License.")
@@ -326,43 +392,11 @@ func Run(
 		},
 	}
 
-	// Disabling http/2 is to
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		c.NextProtos = []string{"http/1.1"}
+	metrics, err := opts.metricsOptions(ctx, setupLog)
+	if err != nil {
+		return err
 	}
-
-	if opts.MetricsBindAddress != "" {
-		config.Metrics = &metricsserver.Options{
-			BindAddress: opts.MetricsBindAddress,
-			// FilterProvider is used to protect the metrics endpoint with authn/authz.
-			// These configurations ensure that only authorized users and service accounts
-			// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
-			// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.4/pkg/metrics/filters#WithAuthenticationAndAuthorization
-			FilterProvider: filters.WithAuthenticationAndAuthorization,
-		}
-
-		if opts.MetricsCertPath != "" || opts.MetricsKeyPath != "" {
-			// Set up all of the certificate watching code
-			metricsCertWatcher, err := certwatcher.New(opts.MetricsCertPath, opts.MetricsKeyPath)
-			if err != nil {
-				setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
-				return err
-			}
-			go func() {
-				setupLog.Error(metricsCertWatcher.Start(ctx), "metrics cert watcher exited")
-			}()
-			fetchCertificates := func(config *tls.Config) {
-				config.GetCertificate = metricsCertWatcher.GetCertificate
-			}
-
-			config.Metrics.SecureServing = true
-			config.Metrics.TLSOpts = []func(*tls.Config){disableHTTP2, fetchCertificates}
-		}
-	}
+	config.Metrics = metrics
 
 	if opts.WebhookCertPath != "" || opts.WebhookKeyPath != "" {
 		// Set up all of the certificate watching code

--- a/operator/cmd/multicluster/multicluster_test.go
+++ b/operator/cmd/multicluster/multicluster_test.go
@@ -10,10 +10,23 @@
 package multicluster
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 // validBaseOptions returns a MulticlusterOptions that passes validate() so a
@@ -59,4 +72,132 @@ func TestValidatePostRestartCaughtUpPercent(t *testing.T) {
 			require.NoError(t, o.validate())
 		})
 	}
+}
+
+// TestMetricsOptionsFlagDefault pins the flag default that the chart's
+// ServiceMonitor depends on. The rendered ServiceMonitor scrapes the metrics
+// port with `scheme: https` and `insecureSkipVerify`, which only works if the
+// metrics server terminates TLS; controller-runtime does that with a
+// self-signed certificate whenever SecureServing is set and no certificate
+// path is supplied.
+func TestMetricsOptionsFlagDefault(t *testing.T) {
+	cmd := Command()
+	require.NoError(t, cmd.Flags().Parse(nil))
+
+	secure, err := cmd.Flags().GetBool("metrics-secure")
+	require.NoError(t, err)
+	assert.True(t, secure, "--metrics-secure must default to true, or ServiceMonitor scrapes fail the TLS handshake")
+}
+
+func TestMetricsOptions(t *testing.T) {
+	ctx := context.Background()
+	logger := testr.New(t)
+
+	// nextProtos reports the ALPN protocols the built TLSOpts settle on,
+	// which is how the HTTP/2 opt-out is observable.
+	nextProtos := func(options *metricsserver.Options) []string {
+		config := &tls.Config{NextProtos: []string{"h2"}} //nolint:gosec // no MinVersion needed; only TLSOpts' effect is under test
+		for _, opt := range options.TLSOpts {
+			opt(config)
+		}
+		return config.NextProtos
+	}
+
+	t.Run("no bind address disables the metrics server", func(t *testing.T) {
+		o := validBaseOptions()
+		o.MetricsSecure = true
+
+		options, err := o.metricsOptions(ctx, logger)
+		require.NoError(t, err)
+		assert.Nil(t, options)
+	})
+
+	t.Run("serves TLS by default", func(t *testing.T) {
+		o := validBaseOptions()
+		o.MetricsBindAddress = ":8443"
+		o.MetricsSecure = true
+
+		options, err := o.metricsOptions(ctx, logger)
+		require.NoError(t, err)
+		require.NotNil(t, options)
+		assert.Equal(t, ":8443", options.BindAddress)
+		assert.True(t, options.SecureServing)
+		assert.NotNil(t, options.FilterProvider, "metrics must stay behind authn/authz")
+		// No certificate path: controller-runtime generates a self-signed one.
+		assert.Equal(t, []string{"http/1.1"}, nextProtos(options), "HTTP/2 must be disabled")
+	})
+
+	t.Run("opting out of TLS keeps authn/authz", func(t *testing.T) {
+		o := validBaseOptions()
+		o.MetricsBindAddress = ":8443"
+		o.MetricsSecure = false
+
+		options, err := o.metricsOptions(ctx, logger)
+		require.NoError(t, err)
+		require.NotNil(t, options)
+		assert.False(t, options.SecureServing)
+		assert.NotNil(t, options.FilterProvider, "--metrics-secure=false must not also drop authentication")
+		assert.Empty(t, options.TLSOpts)
+	})
+
+	t.Run("a certificate path implies TLS", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := writeSelfSignedKeyPair(t, dir)
+
+		o := validBaseOptions()
+		o.MetricsBindAddress = ":8443"
+		// Explicitly off: the certificate flags still win, as their help says.
+		o.MetricsSecure = false
+		o.MetricsCertPath = certPath
+		o.MetricsKeyPath = keyPath
+
+		options, err := o.metricsOptions(ctx, logger)
+		require.NoError(t, err)
+		require.NotNil(t, options)
+		assert.True(t, options.SecureServing)
+
+		config := &tls.Config{} //nolint:gosec // no MinVersion needed; only TLSOpts' effect is under test
+		for _, opt := range options.TLSOpts {
+			opt(config)
+		}
+		assert.Equal(t, []string{"http/1.1"}, config.NextProtos)
+		require.NotNil(t, config.GetCertificate, "the certificate watcher must be wired up")
+	})
+
+	t.Run("an unreadable certificate is a startup error", func(t *testing.T) {
+		o := validBaseOptions()
+		o.MetricsBindAddress = ":8443"
+		o.MetricsCertPath = filepath.Join(t.TempDir(), "absent.crt")
+		o.MetricsKeyPath = filepath.Join(t.TempDir(), "absent.key")
+
+		_, err := o.metricsOptions(ctx, logger)
+		require.Error(t, err)
+	})
+}
+
+// writeSelfSignedKeyPair writes a throwaway certificate/key pair into dir and
+// returns their paths. certwatcher.New insists on a loadable pair.
+func writeSelfSignedKeyPair(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}), 0o600))
+
+	return certPath, keyPath
 }

--- a/operator/cmd/multicluster/multicluster_test.go
+++ b/operator/cmd/multicluster/multicluster_test.go
@@ -10,7 +10,6 @@
 package multicluster
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -90,7 +89,7 @@ func TestMetricsOptionsFlagDefault(t *testing.T) {
 }
 
 func TestMetricsOptions(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := testr.New(t)
 
 	// nextProtos reports the ALPN protocols the built TLSOpts settle on,

--- a/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics.go
@@ -277,8 +277,16 @@ func collectClusterMetrics(
 		}
 		data, err := fetcher.Metrics(ctx, cc.Namespace, cc.Pod.Name, scheme, port)
 		if err != nil && !schemeConfirmed {
-			if fallbackData, fallbackErr := fetcher.Metrics(ctx, cc.Namespace, cc.Pod.Name, fallback, port); fallbackErr == nil {
+			fallbackData, fallbackErr := fetcher.Metrics(ctx, cc.Namespace, cc.Pod.Name, fallback, port)
+			if fallbackErr == nil {
 				scheme, data, err = fallback, fallbackData, nil
+			} else {
+				// Both schemes failed. Keep the args-implied scheme as the
+				// primary cause but carry the fallback's error too: dropping it
+				// makes the bundle look like only one scheme was ever tried,
+				// which is the opposite of what happened and sends whoever
+				// reads it looking for a scheme bug that isn't there.
+				err = fmt.Errorf("%w (fallback %s: %w)", err, fallback, fallbackErr)
 			}
 		}
 		if err != nil {

--- a/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics.go
@@ -244,6 +244,16 @@ func collectClusterMetrics(
 		return nil
 	}
 	scheme := metricsScheme(cc.DeployArgs)
+	// The deployment args only tell us what the operator was *asked* to do,
+	// and the default flipped: builds before secure serving was defaulted on
+	// served plain HTTP for the same args that now mean HTTPS. Rather than
+	// version-sniff the image, fall back to the other scheme once and keep
+	// whichever one answers.
+	fallback := "http"
+	if scheme == "http" {
+		fallback = "https"
+	}
+	schemeConfirmed := false
 
 	if opts.Samples < 1 {
 		opts.Samples = 1
@@ -266,11 +276,17 @@ func collectClusterMetrics(
 			progress("[%s] /metrics sample %d/%d", cc.Context, i+1, opts.Samples)
 		}
 		data, err := fetcher.Metrics(ctx, cc.Namespace, cc.Pod.Name, scheme, port)
+		if err != nil && !schemeConfirmed {
+			if fallbackData, fallbackErr := fetcher.Metrics(ctx, cc.Namespace, cc.Pod.Name, fallback, port); fallbackErr == nil {
+				scheme, data, err = fallback, fallbackData, nil
+			}
+		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("scraping metrics from %s/%s sample %d/%d (%s://:%d): %w",
 				cc.Pod.Namespace, cc.Pod.Name, i+1, opts.Samples, scheme, port, err))
 			continue
 		}
+		schemeConfirmed = true
 		entry := path.Join("clusters", cc.Context, "metrics", fmt.Sprintf("t%d_metrics.txt", i))
 		if werr := bw.writeBytes(entry, data); werr != nil {
 			errs = append(errs, werr)
@@ -308,13 +324,24 @@ func parseMetricsPort(args []string) (int, bool) {
 	return port, true
 }
 
-// metricsScheme returns "https" when the deployment was started with
-// --metrics-cert-path / --metrics-key-path (controller-runtime turns on
-// SecureServing in that case), and "http" otherwise. Used by the
-// apiserver pod-proxy URL builder.
+// metricsScheme returns the scheme the operator's metrics server is expected
+// to speak, read off the deployment's container args.
+//
+// Both `run` and `multicluster` default --metrics-secure to true, so HTTPS is
+// the default answer: controller-runtime serves TLS with a self-signed
+// certificate when no --metrics-cert-path is given. Only an explicit
+// --metrics-secure=false means plain HTTP.
+//
+// This is a best guess, not a contract — see collectClusterMetrics, which
+// retries with the other scheme. Multicluster deployments from before secure
+// serving was defaulted on served plain HTTP with no --metrics-secure flag in
+// their args at all.
 func metricsScheme(args []string) string {
 	if checks.ExtractFlag(args, "--metrics-cert-path") != "" {
 		return "https"
 	}
-	return "http"
+	if checks.ExtractFlag(args, "--metrics-secure") == "false" {
+		return "http"
+	}
+	return "https"
 }

--- a/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics_test.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics_test.go
@@ -246,7 +246,8 @@ type schemeAwareFetcher struct {
 func (f *schemeAwareFetcher) Metrics(_ context.Context, _, _, scheme string, _ int) ([]byte, error) {
 	f.schemes = append(f.schemes, scheme)
 	if scheme != f.serves {
-		return nil, fmt.Errorf("tls: first record does not look like a TLS handshake")
+		// Name the scheme so a caller that tried both can be shown to report both.
+		return nil, fmt.Errorf("tls: first record does not look like a TLS handshake (%s)", scheme)
 	}
 	return []byte("ok"), nil
 }
@@ -298,6 +299,10 @@ func TestCollectClusterMetrics_FallbackDoesNotMaskRealErrors(t *testing.T) {
 	require.Len(t, errs, 1, "a scheme that never answers must still be reported once")
 	assert.Contains(t, errs[0].Error(), "TLS handshake")
 	assert.Equal(t, []string{"https", "http"}, fetcher.schemes, "exactly one fallback attempt")
+	// Both attempts are accounted for, so the report can't be mistaken for a
+	// single-scheme failure.
+	assert.Contains(t, errs[0].Error(), "(https)", "the args-implied scheme's failure")
+	assert.Contains(t, errs[0].Error(), "(http)", "the fallback's failure")
 }
 
 func TestParseMetricsPort(t *testing.T) {

--- a/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics_test.go
+++ b/operator/cmd/rpk-k8s/k8s/multicluster/bundle_metrics_test.go
@@ -87,7 +87,7 @@ func TestCollectClusterMetrics_HappyPath(t *testing.T) {
 
 	// One scrape, against the right pod and port.
 	require.Len(t, fetcher.calls, 1)
-	assert.Equal(t, metricsCall{Namespace: "redpanda", PodName: "operator-0", Scheme: "http", Port: 8443}, fetcher.calls[0])
+	assert.Equal(t, metricsCall{Namespace: "redpanda", PodName: "operator-0", Scheme: "https", Port: 8443}, fetcher.calls[0])
 
 	// t0_metrics.txt must contain the canned body verbatim.
 	files := readZipFilesInternal(t, buf.Bytes())
@@ -235,6 +235,71 @@ func TestCollectClusterMetrics_ErrorIsRecorded(t *testing.T) {
 	}
 }
 
+// schemeAwareFetcher answers only over `serves` and records every attempt,
+// standing in for an operator whose actual TLS mode disagrees with what its
+// deployment args imply.
+type schemeAwareFetcher struct {
+	serves  string
+	schemes []string
+}
+
+func (f *schemeAwareFetcher) Metrics(_ context.Context, _, _, scheme string, _ int) ([]byte, error) {
+	f.schemes = append(f.schemes, scheme)
+	if scheme != f.serves {
+		return nil, fmt.Errorf("tls: first record does not look like a TLS handshake")
+	}
+	return []byte("ok"), nil
+}
+
+// TestCollectClusterMetrics_FallsBackToOtherScheme covers scraping an operator
+// old enough to serve plain HTTP for args that now imply HTTPS. The args say
+// https, the server speaks http, and the bundle must still get its samples —
+// with the working scheme reused rather than re-probed for every sample.
+func TestCollectClusterMetrics_FallsBackToOtherScheme(t *testing.T) {
+	cc := &checks.CheckContext{
+		Context:    "self",
+		Namespace:  "redpanda",
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "operator-0", Namespace: "redpanda"}},
+		DeployArgs: []string{"--metrics-bind-address=:8443"},
+	}
+	fetcher := &schemeAwareFetcher{serves: "http"}
+
+	var buf bytes.Buffer
+	bw := newBundleWriter(&buf)
+	errs := collectClusterMetrics(context.Background(), bw, cc, fetcher, MetricsOptions{Samples: 2, Interval: time.Millisecond}, nil)
+	require.NoError(t, bw.Close())
+	require.Empty(t, errs)
+
+	assert.Equal(t, []string{"https", "http", "http"}, fetcher.schemes)
+
+	files := readZipFilesInternal(t, buf.Bytes())
+	assert.Contains(t, files, "clusters/self/metrics/t0_metrics.txt")
+	assert.Contains(t, files, "clusters/self/metrics/t1_metrics.txt")
+}
+
+// TestCollectClusterMetrics_FallbackDoesNotMaskRealErrors pins that the
+// fallback is a one-shot scheme probe, not a blanket retry: an authorization
+// failure still surfaces, and once a scheme is known to work a later failure
+// isn't re-probed.
+func TestCollectClusterMetrics_FallbackDoesNotMaskRealErrors(t *testing.T) {
+	cc := &checks.CheckContext{
+		Context:    "self",
+		Namespace:  "redpanda",
+		Pod:        &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "operator-0", Namespace: "redpanda"}},
+		DeployArgs: []string{"--metrics-bind-address=:8443"},
+	}
+	fetcher := &schemeAwareFetcher{serves: "neither"}
+
+	var buf bytes.Buffer
+	bw := newBundleWriter(&buf)
+	errs := collectClusterMetrics(context.Background(), bw, cc, fetcher, singleSampleOpts, nil)
+	require.NoError(t, bw.Close())
+
+	require.Len(t, errs, 1, "a scheme that never answers must still be reported once")
+	assert.Contains(t, errs[0].Error(), "TLS handshake")
+	assert.Equal(t, []string{"https", "http"}, fetcher.schemes, "exactly one fallback attempt")
+}
+
 func TestParseMetricsPort(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -258,9 +323,22 @@ func TestParseMetricsPort(t *testing.T) {
 }
 
 func TestMetricsScheme(t *testing.T) {
-	assert.Equal(t, "http", metricsScheme([]string{"--metrics-bind-address=:8443"}))
+	// --metrics-secure defaults to true in both `run` and `multicluster`, so
+	// bare args mean TLS with a self-signed certificate.
+	assert.Equal(t, "https", metricsScheme([]string{"--metrics-bind-address=:8443"}))
 	assert.Equal(t, "https", metricsScheme([]string{
 		"--metrics-bind-address=:8443",
+		"--metrics-cert-path=/tls/tls.crt",
+	}))
+	assert.Equal(t, "http", metricsScheme([]string{
+		"--metrics-bind-address=:8443",
+		"--metrics-secure=false",
+	}))
+	// An explicit certificate wins over --metrics-secure=false, matching the
+	// server: a cert path implies secure serving.
+	assert.Equal(t, "https", metricsScheme([]string{
+		"--metrics-bind-address=:8443",
+		"--metrics-secure=false",
 		"--metrics-cert-path=/tls/tls.crt",
 	}))
 }


### PR DESCRIPTION
## Problem

With `monitoring.enabled: true` on a multicluster (StretchCluster) install, the rendered ServiceMonitor can never scrape the operator. Reported from the field on chart/image 26.2.2; still present on `main`.

* The chart renders the ServiceMonitor unconditionally with `scheme: https`, `insecureSkipVerify: true`, and a bearer token file (`operator/chart/servicemonitor.go`) — there is no multicluster-mode conditional.
* The chart's multicluster Deployment passes only `--metrics-bind-address=:8443` (`operator/chart/multicluster_deployment.go`), never `--metrics-cert-path`/`--metrics-key-path`.
* `operator/cmd/multicluster/multicluster.go` set `SecureServing` **only** when those cert flags were given, while always installing `filters.WithAuthenticationAndAuthorization`.

Net result: plain HTTP on `:8443` behind bearer authn/authz, with Prometheus speaking TLS to it. Every scrape dies in the handshake, so a multicluster installation collects no operator metrics at all.

Root cause is a parity gap with `run`, which has `--metrics-secure` defaulting to **true** — controller-runtime then serves TLS with a self-signed certificate, which is exactly what the ServiceMonitor's `https` + `insecureSkipVerify` was written for. `multicluster` had no such flag.

Reproduced with envtest against the exact `metricsserver.Options` the command builds from the chart's args:

```
REPRO 1: TLS handshake (what the ServiceMonitor / curl -k https:// does): FAILED: tls: first record does not look like a TLS handshake
REPRO 2: plain HTTP, no token: 401 Unauthorized
REPRO 3: plain HTTP + authorized SA token: 200 OK, 54919 bytes of metrics
```

## The fix

Give `multicluster` the same `--metrics-secure` flag, defaulting to true. The existing ServiceMonitor becomes correct as-is — **no chart change needed**.

Two deliberate differences from `run`:

* The authn/authz filter stays installed even with `--metrics-secure=false`. Opting out of TLS shouldn't also opt out of authentication.
* HTTP/2 is always disabled (the CVE mitigation that was previously only applied on the cert-path branch), since `multicluster` has no `--enable-http2` escape hatch.

The metrics options moved out of `Run` into a method so the defaults are unit-testable without standing up a manager.

### Compatibility

Anyone who worked around this by post-rendering the ServiceMonitor to `scheme: http` must drop that override — the scrape now needs `https`. To keep a plain-HTTP endpoint instead, pass `--metrics-secure=false`. Called out in the changelog entry.

The second commit handles the other side of the same flip: `rpk k8s multicluster bundle` inferred the scheme from deployment args and assumed HTTP unless `--metrics-cert-path` was set. It now defaults to HTTPS, honors an explicit `--metrics-secure=false`, and — because an old operator's args are indistinguishable from a new one's, neither carrying the flag — retries a failed scrape once with the other scheme and keeps whichever answers. That keeps bundles working against deployments that predate this change. The retry is a one-shot scheme probe, so a 403 from missing `nonResourceURLs: /metrics` RBAC still surfaces once per sample rather than doubling attempts. When the probe fails too, both errors are reported — the args-implied scheme as the primary cause with the fallback's error carried alongside it — so a bundle can't be misread as having only ever tried one scheme.

## Testing

* `TestMetricsOptionsFlagDefault` pins `--metrics-secure=true` as the default, which is the thing the ServiceMonitor depends on.
* `TestMetricsOptions` covers: no bind address → no metrics server; default → `SecureServing` with HTTP/2 off and the filter installed; `--metrics-secure=false` → plain HTTP but authn/authz retained; a cert path implies TLS and wires the cert watcher (real generated key pair) even against `--metrics-secure=false`; an unreadable cert is a startup error.
* `TestCollectClusterMetrics_FallsBackToOtherScheme` scrapes an HTTP-only server with args that imply HTTPS and asserts the probe sequence `https, http, http` — the working scheme is reused, not re-probed per sample.
* `TestCollectClusterMetrics_FallbackDoesNotMaskRealErrors` asserts exactly one fallback attempt, that a never-answering endpoint still reports an error, and that the report names both schemes tried. The stub fetcher names the scheme in its error so the two are distinguishable.
* Updated `TestCollectClusterMetrics_HappyPath` and `TestMetricsScheme` for the new default.
* `go build ./operator/...`, `go vet`, and `golangci-lint run` on both packages are clean.

## Review follow-ups

Both nits from @RafalKorepta's review, in 704ec2ef:

* `TestMetricsOptions` uses `t.Context()` rather than `context.Background()`.
* The fallback scrape no longer discards `fallbackErr` when it also fails. Concatenated rather than overwritten, since the fallback is the *less* likely scheme by construction — the deploy args say otherwise — so the args-implied scheme stays the primary cause.

## Not in this PR

The sibling reports from the same source — PromQL recording rules and the Grafana dashboard having no job/namespace matcher, and `OperatorReconcileRunaway`/`OperatorWorkerPoolSaturated` firing on a healthy Topic steady state — are separate changes and are tracked separately.
