### PR TITLE
operator: gate rolling restarts on Schema Registry replay (K8S-908)

### DIFF
--- a/.changes/unreleased/operator-Added-20260826-100000.yaml
+++ b/.changes/unreleased/operator-Added-20260826-100000.yaml
@@ -1,0 +1,32 @@
+project: operator
+kind: Added
+body: |-
+    Rolling restarts now wait for a just-restarted broker's Schema Registry to finish replaying `_schemas` before rolling the next broker, so an upgrade cannot leave every broker's Schema Registry replaying at once. Controlled by `--schema-registry-roll-gate`, on by default.
+
+      After a broker restarts, Redpanda serves Kafka immediately but Schema
+      Registry replays `_schemas` before its store is consistent — around 13
+      minutes on a large `_schemas` topic — returning errors (50005, 429) the whole
+      time while the broker stays in traffic rotation. Nothing gated on that, so an
+      upgrade walked the fleet faster than Schema Registry could catch up and the
+      replay windows overlapped, at worst leaving no consistent Schema Registry
+      endpoint anywhere in the cluster.
+
+      The gate reads core's `GET /status/ready` on each broker's Schema Registry
+      listener, which blocks until `_schemas` is caught up. It is asked via the
+      sidecar, which already runs in the pod, so no per-broker addressing or
+      listener TLS is reproduced operator-side.
+
+      This does not make Schema Registry requests reliable. A replaying broker is
+      still published and still serving errors for its own window; only the overlap
+      is prevented. It also makes upgrades slower, by up to the replay time per
+      broker — on healthy clusters replay is fast and the gate is close to a no-op.
+
+      Unaffected: clusters with no Schema Registry listener, and Redpanda older than
+      v23.1 (which has no `/status/ready`). Both read as "nothing to gate on" and
+      roll exactly as before. Sidecars predating this change also read that way, so
+      an operator upgraded ahead of its sidecars degrades to the old behaviour
+      rather than stalling.
+
+      Set `--schema-registry-roll-gate=false` if a persistently unhealthy Schema
+      Registry is blocking rolls; via the chart, use `additionalCmdFlags`.
+time: 2026-08-26T10:00:00.000000000-07:00

--- a/operator/cmd/multicluster/multicluster.go
+++ b/operator/cmd/multicluster/multicluster.go
@@ -106,6 +106,9 @@ type MulticlusterOptions struct {
 	// PostRestartCaughtUpPercent gates the rolling restart on the per-broker
 	// post-restart probe; mirrors the `run` command's flag of the same name.
 	PostRestartCaughtUpPercent int
+	// SchemaRegistryRollGate gates the roll on Schema Registry replay; see the
+	// --schema-registry-roll-gate flag.
+	SchemaRegistryRollGate bool
 
 	// ClearMaintenanceModeAfter is how long a broker may stay down (pod
 	// not-Ready) while stuck in maintenance mode before the operator clears the
@@ -237,6 +240,7 @@ func (o *MulticlusterOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&o.BrokerPodNodeUnavailableToleration, "broker-pod-node-unavailable-toleration", 0, "Controls injection of node.kubernetes.io/not-ready and node.kubernetes.io/unreachable NoExecute tolerations onto broker pods. 0 (default) = feature off, no tolerations injected. Positive = tolerationSeconds set to this duration. Negative (-1s or any negative value) = tolerate forever, no tolerationSeconds field (appropriate for cloud K8s where Node-object deletion is the authoritative signal of permanent node loss). User-set tolerations for these taint keys are always preserved.")
 	cmd.Flags().DurationVar(&o.ClusterConnectionTimeout, "cluster-connection-timeout", 10*time.Second, "Timeout for internal clients used to connect to Redpanda clusters (admin API in particular)")
 	cmd.Flags().DurationVar(&o.ReconcileTimeout, "reconcile-timeout", 2*time.Minute, "Defense-in-depth ceiling on a single reconcile pass; on deadline the reconcile aborts with context.DeadlineExceeded and is requeued with backoff. Primary bounding should still come from per-call timeouts on downstream clients")
+	cmd.Flags().BoolVar(&o.SchemaRegistryRollGate, "schema-registry-roll-gate", true, "Gate the rolling restart on Schema Registry replay: wait for a just-restarted broker's SR to finish replaying _schemas before rolling the next one, so an upgrade cannot leave every broker's SR replaying at once. Clusters without Schema Registry, and Redpanda older than v23.1, are unaffected. Disable if a persistently unhealthy SR is blocking rolls.")
 	cmd.Flags().IntVar(&o.PostRestartCaughtUpPercent, "post-restart-caught-up-percent", probes.DefaultPostRestartCaughtUpPercent, "During a rolling restart, the per-broker post-restart probe load_reclaimed_pc (0-100) a just-restarted broker must report before the next broker is rolled. Default 100 (require full recovery); lower to accept partial recovery at the gate.")
 	cmd.Flags().DurationVar(&o.ClearMaintenanceModeAfter, "clear-maintenance-mode-after", 30*time.Minute, "How long a broker may stay down (its pod not-Ready) while stuck in maintenance mode before the operator clears the maintenance flag so the Redpanda partition balancer can auto-decommission it. There's no signal distinguishing a stuck broker from one intentionally in a longer planned maintenance window, so raise this if your maintenance windows commonly run longer. This threshold does not apply to ghost brokers — dead broker ids superseded at their own advertised address, either by a live registered broker under a different id or by the pod itself reporting that it runs a different broker identity — whose leaked maintenance flag is cleared immediately since they can never rejoin. Default 30m.")
 	cmd.Flags().DurationVar(&o.StaleDiskWipeNotReadyThreshold, "wipe-stale-disk-after", 5*time.Minute, "How long a broker pod must stay not-Ready with a stale on-disk identity (a decommissioned-broker bad_rejoin, K8S-843) before the operator wipes it — deleting the pod's data-dir PVC (if any) and the pod so it reschedules with a fresh identity. Destructive but heavily guarded. Defaults to 5m; 0 or a negative duration disables.")
@@ -424,7 +428,7 @@ func Run(
 
 	factory := internalclient.NewFactory(manager, nil).WithAdminClientTimeout(opts.ClusterConnectionTimeout)
 
-	if err := redpandacontrollers.SetupMulticlusterController(ctx, manager, redpandaImage, sidecarImage, cloudSecrets, factory, opts.ReconcileTimeout, opts.BrokerPodNodeUnavailableToleration, opts.PostRestartCaughtUpPercent, opts.ClearMaintenanceModeAfter, opts.StaleDiskWipeNotReadyThreshold); err != nil {
+	if err := redpandacontrollers.SetupMulticlusterController(ctx, manager, redpandaImage, sidecarImage, cloudSecrets, factory, opts.ReconcileTimeout, opts.BrokerPodNodeUnavailableToleration, opts.PostRestartCaughtUpPercent, opts.ClearMaintenanceModeAfter, opts.StaleDiskWipeNotReadyThreshold, opts.SchemaRegistryRollGate); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Multicluster")
 		return err
 	}

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -147,6 +147,7 @@ type RunOptions struct {
 	enableGhostBrokerDecommissioner     bool
 	ghostBrokerDecommissionerSyncPeriod time.Duration
 	postRestartCaughtUpPercent          int
+	schemaRegistryRollGate              bool
 	clearMaintenanceModeAfter           time.Duration
 	wipeStaleDiskAfter                  time.Duration
 	cloudSecretsEnabled                 bool
@@ -233,6 +234,7 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.autoDeletePVCs, "auto-delete-pvcs", false, "Use StatefulSet PersistentVolumeClaimRetentionPolicy to auto delete PVCs on scale down and Cluster resource delete.")
 	cmd.Flags().BoolVar(&o.enableGhostBrokerDecommissioner, "enable-ghost-broker-decommissioner", false, "Enable ghost broker decommissioner.")
 	cmd.Flags().DurationVar(&o.ghostBrokerDecommissionerSyncPeriod, "ghost-broker-decommissioner-sync-period", time.Minute*5, "Ghost broker sync period. The Ghost Broker Decommissioner is guaranteed to be called after this period.")
+	cmd.Flags().BoolVar(&o.schemaRegistryRollGate, "schema-registry-roll-gate", true, "Gate the rolling restart on Schema Registry replay: wait for a just-restarted broker's SR to finish replaying _schemas before rolling the next one, so an upgrade cannot leave every broker's SR replaying at once. Clusters without Schema Registry, and Redpanda older than v23.1, are unaffected. Disable if a persistently unhealthy SR is blocking rolls.")
 	cmd.Flags().IntVar(&o.postRestartCaughtUpPercent, "post-restart-caught-up-percent", probes.DefaultPostRestartCaughtUpPercent, "During a rolling restart, the per-broker post-restart probe load_reclaimed_pc (0-100) a just-restarted broker must report before the next broker is rolled. Default 100 (require full recovery); lower to accept partial recovery at the gate.")
 	cmd.Flags().DurationVar(&o.clearMaintenanceModeAfter, "clear-maintenance-mode-after", 30*time.Minute, "How long a broker may stay down (its pod not-Ready) while stuck in maintenance mode before the operator clears the maintenance flag so the Redpanda partition balancer can auto-decommission it. A broker left in maintenance mode is excluded from auto-decommission. There's no signal distinguishing a stuck broker from one intentionally in a longer planned maintenance window, so raise this if your maintenance windows commonly run longer. This threshold does not apply to ghost brokers — dead broker ids superseded at their own advertised address, either by a live registered broker under a different id or by the pod itself reporting that it runs a different broker identity — whose leaked maintenance flag is cleared immediately since they can never rejoin. Default 30m.")
 	cmd.Flags().DurationVar(&o.wipeStaleDiskAfter, "wipe-stale-disk-after", 0, "How long a broker pod must stay not-Ready with a stale on-disk identity (a decommissioned-broker bad_rejoin, K8S-843) before the operator wipes it — deleting the pod's data-dir PVC (if any) and the pod so it reschedules with a fresh identity. Destructive but heavily guarded. Opt-in on the single-cluster operator: 0 (the default) disables, a positive duration enables.")
@@ -512,6 +514,7 @@ func Run(
 			CloudSecretsExpander:           cloudExpander,
 			UseNodePools:                   opts.enableV2NodepoolController,
 			PostRestartCaughtUpPercent:     opts.postRestartCaughtUpPercent,
+			SchemaRegistryRollGate:         opts.schemaRegistryRollGate,
 			MaintenanceModeClearThreshold:  opts.clearMaintenanceModeAfter,
 			StaleDiskWipeNotReadyThreshold: opts.wipeStaleDiskAfter,
 		}).SetupWithManager(ctx, mcmanager, opts.namespace); err != nil {

--- a/operator/cmd/sidecar/sidecar.go
+++ b/operator/cmd/sidecar/sidecar.go
@@ -141,7 +141,7 @@ func Command() *cobra.Command {
 
 	// broker probe flags
 	cmd.Flags().BoolVar(&runBrokerProbe, "run-broker-probe", false, "Specifies if the sidecar should run the health probe.")
-	cmd.Flags().StringVar(&brokerProbeAddr, "broker-probe-bind-address", ":8093", "The address the broker probe endpoint binds to.")
+	cmd.Flags().StringVar(&brokerProbeAddr, "broker-probe-bind-address", fmt.Sprintf(":%d", probes.DefaultBrokerProbePort), "The address the broker probe endpoint binds to.")
 	cmd.Flags().DurationVar(&brokerProbeShutdownTimeout, "broker-probe-shutdown-timeout", 10*time.Second, "The time period to wait to gracefully shutdown the broker probe before terminating.")
 	cmd.Flags().StringVar(&brokerProbeBrokerURL, "broker-probe-broker-url", "", "The URL of the broker instance this sidecar is for.")
 

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -102,6 +102,10 @@ type MulticlusterReconciler struct {
 	// loop proceeds to the next broker. Mirrors RedpandaReconciler; defaults
 	// to probes.DefaultPostRestartCaughtUpPercent (100).
 	PostRestartCaughtUpPercent int
+	// SchemaRegistryRollGate makes the roll wait for a just-restarted broker's
+	// Schema Registry to finish replaying _schemas. See the same field on
+	// RedpandaReconciler.
+	SchemaRegistryRollGate bool
 
 	// MaintenanceModeClearThreshold is how long a broker must be down (pod
 	// not-Ready) while stuck in maintenance mode before the operator clears the
@@ -1514,6 +1518,29 @@ func (r *MulticlusterReconciler) reconcileDecommission(ctx context.Context, stat
 		}
 	}
 
+	// Third gate: Schema Registry replay. Same rationale as the single-cluster
+	// reconciler (K8S-908, INC-2903) and it matters more here: a stretch
+	// cluster's brokers sit in different regions, so a cross-region _schemas
+	// replay is slower still, and there are fewer brokers per region to absorb
+	// the loss of one SR endpoint.
+	if r.SchemaRegistryRollGate && len(rollSet) > 0 {
+		existing := state.pools.ExistingPods()
+		pods := make([]*corev1.Pod, 0, len(existing))
+		for _, p := range existing {
+			pods = append(pods, p.Pod)
+		}
+
+		replaying, err := schemaRegistryStillReplaying(ctx, pods, SchemaRegistryGateSidecarPort, logger)
+		switch {
+		case err != nil:
+			logger.V(log.DebugLevel).Info("schema registry probe error, deferring rolling restart", "error", err)
+			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
+		case replaying:
+			logger.V(log.DebugLevel).Info("a broker's schema registry is still replaying, deferring rolling restart")
+			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
+		}
+	}
+
 	rolled := false
 	for _, pod := range rollSet {
 		// Same roll-safety decision as the single-cluster RedpandaReconciler:
@@ -1973,7 +2000,7 @@ func (r *MulticlusterReconciler) setupLicense(ctx context.Context, sc *redpandav
 	return nil
 }
 
-func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, redpandaImage lifecycle.Image, sidecarImage lifecycle.Image, cloudSecrets lifecycle.CloudSecretsFlags, factory *internalclient.Factory, reconcileTimeout time.Duration, brokerPodNodeUnavailableToleration time.Duration, postRestartCaughtUpPercent int, clearMaintenanceModeAfter time.Duration, staleDiskWipeNotReadyThreshold time.Duration) error {
+func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, redpandaImage lifecycle.Image, sidecarImage lifecycle.Image, cloudSecrets lifecycle.CloudSecretsFlags, factory *internalclient.Factory, reconcileTimeout time.Duration, brokerPodNodeUnavailableToleration time.Duration, postRestartCaughtUpPercent int, clearMaintenanceModeAfter time.Duration, staleDiskWipeNotReadyThreshold time.Duration, schemaRegistryRollGate bool) error {
 	return mcbuilder.ControllerManagedBy(mgr).WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
 		// NB: This is gross, but currently the multicluster runtime doesn't hand this global option off to the controller
 		// registration properly, so we can't boot multiple controllers in test without doing this.
@@ -2012,6 +2039,7 @@ func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, 
 				ClientFactory:                  factory,
 				ReconcileTimeout:               reconcileTimeout,
 				PostRestartCaughtUpPercent:     postRestartCaughtUpPercent,
+				SchemaRegistryRollGate:         schemaRegistryRollGate,
 				MaintenanceModeClearThreshold:  clearMaintenanceModeAfter,
 				StaleDiskWipeNotReadyThreshold: staleDiskWipeNotReadyThreshold,
 			}, "StretchCluster", periodicRequeue),

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -100,7 +100,7 @@ func (s *MulticlusterControllerSuite) SetupSuite() {
 		WatchAllNamespaces: true,
 		InstallCertManager: true,
 		SetupFn: func(mgr multicluster.Manager) error {
-			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, nil, 0, 0, 100 /* post-restart caught-up % */, 5*time.Minute /* clear-maintenance-mode-after */, 0 /* wipe-stale-disk-after (default) */)
+			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, nil, 0, 0, 100 /* post-restart caught-up % */, 5*time.Minute /* clear-maintenance-mode-after */, 0 /* wipe-stale-disk-after (default) */, false /* schema-registry-roll-gate: off, this suite has no sidecars to probe */)
 		},
 	})
 }

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -109,6 +109,13 @@ type RedpandaReconciler struct {
 	// probes.DefaultPostRestartCaughtUpPercent (100); set lower to accept
 	// partial recovery at the gate.
 	PostRestartCaughtUpPercent int
+	// SchemaRegistryRollGate makes the roll wait for a just-restarted broker's
+	// Schema Registry to finish replaying _schemas before the next broker is
+	// rolled. Without it an upgrade can put every broker's SR into replay at
+	// once, leaving no consistent SR endpoint (INC-2903). Defaults to enabled;
+	// disable it with --schema-registry-roll-gate=false if a persistently
+	// unhealthy SR is blocking rolls.
+	SchemaRegistryRollGate bool
 	// MaintenanceModeClearThreshold is how long a broker must be down (pod
 	// not-Ready) while stuck in maintenance mode before the operator clears the
 	// maintenance flag so the partition balancer can auto-decommission it. Zero
@@ -694,6 +701,39 @@ func (r *RedpandaReconciler) reconcileDecommission(ctx context.Context, state *c
 			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
 		case recovering:
 			logger.V(log.DebugLevel).Info("a broker is still post-restart recovering, deferring rolling restart")
+			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
+		}
+	}
+
+	// Third gate: Schema Registry. A broker serves Kafka the moment it is up,
+	// but its Schema Registry replays _schemas first and returns errors until
+	// that finishes. The post-restart probe above says nothing about it — it
+	// answers a partition-recovery question — so without this gate an upgrade
+	// walks the fleet faster than SR can catch up and the replay windows
+	// overlap until no consistent SR endpoint is left (K8S-908, INC-2903).
+	//
+	// Nothing to gate on (no SR listener, or Redpanda older than v23.1) reads
+	// as "proceed", so clusters without Schema Registry roll exactly as before.
+	if r.SchemaRegistryRollGate && len(rollSet) > 0 {
+		// ExistingPods, not PodsToRoll: the broker whose SR we most need to wait
+		// for is the one just rolled, and it leaves the roll set as soon as its
+		// revision matches — long before its Schema Registry has caught up.
+		existing := state.pools.ExistingPods()
+		pods := make([]*corev1.Pod, 0, len(existing))
+		for _, p := range existing {
+			pods = append(pods, p.Pod)
+		}
+
+		replaying, err := schemaRegistryStillReplaying(ctx, pods, SchemaRegistryGateSidecarPort, logger)
+		switch {
+		case err != nil:
+			// Fail closed, like the post-restart gate above: an SR we cannot
+			// reach is an SR whose state we do not know, and rolling into that
+			// is what caused the incident.
+			logger.V(log.DebugLevel).Info("schema registry probe error, deferring rolling restart", "error", err)
+			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
+		case replaying:
+			logger.V(log.DebugLevel).Info("a broker's schema registry is still replaying, deferring rolling restart")
 			return ctrl.Result{RequeueAfter: requeueTimeout}, nil
 		}
 	}

--- a/operator/internal/controller/redpanda/schema_registry_gate.go
+++ b/operator/internal/controller/redpanda/schema_registry_gate.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/otelutil/log"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/redpanda-data/redpanda-operator/operator/internal/probes"
+)
+
+const (
+	// schemaRegistryReadyPath is the sidecar endpoint that reports whether that
+	// broker's Schema Registry has caught up on _schemas. See
+	// probes.Server.HandleSchemaRegistryReadyCheck for the status-code contract.
+	schemaRegistryReadyPath = "/schema-registry/ready"
+
+	// schemaRegistryGateRequestTimeout bounds one probe. The sidecar's own
+	// request to the local SR listener is bounded at 5s, so this only needs to
+	// cover that plus in-cluster latency; a longer timeout would just make a
+	// wedged sidecar look like a slow one.
+	schemaRegistryGateRequestTimeout = 10 * time.Second
+)
+
+// schemaRegistryGateClient is the HTTP client used to reach sidecars. Plain
+// HTTP by design: the sidecar's probe server is unauthenticated and
+// bound to the pod, and the operator addresses it by pod IP, so there is no
+// listener TLS to reproduce here. What is behind it — the broker's own SR
+// listener, TLS and all — is the sidecar's problem, which is the point of
+// asking the sidecar rather than the broker.
+var schemaRegistryGateClient = &http.Client{Timeout: schemaRegistryGateRequestTimeout}
+
+// schemaRegistryStillReplaying reports whether any of the given pods has a
+// Schema Registry that has not finished replaying _schemas.
+//
+// This is the gate that keeps an upgrade from putting every broker's SR into
+// replay at once (K8S-908, INC-2903). After a broker restarts, Redpanda serves
+// Kafka immediately but SR replays _schemas before its store is consistent —
+// ~13 min on a large _schemas topic — returning 50005/429 the whole time while
+// the broker stays in traffic rotation. Roll the next broker before the
+// previous one's SR has caught up and the windows overlap; do it across a whole
+// cluster and there is no consistent SR endpoint left.
+//
+// It deliberately does NOT make SR requests reliable: a replaying broker is
+// still published and still serving errors for its own window. Fixing that
+// needs service-side steering, tracked separately.
+//
+// Pods with no assigned IP are skipped rather than treated as unready: a pod
+// that has not been scheduled yet has no SR to replay, and blocking on it would
+// stall a roll on something this gate is not about.
+func schemaRegistryStillReplaying(ctx context.Context, pods []*corev1.Pod, sidecarPort int, logger logr.Logger) (bool, error) {
+	var firstErr error
+
+	for _, pod := range pods {
+		if pod == nil || pod.Status.PodIP == "" {
+			continue
+		}
+
+		ready, gateable, err := podSchemaRegistryReady(ctx, pod, sidecarPort)
+		if err != nil {
+			// One unreachable sidecar must not short-circuit the scan: a
+			// different pod may be confirmably still replaying, and that answer
+			// is more actionable than the first error encountered. Mirrors
+			// brokersStillRecovering.
+			if firstErr == nil {
+				firstErr = errors.Wrapf(err, "probing schema registry readiness of %s", pod.Name)
+			}
+			continue
+		}
+		if !gateable {
+			// No SR listener on this broker, or a Redpanda too old to have
+			// /status/ready. Nothing to wait for.
+			continue
+		}
+		if !ready {
+			logger.V(log.DebugLevel).Info("schema registry still replaying", "pod", pod.Name)
+			return true, nil
+		}
+	}
+
+	return false, firstErr
+}
+
+// podSchemaRegistryReady asks one pod's sidecar about its Schema Registry.
+//
+// gateable is false when there is nothing to gate on, which the caller treats
+// as "proceed" — see the status-code contract in
+// probes.Server.HandleSchemaRegistryReadyCheck. A sidecar predating that
+// endpoint returns 404 from its ServeMux and lands in the same branch, so
+// mixed-version fleets during an operator upgrade degrade to the old behaviour
+// instead of stalling.
+func podSchemaRegistryReady(ctx context.Context, pod *corev1.Pod, sidecarPort int) (ready bool, gateable bool, err error) {
+	url := fmt.Sprintf("http://%s%s", net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(sidecarPort)), schemaRegistryReadyPath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, false, err
+	}
+
+	resp, err := schemaRegistryGateClient.Do(req)
+	if err != nil {
+		return false, false, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, true, nil
+	case http.StatusNotFound:
+		return false, false, nil
+	case http.StatusServiceUnavailable:
+		return false, true, nil
+	default:
+		return false, false, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+}
+
+// SchemaRegistryGateSidecarPort is the port the sidecar's probe server listens
+// on, which is where the roll gate looks for the readiness endpoint. It matches
+// the chart's rendered sidecar probe port.
+const SchemaRegistryGateSidecarPort = probes.DefaultBrokerProbePort

--- a/operator/internal/controller/redpanda/schema_registry_gate_test.go
+++ b/operator/internal/controller/redpanda/schema_registry_gate_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package redpanda
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// sidecarStub stands in for one pod's sidecar probe server, answering
+// /schema-registry/ready with a fixed status. It listens on 127.0.0.1 so the
+// gate can address it the way it addresses a real pod: by IP and port.
+type sidecarStub struct {
+	server *httptest.Server
+	ip     string
+	port   int
+	hits   int
+}
+
+func newSidecarStub(t *testing.T, status int) *sidecarStub {
+	t.Helper()
+
+	stub := &sidecarStub{}
+	mux := http.NewServeMux()
+	// Registering only this path means an unexpected path 404s, exactly as an
+	// older sidecar's ServeMux would.
+	mux.HandleFunc(schemaRegistryReadyPath, func(w http.ResponseWriter, _ *http.Request) {
+		stub.hits++
+		w.WriteHeader(status)
+	})
+
+	stub.server = httptest.NewServer(mux)
+	t.Cleanup(stub.server.Close)
+
+	host, portStr, err := net.SplitHostPort(stub.server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	stub.ip, stub.port = host, port
+	return stub
+}
+
+// oldSidecarStub serves nothing at the Schema Registry path, so requests 404 —
+// the shape of a sidecar predating this endpoint.
+func newOldSidecarStub(t *testing.T) *sidecarStub {
+	t.Helper()
+
+	stub := &sidecarStub{}
+	stub.server = httptest.NewServer(http.NewServeMux())
+	t.Cleanup(stub.server.Close)
+
+	host, portStr, err := net.SplitHostPort(stub.server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	stub.ip, stub.port = host, port
+	return stub
+}
+
+func podWithIP(name, ip string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "redpanda"},
+		Status:     corev1.PodStatus{PodIP: ip},
+	}
+}
+
+// TestSchemaRegistryStillReplaying pins the gate's contract with the sidecar.
+// The status codes are the interface between two separately-versioned
+// components, so each branch is asserted rather than inferred.
+func TestSchemaRegistryStillReplaying(t *testing.T) {
+	ctx := context.Background()
+	logger := testr.New(t)
+
+	t.Run("all caught up: roll proceeds", func(t *testing.T) {
+		stub := newSidecarStub(t, http.StatusOK)
+
+		replaying, err := schemaRegistryStillReplaying(ctx,
+			[]*corev1.Pod{podWithIP("broker-0", stub.ip)}, stub.port, logger)
+
+		require.NoError(t, err)
+		assert.False(t, replaying)
+		assert.Equal(t, 1, stub.hits)
+	})
+
+	t.Run("one broker replaying: roll blocks", func(t *testing.T) {
+		stub := newSidecarStub(t, http.StatusServiceUnavailable)
+
+		replaying, err := schemaRegistryStillReplaying(ctx,
+			[]*corev1.Pod{podWithIP("broker-0", stub.ip)}, stub.port, logger)
+
+		require.NoError(t, err)
+		assert.True(t, replaying, "a 503 from the sidecar must block the roll")
+	})
+
+	t.Run("no schema registry: roll proceeds", func(t *testing.T) {
+		// 404 means "nothing to gate on" — no SR listener, or a Redpanda too
+		// old to have /status/ready. A cluster without Schema Registry must
+		// never be blocked by a gate that exists to protect Schema Registry.
+		stub := newSidecarStub(t, http.StatusNotFound)
+
+		replaying, err := schemaRegistryStillReplaying(ctx,
+			[]*corev1.Pod{podWithIP("broker-0", stub.ip)}, stub.port, logger)
+
+		require.NoError(t, err)
+		assert.False(t, replaying)
+	})
+
+	t.Run("sidecar predating the endpoint: roll proceeds", func(t *testing.T) {
+		// Operator upgraded ahead of the sidecars. The unknown path 404s, which
+		// lands in the same "nothing to gate on" branch, so a mixed-version
+		// fleet degrades to the old behaviour instead of stalling every roll.
+		stub := newOldSidecarStub(t)
+
+		replaying, err := schemaRegistryStillReplaying(ctx,
+			[]*corev1.Pod{podWithIP("broker-0", stub.ip)}, stub.port, logger)
+
+		require.NoError(t, err)
+		assert.False(t, replaying)
+	})
+
+	t.Run("unreachable sidecar surfaces an error so the caller fails closed", func(t *testing.T) {
+		// Port 1 on loopback: nothing listens, so the dial fails fast. The
+		// caller defers the roll on any error — an SR we cannot reach is an SR
+		// whose state we do not know.
+		replaying, err := schemaRegistryStillReplaying(ctx,
+			[]*corev1.Pod{podWithIP("broker-0", "127.0.0.1")}, 1, logger)
+
+		require.Error(t, err)
+		assert.False(t, replaying)
+		assert.Contains(t, err.Error(), "broker-0")
+	})
+
+	t.Run("a confirmed replaying broker outranks another's error", func(t *testing.T) {
+		// Map iteration is not involved here, but ordering is: an error on one
+		// pod must not stop the scan, because a *confirmed* replaying broker is
+		// the more actionable answer and returns cleanly rather than as an error
+		// the caller can only treat as "unknown".
+		replaying := newSidecarStub(t, http.StatusServiceUnavailable)
+
+		got, err := schemaRegistryStillReplaying(ctx, []*corev1.Pod{
+			podWithIP("broker-unreachable", "127.0.0.1"), // wrong port below
+			podWithIP("broker-replaying", replaying.ip),
+		}, replaying.port, logger)
+
+		// broker-unreachable is probed on the replaying stub's port, which it
+		// does not own, so it errors; broker-replaying then answers 503.
+		require.NoError(t, err, "a confirmed replaying broker must win over an error")
+		assert.True(t, got)
+	})
+
+	t.Run("unscheduled pods are skipped, not treated as replaying", func(t *testing.T) {
+		stub := newSidecarStub(t, http.StatusOK)
+
+		replaying, err := schemaRegistryStillReplaying(ctx, []*corev1.Pod{
+			podWithIP("broker-pending", ""), // no IP yet
+			podWithIP("broker-0", stub.ip),
+		}, stub.port, logger)
+
+		require.NoError(t, err)
+		assert.False(t, replaying, "a pod with no IP has no SR to replay")
+		assert.Equal(t, 1, stub.hits, "the IP-less pod must not be probed")
+	})
+
+	t.Run("no pods: nothing to wait for", func(t *testing.T) {
+		replaying, err := schemaRegistryStillReplaying(ctx, nil, 8093, logger)
+
+		require.NoError(t, err)
+		assert.False(t, replaying)
+	})
+}

--- a/operator/internal/probes/schema_registry.go
+++ b/operator/internal/probes/schema_registry.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package probes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"syscall"
+
+	rpkconfig "github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+)
+
+// schemaRegistryReadyPath is core's readiness endpoint on the Schema Registry
+// listener. Added in redpanda#7080 and present since v23.1, it blocks on
+// writer().read_sync() — so a 200 means this broker has finished replaying
+// _schemas and its store is consistent, which is exactly the signal the
+// operator's roll gate needs. It is served at auth::level::publik and so takes
+// no credentials.
+const schemaRegistryReadyPath = "/status/ready"
+
+// SchemaRegistryReady reports whether this broker's Schema Registry has caught
+// up on _schemas.
+//
+// configured is false when the broker has no Schema Registry listener at all,
+// which callers must treat as "nothing to gate on" rather than "not ready" — a
+// cluster running without Schema Registry has to keep rolling.
+//
+// Why this lives in the sidecar rather than in the operator: the check has to be
+// per broker, and the sidecar is already inside the pod. Reaching a specific
+// broker's SR listener from outside would mean resolving per-pod addresses and
+// reproducing that listener's TLS, while from here it is the local endpoint the
+// rpk profile already describes.
+func (p *Prober) SchemaRegistryReady(ctx context.Context) (ready bool, configured bool, err error) {
+	params := rpkconfig.Params{ConfigFlag: p.configPath}
+
+	cfg, err := params.Load(p.fs)
+	if err != nil {
+		return false, false, fmt.Errorf("loading rpk config: %w", err)
+	}
+
+	profile := cfg.VirtualProfile()
+	if profile == nil {
+		return false, false, nil
+	}
+	// NB: do NOT test len(profile.SR.Addresses) == 0 to decide whether Schema
+	// Registry exists. rpk's virtual profile always supplies a default SR
+	// address (127.0.0.1:8081) whether or not the broker runs the listener, so
+	// that check never fires and a cluster without Schema Registry would fall
+	// through to a connection error below — which the operator fails closed on,
+	// stalling every roll forever. Absence is detected from ECONNREFUSED
+	// instead; see the error handling around client.Do.
+
+	client, urls, err := p.factory.SchemaRegistryStatusClientForRPKProfile(profile)
+	if err != nil {
+		return false, true, fmt.Errorf("building schema registry status client: %w", err)
+	}
+	if len(urls) == 0 {
+		return false, false, nil
+	}
+
+	// The profile lists this broker's own listener, so the first URL is the
+	// local one. Probing more than one would answer a question about a
+	// different broker, which the operator asks that broker's own sidecar.
+	target, err := url.JoinPath(urls[0], schemaRegistryReadyPath)
+	if err != nil {
+		return false, true, fmt.Errorf("building schema registry ready URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return false, true, fmt.Errorf("building schema registry ready request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Nothing listening on the Schema Registry port means the broker does
+		// not run the listener: there is nothing to gate on, and reporting an
+		// error here would fail the roll closed forever on every cluster that
+		// runs without Schema Registry.
+		//
+		// This is deliberately narrow. A replaying SR *is* listening — it
+		// answers 503/50005 — so a refused connection cannot be a replay. Other
+		// failures (TLS, timeout) stay errors, because an SR that is listening
+		// but unanswerable is a state the roll must not walk into.
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			p.logger.V(1).Info("nothing listening on the schema registry port; treating as nothing to gate on", "url", target)
+			return false, false, nil
+		}
+		return false, true, fmt.Errorf("requesting %s: %w", target, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		return true, true, nil
+	case resp.StatusCode == http.StatusNotFound:
+		// Redpanda older than v23.1 has no /status/ready. There is no signal to
+		// gate on, so report "not configured" and let the caller proceed rather
+		// than stalling every roll on an old cluster.
+		p.logger.V(1).Info("schema registry has no /status/ready endpoint; treating as nothing to gate on", "url", target)
+		return false, false, nil
+	case resp.StatusCode >= 500:
+		// 503 while replaying is the expected answer, and the whole point.
+		return false, true, nil
+	default:
+		return false, true, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, target)
+	}
+}

--- a/operator/internal/probes/schema_registry_test.go
+++ b/operator/internal/probes/schema_registry_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package probes_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/redpanda-operator/operator/internal/probes"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
+)
+
+// proberForSR builds a Prober whose rpk profile points Schema Registry at
+// srURL, using an in-memory filesystem the way the sidecar reads its real
+// config off disk.
+func proberForSR(t *testing.T, srURL string) *probes.Prober {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	yaml := "rpk:\n"
+	if srURL != "" {
+		yaml += fmt.Sprintf("    schema_registry:\n        addresses:\n            - %q\n", srURL)
+	} else {
+		// A broker with no Schema Registry listener at all.
+		yaml += "    admin_api:\n        addresses:\n            - \"127.0.0.1:9644\"\n"
+	}
+	require.NoError(t, afero.WriteFile(fs, "/redpanda.yaml", []byte(yaml), 0o644))
+
+	factory := internalclient.NewRPKOnlyFactory().WithFS(fs)
+	return probes.NewProber(factory, "/redpanda.yaml",
+		probes.WithFS(fs), probes.WithLogger(testr.New(t)))
+}
+
+// TestSchemaRegistryReady covers the sidecar half of the roll gate: translating
+// core's GET /status/ready into the (ready, configured) pair the operator's
+// gate depends on. The distinction between "not ready" and "nothing to gate on"
+// is the whole contract — conflating them would either stall rolls on clusters
+// without Schema Registry, or roll straight through a replaying one.
+func TestSchemaRegistryReady(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("caught up", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/status/ready", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		ready, configured, err := proberForSR(t, srv.URL).SchemaRegistryReady(ctx)
+		require.NoError(t, err)
+		assert.True(t, configured)
+		assert.True(t, ready)
+	})
+
+	t.Run("still replaying", func(t *testing.T) {
+		// What core returns while _schemas is catching up. This is the answer
+		// that has to block the roll.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		ready, configured, err := proberForSR(t, srv.URL).SchemaRegistryReady(ctx)
+		require.NoError(t, err)
+		assert.True(t, configured, "a replaying SR is still an SR worth gating on")
+		assert.False(t, ready)
+	})
+
+	t.Run("redpanda too old for /status/ready", func(t *testing.T) {
+		// Pre-v23.1: the endpoint doesn't exist. There is no signal to gate on,
+		// so this must report "not configured" rather than "not ready" — else
+		// every roll on an old cluster would stall forever.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		ready, configured, err := proberForSR(t, srv.URL).SchemaRegistryReady(ctx)
+		require.NoError(t, err)
+		assert.False(t, configured)
+		assert.False(t, ready)
+	})
+
+	t.Run("no schema registry listener", func(t *testing.T) {
+		// rpk's virtual profile hands out a default SR address whether or not
+		// the broker runs the listener, so absence shows up as a refused
+		// connection rather than an empty address list. It must read as
+		// "nothing to gate on": treating it as an error would fail the roll
+		// closed forever on every cluster without Schema Registry.
+		ready, configured, err := proberForSR(t, "").SchemaRegistryReady(ctx)
+		require.NoError(t, err)
+		assert.False(t, configured, "a broker without SR has nothing to gate on")
+		assert.False(t, ready)
+	})
+
+	t.Run("timeout is an error, not a verdict", func(t *testing.T) {
+		// An SR that is listening but never answers must fail closed: the
+		// operator cannot tell a hung SR from a replaying one, and rolling into
+		// either is what the gate exists to prevent. Distinct from a refused
+		// connection, which means no listener at all.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+
+		ready, configured, err := proberForSR(t, srv.URL).SchemaRegistryReady(ctx)
+		require.Error(t, err)
+		assert.True(t, configured)
+		assert.False(t, ready)
+	})
+}

--- a/operator/internal/probes/server.go
+++ b/operator/internal/probes/server.go
@@ -19,6 +19,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+// DefaultBrokerProbePort is the port the sidecar's broker probe server listens
+// on. It backs the chart's pod readiness probe and, since it is the only
+// unauthenticated per-pod HTTP surface the operator can reach, the
+// rolling-restart gate's Schema Registry check as well.
+const DefaultBrokerProbePort = 8093
+
 type Server struct {
 	prober *Prober
 	url    string
@@ -68,6 +74,12 @@ func NewServer(config Config) (*Server, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", server.HandleHealthyCheck)
 	mux.HandleFunc("/readyz", server.HandleReadyCheck)
+	// Deliberately NOT wired into pod readiness. Pod readiness is the wrong
+	// lever for Schema Registry: the broker discovery Service sets
+	// publishNotReadyAddresses because raft needs it, so failing readiness
+	// wouldn't remove the pod from the Service anyway. This endpoint exists for
+	// the operator's rolling-restart gate to consult per broker.
+	mux.HandleFunc("/schema-registry/ready", server.HandleSchemaRegistryReadyCheck)
 
 	server.server = &http.Server{
 		Addr:    address,
@@ -153,4 +165,32 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	return err
+}
+
+// HandleSchemaRegistryReadyCheck reports whether this broker's Schema Registry
+// has finished replaying _schemas.
+//
+// The status codes are a contract with the operator's roll gate:
+//
+//	200 — SR is caught up; rolling the next broker is fine.
+//	503 — SR is still replaying; the roll must wait.
+//	404 — there is nothing to gate on: either this broker has no Schema
+//	      Registry listener, or Redpanda is older than v23.1 and has no
+//	      /status/ready. The operator treats this as "proceed", so a cluster
+//	      without SR is never blocked by a gate meant to protect it.
+//	500 — the check itself failed. The operator fails closed on this and defers
+//	      the roll, because an unknown SR state is not a safe one to roll into.
+func (s *Server) HandleSchemaRegistryReadyCheck(w http.ResponseWriter, r *http.Request) {
+	ready, configured, err := s.prober.SchemaRegistryReady(r.Context())
+	switch {
+	case err != nil:
+		s.logger.Error(err, "checking schema registry readiness")
+		w.WriteHeader(http.StatusInternalServerError)
+	case !configured:
+		w.WriteHeader(http.StatusNotFound)
+	case !ready:
+		w.WriteHeader(http.StatusServiceUnavailable)
+	default:
+		w.WriteHeader(http.StatusOK)
+	}
 }

--- a/operator/pkg/client/factory.go
+++ b/operator/pkg/client/factory.go
@@ -11,6 +11,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -99,6 +100,11 @@ type ClientFactory interface {
 	// The struct *must* either be an RPK profile, Redpanda CR, or implement either the v1alpha2.SchemaRegistryConnectedObject interface
 	// or the v1alpha2.ClusterReferencingObject interface to properly initialize.
 	SchemaRegistryClient(ctx context.Context, object any) (*sr.Client, error)
+	// SchemaRegistryStatusClientForRPKProfile returns an HTTP client and the
+	// normalized Schema Registry base URLs for an RPK profile, for callers that
+	// need SR's status surface (GET /status/ready) rather than the schema
+	// registry API that sr.Client exposes.
+	SchemaRegistryStatusClientForRPKProfile(profile *rpkconfig.RpkProfile) (*http.Client, []string, error)
 	// SchemaRegistryClientForCluster is the same as SchemaRegistryClient but it takes a kubernetes cluster name.
 	SchemaRegistryClientForCluster(ctx context.Context, object any, clusterName string) (*sr.Client, error)
 

--- a/operator/pkg/client/rpk.go
+++ b/operator/pkg/client/rpk.go
@@ -23,6 +23,8 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/pkg/sr"
+
+	redpanda "github.com/redpanda-data/redpanda-operator/charts/redpanda/v25/client"
 )
 
 // this roughly implements https://github.com/redpanda-data/redpanda/blob/f5a7a13f7fca3f69a4380f0bbfa8fbc3e7f899d6/src/go/rpk/pkg/adminapi/admin.go#L46
@@ -84,6 +86,50 @@ func normalizeSchemaRegistryURLs(profile *rpkconfig.RpkProfile) ([]string, error
 	return urls, nil
 }
 
+// SchemaRegistryStatusClientForRPKProfile returns an HTTP client and the
+// normalized Schema Registry base URLs for the given RPK profile.
+//
+// It exists because franz-go's sr.Client deliberately exposes only the Schema
+// Registry *API*, while callers sometimes need SR's status surface — notably
+// GET /status/ready, which blocks until the broker has finished replaying
+// _schemas and is therefore the signal for "this broker's SR is consistent".
+// Sharing the profile's URL normalization and TLS with schemaRegistryForRPKProfile
+// keeps the two from drifting: a status probe that trusted different TLS than
+// the API client would be worse than no probe at all.
+func (c *Factory) SchemaRegistryStatusClientForRPKProfile(profile *rpkconfig.RpkProfile) (*http.Client, []string, error) {
+	urls, err := normalizeSchemaRegistryURLs(profile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	httpClient, err := c.schemaRegistryHTTPClientForRPKProfile(profile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return httpClient, urls, nil
+}
+
+// schemaRegistryHTTPClientForRPKProfile builds the HTTP client both the Schema
+// Registry API client and the status-endpoint client use, so the two cannot
+// drift in TLS or transport settings.
+func (c *Factory) schemaRegistryHTTPClientForRPKProfile(profile *rpkconfig.RpkProfile) (*http.Client, error) {
+	tls, err := profile.SR.TLS.Config(c.fs)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := schemaRegistryTransport(c.dialer)
+	if tls != nil {
+		transport.TLSClientConfig = tls
+	}
+
+	return &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
+	}, nil
+}
+
 // schemaRegistryForRPKProfile returns a simple sr.Client able to communicate with a cluster based on the given RPK profile.
 func (c *Factory) schemaRegistryForRPKProfile(profile *rpkconfig.RpkProfile) (*sr.Client, error) {
 	urls, err := normalizeSchemaRegistryURLs(profile)
@@ -96,26 +142,7 @@ func (c *Factory) schemaRegistryForRPKProfile(profile *rpkconfig.RpkProfile) (*s
 		return nil, err
 	}
 
-	// These transport values come from the TLS client options found here:
-	// https://github.com/twmb/franz-go/blob/cea7aa5d803781e5f0162187795482ba1990c729/pkg/sr/clientopt.go#L48-L68
-	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   100,
-		DialContext:           c.dialer,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-
-	if c.dialer == nil {
-		transport.DialContext = (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext
-	}
-
+	transport := schemaRegistryTransport(c.dialer)
 	if tls != nil {
 		transport.TLSClientConfig = tls
 	}
@@ -210,4 +237,31 @@ func (c *Factory) kafkaForRPKProfile(profile *rpkconfig.RpkProfile, opts ...kgo.
 	}
 
 	return kgo.NewClient(kopts...)
+}
+
+// schemaRegistryTransport returns the HTTP transport used for every Schema
+// Registry connection the factory makes.
+//
+// These transport values come from franz-go's own TLS client options:
+// https://github.com/twmb/franz-go/blob/cea7aa5d803781e5f0162187795482ba1990c729/pkg/sr/clientopt.go#L48-L68
+func schemaRegistryTransport(dialer redpanda.DialContextFunc) *http.Transport {
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		DialContext:           dialer,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	if dialer == nil {
+		transport.DialContext = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+	}
+
+	return transport
 }

--- a/operator/pkg/client/stretch_cluster_test.go
+++ b/operator/pkg/client/stretch_cluster_test.go
@@ -109,7 +109,7 @@ func (s *StretchClusterFactorySuite) SetupSuite() {
 					return mc.DialContext(ctx, network, address)
 				},
 			)
-			return redpandacontrollers.SetupMulticlusterController(ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory, 0, 0, 100 /* post-restart caught-up % */, 5*time.Minute /* clear-maintenance-mode-after */, 0 /* wipe-stale-disk-after (default) */)
+			return redpandacontrollers.SetupMulticlusterController(ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory, 0, 0, 100 /* post-restart caught-up % */, 5*time.Minute /* clear-maintenance-mode-after */, 0 /* wipe-stale-disk-after (default) */, false /* schema-registry-roll-gate: off, no sidecars in this suite */)
 		},
 	})
 	mc = s.mc


### PR DESCRIPTION
Implements [K8S-908](https://redpandadata.atlassian.net/browse/K8S-908) — item 1 of the four-part [INC-2903 plan](https://redpandadata.slack.com/archives/C0BH80P779D/p1787756852150359?thread_ts=1787751786.911989&cid=C0BH80P779D). Items 2–4 are tracked under [K8S-931](https://redpandadata.atlassian.net/browse/K8S-931).

## Problem

After a broker restarts, Redpanda serves Kafka immediately but Schema Registry replays `_schemas` before its store is consistent — **~13 min** on the reporting customer's cluster with a maintenance-mode drain, ~30 min without — returning `50005`/`429` the whole time **while the broker stays in traffic rotation**.

Nothing gated on that. So an upgrade walked the fleet faster than SR could catch up, the replay windows overlapped, and at worst no consistent SR endpoint was left anywhere in the cluster.

## What this adds

A third roll gate, next to the two that already exist ("recently replaced pods ready", then the post-restart probe), in **both** the single-cluster and multicluster reconcilers. It reads core's `GET /status/ready` on the Schema Registry listener, which blocks on `writer().read_sync()` and so answers exactly *"has this broker finished replaying `_schemas`"*. Available since v23.1 ([redpanda#7080](https://github.com/redpanda-data/redpanda/pull/7080)) and served at `auth::level::publik`, so it needs no credentials.

**Asked via the sidecar, not the broker.** The check has to be per broker, and the sidecar is already in the pod — from there SR is the local endpoint the rpk profile already describes. Reaching a specific broker's SR listener from the operator would mean resolving per-pod addresses *and* reproducing that listener's TLS. The operator talks to the sidecar's existing probe server (`:8093`) by pod IP over plain HTTP, so there is no new listener and nothing new to secure.

**Explicitly not wired into pod readiness.** The broker discovery Service sets `publishNotReadyAddresses` because raft needs it, so failing readiness would not remove a pod from the Service — it would steer no traffic while risking cluster lifecycle stability. That was the flaw in the original K8S-908 plan.

## What this does *not* fix

* A replaying broker is **still published and still serving errors** for its own ~13 min window. Only the overlap is prevented. Steering traffic away needs SR on its own Service plus a publishing controller — [K8S-932](https://redpandadata.atlassian.net/browse/K8S-932).
* **Upgrades get slower**, by up to the replay time per broker. On healthy clusters replay is fast and the gate is close to a no-op.

## Compatibility: three ways there is nothing to gate on

All three proceed rather than stall, because a gate meant to protect Schema Registry must never block a cluster that hasn't got one:

| Case | Signal |
|---|---|
| Broker runs no SR listener | `ECONNREFUSED` |
| Redpanda older than v23.1 | `404` — no `/status/ready` |
| Sidecar predating this change | `404` from its ServeMux |

That last row matters for rollout order: an operator upgraded ahead of its sidecars degrades to the old behaviour instead of stalling every roll.

Everything else **fails closed** and defers, matching the post-restart gate — an SR whose state we cannot determine is not one to roll into. A *timeout* is deliberately an error rather than a verdict, since a hung SR is indistinguishable from a replaying one.

> The `ECONNREFUSED` detection is worth a second look in review. The obvious check — an empty SR address list — **never fires**: rpk's virtual profile always hands out a default `127.0.0.1:8081` whether or not the listener exists. Without this, every cluster without Schema Registry would have failed closed and stalled its rolls forever. The test found that, not the reading.

## Testing

`schema_registry_gate_test.go` — 8 subtests over the operator/sidecar status-code contract: caught up, replaying, no SR, old sidecar, unreachable sidecar, a confirmed replaying broker outranking another pod's error, unscheduled pods skipped, and the empty case.

`schema_registry_test.go` — 5 subtests over the sidecar half against an httptest SR and a memfs rpk profile: caught up, replaying, pre-v23.1 404, no listener, and timeout-is-an-error.

`task generate` clean, `golangci-lint run ./operator/...` clean (`0 issues`).

## Not done here

* **No chart value.** The flag defaults on, and `additionalCmdFlags` already reaches it, so the chart needs no change. A first-class value is easy to add if reviewers want one.
* **No cross-reconcile deadline.** The opt-out flag is the escape hatch for a permanently unhealthy SR; a wall-clock ceiling would need status to persist across reconciles. Worth doing if the flag proves too blunt.
* **`SetupMulticlusterController` is now twelve positional arguments**, and this change broke two test call sites passing them positionally. Converting it to an options struct is worth doing separately.
* **Not yet exercised against a real replaying SR.** The open question from the thread — whether there's a supported way to force SR into catch-up mode — is still open, so coverage is at the contract boundary rather than end to end.



[K8S-908]: https://redpandadata.atlassian.net/browse/K8S-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[K8S-931]: https://redpandadata.atlassian.net/browse/K8S-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[K8S-932]: https://redpandadata.atlassian.net/browse/K8S-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
