### PR TITLE
licenseupdater: update ignores patterns

### DIFF
--- a/.licenseupdater.yaml
+++ b/.licenseupdater.yaml
@@ -17,6 +17,10 @@ ignore:
   - match: .+\.rewritten\.go$
   # Ignore go files from genpartial, they utilize a -header flag.
   - match: .+\.gen\.go$
+  # Ignore protobuf files. Generating and license appending end up racing.
+  - match: .+\.pb\.go$
+  # Prevent the updater from recursing into claude's worktrees.
+  - directory: .claude
 files:
   - name: ../licenses/boilerplate.go.txt
     type: go


### PR DESCRIPTION
licenseupdater would occasionally recurse into claude worktrees
(`.claude/worktrees`) and race to modify generated protofiles
(`pkg/multicluster/leaderelection/proto/gen`). Update the ignore
patterns to exclude both.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>