### PR TITLE
operator: defer, don't abort, when the maintenance-mode broker read fails

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260826-193000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260826-193000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: An unreadable broker list no longer aborts the whole reconcile pass — the maintenance-mode step defers instead. Because it runs first in both the single-cluster and StretchCluster chains, a transient admin-API read failure against a broker whose pod is already gone (mid-roll, mid-decommission, or a BrokerPool being deleted) previously aborted decommissioning and cluster-config sync for that pass, so the very broker that made the read fail was never removed
+time: 2026-08-26T19:30:00.000000000-07:00

--- a/operator/internal/controller/redpanda/maintenance_mode.go
+++ b/operator/internal/controller/redpanda/maintenance_mode.go
@@ -376,9 +376,22 @@ func clearStuckMaintenanceMode(ctx context.Context, admin *rpadmin.AdminAPI, pod
 	// only gates WHETHER we pin the leader, never a write — a stale view that
 	// hides work defers to a later pass, and one that invents work is caught by
 	// the leader-pinned re-read below that keys every actual clear.
+	//
+	// A failed read defers the pass rather than aborting it. This step is FIRST
+	// in both reconcile chains, and an error from it aborts every later step for
+	// that pass — including reconcileDecommission and reconcileClusterConfig. The
+	// cluster admin client resolves through the internal service
+	// (PublishNotReadyAddresses), so it can dial a broker whose pod is already
+	// gone: mid-roll, mid-decommission, or a BrokerPool being deleted. Those are
+	// exactly the states the later steps exist to resolve, so propagating the
+	// error deadlocks — the pass that would remove the unreachable broker never
+	// runs, which keeps it unreachable. Deferring costs at most one pass of
+	// maintenance-mode clearing, and no clear is possible without a readable
+	// broker list anyway.
 	brokers, err := admin.Brokers(ctx)
 	if err != nil {
-		return errors.Wrap(err, "listing brokers for maintenance-mode reconcile")
+		logger.Info("broker list unavailable; deferring maintenance-mode reconcile this pass", "error", err.Error())
+		return nil
 	}
 	if !maintenanceWorkPending(brokers) {
 		return nil

--- a/operator/internal/controller/redpanda/maintenance_mode_test.go
+++ b/operator/internal/controller/redpanda/maintenance_mode_test.go
@@ -1543,3 +1543,43 @@ func TestReconcilersRunMaintenanceModeBeforeStaleDiskWipe(t *testing.T) {
 			"%s: the non-destructive maintenance clear must be attempted before the destructive stale-disk wipe", name)
 	}
 }
+
+// TestClearStuckMaintenanceModeDefersOnBrokerListFailure pins the contract that
+// an unreadable broker list defers the pass instead of aborting the reconcile
+// chain.
+//
+// reconcileMaintenanceMode is the FIRST step in both the single-cluster and
+// StretchCluster chains, and any error it returns aborts every later step for
+// that pass — including reconcileDecommission and reconcileClusterConfig (the
+// ordering the *RunsMaintenanceModeBeforeDecommission tests pin). The cluster
+// admin client resolves through the internal service, so it can dial a broker
+// whose pod is already gone: mid-roll, mid-decommission, or a BrokerPool being
+// deleted.
+// Those are exactly the states the later steps exist to resolve, so returning
+// the error deadlocks — the pass that would remove the unreachable broker never
+// runs, so the broker stays unreachable and every subsequent pass aborts the
+// same way.
+func TestClearStuckMaintenanceModeDefersOnBrokerListFailure(t *testing.T) {
+	ctx := t.Context()
+
+	// An already-closed server: every request fails to dial, the same shape as a
+	// broker whose pod no longer exists.
+	srv := httptest.NewServer(http.NewServeMux())
+	addr := srv.URL
+	srv.Close()
+
+	client, err := rpadmin.NewAdminAPI([]string{addr}, new(rpadmin.NopAuth), nil)
+	require.NoError(t, err)
+	defer client.Close()
+
+	pods := []*lifecycle.MulticlusterPod{{Pod: &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "redpanda-rp-east-0"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+			Type: corev1.PodReady, Status: corev1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+		}}},
+	}}}
+
+	require.NoError(t, clearStuckMaintenanceMode(ctx, client, pods, 5*time.Minute, nil, testr.New(t)),
+		"an unreadable broker list must defer the pass, not abort the reconcile chain")
+}


### PR DESCRIPTION
## What

`reconcileMaintenanceMode` is the **first** step in both the single-cluster and StretchCluster reconcile chains. As the chain's own comment states, *"any step returning a non-zero RequeueAfter or an error aborts the rest of the chain for this pass"* — so an error here skips `reconcileStaleDiskWipe`, `reconcileDecommission`, `reconcileLicense` and `reconcileClusterConfig`.

`clearStuckMaintenanceMode` opens with a detection-only read of the broker list, documented as never gating a write (*"a stale view that hides work defers to a later pass"*). Every downstream failure in that function already defers the pass and returns `nil` — no per-pod endpoints, leader unavailable, leader re-read failed. The opening read was the one exception: it wrapped and returned the error.

This makes it defer like the rest.

## Why it deadlocks

The cluster admin client resolves through the internal service (`PublishNotReadyAddresses`), so it can dial a broker whose pod is already gone — mid-roll, mid-decommission, or a BrokerPool being deleted. Those are exactly the states the later steps exist to resolve, so returning the error is self-perpetuating: the pass that would have removed the unreachable broker never runs, so it stays unreachable and the next pass aborts identically.

## Where it was observed

The multicluster StretchCluster suite on `release/v26.2.x` (builds 15409 and 15412). 62 consecutive passes aborted on:

```
listing brokers for maintenance-mode reconcile: Get
"https://<pool>-0.<ns>:9644/v1/brokers": pods "<pool>-0" not found
```

Two subtests timed out as a direct consequence, both with one cause:

| Test | Step never reached |
| --- | --- |
| `TestClusterConfigSync` | `reconcileClusterConfig` (last in chain) |
| `TestResourceCleanup/SingleBrokerPoolDeletion` | `reconcileDecommission` — so the removed pool's StatefulSet was never deleted; the poll sat at `StatefulSet count: 3 (want 2)` for the full 5 minutes, 3 runs in a row |

Note this is **not** a code regression on `release/v26.2.x`: every file in the failing path (`operator/internal/lifecycle/`, `operator/pkg/client/`, `maintenance_mode.go`, `multicluster_controller.go`, `internal/testenv/`) is byte-identical to `main`, as is the Redpanda image pin. Both recent backports were also exonerated — #1770 and #1773 passed Multicluster *after* #1761 and #1765 merged. It's a latent race that `main` has been winning; the release branch's runs hit the pod-churn window reliably.

## Fix

Log and defer instead of returning the error. Deferring costs at most one pass of maintenance-mode clearing, and no clear is possible without a readable broker list anyway.

## Test

`TestClearStuckMaintenanceModeDefersOnBrokerListFailure` points the admin client at an already-closed server so the read fails to dial — the same shape as a pod that no longer exists — and asserts the pass defers. Verified it fails without the production change, with the exact CI error shape:

```
Wraps: (2) listing brokers for maintenance-mode reconcile
Wraps: (3) Get "http://127.0.0.1:59009/v1/brokers"
Wraps: (6) connection refused
Messages: an unreadable broker list must defer the pass, not abort the reconcile chain
```

Package unit tests and `golangci-lint` pass (the ~20 testcontainers tests in this package are skipped locally — no Docker provider — and are unaffected by this change).

Needs backporting to `release/v26.2.x` to turn that branch's Multicluster job green.
