### PR TITLE
operator: fix multicluster telemetry dropping every report

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260826-101500.yaml
+++ b/.changes/unreleased/operator-Fixed-20260826-101500.yaml
@@ -3,21 +3,25 @@ kind: Fixed
 body: |-
     The multicluster operator now reports telemetry instead of dropping every report.
 
-      The telemetry collector lists the legacy `vectorized.io/v1alpha1` `Cluster`
-      API, which the multicluster command's scheme does not register because it
-      does not reconcile that API. The resulting
+      The telemetry collector listed the legacy `vectorized.io/v1alpha1` `Cluster`
+      API unconditionally, which the multicluster command's scheme does not
+      register because it does not reconcile that API. The resulting
       `no kind is registered for the type v1alpha1.ClusterList` is neither a
       NoMatch nor a Forbidden, so it propagated out of `Collect` and the reporter
       discarded the whole document on every cycle — no stretch or multicluster
       install has ever reported telemetry, in any release.
 
-      The collector now tolerates a type that is missing from the running
-      command's scheme the same way it already tolerated a missing CRD or missing
-      RBAC: that field degrades to its zero value and every other field is still
-      reported.
+      The `multicluster` command now declares that it does not collect the legacy
+      v1 API, so that list is skipped outright rather than attempted against a
+      scheme that cannot serialize it. This keeps each command's scheme matching
+      the CRDs it actually installs and saves an API server round trip per
+      reporting cycle. As a backstop for any future type a command's scheme
+      omits, the collector also tolerates a not-registered type the same way it
+      already tolerated a missing CRD or missing RBAC: that one field degrades to
+      its zero value and every other field is still reported, instead of the
+      whole install vanishing from the dataset.
 
       One consequence worth knowing: legacy `vectorized.io/v1alpha1` clusters
-      running alongside a multicluster install are reported as zero, because the
-      multicluster command never registers that type. Those clusters are not
-      managed by that command either.
+      running alongside a multicluster install are reported as zero. Those
+      clusters are not managed by that command either.
 time: 2026-08-26T10:15:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260826-101500.yaml
+++ b/.changes/unreleased/operator-Fixed-20260826-101500.yaml
@@ -4,13 +4,20 @@ body: |-
     The multicluster operator now reports telemetry instead of dropping every report.
 
       The telemetry collector lists the legacy `vectorized.io/v1alpha1` `Cluster`
-      API, which `multiclusterSchemeFns` deliberately does not register (the
-      multicluster command does not reconcile it). The resulting
+      API, which the multicluster command's scheme does not register because it
+      does not reconcile that API. The resulting
       `no kind is registered for the type v1alpha1.ClusterList` is neither a
       NoMatch nor a Forbidden, so it propagated out of `Collect` and the reporter
-      discarded the whole document on every cycle — no stretch/multicluster
-      install has ever reported, in any release. The collector now tolerates a
-      type that is missing from the scheme the same way it tolerates a missing
-      CRD, and the multicluster scheme registers the type so legacy clusters
-      alongside a multicluster install are counted.
+      discarded the whole document on every cycle — no stretch or multicluster
+      install has ever reported telemetry, in any release.
+
+      The collector now tolerates a type that is missing from the running
+      command's scheme the same way it already tolerated a missing CRD or missing
+      RBAC: that field degrades to its zero value and every other field is still
+      reported.
+
+      One consequence worth knowing: legacy `vectorized.io/v1alpha1` clusters
+      running alongside a multicluster install are reported as zero, because the
+      multicluster command never registers that type. Those clusters are not
+      managed by that command either.
 time: 2026-08-26T10:15:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260826-101500.yaml
+++ b/.changes/unreleased/operator-Fixed-20260826-101500.yaml
@@ -1,0 +1,16 @@
+project: operator
+kind: Fixed
+body: |-
+    The multicluster operator now reports telemetry instead of dropping every report.
+
+      The telemetry collector lists the legacy `vectorized.io/v1alpha1` `Cluster`
+      API, which `multiclusterSchemeFns` deliberately does not register (the
+      multicluster command does not reconcile it). The resulting
+      `no kind is registered for the type v1alpha1.ClusterList` is neither a
+      NoMatch nor a Forbidden, so it propagated out of `Collect` and the reporter
+      discarded the whole document on every cycle — no stretch/multicluster
+      install has ever reported, in any release. The collector now tolerates a
+      type that is missing from the scheme the same way it tolerates a missing
+      CRD, and the multicluster scheme registers the type so legacy clusters
+      alongside a multicluster install are counted.
+time: 2026-08-26T10:15:00.000000-07:00

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -601,6 +601,12 @@ func Run(
 			IDHash:   telemetry.LicenseChecksum(l),
 			Features: features,
 			Period:   opts.telemetryPeriod,
+			// This command does not reconcile the legacy v1
+			// (vectorized.io/v1alpha1) Cluster API, so that type is not in its
+			// scheme and listing it could only ever fail. Declining the
+			// collection explicitly keeps the scheme matching the CRDs this
+			// command installs and saves an API server round trip per cycle.
+			SkipV1Collection: true,
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to build telemetry runnable")

--- a/operator/internal/controller/scheme.go
+++ b/operator/internal/controller/scheme.go
@@ -51,13 +51,6 @@ var (
 		clientgoscheme.AddToScheme,
 		redpandav1alpha2.Install,
 		monitoringv1.AddToScheme,
-		// The multicluster command does not reconcile the legacy vectorized
-		// Cluster API, but the telemetry collector lists it to count legacy
-		// clusters (internal/telemetry/collector.go). Registering the type keeps
-		// that list a NoMatch when the CRD is absent — which the collector
-		// tolerates — instead of a NotRegistered error, and lets a multicluster
-		// install report legacy clusters that do exist alongside it.
-		vectorizedv1alpha1.Install,
 		// Register gatewayv1 (HTTPRoute) in the multicluster scheme too — the
 		// multicluster Console controller references HTTPRoute exactly like the
 		// v2 controller. The Gateway API CRDs are optional: skipWatchIfNotInstalled

--- a/operator/internal/controller/scheme.go
+++ b/operator/internal/controller/scheme.go
@@ -51,6 +51,13 @@ var (
 		clientgoscheme.AddToScheme,
 		redpandav1alpha2.Install,
 		monitoringv1.AddToScheme,
+		// The multicluster command does not reconcile the legacy vectorized
+		// Cluster API, but the telemetry collector lists it to count legacy
+		// clusters (internal/telemetry/collector.go). Registering the type keeps
+		// that list a NoMatch when the CRD is absent — which the collector
+		// tolerates — instead of a NotRegistered error, and lets a multicluster
+		// install report legacy clusters that do exist alongside it.
+		vectorizedv1alpha1.Install,
 		// Register gatewayv1 (HTTPRoute) in the multicluster scheme too — the
 		// multicluster Console controller references HTTPRoute exactly like the
 		// v2 controller. The Gateway API CRDs are optional: skipWatchIfNotInstalled

--- a/operator/internal/controller/scheme_test.go
+++ b/operator/internal/controller/scheme_test.go
@@ -13,38 +13,69 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
 )
 
-// TestSchemesRecognizeTelemetryTypes guards the types the telemetry collector
-// lists (internal/telemetry/collector.go) against the schemes the commands
-// actually run with. The collector tolerates a missing CRD and missing RBAC, but
-// a type absent from the scheme is a client-side serialization failure, and
-// before this was fixed it made the multicluster operator drop every report for
-// the life of the process ("no kind is registered for the type
-// v1alpha1.ClusterList in scheme"). Add any new type the collector lists here.
-func TestSchemesRecognizeTelemetryTypes(t *testing.T) {
-	collected := []client.ObjectList{
-		&redpandav1alpha2.RedpandaList{},
-		&redpandav1alpha2.NodePoolList{},
-		&redpandav1alpha2.StretchClusterList{},
-		&redpandav1alpha2.RedpandaBrokerPoolList{},
-		&redpandav1alpha2.ConsoleList{},
-		&redpandav1alpha2.PipelineList{},
-		&vectorizedv1alpha1.ClusterList{},
-	}
+// telemetryCollectedLists are the types the telemetry collector lists
+// (internal/telemetry/collector.go). Add any new one here.
+var telemetryCollectedLists = []client.ObjectList{
+	&redpandav1alpha2.RedpandaList{},
+	&redpandav1alpha2.NodePoolList{},
+	&redpandav1alpha2.StretchClusterList{},
+	&redpandav1alpha2.RedpandaBrokerPoolList{},
+	&redpandav1alpha2.ConsoleList{},
+	&redpandav1alpha2.PipelineList{},
+	&vectorizedv1alpha1.ClusterList{},
+}
 
-	for name, scheme := range map[string]*runtime.Scheme{
-		"multicluster": MulticlusterScheme,
-		"unified":      UnifiedScheme,
-	} {
-		for _, list := range collected {
-			_, _, err := scheme.ObjectKinds(list)
-			require.NoErrorf(t, err, "%s scheme does not recognize %T", name, list)
+// TestUnifiedSchemeRecognizesTelemetryTypes pins that the `run` command's scheme
+// covers everything the telemetry collector lists.
+//
+// A type absent from the scheme is not a missing CRD or missing RBAC — it is a
+// client-side serialization failure ("no kind is registered for the type
+// v1alpha1.ClusterList in scheme"), and until the collector learned to tolerate
+// it, one such type made the operator drop every telemetry report for the life
+// of the process.
+func TestUnifiedSchemeRecognizesTelemetryTypes(t *testing.T) {
+	for _, list := range telemetryCollectedLists {
+		_, _, err := UnifiedScheme.ObjectKinds(list)
+		require.NoErrorf(t, err, "unified scheme does not recognize %T", list)
+	}
+}
+
+// TestMulticlusterSchemeOmitsVectorizedByDesign records a deliberate asymmetry
+// rather than an oversight.
+//
+// The multicluster command does not reconcile the legacy vectorized Cluster API,
+// so that type stays out of its scheme: the schemes are meant to match the CRDs
+// each command actually installs, so nobody has to work out what is installed
+// versus what is merely registered with the client.
+//
+// The collector lists that type anyway, and gets a NotRegistered error here.
+// That is safe only because Collector.list tolerates NotRegistered alongside
+// NoMatch and Forbidden — see TestCollect_ToleratesTypeMissingFromScheme in
+// internal/telemetry, which is the test that makes this omission survivable.
+// The visible consequence is that legacy vectorized Clusters running alongside a
+// multicluster install are not counted in telemetry; they are not managed by
+// that command either.
+//
+// If this assertion ever fails because the type was registered, delete the test
+// — but check first that it was registered for a reason beyond telemetry.
+func TestMulticlusterSchemeOmitsVectorizedByDesign(t *testing.T) {
+	_, _, err := MulticlusterScheme.ObjectKinds(&vectorizedv1alpha1.ClusterList{})
+	require.Error(t, err, "multicluster scheme unexpectedly recognizes the legacy vectorized Cluster API")
+
+	// Everything else the collector lists must still be recognized: the
+	// multicluster command does reconcile those, and a NotRegistered error there
+	// would be a real bug rather than a documented gap.
+	for _, list := range telemetryCollectedLists {
+		if _, ok := list.(*vectorizedv1alpha1.ClusterList); ok {
+			continue
 		}
+		_, _, err := MulticlusterScheme.ObjectKinds(list)
+		require.NoErrorf(t, err, "multicluster scheme does not recognize %T", list)
 	}
 }

--- a/operator/internal/controller/scheme_test.go
+++ b/operator/internal/controller/scheme_test.go
@@ -54,10 +54,13 @@ func TestUnifiedSchemeRecognizesTelemetryTypes(t *testing.T) {
 // each command actually installs, so nobody has to work out what is installed
 // versus what is merely registered with the client.
 //
-// The collector lists that type anyway, and gets a NotRegistered error here.
-// That is safe only because Collector.list tolerates NotRegistered alongside
-// NoMatch and Forbidden — see TestCollect_ToleratesTypeMissingFromScheme in
-// internal/telemetry, which is the test that makes this omission survivable.
+// The telemetry collector therefore does not list that type when running under
+// this command: cmd/multicluster sets telemetry.Options.SkipV1Collection, so the
+// list is skipped outright rather than attempted and tolerated — see
+// TestCollect_SkipV1CollectionIssuesNoV1List in internal/telemetry. (Collector.list
+// also tolerates NotRegistered as a backstop for a type nobody thought to gate,
+// but that is not what keeps this omission safe.)
+//
 // The visible consequence is that legacy vectorized Clusters running alongside a
 // multicluster install are not counted in telemetry; they are not managed by
 // that command either.

--- a/operator/internal/controller/scheme_test.go
+++ b/operator/internal/controller/scheme_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+)
+
+// TestSchemesRecognizeTelemetryTypes guards the types the telemetry collector
+// lists (internal/telemetry/collector.go) against the schemes the commands
+// actually run with. The collector tolerates a missing CRD and missing RBAC, but
+// a type absent from the scheme is a client-side serialization failure, and
+// before this was fixed it made the multicluster operator drop every report for
+// the life of the process ("no kind is registered for the type
+// v1alpha1.ClusterList in scheme"). Add any new type the collector lists here.
+func TestSchemesRecognizeTelemetryTypes(t *testing.T) {
+	collected := []client.ObjectList{
+		&redpandav1alpha2.RedpandaList{},
+		&redpandav1alpha2.NodePoolList{},
+		&redpandav1alpha2.StretchClusterList{},
+		&redpandav1alpha2.RedpandaBrokerPoolList{},
+		&redpandav1alpha2.ConsoleList{},
+		&redpandav1alpha2.PipelineList{},
+		&vectorizedv1alpha1.ClusterList{},
+	}
+
+	for name, scheme := range map[string]*runtime.Scheme{
+		"multicluster": MulticlusterScheme,
+		"unified":      UnifiedScheme,
+	} {
+		for _, list := range collected {
+			_, _, err := scheme.ObjectKinds(list)
+			require.NoErrorf(t, err, "%s scheme does not recognize %T", name, list)
+		}
+	}
+}

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -72,6 +72,14 @@ type Collector struct {
 	// .spec.image — without it, fleets running the chart default would be
 	// misreported as running the binary-baked constant.
 	ConnectDefaultImage string
+	// SkipV1Collection omits the legacy v1 (vectorized.io/v1alpha1) Cluster
+	// list. Set it on commands that do not reconcile that API — the
+	// multicluster command — where the type is deliberately absent from the
+	// scheme (internal/controller/scheme.go), so the list could only ever fail.
+	// Skipping is declarative and saves an API server round trip per cycle;
+	// vectorizedClusters then reports its zero value, the same as when the CRD
+	// is not installed.
+	SkipV1Collection bool
 }
 
 // Collect builds a Payload describing the current shape of the cluster.
@@ -163,29 +171,33 @@ func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
 		sc.into(&payload.StretchCluster.TotalCPUCores, &payload.StretchCluster.TotalMemoryGiB, &payload.StretchCluster.BrokerSizes)
 	}
 
-	var vectorized vectorizedv1alpha1.ClusterList
-	if ok, err := c.list(ctx, &vectorized); err != nil {
-		return nil, err
-	} else if ok {
-		payload.VectorizedClusters.Count = len(vectorized.Items)
-		var vec sizing
-		for i := range vectorized.Items {
-			spec := vectorized.Items[i].Spec
-			// Either the legacy single pool (spec.replicas) or explicit nodePools,
-			// not both — avoid double counting.
-			if len(spec.NodePools) == 0 {
-				replicas := derefInt32(spec.Replicas)
-				payload.VectorizedClusters.BrokerCount += replicas
-				vec.add(spec.Resources.ResourceRequirements, replicas)
-			} else {
-				for _, np := range spec.NodePools {
-					replicas := derefInt32(np.Replicas)
+	// Legacy v1 clusters, unless the running command declares it does not
+	// reconcile that API (SkipV1Collection).
+	if !c.SkipV1Collection {
+		var vectorized vectorizedv1alpha1.ClusterList
+		if ok, err := c.list(ctx, &vectorized); err != nil {
+			return nil, err
+		} else if ok {
+			payload.VectorizedClusters.Count = len(vectorized.Items)
+			var vec sizing
+			for i := range vectorized.Items {
+				spec := vectorized.Items[i].Spec
+				// Either the legacy single pool (spec.replicas) or explicit nodePools,
+				// not both — avoid double counting.
+				if len(spec.NodePools) == 0 {
+					replicas := derefInt32(spec.Replicas)
 					payload.VectorizedClusters.BrokerCount += replicas
-					vec.add(np.Resources.ResourceRequirements, replicas)
+					vec.add(spec.Resources.ResourceRequirements, replicas)
+				} else {
+					for _, np := range spec.NodePools {
+						replicas := derefInt32(np.Replicas)
+						payload.VectorizedClusters.BrokerCount += replicas
+						vec.add(np.Resources.ResourceRequirements, replicas)
+					}
 				}
 			}
+			vec.into(&payload.VectorizedClusters.TotalCPUCores, &payload.VectorizedClusters.TotalMemoryGiB, &payload.VectorizedClusters.BrokerSizes)
 		}
-		vec.into(&payload.VectorizedClusters.TotalCPUCores, &payload.VectorizedClusters.TotalMemoryGiB, &payload.VectorizedClusters.BrokerSizes)
 	}
 
 	// Supporting CR-type counts. Metadata-only lists: we only need len(), so
@@ -537,12 +549,15 @@ func (c *Collector) count(ctx context.Context, listGVK schema.GroupVersionKind, 
 // (with a nil error) in those cases so the caller leaves the field at its zero
 // value and continues; any other error is returned for the caller to propagate.
 //
-// NotRegistered is not hypothetical: each command builds its own scheme
-// (internal/controller/scheme.go), and the multicluster command deliberately
-// omits vectorized/v1alpha1 because it does not reconcile the legacy Cluster
-// API. A collector that treats that as fatal reports nothing at all, which is
-// strictly worse than reporting every other field, so it is tolerated here
-// rather than only fixed in the scheme.
+// NotRegistered is the backstop, not the mechanism. Each command builds its own
+// scheme (internal/controller/scheme.go), so a type this collector lists can be
+// absent from the scheme the process is running with. The one case known today —
+// the multicluster command and vectorized/v1alpha1 — is handled declaratively by
+// SkipV1Collection, which is preferable: it states the intent and spends no API
+// call. This tolerance exists for the case nobody anticipated, because the
+// alternative failure mode is the whole telemetry document being discarded, in a
+// debug-level log, for the life of the process. One unregistered type should
+// cost one field.
 func (c *Collector) list(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (bool, error) {
 	if err := c.Reader.List(ctx, list, opts...); err != nil {
 		if meta.IsNoMatchError(err) || apierrors.IsForbidden(err) || k8sruntime.IsNotRegisteredError(err) {

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -529,14 +530,22 @@ func (c *Collector) count(ctx context.Context, listGVK schema.GroupVersionKind, 
 	return nil
 }
 
-// list reads a resource list, tolerating the two permanent, install-specific
+// list reads a resource list, tolerating the three permanent, install-specific
 // conditions that would otherwise discard the whole telemetry document: a
-// missing CRD (NoMatch) and missing RBAC (Forbidden). It returns ok=false (with
-// a nil error) in those cases so the caller leaves the field at its zero value
-// and continues; any other error is returned for the caller to propagate.
+// missing CRD (NoMatch), missing RBAC (Forbidden), and a type the running
+// command never registered in its scheme (NotRegistered). It returns ok=false
+// (with a nil error) in those cases so the caller leaves the field at its zero
+// value and continues; any other error is returned for the caller to propagate.
+//
+// NotRegistered is not hypothetical: each command builds its own scheme
+// (internal/controller/scheme.go), and the multicluster command deliberately
+// omits vectorized/v1alpha1 because it does not reconcile the legacy Cluster
+// API. A collector that treats that as fatal reports nothing at all, which is
+// strictly worse than reporting every other field, so it is tolerated here
+// rather than only fixed in the scheme.
 func (c *Collector) list(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (bool, error) {
 	if err := c.Reader.List(ctx, list, opts...); err != nil {
-		if meta.IsNoMatchError(err) || apierrors.IsForbidden(err) {
+		if meta.IsNoMatchError(err) || apierrors.IsForbidden(err) || k8sruntime.IsNotRegisteredError(err) {
 			return false, nil
 		}
 		return false, err

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -484,11 +484,17 @@ func TestCollect_DegradesOnMissingCRDAndForbidden(t *testing.T) {
 	require.Equal(t, 0, raw.Resources.Users)
 }
 
+// TestCollect_ToleratesTypeMissingFromScheme covers the backstop rather than the
+// mechanism: SkipV1Collection is how the multicluster command avoids this
+// specific list (see TestCollect_SkipV1CollectionIssuesNoV1List). This asserts
+// what happens when some future collected type is missing from some command's
+// scheme with no flag guarding it — one field degrades, the document still goes
+// out. Without the tolerance in Collector.list, that case silently discards
+// every report for the life of the process.
 func TestCollect_ToleratesTypeMissingFromScheme(t *testing.T) {
-	// A scheme that never registered vectorized/v1alpha1 — exactly what the
-	// multicluster command builds, since it does not reconcile the legacy
-	// Cluster API. The client then fails that one List with a NotRegistered
-	// error, which must not discard the rest of the document.
+	// A scheme that never registered vectorized/v1alpha1, with the skip flag
+	// deliberately left unset so the List is actually attempted and fails with
+	// a NotRegistered error.
 	scheme := apimachineryruntime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
@@ -512,6 +518,57 @@ func TestCollect_ToleratesTypeMissingFromScheme(t *testing.T) {
 	require.Equal(t, 1, raw.StretchCluster.Count)
 	// The unregistered type degrades to its zero value.
 	require.Equal(t, 0, raw.VectorizedClusters.Count)
+}
+
+// TestCollect_SkipV1CollectionIssuesNoV1List asserts that SkipV1Collection is a
+// real skip and not merely error tolerance: the legacy v1 Cluster list must
+// never be issued, so a command whose scheme omits the type spends no API server
+// round trip on it. This is the mechanism the multicluster command relies on.
+func TestCollect_SkipV1CollectionIssuesNoV1List(t *testing.T) {
+	// A full scheme, so a vectorized List would actually succeed here. The
+	// assertion is that it is never attempted.
+	scheme := testScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&redpandav1alpha2.StretchCluster{ObjectMeta: metav1.ObjectMeta{Name: "sc-1", Namespace: "default"}},
+		&vectorizedv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "legacy-1", Namespace: "default"}},
+	).Build()
+
+	var v1Listed bool
+	reader := stubReader{
+		Reader: base,
+		listErr: func(list client.ObjectList) error {
+			if _, ok := list.(*vectorizedv1alpha1.ClusterList); ok {
+				v1Listed = true
+			}
+			return nil
+		},
+	}
+
+	collector := &Collector{Reader: reader, ID: "id", OperatorVersion: "v26.2.2", SkipV1Collection: true}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	require.False(t, v1Listed, "SkipV1Collection must not issue the legacy v1 Cluster list")
+	// Skipped, so the field reports its zero value even though a legacy Cluster
+	// exists — the same shape as an install without the v1 CRD.
+	require.Equal(t, 0, raw.VectorizedClusters.Count)
+	// Everything else is still collected.
+	require.True(t, raw.StretchCluster.Enabled)
+	require.Equal(t, 1, raw.StretchCluster.Count)
+}
+
+// TestCollect_V1CollectedByDefault is the counterpart: with the flag unset (the
+// `run` command), legacy clusters are listed and counted as before.
+func TestCollect_V1CollectedByDefault(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&vectorizedv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "legacy-1", Namespace: "default"}},
+	).Build()
+
+	collector := &Collector{Reader: c, ID: "id", OperatorVersion: "v26.2.2"}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, raw.VectorizedClusters.Count)
 }
 
 func TestCollect_PropagatesUnexpectedError(t *testing.T) {

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -484,6 +484,36 @@ func TestCollect_DegradesOnMissingCRDAndForbidden(t *testing.T) {
 	require.Equal(t, 0, raw.Resources.Users)
 }
 
+func TestCollect_ToleratesTypeMissingFromScheme(t *testing.T) {
+	// A scheme that never registered vectorized/v1alpha1 — exactly what the
+	// multicluster command builds, since it does not reconcile the legacy
+	// Cluster API. The client then fails that one List with a NotRegistered
+	// error, which must not discard the rest of the document.
+	scheme := apimachineryruntime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&redpandav1alpha2.StretchCluster{ObjectMeta: metav1.ObjectMeta{Name: "sc-1", Namespace: "default"}},
+	).Build()
+
+	// Guard the premise: the List really does fail, and with NotRegistered.
+	err := c.List(t.Context(), &vectorizedv1alpha1.ClusterList{})
+	require.Error(t, err)
+	require.True(t, apimachineryruntime.IsNotRegisteredError(err), "expected NotRegistered, got %v", err)
+
+	collector := &Collector{Reader: c, ID: "id", OperatorVersion: "v26.2.2"}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err) // tolerated, document still sent
+
+	require.Equal(t, "id", raw.ID)
+	require.True(t, raw.StretchCluster.Enabled)
+	require.Equal(t, 1, raw.StretchCluster.Count)
+	// The unregistered type degrades to its zero value.
+	require.Equal(t, 0, raw.VectorizedClusters.Count)
+}
+
 func TestCollect_PropagatesUnexpectedError(t *testing.T) {
 	scheme := testScheme(t)
 	base := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/operator/internal/telemetry/runnable.go
+++ b/operator/internal/telemetry/runnable.go
@@ -44,6 +44,11 @@ type Options struct {
 	// (--connect-default-image); used to resolve the effective image version
 	// of Pipelines that don't pin .spec.image.
 	ConnectDefaultImage string
+	// SkipV1Collection omits the legacy v1 (vectorized.io/v1alpha1) Cluster
+	// list from collection. Set by commands that do not reconcile that API, so
+	// they neither list a type their scheme deliberately omits nor spend an API
+	// server round trip on it.
+	SkipV1Collection bool
 	// Delay is the wait before the first report; zero means the shared library default (5m).
 	Delay  time.Duration
 	Period time.Duration
@@ -87,6 +92,7 @@ func NewRunnable(reader client.Reader, disco discovery.ServerVersionInterface, l
 		Features:            opts.Features,
 		Discovery:           disco,
 		ConnectDefaultImage: opts.ConnectDefaultImage,
+		SkipV1Collection:    opts.SkipV1Collection,
 	}
 
 	return &Runnable{reporter: &commontelemetry.Reporter{


### PR DESCRIPTION
## What

The multicluster (stretch) operator has never emitted telemetry, in any release. It collects a payload, fails on one list, and throws the whole document away — every period, for the life of the process.

```
{"level":"debug","logger":"setup","msg":"failed to collect telemetry",
 "error":"no kind is registered for the type v1alpha1.ClusterList in scheme \"pkg/runtime/scheme.go:111\""}
```

`internal/telemetry/collector.go` lists the legacy `vectorized.io/v1alpha1` `Cluster` API unconditionally. `multiclusterSchemeFns` doesn't register it — correctly, since the multicluster command doesn't reconcile that API. `Collector.list` tolerates only `NoMatch` (CRD absent) and `Forbidden` (RBAC absent); a not-registered error is neither, so it propagates out of `Collect` and `Reporter.collectAndSend` drops the payload.

## How it was found

Ran a three-region EKS StretchCluster (us-east-1 / us-west-2 / eu-west-1) on official `v26.2.2` — the first release whose images actually embed the telemetry signing key (#1732/#1734) — with `--telemetry-period=5m`. All three operators logged the error above at their first report and sent nothing.

That matches the warehouse: over 30 days, `callhome_layer_1.kubernetes_telemetry` holds 854 rows and **not one** carries the `features.multicluster` key that `cmd/multicluster` sets on every report. Run-mode installs report fine; multicluster installs have never appeared.

## Fix

Both the declarative skip and a backstop, because either alone leaves a gap:

- **`cmd/multicluster` sets `telemetry.Options.SkipV1Collection`.** That command does not reconcile the legacy `vectorized.io/v1alpha1` `Cluster` API, so the collector no longer lists it there — the list is skipped outright instead of attempted against a scheme that cannot serialize it. Each command's scheme keeps matching the CRDs it actually installs, and every reporting cycle spends one fewer API server round trip.
- **`Collector.list` tolerates `runtime.IsNotRegisteredError`** as a backstop. Each command builds its own scheme, so this will recur the next time the collector grows a type some command omits with no flag gating it. One unregistered type should cost one field, not the entire install's telemetry — especially since the failure is a debug-level log and permanent for the process lifetime.

The reported shape is unchanged by the skip: `vectorizedClusters.count` has no `omitempty`, so it was already `0` when the list was tolerated away.

## Tests

- `TestCollect_SkipV1CollectionIssuesNoV1List` — the legacy v1 list is never *issued* (not merely tolerated), on a scheme where it would have succeeded and with a legacy `Cluster` present. Fails if the guard is removed.
- `TestCollect_V1CollectedByDefault` — with the flag unset (the `run` command), legacy clusters are still listed and counted.
- `TestCollect_ToleratesTypeMissingFromScheme` — the backstop: a real fake client on a scheme without `vectorized/v1alpha1` and the skip flag deliberately unset. Asserts the premise (the List genuinely fails with `NotRegistered`), then that `Collect` still succeeds and still reports the stretch fields. Fails with the exact production error string without the collector change.
- `TestUnifiedSchemeRecognizesTelemetryTypes` / `TestMulticlusterSchemeOmitsVectorizedByDesign` — pin every type the collector lists against `UnifiedScheme`, and record the multicluster scheme's omission of the vectorized type as deliberate, pointing at the flag that makes it safe.

Verified all directions locally (`go test -count=1`), including that each new assertion fails without its corresponding change.

## Not in this PR

`id_hash` is empty on **every** row ingested so far (0/860), so no licensed install is identifiable as licensed. That's a separate, deliberate design limit rather than a bug: `id_hash` comes only from the *operator* chart's `enterprise.licenseSecretRef` → `--license-file-path`, which people set for Connect or multicluster. A cluster license lives on the Redpanda CR (`charts/redpanda` `enterprise.license` / `licenseSecretRef`) and the collector never reads it — 26 rows in 14 days run tiered storage with no `id_hash`. `Redpanda.status.licenseStatus` (type, organization, expiration, expired, inUseFeatures) is already populated from the broker admin API and would close that gap; happy to open a follow-up if that shape sounds right.
