### PR TITLE
operator: populate id_hash from cluster licenses

### DIFF
--- a/.changes/unreleased/operator-Added-20260826-113000.yaml
+++ b/.changes/unreleased/operator-Added-20260826-113000.yaml
@@ -10,11 +10,18 @@ body: |-
       `id_hash` and could not be correlated to an account. The collector now
       resolves the license configured on each managed cluster
       (`Redpanda .spec.clusterSpec.enterprise.license`/`licenseSecretRef` and
-      legacy `Cluster .spec.licenseRef`) and reports its checksum. The operator's
-      own license stays authoritative when present, and when the fleet holds
-      several distinct licenses no single checksum is reported; the new
-      `clusterLicenses.licensed` and `clusterLicenses.distinct` counts
-      distinguish that case from an unlicensed install. Licenses that are
-      expired, non-enterprise, or unreadable are skipped rather than failing the
-      report.
+      legacy `Cluster .spec.licenseRef`) and reports its checksum.
+
+      The operator's own license stays authoritative when present. A new
+      `clusterLicenses.checksums` field carries the distinct license checksums
+      found across the managed clusters, sorted, so a fleet holding several
+      licenses still correlates to every account it belongs to instead of to
+      none; `id_hash` itself is left empty in that case, since no single checksum
+      represents the install. `clusterLicenses.licensed` counts the clusters
+      carrying a valid license, which the deduplicated checksum list cannot
+      express — several clusters commonly share one license.
+
+      Licenses that are expired, non-enterprise, or unreadable are skipped rather
+      than failing the report, and commands that do not reconcile the legacy v1
+      API do not report those clusters' licenses.
 time: 2026-08-26T11:30:00.000000-07:00

--- a/.changes/unreleased/operator-Added-20260826-113000.yaml
+++ b/.changes/unreleased/operator-Added-20260826-113000.yaml
@@ -1,0 +1,20 @@
+project: operator
+kind: Added
+body: |-
+    Telemetry now reports `id_hash` for clusters licensed through their CR, not only for operators given their own license file.
+
+      `id_hash` was previously derived solely from the operator's own
+      `--license-file-path` (operator chart `enterprise.licenseSecretRef`), which
+      deployers set only for the Connect controller or multicluster — so every
+      install that licensed Redpanda the usual way, on the CR, reported no
+      `id_hash` and could not be correlated to an account. The collector now
+      resolves the license configured on each managed cluster
+      (`Redpanda .spec.clusterSpec.enterprise.license`/`licenseSecretRef` and
+      legacy `Cluster .spec.licenseRef`) and reports its checksum. The operator's
+      own license stays authoritative when present, and when the fleet holds
+      several distinct licenses no single checksum is reported; the new
+      `clusterLicenses.licensed` and `clusterLicenses.distinct` counts
+      distinguish that case from an unlicensed install. Licenses that are
+      expired, non-enterprise, or unreadable are skipped rather than failing the
+      report.
+time: 2026-08-26T11:30:00.000000-07:00

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -58,6 +58,12 @@ import (
 // uncached API reader, so only "list" (not "watch") is required.
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
 // +kubebuilder:rbac:groups=apps,namespace=default,resources=replicasets,verbs=get
+// Telemetry also reads the Secrets referenced by a cluster's enterprise license
+// (Redpanda .spec.clusterSpec.enterprise.licenseSecretRef, legacy
+// Cluster .spec.licenseRef) to report the license checksum as id_hash. That
+// needs no marker of its own: the manager already holds get on secrets
+// cluster-wide, and a Forbidden read is tolerated — the install simply reports
+// no id_hash.
 
 type RaftCluster struct {
 	Name    string

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -308,6 +308,12 @@ func (o *RunOptions) ControllerEnabled(controller Controller) bool {
 // uncached API reader, so only "list" (not "watch") is required.
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
 // +kubebuilder:rbac:groups=apps,namespace=default,resources=replicasets,verbs=get
+// Telemetry also reads the Secrets referenced by a cluster's enterprise license
+// (Redpanda .spec.clusterSpec.enterprise.licenseSecretRef, legacy
+// Cluster .spec.licenseRef) to report the license checksum as id_hash. That
+// needs no marker of its own: the manager already holds get on secrets
+// cluster-wide, and a Forbidden read is tolerated — the install simply reports
+// no id_hash.
 
 func Command() *cobra.Command {
 	var options RunOptions

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/redpanda-data/common-go/license"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,8 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/redpanda-data/common-go/license"
 
 	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/redpanda-data/common-go/license"
+
 	"github.com/redpanda-data/redpanda-operator/operator/api/apiutil"
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
@@ -66,6 +68,12 @@ type Collector struct {
 	// the reported version tracks in-place cluster upgrades. Optional: when nil,
 	// kubeVersion is omitted from the payload.
 	Discovery discovery.ServerVersionInterface
+	// ParseLicense parses a raw license token, defaulting to
+	// license.ParseLicense. It exists as a seam only because a license cannot be
+	// minted in a test: the parser verifies an RSA signature against a public
+	// key embedded in common-go, and committing a real token to satisfy it is
+	// not an option.
+	ParseLicense func([]byte) (license.RedpandaLicense, error)
 	// ConnectDefaultImage is the operator-level Connect image override (the
 	// --connect-default-image flag / connectController.image chart values).
 	// Needed to resolve the effective image of Pipelines that don't pin
@@ -197,6 +205,22 @@ func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
 				}
 			}
 			vec.into(&payload.VectorizedClusters.TotalCPUCores, &payload.VectorizedClusters.TotalMemoryGiB, &payload.VectorizedClusters.BrokerSizes)
+		}
+	}
+
+	// Licensing of the managed clusters. c.IDHash, when set, is the operator's
+	// own license and stays authoritative; otherwise a single license across the
+	// fleet is reported as id_hash, which is the shape of nearly every install.
+	// With several distinct licenses no one checksum represents the install, so
+	// id_hash is left empty and the counts below say why.
+	licenses := c.clusterLicenses(ctx, redpandas.Items, vectorized.Items)
+	for _, clusters := range licenses {
+		payload.ClusterLicenses.Licensed += clusters
+	}
+	payload.ClusterLicenses.Distinct = len(licenses)
+	if payload.IDHash == "" && len(licenses) == 1 {
+		for checksum := range licenses {
+			payload.IDHash = checksum
 		}
 	}
 

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -179,9 +179,12 @@ func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
 	}
 
 	// Legacy v1 clusters, unless the running command declares it does not
-	// reconcile that API (SkipV1Collection).
+	// reconcile that API (SkipV1Collection). Declared outside the guard so the
+	// license pass below sees an empty list rather than nothing when skipped —
+	// a command that does not manage those clusters does not own their licenses
+	// either.
+	var vectorized vectorizedv1alpha1.ClusterList
 	if !c.SkipV1Collection {
-		var vectorized vectorizedv1alpha1.ClusterList
 		if ok, err := c.list(ctx, &vectorized); err != nil {
 			return nil, err
 		} else if ok {
@@ -211,15 +214,20 @@ func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
 	// own license and stays authoritative; otherwise a single license across the
 	// fleet is reported as id_hash, which is the shape of nearly every install.
 	// With several distinct licenses no one checksum represents the install, so
-	// id_hash is left empty and the counts below say why.
+	// id_hash is left empty and clusterLicenses.checksums carries them all —
+	// such a fleet still correlates to every account it belongs to.
 	licenses := c.clusterLicenses(ctx, redpandas.Items, vectorized.Items)
-	for _, clusters := range licenses {
-		payload.ClusterLicenses.Licensed += clusters
-	}
-	payload.ClusterLicenses.Distinct = len(licenses)
-	if payload.IDHash == "" && len(licenses) == 1 {
-		for checksum := range licenses {
-			payload.IDHash = checksum
+	if len(licenses) > 0 {
+		checksums := make([]string, 0, len(licenses))
+		for checksum, clusters := range licenses {
+			checksums = append(checksums, checksum)
+			payload.ClusterLicenses.Licensed += clusters
+		}
+		sort.Strings(checksums)
+		payload.ClusterLicenses.Checksums = checksums
+
+		if payload.IDHash == "" && len(checksums) == 1 {
+			payload.IDHash = checksums[0]
 		}
 	}
 

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -14,7 +14,9 @@ import (
 	"errors"
 	"runtime"
 	"testing"
+	"time"
 
+	"github.com/redpanda-data/common-go/license"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -589,6 +591,181 @@ func TestCollect_PropagatesUnexpectedError(t *testing.T) {
 	_, err := collector.Collect(t.Context())
 	// A non-tolerated error drops the cycle rather than sending a partial payload.
 	require.Error(t, err)
+}
+
+func enterpriseLicense(checksum string) *license.V1RedpandaLicense {
+	return &license.V1RedpandaLicense{
+		Version:  1,
+		Type:     license.LicenseTypeEnterprise,
+		Expiry:   time.Now().Add(24 * time.Hour).Unix(),
+		Checksum: checksum,
+	}
+}
+
+// stubParser maps a raw token to a parsed license, standing in for
+// license.ParseLicense (which verifies a signature we cannot produce in a test).
+func stubParser(byToken map[string]*license.V1RedpandaLicense) func([]byte) (license.RedpandaLicense, error) {
+	return func(raw []byte) (license.RedpandaLicense, error) {
+		if parsed, ok := byToken[string(raw)]; ok {
+			return parsed, nil
+		}
+		return license.OpenSourceLicense, errors.New("unparseable license")
+	}
+}
+
+func licensedRedpanda(name, namespace string, enterprise *redpandav1alpha2.Enterprise) *redpandav1alpha2.Redpanda {
+	return &redpandav1alpha2.Redpanda{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: redpandav1alpha2.RedpandaSpec{
+			ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{Enterprise: enterprise},
+		},
+	}
+}
+
+func TestCollect_IDHashFromClusterLicense(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		// Inline license on one cluster...
+		licensedRedpanda("rp-inline", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-a")}),
+		// ...and the same license by secret reference on another. One account,
+		// two clusters: one checksum, so it is safe to report as id_hash.
+		licensedRedpanda("rp-secret", "other", &redpandav1alpha2.Enterprise{
+			LicenseSecretRef: &redpandav1alpha2.EnterpriseLicenseSecretRef{
+				Name: ptr.To("rp-license"), Key: ptr.To("license"),
+			},
+		}),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "rp-license", Namespace: "other"},
+			Data:       map[string][]byte{"license": []byte("token-a")},
+		},
+	).Build()
+
+	collector := &Collector{
+		Reader:       c,
+		ID:           "id",
+		ParseLicense: stubParser(map[string]*license.V1RedpandaLicense{"token-a": enterpriseLicense("sum-a")}),
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, "sum-a", raw.IDHash)
+	require.Equal(t, 2, raw.ClusterLicenses.Licensed)
+	require.Equal(t, 1, raw.ClusterLicenses.Distinct)
+}
+
+func TestCollect_OperatorLicenseWinsOverClusterLicense(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		licensedRedpanda("rp-1", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-a")}),
+	).Build()
+
+	collector := &Collector{
+		Reader: c,
+		// The operator's own --license-file-path checksum stays authoritative.
+		IDHash:       "operator-sum",
+		ParseLicense: stubParser(map[string]*license.V1RedpandaLicense{"token-a": enterpriseLicense("sum-a")}),
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, "operator-sum", raw.IDHash)
+	require.Equal(t, 1, raw.ClusterLicenses.Licensed)
+}
+
+func TestCollect_SeveralLicensesLeaveIDHashEmpty(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		licensedRedpanda("rp-1", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-a")}),
+		licensedRedpanda("rp-2", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-b")}),
+	).Build()
+
+	collector := &Collector{
+		Reader: c,
+		ParseLicense: stubParser(map[string]*license.V1RedpandaLicense{
+			"token-a": enterpriseLicense("sum-a"),
+			"token-b": enterpriseLicense("sum-b"),
+		}),
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	// No single checksum represents this install, so id_hash stays empty and the
+	// counts are what tell it apart from an unlicensed one.
+	require.Empty(t, raw.IDHash)
+	require.Equal(t, 2, raw.ClusterLicenses.Licensed)
+	require.Equal(t, 2, raw.ClusterLicenses.Distinct)
+}
+
+func TestCollect_UnresolvableAndExpiredLicensesAreSkipped(t *testing.T) {
+	scheme := testScheme(t)
+	expired := &license.V1RedpandaLicense{
+		Version: 1, Type: license.LicenseTypeEnterprise,
+		Expiry: time.Now().Add(-24 * time.Hour).Unix(), Checksum: "sum-expired",
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		// Secret that does not exist.
+		licensedRedpanda("rp-missing-secret", "default", &redpandav1alpha2.Enterprise{
+			LicenseSecretRef: &redpandav1alpha2.EnterpriseLicenseSecretRef{
+				Name: ptr.To("nope"), Key: ptr.To("license"),
+			},
+		}),
+		// Secret reference with no key: unresolvable, and not ours to guess.
+		licensedRedpanda("rp-no-key", "default", &redpandav1alpha2.Enterprise{
+			LicenseSecretRef: &redpandav1alpha2.EnterpriseLicenseSecretRef{Name: ptr.To("rp-license")},
+		}),
+		// Garbage that will not parse.
+		licensedRedpanda("rp-garbage", "default", &redpandav1alpha2.Enterprise{License: ptr.To("not-a-license")}),
+		// Parses, but expired, so it grants nothing.
+		licensedRedpanda("rp-expired", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-expired")}),
+		// No enterprise stanza at all.
+		&redpandav1alpha2.Redpanda{ObjectMeta: metav1.ObjectMeta{Name: "rp-oss", Namespace: "default"}},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "rp-license", Namespace: "default"},
+			Data:       map[string][]byte{"license": []byte("token-a")},
+		},
+	).Build()
+
+	collector := &Collector{
+		Reader: c,
+		ParseLicense: stubParser(map[string]*license.V1RedpandaLicense{
+			"token-a":       enterpriseLicense("sum-a"),
+			"token-expired": expired,
+		}),
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err) // every one of these is tolerated
+
+	require.Empty(t, raw.IDHash)
+	require.Equal(t, 0, raw.ClusterLicenses.Licensed)
+	require.Equal(t, 0, raw.ClusterLicenses.Distinct)
+	require.Equal(t, 5, raw.Redpanda.Count)
+}
+
+func TestCollect_IDHashFromLegacyClusterLicense(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&vectorizedv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "legacy", Namespace: "default"},
+			Spec: vectorizedv1alpha1.ClusterSpec{
+				// Key omitted: SecretKeyRef documents "license" as the default.
+				LicenseRef: &vectorizedv1alpha1.SecretKeyRef{Name: "legacy-license", Namespace: "default"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "legacy-license", Namespace: "default"},
+			Data:       map[string][]byte{"license": []byte("token-a")},
+		},
+	).Build()
+
+	collector := &Collector{
+		Reader:       c,
+		ParseLicense: stubParser(map[string]*license.V1RedpandaLicense{"token-a": enterpriseLicense("sum-a")}),
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, "sum-a", raw.IDHash)
+	require.Equal(t, 1, raw.ClusterLicenses.Licensed)
 }
 
 func TestSizing(t *testing.T) {

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -650,7 +650,7 @@ func TestCollect_IDHashFromClusterLicense(t *testing.T) {
 
 	require.Equal(t, "sum-a", raw.IDHash)
 	require.Equal(t, 2, raw.ClusterLicenses.Licensed)
-	require.Equal(t, 1, raw.ClusterLicenses.Distinct)
+	require.Equal(t, []string{"sum-a"}, raw.ClusterLicenses.Checksums)
 }
 
 func TestCollect_OperatorLicenseWinsOverClusterLicense(t *testing.T) {
@@ -670,6 +670,9 @@ func TestCollect_OperatorLicenseWinsOverClusterLicense(t *testing.T) {
 
 	require.Equal(t, "operator-sum", raw.IDHash)
 	require.Equal(t, 1, raw.ClusterLicenses.Licensed)
+	// The cluster's own license is still reported, so a fleet whose operator and
+	// clusters are licensed to different accounts is not silently collapsed.
+	require.Equal(t, []string{"sum-a"}, raw.ClusterLicenses.Checksums)
 }
 
 func TestCollect_SeveralLicensesLeaveIDHashEmpty(t *testing.T) {
@@ -689,11 +692,12 @@ func TestCollect_SeveralLicensesLeaveIDHashEmpty(t *testing.T) {
 	raw, err := collector.Collect(t.Context())
 	require.NoError(t, err)
 
-	// No single checksum represents this install, so id_hash stays empty and the
-	// counts are what tell it apart from an unlicensed one.
+	// No single checksum represents this install, so id_hash stays empty — but
+	// every checksum is still reported, sorted, so the fleet correlates to both
+	// accounts rather than to none.
 	require.Empty(t, raw.IDHash)
 	require.Equal(t, 2, raw.ClusterLicenses.Licensed)
-	require.Equal(t, 2, raw.ClusterLicenses.Distinct)
+	require.Equal(t, []string{"sum-a", "sum-b"}, raw.ClusterLicenses.Checksums)
 }
 
 func TestCollect_UnresolvableAndExpiredLicensesAreSkipped(t *testing.T) {
@@ -737,7 +741,7 @@ func TestCollect_UnresolvableAndExpiredLicensesAreSkipped(t *testing.T) {
 
 	require.Empty(t, raw.IDHash)
 	require.Equal(t, 0, raw.ClusterLicenses.Licensed)
-	require.Equal(t, 0, raw.ClusterLicenses.Distinct)
+	require.Empty(t, raw.ClusterLicenses.Checksums)
 	require.Equal(t, 5, raw.Redpanda.Count)
 }
 
@@ -766,6 +770,73 @@ func TestCollect_IDHashFromLegacyClusterLicense(t *testing.T) {
 
 	require.Equal(t, "sum-a", raw.IDHash)
 	require.Equal(t, 1, raw.ClusterLicenses.Licensed)
+	require.Equal(t, []string{"sum-a"}, raw.ClusterLicenses.Checksums)
+}
+
+// TestCollect_ChecksumsDedupedAndSorted pins the two things the checksum list
+// does that a bare count could not: it deduplicates (several clusters commonly
+// share one license, which is why Licensed is kept alongside it) and it is
+// sorted, so the field does not churn between cycles on Go's map ordering.
+func TestCollect_ChecksumsDedupedAndSorted(t *testing.T) {
+	scheme := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		// Two clusters on one license, one on another. Tokens are introduced in
+		// reverse checksum order so a missing sort would show.
+		licensedRedpanda("rp-1", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-z")}),
+		licensedRedpanda("rp-2", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-a")}),
+		licensedRedpanda("rp-3", "default", &redpandav1alpha2.Enterprise{License: ptr.To("token-a")}),
+	).Build()
+
+	collector := &Collector{
+		Reader: c,
+		ParseLicense: stubParser(map[string]*license.V1RedpandaLicense{
+			"token-z": enterpriseLicense("sum-z"),
+			"token-a": enterpriseLicense("sum-a"),
+		}),
+	}
+	raw, err := collector.Collect(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"sum-a", "sum-z"}, raw.ClusterLicenses.Checksums, "distinct and sorted")
+	require.Equal(t, 3, raw.ClusterLicenses.Licensed, "counts clusters, not licenses")
+	require.Empty(t, raw.IDHash, "more than one license, so no single representative")
+}
+
+// TestCollect_SkipV1CollectionSkipsLegacyLicenses covers the interaction with
+// SkipV1Collection: a command that does not reconcile the legacy v1 API does not
+// list those clusters, so it does not report their licenses either. Their
+// Secrets are readable — the point is that the clusters are never enumerated.
+func TestCollect_SkipV1CollectionSkipsLegacyLicenses(t *testing.T) {
+	scheme := testScheme(t)
+	objs := []client.Object{
+		&vectorizedv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "legacy", Namespace: "default"},
+			Spec: vectorizedv1alpha1.ClusterSpec{
+				LicenseRef: &vectorizedv1alpha1.SecretKeyRef{Name: "legacy-license", Namespace: "default"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "legacy-license", Namespace: "default"},
+			Data:       map[string][]byte{"license": []byte("token-a")},
+		},
+	}
+	parse := stubParser(map[string]*license.V1RedpandaLicense{"token-a": enterpriseLicense("sum-a")})
+
+	// Baseline: without the flag, the legacy license is found (this is
+	// TestCollect_IDHashFromLegacyClusterLicense's shape).
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	raw, err := (&Collector{Reader: base, ParseLicense: parse}).Collect(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{"sum-a"}, raw.ClusterLicenses.Checksums)
+
+	// With the flag, the legacy clusters are never listed, so neither is their
+	// license.
+	skipped := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	raw, err = (&Collector{Reader: skipped, ParseLicense: parse, SkipV1Collection: true}).Collect(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, raw.ClusterLicenses.Checksums)
+	require.Equal(t, 0, raw.ClusterLicenses.Licensed)
+	require.Empty(t, raw.IDHash)
 }
 
 func TestSizing(t *testing.T) {

--- a/operator/internal/telemetry/license.go
+++ b/operator/internal/telemetry/license.go
@@ -9,7 +9,17 @@
 
 package telemetry
 
-import "github.com/redpanda-data/common-go/license"
+import (
+	"context"
+
+	"github.com/redpanda-data/common-go/license"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	vectorizedv1alpha1 "github.com/redpanda-data/redpanda-operator/operator/api/vectorized/v1alpha1"
+)
 
 // LicenseChecksum returns the hex SHA-256 checksum of a parsed enterprise
 // license — the same value Redpanda core reports as id_hash. The
@@ -28,4 +38,96 @@ func LicenseChecksum(l license.RedpandaLicense) string {
 	default:
 		return ""
 	}
+}
+
+// clusterLicenses resolves the enterprise licenses configured on the managed
+// clusters and returns the number of licensed clusters keyed by license
+// checksum.
+//
+// This is what makes a licensed install identifiable at all in the common case.
+// The operator's own --license-file-path (operator chart
+// enterprise.licenseSecretRef) is set only by deployers who need the Connect
+// controller or multicluster; a cluster license lives on the CR
+// (Redpanda .spec.clusterSpec.enterprise, legacy Cluster .spec.licenseRef), and
+// before this the collector never looked at it — so every licensed install
+// reported an empty id_hash.
+//
+// Unresolvable licenses are skipped, never fatal: a secret that is missing,
+// unreadable (Forbidden) or holds something unparseable is a property of one
+// cluster's configuration, and dropping the whole telemetry document over it
+// would be strictly worse than reporting the rest. Non-enterprise and expired
+// licenses are skipped too, matching LicenseChecksum's contract.
+func (c *Collector) clusterLicenses(ctx context.Context, redpandas []redpandav1alpha2.Redpanda, legacy []vectorizedv1alpha1.Cluster) map[string]int {
+	counts := map[string]int{}
+
+	parse := c.ParseLicense
+	if parse == nil {
+		parse = license.ParseLicense
+	}
+
+	record := func(raw []byte) {
+		parsed, err := parse(raw)
+		if err != nil || !parsed.AllowsEnterpriseFeatures() {
+			return
+		}
+		if sum := LicenseChecksum(parsed); sum != "" {
+			counts[sum]++
+		}
+	}
+
+	for i := range redpandas {
+		rp := &redpandas[i]
+		if rp.Spec.ClusterSpec == nil || rp.Spec.ClusterSpec.Enterprise == nil {
+			continue
+		}
+		enterprise := rp.Spec.ClusterSpec.Enterprise
+		if inline := ptr.Deref(enterprise.License, ""); inline != "" {
+			record([]byte(inline))
+			continue
+		}
+		if ref := enterprise.LicenseSecretRef; ref != nil {
+			// No default key here: the chart hands this SecretKeySelector
+			// straight to the kubelet, so an unset key is a broken cluster
+			// rather than a shape we should guess at.
+			if raw, ok := c.secretValue(ctx, rp.Namespace, ptr.Deref(ref.Name, ""), ptr.Deref(ref.Key, "")); ok {
+				record(raw)
+			}
+		}
+	}
+
+	for i := range legacy {
+		ref := legacy[i].Spec.LicenseRef
+		if ref == nil {
+			continue
+		}
+		// SecretKeyRef documents "license" as the key when none is given.
+		key := ref.Key
+		if key == "" {
+			key = "license"
+		}
+		if raw, ok := c.secretValue(ctx, ref.Namespace, ref.Name, key); ok {
+			record(raw)
+		}
+	}
+
+	return counts
+}
+
+// secretValue reads one key out of one Secret, returning ok=false for every
+// reason a telemetry cycle should shrug at rather than fail on.
+func (c *Collector) secretValue(ctx context.Context, namespace, name, key string) ([]byte, bool) {
+	if namespace == "" || name == "" || key == "" {
+		return nil, false
+	}
+
+	var secret corev1.Secret
+	if err := c.Reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &secret); err != nil {
+		return nil, false
+	}
+
+	raw, ok := secret.Data[key]
+	if !ok || len(raw) == 0 {
+		return nil, false
+	}
+	return raw, true
 }

--- a/operator/internal/telemetry/payload.go
+++ b/operator/internal/telemetry/payload.go
@@ -21,6 +21,19 @@ type Payload struct {
 	// clusters correlate to an account. Absent (omitted) for OSS/unlicensed
 	// installs, keeping those reports anonymous.
 	IDHash string `json:"id_hash,omitempty"`
+	// ClusterLicenses describes where IDHash came from when it was derived from
+	// the managed clusters rather than the operator's own license file, and is
+	// how an empty IDHash is told apart from an unlicensed install: Licensed>0
+	// with Distinct>1 means the fleet holds several licenses and no single
+	// checksum represents it.
+	ClusterLicenses struct {
+		// Licensed counts clusters carrying a valid, unexpired enterprise
+		// license (Redpanda .spec.clusterSpec.enterprise, legacy
+		// Cluster .spec.licenseRef).
+		Licensed int `json:"licensed"`
+		// Distinct counts the distinct license checksums among them.
+		Distinct int `json:"distinct"`
+	} `json:"clusterLicenses"`
 
 	NodePools struct {
 		Enabled bool `json:"enabled"`

--- a/operator/internal/telemetry/payload.go
+++ b/operator/internal/telemetry/payload.go
@@ -21,18 +21,22 @@ type Payload struct {
 	// clusters correlate to an account. Absent (omitted) for OSS/unlicensed
 	// installs, keeping those reports anonymous.
 	IDHash string `json:"id_hash,omitempty"`
-	// ClusterLicenses describes where IDHash came from when it was derived from
-	// the managed clusters rather than the operator's own license file, and is
-	// how an empty IDHash is told apart from an unlicensed install: Licensed>0
-	// with Distinct>1 means the fleet holds several licenses and no single
-	// checksum represents it.
+	// ClusterLicenses describes the enterprise licenses configured on the
+	// managed clusters. It is also how an empty IDHash is told apart from an
+	// unlicensed install: len(Checksums)>1 means the fleet holds several
+	// licenses and no single one represents it, so IDHash is left empty and the
+	// correlation is done from this list instead.
 	ClusterLicenses struct {
+		// Checksums are the distinct license checksums found across the managed
+		// clusters, sorted. Same value Redpanda core reports as id_hash, so a
+		// multi-license fleet still correlates to every account it belongs to
+		// rather than to none.
+		Checksums []string `json:"checksums,omitempty"`
 		// Licensed counts clusters carrying a valid, unexpired enterprise
 		// license (Redpanda .spec.clusterSpec.enterprise, legacy
-		// Cluster .spec.licenseRef).
+		// Cluster .spec.licenseRef). Not derivable from Checksums, which is
+		// deduplicated: several clusters commonly share one license.
 		Licensed int `json:"licensed"`
-		// Distinct counts the distinct license checksums among them.
-		Distinct int `json:"distinct"`
 	} `json:"clusterLicenses"`
 
 	NodePools struct {


### PR DESCRIPTION
Follow-up to #1762 (stacked on it — base retargets to `main` when that merges).

## Why

`id_hash` is empty on **every** row telemetry has ever ingested — 0 of ~860 since reports started on 2026-08-17. Meanwhile 26 rows in the last 14 days run tiered storage, which is enterprise-gated, so those installs are certainly licensed. We cannot correlate a single licensed install to an account today.

The cause isn't a bug so much as a wrong assumption about where the license lives. `id_hash` is derived only from the **operator's own** `--license-file-path`, which the operator chart sets from `enterprise.licenseSecretRef` — and deployers set that only when they need the Connect controller or multicluster. A Redpanda license is normally configured on the CR (`spec.clusterSpec.enterprise`, i.e. `charts/redpanda`'s `enterprise.license` / `licenseSecretRef`), and the collector never looked there.

## What

Resolve the license configured on each managed cluster and report its checksum — the same value core reports as `id_hash`:

- `Redpanda .spec.clusterSpec.enterprise.license` (inline) or `.licenseSecretRef`
- legacy `Cluster .spec.licenseRef` (defaulting the key to `license`, as `SecretKeyRef` documents)

Precedence and ambiguity are explicit rather than guessed:

| Situation | `id_hash` | `clusterLicenses` |
|---|---|---|
| Operator has its own license | operator's checksum (unchanged) | cluster licenses still reported |
| One license across the fleet | that checksum | `checksums: [sum], licensed: N` |
| Several licenses | *empty* | `checksums: [sum-a, sum-b], licensed: N` |
| No enterprise license | *empty* | `checksums: [], licensed: 0` |

Row 3 is the reason for the `clusterLicenses` block. An empty `id_hash` alone cannot distinguish "licensed, but the fleet holds several licenses so no single one represents it" from "not licensed" — and reporting the checksums rather than just how many there are (thanks @hidalgopl) means such a fleet correlates to *every* account it belongs to instead of to none, which is the whole point of the PR. `id_hash` is still left empty there rather than misattributing the install to one arbitrary account.

`checksums` is deduplicated and sorted — sorted because Go map order would otherwise churn the field between cycles and make every report look like a change. `licensed` is kept alongside it because it is the one datum a deduplicated list cannot express: several clusters commonly share one license, so "3 of 10 clusters are licensed" is different information from "1 license in use".

Arrays are already ingested in this payload (`storage.csiDrivers`, `brokerSizes`), and everything here lives inside the payload JSON, so no warehouse schema change is needed.

## Safety

Nothing added here can fail a report. A license secret that is missing, Forbidden, keyless, or unparseable is one cluster's misconfiguration; expired and non-enterprise licenses grant nothing. All are skipped, and the rest of the document still goes out.

No new RBAC: the manager already holds `get` on `secrets` cluster-wide (`files/rbac/v2-manager.ClusterRole.yaml`, and the multicluster ClusterRole likewise), so this needed no marker and no regenerated artifacts. If that grant were ever narrowed, the read returns Forbidden and the install simply reports no `id_hash`. Noted in the telemetry RBAC comments in both commands.

## Deliberately not included

Organization name, license type, and expiry. `Redpanda.status.licenseStatus` already carries all three from the broker admin API and they would be genuinely useful, but the checksum alone preserves the "anonymous telemetry" posture the payload documents — shipping org names is a policy call, not a bug fix. Easy to add if product wants it.

## Tests

Seven cases, all passing (`go test -count=1`): inline and secret-ref licenses collapsing to one `id_hash`; operator license winning over cluster licenses; several licenses leaving `id_hash` empty while still reporting every checksum; missing/keyless/garbage/expired licenses all skipped without failing the report; the legacy `Cluster.spec.licenseRef` path; `TestCollect_ChecksumsDedupedAndSorted` (three clusters, two licenses, tokens introduced in reverse checksum order — pins dedup, sort, and that `licensed` counts clusters rather than licenses); and `TestCollect_SkipV1CollectionSkipsLegacyLicenses` (a command that does not list legacy clusters does not report their licenses, with the Secret readable either way).

`Collector.ParseLicense` is a seam for those tests: `license.ParseLicense` verifies an RSA signature against a key embedded in common-go, so a valid token cannot be minted in a test — and committing a real one to satisfy it is not an option. Production behavior is unchanged (nil → `license.ParseLicense`).

## Stacked on #1762

Base is `dyu/fix-multicluster-telemetry-scheme`. That branch now sets `SkipV1Collection` for the multicluster command, which moved the `vectorized` `ClusterList` inside a guard; the declaration moves back outside it here so the license pass still sees the (possibly empty) list. Review #1762 first.
