### PR TITLE
operator/chart: opt-in cluster label for aggregated operator metrics

### DIFF
--- a/.changes/unreleased/operator-Added-20260825-160000.yaml
+++ b/.changes/unreleased/operator-Added-20260825-160000.yaml
@@ -1,26 +1,29 @@
 project: operator
 kind: Added
 body: |-
-    The operator chart can add a scrape-time label identifying which Kubernetes cluster a metrics series came from, via `monitoring.clusterLabel`. Off by default.
+    The operator chart can add a scrape-time label identifying which Kubernetes cluster a metrics series came from, via `monitoring.clusterLabel`. Off by default. Applies to single-cluster and stretch-cluster deployments alike.
 
-      This is for stretch clusters. One StretchCluster spans several Kubernetes
-      clusters, each running its own operator, and the questions you ask of it are
-      inherently cross-cluster — which operator holds raft leadership, which region
-      is behind — so the operator metrics have to be aggregated into a single
-      Prometheus-compatible backend to be queryable together. Once they are,
-      nothing in the scraped series says which cluster produced it: job, namespace,
-      service and pod names are identical in every cluster, and identical by design
-      when the deployment follows the documented pattern. The series collide.
+      Use it whenever operator metrics from more than one Kubernetes cluster land in
+      the same Prometheus-compatible backend — several independent installs
+      remote_writing to a shared Mimir/Thanos, or one StretchCluster spanning
+      clusters. In either case nothing in the scraped series says which cluster
+      produced it: job, namespace, service and pod names are identical in every
+      cluster, and identical by design when each install uses the same release
+      name. The series collide, and a graph of, say,
+      `controller_runtime_reconcile_total` sums clusters together without saying so.
 
-      Setting `monitoring.clusterLabel.enabled=true` renders a relabeling on the
+      `monitoring.clusterLabel.enabled=true` renders a relabeling on the
       ServiceMonitor endpoint that stamps `redpanda_k8s_cluster` onto every series
-      from that operator, defaulting its value to `multicluster.name` — so a
-      stretch deployment needs no further configuration. `monitoring.clusterLabel.name`
-      and `.value` override the label and its value; the value is required when
-      multicluster is disabled, and the render fails rather than emitting an empty
-      label.
+      from that operator. `monitoring.clusterLabel.name` and `.value` override the
+      label and its value.
 
-      Off by default because a single-cluster install has nothing to disambiguate,
-      and adding a label to everyone's series would churn existing dashboards and
-      recording rules.
+      For a **stretch cluster** the value defaults to `multicluster.name`, which is
+      already the cluster's identity in the operator's raft group, so only the
+      toggle is needed. For a **single-cluster** install there is no cluster
+      identity to inherit, so `.value` is required; the render fails rather than
+      emitting an empty label, since an empty label looks like data.
+
+      Off by default because one cluster reporting to its own Prometheus has nothing
+      to disambiguate, and adding a label to everyone's series would churn existing
+      dashboards and recording rules.
 time: 2026-08-25T16:00:00.000000000-07:00

--- a/.changes/unreleased/operator-Added-20260825-160000.yaml
+++ b/.changes/unreleased/operator-Added-20260825-160000.yaml
@@ -17,11 +17,14 @@ body: |-
       from that operator. `monitoring.clusterLabel.name` and `.value` override the
       label and its value.
 
-      For a **stretch cluster** the value defaults to `multicluster.name`, which is
-      already the cluster's identity in the operator's raft group, so only the
-      toggle is needed. For a **single-cluster** install there is no cluster
-      identity to inherit, so `.value` is required; the render fails rather than
-      emitting an empty label, since an empty label looks like data.
+      When `multicluster.enabled` is true the value defaults to
+      `multicluster.name`, which is already the cluster's identity in the
+      operator's raft group, so a stretch deployment needs only the toggle.
+      Otherwise `.value` is required — including when `multicluster.name` happens
+      to be set but multicluster mode is off, since that name configures nothing
+      else there and inheriting it would turn a stale value into a metric label.
+      The render fails rather than emitting an empty label, since an empty label
+      looks like data.
 
       Off by default because one cluster reporting to its own Prometheus has nothing
       to disambiguate, and adding a label to everyone's series would churn existing

--- a/.changes/unreleased/operator-Added-20260825-160000.yaml
+++ b/.changes/unreleased/operator-Added-20260825-160000.yaml
@@ -1,0 +1,26 @@
+project: operator
+kind: Added
+body: |-
+    The operator chart can add a scrape-time label identifying which Kubernetes cluster a metrics series came from, via `monitoring.clusterLabel`. Off by default.
+
+      This is for stretch clusters. One StretchCluster spans several Kubernetes
+      clusters, each running its own operator, and the questions you ask of it are
+      inherently cross-cluster — which operator holds raft leadership, which region
+      is behind — so the operator metrics have to be aggregated into a single
+      Prometheus-compatible backend to be queryable together. Once they are,
+      nothing in the scraped series says which cluster produced it: job, namespace,
+      service and pod names are identical in every cluster, and identical by design
+      when the deployment follows the documented pattern. The series collide.
+
+      Setting `monitoring.clusterLabel.enabled=true` renders a relabeling on the
+      ServiceMonitor endpoint that stamps `redpanda_k8s_cluster` onto every series
+      from that operator, defaulting its value to `multicluster.name` — so a
+      stretch deployment needs no further configuration. `monitoring.clusterLabel.name`
+      and `.value` override the label and its value; the value is required when
+      multicluster is disabled, and the render fails rather than emitting an empty
+      label.
+
+      Off by default because a single-cluster install has nothing to disambiguate,
+      and adding a label to everyone's series would churn existing dashboards and
+      recording rules.
+time: 2026-08-25T16:00:00.000000000-07:00

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -290,7 +290,7 @@ Configuration for monitoring.
 
 ### [monitoring.clusterLabel](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel)
 
-Adds a scrape-time label identifying which Kubernetes cluster a series came from. Use it whenever operator metrics from more than one Kubernetes cluster land in the same Prometheus-compatible backend — several independent installs remote_writing to a shared Mimir/Thanos, or one stretch cluster spanning clusters. Without it the series collide, since job, namespace, service and pod names are identical in each. Stretch clusters inherit the value from `multicluster.name`; a single-cluster install supplies `value` itself. Off by default: one cluster reporting to its own Prometheus has nothing to disambiguate.
+Adds a scrape-time label identifying which Kubernetes cluster a series came from. Use it whenever operator metrics from more than one Kubernetes cluster land in the same Prometheus-compatible backend — several independent installs remote_writing to a shared Mimir/Thanos, or one stretch cluster spanning clusters. Without it the series collide, since job, namespace, service and pod names are identical in each. With `multicluster.enabled`, the value is inherited from `multicluster.name`; otherwise supply `value` yourself. Off by default: one cluster reporting to its own Prometheus has nothing to disambiguate.
 
 **Default:**
 
@@ -312,7 +312,7 @@ The label to set. Empty uses `redpanda_k8s_cluster`.
 
 ### [monitoring.clusterLabel.value](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel.value)
 
-The label's value. Empty uses `multicluster.name`, so a stretch deployment needs nothing further. Required for a single-cluster install, which has no `multicluster.name` to inherit; the render fails rather than emitting an empty label.
+The label's value. When `multicluster.enabled` is true, empty inherits `multicluster.name`, so a stretch deployment needs nothing further. Required otherwise — including when `multicluster.name` is set but `multicluster.enabled` is false, since that name configures nothing else there. The render fails rather than emitting an empty label.
 
 **Default:** `""`
 

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -290,7 +290,7 @@ Configuration for monitoring.
 
 ### [monitoring.clusterLabel](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel)
 
-Adds a scrape-time label identifying which Kubernetes cluster a series came from. For stretch clusters, whose operator metrics have to be aggregated into one Prometheus-compatible backend to be queryable together — without it, series from every cluster collide, since job, namespace, service and pod names are identical in each. Off by default: a single-cluster install has nothing to disambiguate.
+Adds a scrape-time label identifying which Kubernetes cluster a series came from. Use it whenever operator metrics from more than one Kubernetes cluster land in the same Prometheus-compatible backend — several independent installs remote_writing to a shared Mimir/Thanos, or one stretch cluster spanning clusters. Without it the series collide, since job, namespace, service and pod names are identical in each. Stretch clusters inherit the value from `multicluster.name`; a single-cluster install supplies `value` itself. Off by default: one cluster reporting to its own Prometheus has nothing to disambiguate.
 
 **Default:**
 
@@ -312,7 +312,7 @@ The label to set. Empty uses `redpanda_k8s_cluster`.
 
 ### [monitoring.clusterLabel.value](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel.value)
 
-The label's value. Empty uses `multicluster.name`, so a stretch deployment needs nothing further. Required when multicluster is disabled.
+The label's value. Empty uses `multicluster.name`, so a stretch deployment needs nothing further. Required for a single-cluster install, which has no `multicluster.name` to inherit; the render fails rather than emitting an empty label.
 
 **Default:** `""`
 

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -285,8 +285,36 @@ Configuration for monitoring.
 **Default:**
 
 ```
-{"enabled":false,"labels":{},"rulesEnabled":false,"scrapeInterval":""}
+{"clusterLabel":{"enabled":false,"name":"","value":""},"enabled":false,"labels":{},"rulesEnabled":false,"scrapeInterval":""}
 ```
+
+### [monitoring.clusterLabel](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel)
+
+Adds a scrape-time label identifying which Kubernetes cluster a series came from. For stretch clusters, whose operator metrics have to be aggregated into one Prometheus-compatible backend to be queryable together — without it, series from every cluster collide, since job, namespace, service and pod names are identical in each. Off by default: a single-cluster install has nothing to disambiguate.
+
+**Default:**
+
+```
+{"enabled":false,"name":"","value":""}
+```
+
+### [monitoring.clusterLabel.enabled](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel.enabled)
+
+Adds the label to every series scraped from this operator.
+
+**Default:** `false`
+
+### [monitoring.clusterLabel.name](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel.name)
+
+The label to set. Empty uses `redpanda_k8s_cluster`.
+
+**Default:** `""`
+
+### [monitoring.clusterLabel.value](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.clusterLabel.value)
+
+The label's value. Empty uses `multicluster.name`, so a stretch deployment needs nothing further. Required when multicluster is disabled.
+
+**Default:** `""`
 
 ### [monitoring.enabled](https://artifacthub.io/packages/helm/redpanda-data/operator?modal=values&path=monitoring.enabled)
 

--- a/operator/chart/servicemonitor.go
+++ b/operator/chart/servicemonitor.go
@@ -63,16 +63,22 @@ func ServiceMonitor(dot *helmette.Dot) *monitoringv1.ServiceMonitor {
 			labelName = "redpanda_k8s_cluster"
 		}
 
+		// Inherit multicluster.name only when multicluster mode is actually
+		// enabled. The value is a plain string that can be set with
+		// multicluster.enabled false, where it configures nothing else — so
+		// falling back to it unconditionally would let a stale or aspirational
+		// name silently become a metric label, which is the kind of action at a
+		// distance nobody goes looking for.
 		labelValue := values.Monitoring.ClusterLabel.Value
-		if labelValue == "" {
+		if labelValue == "" && values.Multicluster.Enabled {
 			labelValue = values.Multicluster.Name
 		}
 
-		// With multicluster disabled and no explicit value there is nothing
-		// meaningful to stamp, and an empty replacement would silently produce
-		// an empty label. Fail the render instead of shipping that.
+		// Nothing meaningful to stamp. An empty replacement would produce an
+		// empty label, which reads as data rather than as absence, so fail the
+		// render instead of shipping it.
 		if labelValue == "" {
-			panic("monitoring.clusterLabel.value must be set when multicluster.name is empty")
+			panic("monitoring.clusterLabel.value must be set unless multicluster.enabled is true and multicluster.name is non-empty")
 		}
 
 		endpoint.RelabelConfigs = append(endpoint.RelabelConfigs, monitoringv1.RelabelConfig{

--- a/operator/chart/servicemonitor.go
+++ b/operator/chart/servicemonitor.go
@@ -50,6 +50,37 @@ func ServiceMonitor(dot *helmette.Dot) *monitoringv1.ServiceMonitor {
 		endpoint.Interval = monitoringv1.Duration(values.Monitoring.ScrapeInterval)
 	}
 
+	// Stamp the source cluster onto every series, for deployments that
+	// aggregate several clusters' operator metrics into one backend. See the
+	// ClusterLabel godoc for why this is off by default.
+	//
+	// A relabeling with a targetLabel and a replacement but no sourceLabels is
+	// the standard way to set a static label at scrape time; `action` defaults
+	// to "replace".
+	if values.Monitoring.ClusterLabel.Enabled {
+		labelName := values.Monitoring.ClusterLabel.Name
+		if labelName == "" {
+			labelName = "redpanda_k8s_cluster"
+		}
+
+		labelValue := values.Monitoring.ClusterLabel.Value
+		if labelValue == "" {
+			labelValue = values.Multicluster.Name
+		}
+
+		// With multicluster disabled and no explicit value there is nothing
+		// meaningful to stamp, and an empty replacement would silently produce
+		// an empty label. Fail the render instead of shipping that.
+		if labelValue == "" {
+			panic("monitoring.clusterLabel.value must be set when multicluster.name is empty")
+		}
+
+		endpoint.RelabelConfigs = append(endpoint.RelabelConfigs, monitoringv1.RelabelConfig{
+			TargetLabel: labelName,
+			Replacement: ptr.To(labelValue),
+		})
+	}
+
 	return &monitoringv1.ServiceMonitor{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceMonitor",

--- a/operator/chart/servicemonitor_test.go
+++ b/operator/chart/servicemonitor_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package operator
+
+import (
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/redpanda-operator/gotohelm/helmette"
+)
+
+// renderServiceMonitor renders the operator ServiceMonitor with the given
+// partial values merged over the chart defaults.
+func renderServiceMonitor(t *testing.T, partial map[string]any) *monitoringv1.ServiceMonitor {
+	t.Helper()
+	values, err := Chart.LoadValues(partial)
+	require.NoError(t, err)
+	dot, err := Chart.Dot(nil, helmette.Release{
+		Name:      "rp-op",
+		Namespace: "redpanda-operator",
+		Service:   "Helm",
+	}, values)
+	require.NoError(t, err)
+	return ServiceMonitor(dot)
+}
+
+// multiclusterValues is the minimum multicluster stanza that renders, so the
+// inherit path can be exercised without dragging in a full stretch config.
+func multiclusterValues(name string) map[string]any {
+	return map[string]any{
+		"enabled":                  true,
+		"name":                     name,
+		"apiServerExternalAddress": "https://ABCD.gr7.us-east-1.eks.amazonaws.com",
+		"peers": []any{
+			map[string]any{"name": name, "address": "a.us-east-1.elb.amazonaws.com"},
+		},
+	}
+}
+
+func relabelings(t *testing.T, sm *monitoringv1.ServiceMonitor) []monitoringv1.RelabelConfig {
+	t.Helper()
+	require.NotNil(t, sm)
+	require.Len(t, sm.Spec.Endpoints, 1)
+	return sm.Spec.Endpoints[0].RelabelConfigs
+}
+
+// TestServiceMonitorClusterLabel covers monitoring.clusterLabel. The label is
+// motivated by stretch clusters, but nothing about it is gated on multicluster:
+// any deployment that aggregates several clusters' operator metrics into one
+// Prometheus-compatible backend has the same collision to solve, since job,
+// namespace, service and pod names are identical across clusters. Multicluster
+// only supplies a default for the value.
+func TestServiceMonitorClusterLabel(t *testing.T) {
+	t.Run("off by default", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{"enabled": true},
+		})
+		assert.Empty(t, relabelings(t, sm), "a single-cluster install has nothing to disambiguate")
+	})
+
+	// The case this exists for outside of stretch: N independent single-cluster
+	// installs, each remote_writing to one central Prometheus. No multicluster
+	// anywhere, so the value is supplied per install and the label name is left
+	// at its default.
+	t.Run("single cluster: value only, default label name", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{
+				"enabled": true,
+				"clusterLabel": map[string]any{
+					"enabled": true,
+					"value":   "prod-us-east-1",
+				},
+			},
+		})
+
+		require.Equal(t, []monitoringv1.RelabelConfig{{
+			TargetLabel: "redpanda_k8s_cluster",
+			Replacement: ptrTo("prod-us-east-1"),
+		}}, relabelings(t, sm))
+	})
+
+	t.Run("single cluster: explicit label name", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{
+				"enabled": true,
+				"clusterLabel": map[string]any{
+					"enabled": true,
+					"name":    "k8s_cluster",
+					"value":   "prod-eu-west-1",
+				},
+			},
+		})
+
+		require.Equal(t, []monitoringv1.RelabelConfig{{
+			TargetLabel: "k8s_cluster",
+			Replacement: ptrTo("prod-eu-west-1"),
+		}}, relabelings(t, sm))
+	})
+
+	t.Run("multicluster: value inherited from multicluster.name", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{
+				"enabled":      true,
+				"clusterLabel": map[string]any{"enabled": true},
+			},
+			"multicluster": multiclusterValues("rp-us-east-1"),
+		})
+
+		require.Equal(t, []monitoringv1.RelabelConfig{{
+			TargetLabel: "redpanda_k8s_cluster",
+			Replacement: ptrTo("rp-us-east-1"),
+		}}, relabelings(t, sm))
+	})
+
+	t.Run("multicluster: explicit value wins over multicluster.name", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{
+				"enabled": true,
+				"clusterLabel": map[string]any{
+					"enabled": true,
+					"value":   "east",
+				},
+			},
+			"multicluster": multiclusterValues("rp-us-east-1"),
+		})
+
+		require.Equal(t, []monitoringv1.RelabelConfig{{
+			TargetLabel: "redpanda_k8s_cluster",
+			Replacement: ptrTo("east"),
+		}}, relabelings(t, sm))
+	})
+
+	// An empty replacement would stamp an empty label, which reads as data
+	// rather than as missing configuration, so the render fails instead.
+	t.Run("no value and no multicluster.name fails the render", func(t *testing.T) {
+		assert.PanicsWithValue(t, "monitoring.clusterLabel.value must be set when multicluster.name is empty", func() {
+			renderServiceMonitor(t, map[string]any{
+				"monitoring": map[string]any{
+					"enabled":      true,
+					"clusterLabel": map[string]any{"enabled": true},
+				},
+			})
+		})
+	})
+
+	// #1752 made the multicluster metrics server serve TLS so this endpoint
+	// shape works; the label must not perturb any of it.
+	t.Run("endpoint shape is untouched", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{
+				"enabled": true,
+				"clusterLabel": map[string]any{
+					"enabled": true,
+					"value":   "prod-us-east-1",
+				},
+			},
+		})
+
+		endpoint := sm.Spec.Endpoints[0]
+		assert.Equal(t, "https", endpoint.Port)
+		assert.Equal(t, "/metrics", endpoint.Path)
+		require.NotNil(t, endpoint.Scheme)
+		assert.Equal(t, monitoringv1.Scheme("https"), *endpoint.Scheme)
+		require.NotNil(t, endpoint.TLSConfig)
+		assert.Equal(t, ptrTo(true), endpoint.TLSConfig.InsecureSkipVerify)
+		// The chart sets the deprecated BearerTokenFile deliberately (see
+		// servicemonitor.go); asserting it is how that choice stays pinned.
+		assert.Equal(t, "/var/run/secrets/kubernetes.io/serviceaccount/token", endpoint.BearerTokenFile) //nolint:staticcheck // SA1019: pinning the field the chart intentionally sets
+	})
+
+	t.Run("monitoring disabled renders nothing", func(t *testing.T) {
+		sm := renderServiceMonitor(t, map[string]any{
+			"monitoring": map[string]any{
+				"enabled":      false,
+				"clusterLabel": map[string]any{"enabled": true, "value": "prod"},
+			},
+		})
+		assert.Nil(t, sm)
+	})
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/operator/chart/servicemonitor_test.go
+++ b/operator/chart/servicemonitor_test.go
@@ -143,11 +143,32 @@ func TestServiceMonitorClusterLabel(t *testing.T) {
 	// An empty replacement would stamp an empty label, which reads as data
 	// rather than as missing configuration, so the render fails instead.
 	t.Run("no value and no multicluster.name fails the render", func(t *testing.T) {
-		assert.PanicsWithValue(t, "monitoring.clusterLabel.value must be set when multicluster.name is empty", func() {
+		assert.PanicsWithValue(t, "monitoring.clusterLabel.value must be set unless multicluster.enabled is true and multicluster.name is non-empty", func() {
 			renderServiceMonitor(t, map[string]any{
 				"monitoring": map[string]any{
 					"enabled":      true,
 					"clusterLabel": map[string]any{"enabled": true},
+				},
+			})
+		})
+	})
+
+	// The fallback is gated on multicluster mode being ENABLED, not merely on
+	// multicluster.name being non-empty. That name is a plain string settable
+	// with multicluster.enabled false, where it configures nothing else — so
+	// inheriting it there would turn a stale or aspirational name into a metric
+	// label with nothing pointing at the connection. Raised in review on #1758.
+	t.Run("multicluster.name is not inherited when multicluster is disabled", func(t *testing.T) {
+		assert.PanicsWithValue(t, "monitoring.clusterLabel.value must be set unless multicluster.enabled is true and multicluster.name is non-empty", func() {
+			renderServiceMonitor(t, map[string]any{
+				"monitoring": map[string]any{
+					"enabled":      true,
+					"clusterLabel": map[string]any{"enabled": true},
+				},
+				// Set, but multicluster mode is off.
+				"multicluster": map[string]any{
+					"enabled": false,
+					"name":    "rp-us-east-1",
 				},
 			})
 		})

--- a/operator/chart/templates/_servicemonitor.go.tpl
+++ b/operator/chart/templates/_servicemonitor.go.tpl
@@ -15,6 +15,20 @@
 {{- if (ne $values.monitoring.scrapeInterval "") -}}
 {{- $_ := (set $endpoint "interval" (toString $values.monitoring.scrapeInterval)) -}}
 {{- end -}}
+{{- if $values.monitoring.clusterLabel.enabled -}}
+{{- $labelName := $values.monitoring.clusterLabel.name -}}
+{{- if (eq $labelName "") -}}
+{{- $labelName = "redpanda_k8s_cluster" -}}
+{{- end -}}
+{{- $labelValue := $values.monitoring.clusterLabel.value -}}
+{{- if (eq $labelValue "") -}}
+{{- $labelValue = $values.multicluster.name -}}
+{{- end -}}
+{{- if (eq $labelValue "") -}}
+{{- $_ := (fail "monitoring.clusterLabel.value must be set when multicluster.name is empty") -}}
+{{- end -}}
+{{- $_ := (set $endpoint "relabelings" (concat (default (list) $endpoint.relabelings) (list (mustMergeOverwrite (dict) (dict "targetLabel" $labelName "replacement" $labelValue))))) -}}
+{{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict) "spec" (dict "endpoints" (coalesce nil) "selector" (dict) "namespaceSelector" (dict))) (mustMergeOverwrite (dict) (dict "kind" "ServiceMonitor" "apiVersion" "monitoring.coreos.com/v1")) (dict "metadata" (mustMergeOverwrite (dict) (dict "name" (get (fromJson (include "operator.cleanForK8sWithSuffix" (dict "a" (list (get (fromJson (include "operator.Fullname" (dict "a" (list $dot)))) "r") "metrics-monitor")))) "r") "labels" (merge (dict) (get (fromJson (include "operator.Labels" (dict "a" (list $dot)))) "r") $values.monitoring.labels) "namespace" $dot.Release.Namespace "annotations" $values.annotations)) "spec" (mustMergeOverwrite (dict "endpoints" (coalesce nil) "selector" (dict) "namespaceSelector" (dict)) (dict "endpoints" (list $endpoint) "namespaceSelector" (mustMergeOverwrite (dict) (dict "matchNames" (list $dot.Release.Namespace))) "selector" (mustMergeOverwrite (dict) (dict "matchLabels" (get (fromJson (include "operator.Labels" (dict "a" (list $dot)))) "r")))))))) | toJson -}}
 {{- break -}}

--- a/operator/chart/templates/_servicemonitor.go.tpl
+++ b/operator/chart/templates/_servicemonitor.go.tpl
@@ -21,11 +21,11 @@
 {{- $labelName = "redpanda_k8s_cluster" -}}
 {{- end -}}
 {{- $labelValue := $values.monitoring.clusterLabel.value -}}
-{{- if (eq $labelValue "") -}}
+{{- if (and (eq $labelValue "") $values.multicluster.enabled) -}}
 {{- $labelValue = $values.multicluster.name -}}
 {{- end -}}
 {{- if (eq $labelValue "") -}}
-{{- $_ := (fail "monitoring.clusterLabel.value must be set when multicluster.name is empty") -}}
+{{- $_ := (fail "monitoring.clusterLabel.value must be set unless multicluster.enabled is true and multicluster.name is non-empty") -}}
 {{- end -}}
 {{- $_ := (set $endpoint "relabelings" (concat (default (list) $endpoint.relabelings) (list (mustMergeOverwrite (dict) (dict "targetLabel" $labelName "replacement" $labelValue))))) -}}
 {{- end -}}

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -107589,6 +107589,3420 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
+-- testdata/monitoring-cluster-label-explicit.yaml.golden --
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |-
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: :8081
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: aa9fc693.vectorized.io
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-config
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/finalizers
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/status
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-additional-controllers-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-additional-controllers-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/name: operator
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/name: operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
+        - --configurator-tag=v26.2.1
+        - --connect-monitoring-enabled=false
+        - --enable-connect=false
+        - --enable-console=true
+        - --enable-vectorized-controllers=false
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        - --log-level=info
+        - --metrics-bind-address=:8443
+        - --webhook-enabled=false
+        command:
+        - /manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      ephemeralContainers: null
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-metrics-monitor
+  namespace: default
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    relabelings:
+    - replacement: prod-eu-west-1
+      targetLabel: k8s_cluster
+    scheme: https
+    tlsConfig:
+      ca: {}
+      cert: {}
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/version: v26.2.1
+      helm.sh/chart: operator-26.2.1
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/finalizers
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/status
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-migration-job-default
+subjects:
+- kind: ServiceAccount
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-4"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - migration
+        command:
+        - /redpanda-operator
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1
+        imagePullPolicy: IfNotPresent
+        name: migration
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: OnFailure
+      serviceAccountName: operator-migration-job
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+-- testdata/monitoring-cluster-label-from-multicluster.yaml.golden --
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |-
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: :8081
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: aa9fc693.vectorized.io
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-config
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/finalizers
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/status
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-additional-controllers-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-additional-controllers-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/name: operator
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/name: operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - multicluster
+        - --base-image=docker.redpanda.com/redpandadata/redpanda-operator
+        - --base-tag=v26.2.1
+        - --ca-file=/tls/ca.crt
+        - --certificate-file=/tls/tls.crt
+        - --health-probe-bind-address=:8081
+        - --kubeconfig-name=operator
+        - --kubeconfig-namespace=default
+        - --kubernetes-api-address=https://ABCD.gr7.us-east-1.eks.amazonaws.com
+        - --log-level=info
+        - --metrics-bind-address=:8443
+        - --name=rp-us-east-1
+        - --private-key-file=/tls/tls.key
+        - --raft-address=0.0.0.0:9443
+        - --peer=rp-us-east-1://a.us-east-1.elb.amazonaws.com:9443
+        - --peer=rp-us-west-2://b.us-west-2.elb.amazonaws.com:9443
+        - --peer=rp-eu-west-1://c.eu-west-1.elb.amazonaws.com:9443
+        command:
+        - /redpanda-operator
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+        - mountPath: /tls
+          name: operator-multicluster-certificates
+          readOnly: true
+      ephemeralContainers: null
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+      - name: operator-multicluster-certificates
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: ca.crt
+            path: ca.crt
+          secretName: operator-multicluster-certificates
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-metrics-monitor
+  namespace: default
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    relabelings:
+    - replacement: rp-us-east-1
+      targetLabel: redpanda_k8s_cluster
+    scheme: https
+    tlsConfig:
+      ca: {}
+      cert: {}
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/version: v26.2.1
+      helm.sh/chart: operator-26.2.1
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/finalizers
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/status
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-migration-job-default
+subjects:
+- kind: ServiceAccount
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-4"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - migration
+        command:
+        - /redpanda-operator
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1
+        imagePullPolicy: IfNotPresent
+        name: migration
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: OnFailure
+      serviceAccountName: operator-migration-job
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 -- testdata/monitoring-enabled.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml

--- a/operator/chart/testdata/template-cases.golden.txtar
+++ b/operator/chart/testdata/template-cases.golden.txtar
@@ -111003,6 +111003,1684 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
+-- testdata/monitoring-cluster-label-single-cluster.yaml.golden --
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |-
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: :8081
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: aa9fc693.vectorized.io
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+kind: ConfigMap
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-config
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/finalizers
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/status
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-additional-controllers-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-additional-controllers-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-additional-controllers-default
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/name: operator
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/name: operator
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - --configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator
+        - --configurator-tag=v26.2.1
+        - --connect-monitoring-enabled=false
+        - --enable-connect=false
+        - --enable-console=true
+        - --enable-vectorized-controllers=false
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        - --log-level=info
+        - --metrics-bind-address=:8443
+        - --webhook-enabled=false
+        command:
+        - /manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      ephemeralContainers: null
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-metrics-monitor
+  namespace: default
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    relabelings:
+    - replacement: prod-us-east-1
+      targetLabel: redpanda_k8s_cluster
+    scheme: https
+    tlsConfig:
+      ca: {}
+      cert: {}
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: operator
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: operator
+      app.kubernetes.io/version: v26.2.1
+      helm.sh/chart: operator-26.2.1
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - redpandas
+  - stretchclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers
+  - consoles
+  - nodepools
+  - redpandabrokerpools
+  - redpandas
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/finalizers
+  - groups/finalizers
+  - nodepools/finalizers
+  - redpandabrokerpools/finalizers
+  - redpandaroles/finalizers
+  - redpandas/finalizers
+  - schemas/finalizers
+  - shadowlinks/finalizers
+  - stretchclusters/finalizers
+  - topics/finalizers
+  - users/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - brokers/status
+  - groups/status
+  - nodepools/status
+  - redpandabrokerpools/status
+  - redpandaroles/status
+  - redpandas/status
+  - schemas/status
+  - shadowlinks/status
+  - stretchclusters/status
+  - topics/status
+  - users/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.redpanda.com
+  resources:
+  - groups
+  - redpandaroles
+  - schemas
+  - shadowlinks
+  - stretchclusters
+  - topics
+  - users
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - get
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration-job-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-migration-job-default
+subjects:
+- kind: ServiceAccount
+  name: operator-migration-job
+  namespace: default
+---
+# Source: operator/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-4"
+  labels:
+    app.kubernetes.io/instance: operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v26.2.1
+    helm.sh/chart: operator-26.2.1
+  name: operator-migration
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/instance: operator
+        app.kubernetes.io/name: operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - migration
+        command:
+        - /redpanda-operator
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v26.2.1
+        imagePullPolicy: IfNotPresent
+        name: migration
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: OnFailure
+      serviceAccountName: operator-migration-job
+      terminationGracePeriodSeconds: 10
+      tolerations: []
+      volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 -- testdata/monitoring-enabled.yaml.golden --
 ---
 # Source: operator/templates/entry-point.yaml

--- a/operator/chart/testdata/template-cases.txtar
+++ b/operator/chart/testdata/template-cases.txtar
@@ -267,6 +267,16 @@ connectController:
     scrapeInterval: "30s"
     labels:
       team: platform
+-- monitoring-cluster-label-single-cluster --
+# Not a stretch cluster: one standalone install remote_writing to a central
+# Prometheus alongside others. No multicluster, so the value is supplied here
+# and the label name is left at its default.
+monitoring:
+  enabled: true
+  clusterLabel:
+    enabled: true
+    value: prod-us-east-1
+
 -- monitoring-cluster-label-explicit --
 monitoring:
   enabled: true

--- a/operator/chart/testdata/template-cases.txtar
+++ b/operator/chart/testdata/template-cases.txtar
@@ -267,3 +267,27 @@ connectController:
     scrapeInterval: "30s"
     labels:
       team: platform
+-- monitoring-cluster-label-explicit --
+monitoring:
+  enabled: true
+  clusterLabel:
+    enabled: true
+    name: k8s_cluster
+    value: prod-eu-west-1
+
+-- monitoring-cluster-label-from-multicluster --
+monitoring:
+  enabled: true
+  clusterLabel:
+    enabled: true
+multicluster:
+  enabled: true
+  name: rp-us-east-1
+  apiServerExternalAddress: https://ABCD.gr7.us-east-1.eks.amazonaws.com
+  peers:
+  - name: rp-us-east-1
+    address: a.us-east-1.elb.amazonaws.com
+  - name: rp-us-west-2
+    address: b.us-west-2.elb.amazonaws.com
+  - name: rp-eu-west-1
+    address: c.eu-west-1.elb.amazonaws.com

--- a/operator/chart/values.go
+++ b/operator/chart/values.go
@@ -271,4 +271,32 @@ type MonitoringConfig struct {
 	RulesEnabled   bool              `json:"rulesEnabled"`
 	Labels         map[string]string `json:"labels"`
 	ScrapeInterval string            `json:"scrapeInterval"`
+	ClusterLabel   ClusterLabel      `json:"clusterLabel"`
+}
+
+// ClusterLabel configures an opt-in scrape-time label identifying which
+// Kubernetes cluster a series came from.
+//
+// It exists for stretch clusters. One StretchCluster spans several Kubernetes
+// clusters, each running its own operator, and diagnosing it means querying
+// across all of them — so the operator metrics have to be aggregated into one
+// Prometheus-compatible backend (remote_write to Mimir/Thanos, or a Thanos
+// Querier fanning out). Once they are, nothing in the scraped series says which
+// cluster produced it: job, namespace, service and pod names are identical in
+// every cluster, and identical by design when the deployment follows the
+// documented pattern of one release name per cluster. The series then collide.
+//
+// Off by default: a single-cluster install has nothing to disambiguate, and
+// adding a label to everyone's metrics would churn existing dashboards and
+// recording rules.
+type ClusterLabel struct {
+	// Enabled adds the label to every series scraped from this operator.
+	Enabled bool `json:"enabled"`
+	// Name is the label to set. Defaults to "redpanda_k8s_cluster".
+	Name string `json:"name"`
+	// Value is the label's value. Defaults to `multicluster.name`, which is
+	// already the cluster's identity in the operator's raft group, so a stretch
+	// deployment needs no extra configuration. Required when multicluster is
+	// disabled, since there is no name to fall back to.
+	Value string `json:"value"`
 }

--- a/operator/chart/values.go
+++ b/operator/chart/values.go
@@ -277,18 +277,25 @@ type MonitoringConfig struct {
 // ClusterLabel configures an opt-in scrape-time label identifying which
 // Kubernetes cluster a series came from.
 //
-// It exists for stretch clusters. One StretchCluster spans several Kubernetes
-// clusters, each running its own operator, and diagnosing it means querying
-// across all of them — so the operator metrics have to be aggregated into one
-// Prometheus-compatible backend (remote_write to Mimir/Thanos, or a Thanos
-// Querier fanning out). Once they are, nothing in the scraped series says which
-// cluster produced it: job, namespace, service and pod names are identical in
-// every cluster, and identical by design when the deployment follows the
-// documented pattern of one release name per cluster. The series then collide.
+// It applies whenever operator metrics from more than one Kubernetes cluster
+// end up in the same Prometheus-compatible backend — whether that is several
+// independent single-cluster installs remote_writing to a shared Mimir/Thanos,
+// or one StretchCluster spanning clusters. In either case nothing in the
+// scraped series says which cluster produced it: job, namespace, service and
+// pod names are identical in every cluster, and identical by design when each
+// install uses the same release name. The series collide, and a graph sums
+// clusters together without saying so.
 //
-// Off by default: a single-cluster install has nothing to disambiguate, and
-// adding a label to everyone's metrics would churn existing dashboards and
-// recording rules.
+// Stretch clusters are the case that forces it, because a StretchCluster is one
+// logical cluster and the questions asked of it — which operator holds raft
+// leadership, which region is behind — cannot be answered from any single
+// cluster's metrics. There the value defaults to multicluster.name, so only the
+// toggle is needed. A single-cluster install must supply Value itself, since
+// there is no cluster identity to inherit.
+//
+// Off by default: one cluster reporting to its own Prometheus has nothing to
+// disambiguate, and adding a label to everyone's metrics would churn existing
+// dashboards and recording rules.
 type ClusterLabel struct {
 	// Enabled adds the label to every series scraped from this operator.
 	Enabled bool `json:"enabled"`

--- a/operator/chart/values.go
+++ b/operator/chart/values.go
@@ -301,9 +301,15 @@ type ClusterLabel struct {
 	Enabled bool `json:"enabled"`
 	// Name is the label to set. Defaults to "redpanda_k8s_cluster".
 	Name string `json:"name"`
-	// Value is the label's value. Defaults to `multicluster.name`, which is
-	// already the cluster's identity in the operator's raft group, so a stretch
-	// deployment needs no extra configuration. Required when multicluster is
-	// disabled, since there is no name to fall back to.
+	// Value is the label's value. When `multicluster.enabled` is true it
+	// defaults to `multicluster.name`, which is already the cluster's identity
+	// in the operator's raft group, so a stretch deployment needs no extra
+	// configuration.
+	//
+	// Required otherwise. The fallback is deliberately gated on multicluster
+	// mode being enabled rather than merely on `multicluster.name` being set:
+	// that value configures nothing else when multicluster is disabled, so
+	// inheriting it there would turn a stale or aspirational name into a metric
+	// label with nothing pointing at the connection.
 	Value string `json:"value"`
 }

--- a/operator/chart/values.schema.json
+++ b/operator/chart/values.schema.json
@@ -978,6 +978,21 @@
     "monitoring": {
       "additionalProperties": false,
       "properties": {
+        "clusterLabel": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "enabled": {
           "type": "boolean"
         },

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -226,6 +226,20 @@ monitoring:
   scrapeInterval: ""
   # -- Additional labels to add to the ServiceMonitor metadata.
   labels: {}
+  # -- Adds a scrape-time label identifying which Kubernetes cluster a series
+  # came from. For stretch clusters, whose operator metrics have to be
+  # aggregated into one Prometheus-compatible backend to be queryable together —
+  # without it, series from every cluster collide, since job, namespace, service
+  # and pod names are identical in each. Off by default: a single-cluster
+  # install has nothing to disambiguate.
+  clusterLabel:
+    # -- Adds the label to every series scraped from this operator.
+    enabled: false
+    # -- The label to set. Empty uses `redpanda_k8s_cluster`.
+    name: ""
+    # -- The label's value. Empty uses `multicluster.name`, so a stretch
+    # deployment needs nothing further. Required when multicluster is disabled.
+    value: ""
 
 # Sets the name of the Secret in which to store the self-signed TLS certificate for the Webhooks when `webhook.enabled` is `true`.
 webhookSecretName: webhook-server-cert

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -227,18 +227,23 @@ monitoring:
   # -- Additional labels to add to the ServiceMonitor metadata.
   labels: {}
   # -- Adds a scrape-time label identifying which Kubernetes cluster a series
-  # came from. For stretch clusters, whose operator metrics have to be
-  # aggregated into one Prometheus-compatible backend to be queryable together —
-  # without it, series from every cluster collide, since job, namespace, service
-  # and pod names are identical in each. Off by default: a single-cluster
-  # install has nothing to disambiguate.
+  # came from. Use it whenever operator metrics from more than one Kubernetes
+  # cluster land in the same Prometheus-compatible backend — several independent
+  # installs remote_writing to a shared Mimir/Thanos, or one stretch cluster
+  # spanning clusters. Without it the series collide, since job, namespace,
+  # service and pod names are identical in each. Stretch clusters inherit the
+  # value from `multicluster.name`; a single-cluster install supplies `value`
+  # itself. Off by default: one cluster reporting to its own Prometheus has
+  # nothing to disambiguate.
   clusterLabel:
     # -- Adds the label to every series scraped from this operator.
     enabled: false
     # -- The label to set. Empty uses `redpanda_k8s_cluster`.
     name: ""
     # -- The label's value. Empty uses `multicluster.name`, so a stretch
-    # deployment needs nothing further. Required when multicluster is disabled.
+    # deployment needs nothing further. Required for a single-cluster install,
+    # which has no `multicluster.name` to inherit; the render fails rather than
+    # emitting an empty label.
     value: ""
 
 # Sets the name of the Secret in which to store the self-signed TLS certificate for the Webhooks when `webhook.enabled` is `true`.

--- a/operator/chart/values.yaml
+++ b/operator/chart/values.yaml
@@ -231,19 +231,20 @@ monitoring:
   # cluster land in the same Prometheus-compatible backend — several independent
   # installs remote_writing to a shared Mimir/Thanos, or one stretch cluster
   # spanning clusters. Without it the series collide, since job, namespace,
-  # service and pod names are identical in each. Stretch clusters inherit the
-  # value from `multicluster.name`; a single-cluster install supplies `value`
-  # itself. Off by default: one cluster reporting to its own Prometheus has
+  # service and pod names are identical in each. With `multicluster.enabled`,
+  # the value is inherited from `multicluster.name`; otherwise supply `value`
+  # yourself. Off by default: one cluster reporting to its own Prometheus has
   # nothing to disambiguate.
   clusterLabel:
     # -- Adds the label to every series scraped from this operator.
     enabled: false
     # -- The label to set. Empty uses `redpanda_k8s_cluster`.
     name: ""
-    # -- The label's value. Empty uses `multicluster.name`, so a stretch
-    # deployment needs nothing further. Required for a single-cluster install,
-    # which has no `multicluster.name` to inherit; the render fails rather than
-    # emitting an empty label.
+    # -- The label's value. When `multicluster.enabled` is true, empty inherits
+    # `multicluster.name`, so a stretch deployment needs nothing further.
+    # Required otherwise — including when `multicluster.name` is set but
+    # `multicluster.enabled` is false, since that name configures nothing else
+    # there. The render fails rather than emitting an empty label.
     value: ""
 
 # Sets the name of the Secret in which to store the self-signed TLS certificate for the Webhooks when `webhook.enabled` is `true`.

--- a/operator/chart/values_partial.gen.go
+++ b/operator/chart/values_partial.gen.go
@@ -88,10 +88,11 @@ type PartialServiceAccountConfig struct {
 }
 
 type PartialMonitoringConfig struct {
-	Enabled        *bool             "json:\"enabled,omitempty\""
-	RulesEnabled   *bool             "json:\"rulesEnabled,omitempty\""
-	Labels         map[string]string "json:\"labels,omitempty\""
-	ScrapeInterval *string           "json:\"scrapeInterval,omitempty\""
+	Enabled        *bool                "json:\"enabled,omitempty\""
+	RulesEnabled   *bool                "json:\"rulesEnabled,omitempty\""
+	Labels         map[string]string    "json:\"labels,omitempty\""
+	ScrapeInterval *string              "json:\"scrapeInterval,omitempty\""
+	ClusterLabel   *PartialClusterLabel "json:\"clusterLabel,omitempty\""
 }
 
 type PartialCRDs struct {
@@ -154,6 +155,12 @@ type PartialWebhookConfig struct {
 type PartialLeaderElectionConfig struct {
 	LeaderElect  *bool   "json:\"leaderElect,omitempty\""
 	ResourceName *string "json:\"resourceName,omitempty\""
+}
+
+type PartialClusterLabel struct {
+	Enabled *bool   "json:\"enabled,omitempty\""
+	Name    *string "json:\"name,omitempty\""
+	Value   *string "json:\"value,omitempty\""
 }
 
 type PartialConnectMonitoringConfig struct {


### PR DESCRIPTION
## Why

Aggregate the operator metrics from more than one Kubernetes cluster into a single Prometheus-compatible backend and **nothing in the scraped series says which cluster produced it.** Job, namespace, service and pod names are identical in every cluster — identical *by design* when each install follows the documented pattern — so the series collide, and a graph of, say, `controller_runtime_reconcile_total` silently sums three clusters into one line.

Two topologies hit this, and this change serves both:

**A stretch cluster**, which is what prompted it. A `StretchCluster` spans several Kubernetes clusters, each running its own operator. The questions you ask of it are inherently cross-cluster — which operator holds raft leadership, which region is behind, is a member unreachable — and you cannot answer any of them from three disjoint Prometheus instances without doing the join in your head during an incident. Accordingly, [the stretch-cluster monitoring guide](https://docs.redpanda.com/streaming/current/manage/kubernetes/monitoring/k-monitor-stretch-clusters/) already requires the aggregation:

> The stretch cluster dashboard reads from a single Prometheus data source, so aggregate the operator metrics from all Kubernetes clusters into one Prometheus-compatible backend.

**A fleet of independent single-cluster installs**, each `remote_write`ing to one central Prometheus. No stretch cluster, no multicluster mode, same collision — one central view of many operators, with no way to tell them apart.

## What this adds

`monitoring.clusterLabel`, off by default:

```yaml
monitoring:
  enabled: true
  clusterLabel:
    enabled: true      # off by default
    name: ""           # empty -> redpanda_k8s_cluster
    value: ""          # empty -> multicluster.name
```

It renders a relabeling on the ServiceMonitor endpoint that stamps the source cluster onto every series from that operator:

```yaml
relabelings:
  - replacement: rp-us-east-1
    targetLabel: redpanda_k8s_cluster
```

**Off by default** because a single-cluster install that isn't being aggregated has nothing to disambiguate, and adding a label to everyone's series would churn existing dashboards and recording rules for no benefit.

## Both topologies

Nothing here is gated on multicluster: the gates are `monitoring.enabled` and `monitoring.clusterLabel.enabled`. Multicluster only supplies a *default* for the value.

**Stretch** — the toggle is enough. The value defaults to `multicluster.name`, which is already the cluster's identity in the operator's raft group:

```yaml
monitoring:
  enabled: true
  clusterLabel:
    enabled: true
multicluster:
  enabled: true
  name: rp-us-east-1        # -> redpanda_k8s_cluster: rp-us-east-1
```

**Single cluster** — supply the value per install:

```yaml
monitoring:
  enabled: true
  clusterLabel:
    enabled: true
    value: prod-us-east-1   # required here; there is no multicluster.name to inherit
```

`.name` overrides the label name in either topology, for fitting an existing convention.

The one wrinkle outside a stretch deployment: `value` is **mandatory**, and omitting it *fails the render* rather than stamping an empty label. An empty label is worse than no label — it looks like data. It does mean the toggle alone isn't enough without multicluster, which is the deliberate trade.

## Behaviour, verified against the real chart

| values | result |
|---|---|
| default | no `relabelings` on the endpoint |
| `clusterLabel.enabled` + multicluster | `redpanda_k8s_cluster: rp-us-east-1` (inherited) |
| `clusterLabel.enabled` + `value`, no multicluster | `redpanda_k8s_cluster: prod-us-east-1` |
| `clusterLabel.enabled` + explicit name/value | `k8s_cluster: prod-eu-west-1` |
| `clusterLabel.enabled` + `value` + multicluster | `redpanda_k8s_cluster: <value>` — an explicit value wins over `multicluster.name` |
| `clusterLabel.enabled`, multicluster off, no value | render fails: `monitoring.clusterLabel.value must be set when multicluster.name is empty` |
| `monitoring.enabled: false` | nothing rendered |

The existing endpoint shape (`port: https`, `scheme: https`, `insecureSkipVerify`, bearer token file) is untouched — asserted in the rendered output, since that shape is what #1752 depends on.

## Testing

* **`operator/chart/servicemonitor_test.go`** (new) renders through the chart's own values path, one subtest per row of the table above: off by default; single cluster with only a value (default label name); single cluster with an explicit name; inherit from `multicluster.name`; an explicit value winning over `multicluster.name`; the render failing when both are empty; the #1752 endpoint shape surviving the relabeling; and `monitoring.enabled: false` rendering nothing.
* **Three golden cases** in `template-cases.txtar`, rendered through the `helm` binary: `monitoring-cluster-label-single-cluster` (added here), `monitoring-cluster-label-explicit`, and `monitoring-cluster-label-from-multicluster` — the single-cluster, override and inherit paths. Goldens regenerated; the diff is additive only, no existing entry changed.
* Both guards were checked by mutation: renaming the default label fails the single-cluster test, and deleting the empty-value `panic` fails the guard test.
* `go test ./operator/chart/` green. (`TestChartYaml` needs `changie` on `PATH`; it passes in the devshell.)
* `task generate` produces no diff, and `task lint` is clean (`0 issues`, plus `helm lint --strict` and `actionlint`).

## Scope

Deliberately just the label. Two adjacent things are *not* here:

* **The recording rules.** `monitoring.rulesEnabled` renders rules that aggregate with `sum by (controller)`, which drops this label along with `job` and `namespace`. Aggregated deployments will want those rules to preserve it — separate change, and it interacts with the unscoped-rules issue already filed.
* **A general `relabelings` passthrough.** An escape hatch for arbitrary relabeling would be more flexible but invites questions about ordering and validation that this focused change doesn't have to answer.

Neither is needed for aggregation to work; both are worth doing on their own.
