### PR TITLE
operator: cover v1 Cluster annotation propagation in envtest

### DIFF
--- a/operator/internal/controller/vectorized/cluster_controller_annotations_test.go
+++ b/operator/internal/controller/vectorized/cluster_controller_annotations_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package vectorized
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/redpanda-data/common-go/kube"
+	"github.com/redpanda-data/common-go/kube/kubetest"
+	"github.com/redpanda-data/common-go/otelutil/log"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+	crds "github.com/redpanda-data/redpanda-operator/operator/config/crd/bases"
+	"github.com/redpanda-data/redpanda-operator/operator/internal/controller"
+	"github.com/redpanda-data/redpanda-operator/operator/pkg/resources"
+)
+
+// annotationKey is the pod annotation the propagation subtests add to
+// Cluster.Spec.Annotations and then look for downstream.
+const annotationKey = "test.redpanda.com/propagation"
+
+// TestClusterSpecAnnotationsReachStatefulSet covers, deterministically and
+// without a cluster, the half of the sts-annotation-propagation kuttl test
+// that lives in the operator: Cluster.Spec.Annotations must reach the
+// StatefulSet's pod template.
+//
+// envtest has no kubelet, so the kuttl test is still what proves the
+// annotation lands on live *pods* — that needs the health-gated, one-at-a-time
+// roll, since these StatefulSets run OnDelete and a template update alone
+// never touches a running pod. What's covered here is everything up to that
+// point, which is where a template-propagation regression would actually show:
+// when the kuttl test last failed, the pod template itself had never been
+// updated.
+func TestClusterSpecAnnotationsReachStatefulSet(t *testing.T) {
+	testScheme := controller.UnifiedScheme
+	ctx := log.IntoContext(t.Context(), testr.New(t))
+
+	ctl := kubetest.NewEnv(t, kube.Options{
+		Options: client.Options{Scheme: testScheme},
+	})
+
+	require.NoError(t, kube.ApplyAllAndWait(ctx, ctl, func(crd *apiextensionsv1.CustomResourceDefinition, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+
+		for _, cond := range crd.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established {
+				return cond.Status == apiextensionsv1.ConditionTrue, nil
+			}
+		}
+
+		return false, nil
+	}, crds.All()...))
+
+	mgr, err := ctrl.NewManager(ctl.RestConfig(), manager.Options{
+		Logger:  testr.New(t),
+		Scheme:  testScheme,
+		Metrics: server.Options{BindAddress: "0"},
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	require.NoError(t, err)
+
+	reconciler, adminAPIs := createTestReconcilerWithAdminAPIs(t, mgr)
+	require.NoError(t, reconciler.SetupWithManager(mgr))
+
+	go func() {
+		require.NoError(t, mgr.Start(ctx))
+	}()
+
+	// createConvergedCluster applies a Cluster and waits for its StatefulSet to
+	// exist. Waiting matters: annotating before the StatefulSet is created
+	// would be picked up by the create path, which proves nothing about
+	// updates.
+	//
+	// externalKafkaPort must be unique per cluster. minimalClusterDef hardcodes
+	// the external Kafka listener's node port, and its NodePort Service failing
+	// to allocate blocks the StatefulSet entirely: Ensure resolves the node port
+	// Service before it renders anything.
+	createConvergedCluster := func(t *testing.T, name string, externalKafkaPort int) (*vectorizedv1alpha1.Cluster, *appsv1.StatefulSet) {
+		t.Helper()
+
+		cluster := minimalClusterDef()
+		cluster.Name = name
+		for i := range cluster.Spec.Configuration.KafkaAPI {
+			if cluster.Spec.Configuration.KafkaAPI[i].External.Enabled {
+				cluster.Spec.Configuration.KafkaAPI[i].Port = externalKafkaPort
+			}
+		}
+		require.NoError(t, ctl.Apply(ctx, cluster))
+
+		sts := &appsv1.StatefulSet{ObjectMeta: cluster.ObjectMeta}
+		sts.Name = cluster.Name
+		require.NoError(t, ctl.WaitFor(ctx, sts, func(_ kube.Object, err error) (bool, error) {
+			if err != nil {
+				return false, client.IgnoreNotFound(err)
+			}
+			return true, nil
+		}), "the StatefulSet was never created")
+		require.NotContains(t, sts.Spec.Template.Annotations, annotationKey)
+
+		return cluster, sts
+	}
+
+	annotate := func(t *testing.T, cluster *vectorizedv1alpha1.Cluster) {
+		t.Helper()
+
+		live := &vectorizedv1alpha1.Cluster{}
+		require.NoError(t, ctl.Get(ctx, kube.AsKey(cluster), live))
+		live.Spec.Annotations = map[string]string{annotationKey: "works"}
+		require.NoError(t, ctl.Update(ctx, live))
+	}
+
+	awaitPropagation := func(t *testing.T, sts *appsv1.StatefulSet) error {
+		t.Helper()
+
+		return ctl.WaitFor(ctx, sts, func(obj kube.Object, err error) (bool, error) {
+			if err != nil {
+				return false, client.IgnoreNotFound(err)
+			}
+			return obj.(*appsv1.StatefulSet).Spec.Template.Annotations[annotationKey] == "works", nil
+		})
+	}
+
+	t.Run("annotating a live Cluster updates the pod template", func(t *testing.T) {
+		cluster, sts := createConvergedCluster(t, "annotation-propagation", 30093)
+		annotate(t, cluster)
+
+		require.NoError(t, awaitPropagation(t, sts),
+			"the annotation never reached the StatefulSet pod template")
+		// The rendered configmap hash must survive alongside it — the render
+		// merges spec.annotations with its own bookkeeping rather than
+		// replacing either.
+		require.Contains(t, sts.Spec.Template.Annotations, resources.ConfigMapHashAnnotationKey)
+	})
+
+	t.Run("an unreachable cluster doesn't hold up the pod template", func(t *testing.T) {
+		cluster, sts := createConvergedCluster(t, "annotation-unreachable", 30094)
+
+		// Writing the StatefulSet spec is deliberately upstream of every
+		// health gate: updateStatefulSet runs before isClusterHealthy, and the
+		// admin API is only consulted after the resources are ensured. Only
+		// the subsequent pod roll waits on the cluster. If that ordering ever
+		// inverts, a spec change would become undeliverable exactly when the
+		// cluster most needs one.
+		api := adminAPIs.Get(cluster.Name)
+		require.NotNil(t, api, "the reconciler never built an admin API client for this cluster")
+		api.SetUnavailable(true)
+		api.SetClusterHealth(false)
+
+		annotate(t, cluster)
+
+		require.NoError(t, awaitPropagation(t, sts),
+			"an unreachable cluster blocked a change that needs no cluster interaction")
+	})
+}

--- a/operator/internal/controller/vectorized/cluster_controller_test.go
+++ b/operator/internal/controller/vectorized/cluster_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -136,7 +137,31 @@ func TestClusterControllerGolden(t *testing.T) {
 
 // createTestReconciler creates a standard test reconciler with mock admin API
 func createTestReconciler(t *testing.T, mgr manager.Manager) *ClusterReconciler {
-	adminAPIs := map[string]*admin.MockAdminAPI{}
+	reconciler, _ := createTestReconcilerWithAdminAPIs(t, mgr)
+	return reconciler
+}
+
+// mockAdminAPIRegistry holds the per-cluster mock admin APIs a test reconciler
+// hands out, so a test can reach in and change how the "cluster" behaves
+// mid-test (see SetUnavailable, SetClusterHealth).
+type mockAdminAPIRegistry struct {
+	mu   sync.Mutex
+	apis map[string]*admin.MockAdminAPI
+}
+
+// Get returns the mock built for the named cluster, or nil if the reconciler
+// hasn't asked for one yet.
+func (r *mockAdminAPIRegistry) Get(name string) *admin.MockAdminAPI {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.apis[name]
+}
+
+// createTestReconcilerWithAdminAPIs is createTestReconciler with the mock admin
+// API registry returned as well.
+func createTestReconcilerWithAdminAPIs(t *testing.T, mgr manager.Manager) (*ClusterReconciler, *mockAdminAPIRegistry) {
+	registry := &mockAdminAPIRegistry{apis: map[string]*admin.MockAdminAPI{}}
+	adminAPIs := registry.apis
 
 	return (&ClusterReconciler{
 		Client:                   mgr.GetClient(),
@@ -147,6 +172,9 @@ func createTestReconciler(t *testing.T, mgr manager.Manager) *ClusterReconciler 
 		Timeout:                  10 * time.Second,
 		CloudSecretsExpander:     &secrets.CloudExpander{},
 		AdminAPIClientFactory: func(ctx context.Context, k8sClient client.Reader, redpandaCluster *vectorizedv1alpha1.Cluster, fqdn string, adminTLSProvider resourcetypes.AdminTLSConfigProvider, dialer redpanda.DialContextFunc, timeout time.Duration, pods ...string) (admin.AdminAPIClient, error) {
+			registry.mu.Lock()
+			defer registry.mu.Unlock()
+
 			if api, ok := adminAPIs[redpandaCluster.Name]; ok {
 				return api, nil
 			}
@@ -169,7 +197,7 @@ func createTestReconciler(t *testing.T, mgr manager.Manager) *ClusterReconciler 
 		skipNameValidation: true,
 	}).WithClusterDomain("cluster.local").WithConfiguratorSettings(resources.ConfiguratorSettings{
 		ImagePullPolicy: corev1.PullIfNotPresent,
-	})
+	}), registry
 }
 
 func minimalClusterDef() *vectorizedv1alpha1.Cluster {


### PR DESCRIPTION
## Why

`sts-annotation-propagation` (the kuttl control experiment added alongside the v1 Broker CRD work) is the only coverage that `Cluster.Spec.Annotations` reaches the brokers. Getting there needs a real three-broker cluster and a health-gated, one-at-a-time roll — roughly ten minutes of wall clock, nearly all of it waiting on machinery the propagation logic has no part in. It timed out in build 15363.

Its diagnostic dump showed the StatefulSet's **pod template** had never been updated:

```
sts-annotation: {"redpanda.vectorized.io/configmap-hash":"4f5983102c41de9c4fe340d87ae0102a"}
```

That claim needs neither a kubelet nor a broker to check, so this adds a ~20s deterministic test for it.

## What's covered

Two subtests sharing one envtest environment and manager, driving the real `ClusterReconciler` with the existing mocked admin API:

1. **`annotating a live Cluster updates the pod template`** — create the Cluster, wait for the StatefulSet to exist (so we exercise the update path, not the create path), patch `spec.annotations`, and assert the pod template picks it up alongside the rendered configmap hash.

2. **`an unreachable cluster doesn't hold up the pod template`** — same flow with the admin API made unavailable and cluster health false before annotating. This pins the ordering that makes the change land promptly: `updateStatefulSet` runs before `isClusterHealthy`, and the admin API is only consulted after `ar.Ensure()`, so an unreachable cluster delays the pod *roll* but not the spec write. If that ordering ever inverts, a spec change becomes undeliverable exactly when the cluster most needs one.

## What is deliberately not covered

The kuttl test stays exactly as-is. These StatefulSets run `OnDelete`, so a template update alone never touches a running pod — end-to-end propagation onto live pods is only observable with a kubelet, and that remains kuttl's job. This is the operator-side half.

## Note for anyone extending this

Each Cluster in the shared environment needs its own external Kafka node port. `minimalClusterDef` hardcodes `30093`, and a NodePort Service that can't allocate blocks the StatefulSet outright — `StatefulSetResource.Ensure` resolves that Service before it renders anything. A collision therefore presents as "the template never updated", which is indistinguishable from the bug this test is looking for. It cost me one confusing run; the helper now takes the port explicitly and says why.

`createTestReconciler` grows a variant returning the mock admin API registry so a test can take the cluster away mid-run. The existing golden test is unaffected.

## Testing

Whole `internal/controller/vectorized` package green over three consecutive runs (`-count=3`, ~4 min), `golangci-lint` clean.

Labeled `no-changelog`: test-only, no user-facing change.
