### PR TITLE
*: suppress text diffs and merging of generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# -diff: Diff suppression of noisy / generated files. Override with `git diff --text`
+# -merge: Don't perform merges.
+# See: https://git-scm.com/docs/gitattributes
+
+# gotohelm files
+charts/*/templates/* text -diff -merge
+charts/*/chart/templates/* text -diff -merge
+gotohelm/testdata/src/example/*.tpl text -diff -merge
+
+# Lock files
+go.sum text -diff
+go.work.sum text -diff
+flake.lock text -diff


### PR DESCRIPTION
Add `.gitattributes` to minimize diff noise of generated files. Namely,
this is targeting gotohelm files. Diffs can still be manually inspected
using `git diff --text`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>