### PR TITLE
api: fix stale useFlux/chartVersion field docs after Flux removal

### DIFF
--- a/operator/api/redpanda/v1alpha2/redpanda_types.go
+++ b/operator/api/redpanda/v1alpha2/redpanda_types.go
@@ -40,6 +40,9 @@ type ChartRef struct {
 	// Specifies the name of the chart to deploy.
 	ChartName string `json:"chartName,omitempty"`
 	// Defines the version of the Redpanda Helm chart to deploy.
+	//
+	// Deprecated: FluxCD-based reconciliation was removed. The operator rejects
+	// reconciliation of any Redpanda resource that sets this field; unset it.
 	ChartVersion string `json:"chartVersion,omitempty"`
 	// Defines the chart repository to use. Defaults to `redpanda` if not defined.
 	HelmRepositoryName string `json:"helmRepositoryName,omitempty"`
@@ -52,22 +55,9 @@ type ChartRef struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// Defines how to handle upgrades, including failures.
 	Upgrade *runtime.RawExtension `json:"upgrade,omitempty"`
-	// Setting the `useFlux` flag to `false` disables the Helm controller's reconciliation of the Helm chart.
-	// This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other
-	// ChartRef fields to be ignored.
-	//
-	// Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding
-	// version of the Redpanda chart.
-	//
-	// Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is
-	// manually deleted.
-	//
-	// To dynamically switch Flux controllers (HelmRelease and HelmRepository), setting `useFlux` to `false`
-	// will suspend these resources instead of removing them.
-	//
-	// References:
-	// - https://fluxcd.io/flux/components/helm/helmreleases/#suspend
-	// - https://fluxcd.io/flux/components/source/helmrepositories/#suspend
+	// Deprecated: FluxCD-based reconciliation was removed. The operator rejects
+	// reconciliation of any Redpanda resource that sets this field to true; unset
+	// it or set it to false. All other ChartRef fields are ignored.
 	//
 	// +optional
 	UseFlux *bool `json:"useFlux,omitempty"`

--- a/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
+++ b/operator/api/redpanda/v1alpha2/testdata/crd-docs.adoc
@@ -558,7 +558,10 @@ Certificate configures TLS certificates.
 |===
 | Field | Description | Default | Validation
 | *`chartName`* __string__ | Specifies the name of the chart to deploy. + |  | 
-| *`chartVersion`* __string__ | Defines the version of the Redpanda Helm chart to deploy. + |  | 
+| *`chartVersion`* __string__ | Defines the version of the Redpanda Helm chart to deploy. +
+
+Deprecated: FluxCD-based reconciliation was removed. The operator rejects +
+reconciliation of any Redpanda resource that sets this field; unset it. + |  | 
 | *`helmRepositoryName`* __string__ | Defines the chart repository to use. Defaults to `redpanda` if not defined. + |  | 
 | *`timeout`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta[$$Duration$$]__ | Specifies the time to wait for any individual Kubernetes operation (like Jobs +
 for hooks) during Helm actions. Defaults to `15m0s`. + |  | Pattern: `^([0-9]+(\.[0-9]+)?(ms\|s\|m\|h))+$` +
@@ -566,22 +569,9 @@ Type: string +
 Optional: \{} +
 
 | *`upgrade`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Defines how to handle upgrades, including failures. + |  | 
-| *`useFlux`* __boolean__ | Setting the `useFlux` flag to `false` disables the Helm controller's reconciliation of the Helm chart. +
-This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other +
-ChartRef fields to be ignored. +
-
-Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding +
-version of the Redpanda chart. +
-
-Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is +
-manually deleted. +
-
-To dynamically switch Flux controllers (HelmRelease and HelmRepository), setting `useFlux` to `false` +
-will suspend these resources instead of removing them. +
-
-References: +
-- https://fluxcd.io/flux/components/helm/helmreleases/#suspend +
-- https://fluxcd.io/flux/components/source/helmrepositories/#suspend + |  | Optional: \{} +
+| *`useFlux`* __boolean__ | Deprecated: FluxCD-based reconciliation was removed. The operator rejects +
+reconciliation of any Redpanda resource that sets this field to true; unset +
+it or set it to false. All other ChartRef fields are ignored. + |  | Optional: \{} +
 
 |===
 

--- a/operator/api/redpanda/v1alpha2/zz_generated.deprecations_test.go
+++ b/operator/api/redpanda/v1alpha2/zz_generated.deprecations_test.go
@@ -7,6 +7,8 @@ package v1alpha2
 // this package:
 //
 // - Redpanda:
+//   - ChartRef.ChartVersion
+//   - ChartRef.UseFlux
 //   - ClusterSpec.Console
 //   - ClusterSpec.Connectors
 //   - ClusterSpec.Connectors.Test.Enabled

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandas.yaml
@@ -55,8 +55,11 @@ spec:
                     description: Specifies the name of the chart to deploy.
                     type: string
                   chartVersion:
-                    description: Defines the version of the Redpanda Helm chart to
-                      deploy.
+                    description: |-
+                      Defines the version of the Redpanda Helm chart to deploy.
+
+                      Deprecated: FluxCD-based reconciliation was removed. The operator rejects
+                      reconciliation of any Redpanda resource that sets this field; unset it.
                     type: string
                   helmRepositoryName:
                     description: Defines the chart repository to use. Defaults to
@@ -74,22 +77,9 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   useFlux:
                     description: |-
-                      Setting the `useFlux` flag to `false` disables the Helm controller's reconciliation of the Helm chart.
-                      This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other
-                      ChartRef fields to be ignored.
-
-                      Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding
-                      version of the Redpanda chart.
-
-                      Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is
-                      manually deleted.
-
-                      To dynamically switch Flux controllers (HelmRelease and HelmRepository), setting `useFlux` to `false`
-                      will suspend these resources instead of removing them.
-
-                      References:
-                      - https://fluxcd.io/flux/components/helm/helmreleases/#suspend
-                      - https://fluxcd.io/flux/components/source/helmrepositories/#suspend
+                      Deprecated: FluxCD-based reconciliation was removed. The operator rejects
+                      reconciliation of any Redpanda resource that sets this field to true; unset
+                      it or set it to false. All other ChartRef fields are ignored.
                     type: boolean
                 type: object
               clusterSpec:
@@ -34064,8 +34054,11 @@ spec:
                     description: Specifies the name of the chart to deploy.
                     type: string
                   chartVersion:
-                    description: Defines the version of the Redpanda Helm chart to
-                      deploy.
+                    description: |-
+                      Defines the version of the Redpanda Helm chart to deploy.
+
+                      Deprecated: FluxCD-based reconciliation was removed. The operator rejects
+                      reconciliation of any Redpanda resource that sets this field; unset it.
                     type: string
                   helmRepositoryName:
                     description: Defines the chart repository to use. Defaults to
@@ -34083,22 +34076,9 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   useFlux:
                     description: |-
-                      Setting the `useFlux` flag to `false` disables the Helm controller's reconciliation of the Helm chart.
-                      This ties the operator to a specific version of the Go-based Redpanda Helm chart, causing all other
-                      ChartRef fields to be ignored.
-
-                      Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21` or the corresponding
-                      version of the Redpanda chart.
-
-                      Note: When `useFlux` is set to `false`, `RedpandaStatus` may become inaccurate if the HelmRelease is
-                      manually deleted.
-
-                      To dynamically switch Flux controllers (HelmRelease and HelmRepository), setting `useFlux` to `false`
-                      will suspend these resources instead of removing them.
-
-                      References:
-                      - https://fluxcd.io/flux/components/helm/helmreleases/#suspend
-                      - https://fluxcd.io/flux/components/source/helmrepositories/#suspend
+                      Deprecated: FluxCD-based reconciliation was removed. The operator rejects
+                      reconciliation of any Redpanda resource that sets this field to true; unset
+                      it or set it to false. All other ChartRef fields are ignored.
                     type: boolean
                 type: object
               clusterSpec:

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -1433,13 +1433,19 @@ func ignoreConflict(err error) (ctrl.Result, error) {
 	return ctrl.Result{}, err
 }
 
+// validateClusterParameters rejects Redpanda resources that still carry
+// FluxCD-era settings.
+//
+// The deprecated reads below are the point of this function, not an oversight:
+// rejecting a field is the one thing that has to keep looking at it. They stay
+// until the fields themselves are removed from the API.
 func validateClusterParameters(rp *redpandav1alpha2.Redpanda) error {
 	// Upgrade checks. Don't reconcile if UseFlux is true or if ChartRef is set.
-	if rp.Spec.ChartRef.UseFlux != nil && *rp.Spec.ChartRef.UseFlux {
+	if rp.Spec.ChartRef.UseFlux != nil && *rp.Spec.ChartRef.UseFlux { //nolint:staticcheck // SA1019: deprecated on purpose — this check exists to reject it
 		return errors.New("useFlux: true is no longer supported. Please downgrade or unset `useFlux`")
 	}
 
-	if rp.Spec.ChartRef.ChartVersion != "" {
+	if rp.Spec.ChartRef.ChartVersion != "" { //nolint:staticcheck // SA1019: deprecated on purpose — this check exists to reject it
 		return errors.New("Specifying chartVersion is no longer supported. Please downgrade or unset `chartRef.chartVersion`")
 	}
 


### PR DESCRIPTION
## What

`ChartRef.UseFlux` and `ChartRef.ChartVersion` still document pre-removal FluxCD behavior:

- "Setting the `useFlux` flag to `false` disables the Helm controller's reconciliation of the Helm chart... causing all other ChartRef fields to be ignored."
- "Before disabling `useFlux`, ensure that your `chartVersion` is aligned with `5.9.21`..."
- "To dynamically switch Flux controllers... setting `useFlux` to `false` will suspend these resources instead of removing them."

None of that is accurate anymore. `validateClusterParameters()` in `internal/controller/redpanda/redpanda_controller.go` now unconditionally rejects any Redpanda resource that sets `useFlux` to `true` or sets `chartVersion` to a non-empty value:

```go
func validateClusterParameters(rp *redpandav1alpha2.Redpanda) error {
	if rp.Spec.ChartRef.UseFlux != nil && *rp.Spec.ChartRef.UseFlux {
		return errors.New("useFlux: true is no longer supported. Please downgrade or unset `useFlux`")
	}
	if rp.Spec.ChartRef.ChartVersion != "" {
		return errors.New("Specifying chartVersion is no longer supported. Please downgrade or unset `chartRef.chartVersion`")
	}
	return nil
}
```

There's no "dynamic switching" and no "5.9.21" version to align with anymore -- every other `ChartRef` field is already ignored regardless of `useFlux`.

## Why

Found this from the docs side while writing a Kubernetes upgrade guide (redpanda-data/docs#1922) that documents the upgraded operator refusing to reconcile until these fields are unset. A reviewer flagged that this contradicts the generated CRD reference on docs.redpanda.com, which is generated from these Go doc comments (`.github/workflows/dispatch-crd-docs.yml` dispatches to `redpanda-data/docs` on release).

## What changed

Replaced both field comments with a `Deprecated:` note describing the actually-enforced behavior, matching this repo's existing `Deprecated:` convention (see `api/redpanda/v1alpha2/common.go`).

I hand-synced the two generated artifacts that embed this text (`config/crd/bases/cluster.redpanda.com_redpandas.yaml`, `api/redpanda/v1alpha2/testdata/crd-docs.adoc`) since I don't have `rp-controller-gen`/`crd-ref-docs` available to regenerate them in my environment. **Please run `task generate` to confirm there's no drift from the actual generated output** before merging.

## Verification

- `go build ./api/redpanda/v1alpha2/... ./internal/controller/redpanda/...` passes.
- `go vet` on both packages passes.
- Could not run this package's test suite locally -- it panics on a pre-existing protobuf global-registry double-registration in a transitive dependency, reproduced identically on `main` before this change (not introduced by it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)