### PR TITLE
operator: don't offer undialable brokers to the StretchCluster admin client

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260827-120000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260827-120000.yaml
@@ -3,9 +3,8 @@ kind: Fixed
 body: |-
     The StretchCluster admin, Kafka, and Schema Registry clients no longer offer brokers whose pod cannot be dialed.
 
-      Endpoints came purely from each RedpandaBrokerPool's declared replica count, so
-      every call also tried brokers deliberately absent — a deleted pool, or the broker
-      mid-roll during a restart-requiring config change — spending the client's timeout
-      on each. Terminating, finished, and address-less pods are now skipped; when none
-      look dialable the full declared list is returned, exactly as before.
+      Endpoints came from declared replica counts alone, so clients also tried
+      deliberately absent brokers — a deleted pool, a broker mid-roll — spending
+      their timeout on each. Terminating, finished, and address-less pods are now
+      skipped; with none dialable, the full declared list is used as before.
 time: 2026-08-27T12:00:00.000000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260827-120000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260827-120000.yaml
@@ -1,0 +1,25 @@
+project: operator
+kind: Fixed
+body: |-
+    The StretchCluster admin client no longer offers brokers whose pod cannot be reached, so a broker pool deletion and a restart-requiring config change no longer stall on the broker they are about to remove or restart.
+
+      The admin client's host list was built purely from each
+      RedpandaBrokerPool's declared replica count, so it offered every broker
+      the spec asked for — including ones deliberately absent: a pool that was
+      just deleted, or the broker being rolled during a config change that
+      requires a restart. Whichever host a reconcile happened to pick, an absent
+      one failed the call, and the steps that gate on it made no progress as a
+      result. `reconcileDecommission` could not read cluster health, so it never
+      deleted the removed pool's StatefulSet; the maintenance-mode pass deferred
+      on an unreadable broker list instead of advancing the roll. Neither
+      recovered on its own while the host list kept offering the same absent
+      broker, so both surfaced as intermittent stalls that cleared only once the
+      pod happened to come back.
+
+      Endpoints are now filtered to pods that can accept a connection: present,
+      not terminating, and with an address assigned. Readiness is deliberately
+      not part of the test, since the operator reads a rejoining broker's
+      identity from an unready pod on purpose. When no pod looks reachable — a
+      whole-cluster outage — the full declared list is still returned, so that
+      case behaves exactly as it did before.
+time: 2026-08-27T12:00:00.000000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260827-120000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260827-120000.yaml
@@ -1,25 +1,11 @@
 project: operator
 kind: Fixed
 body: |-
-    The StretchCluster admin client no longer offers brokers whose pod cannot be reached, so a broker pool deletion and a restart-requiring config change no longer stall on the broker they are about to remove or restart.
+    The StretchCluster admin, Kafka, and Schema Registry clients no longer offer brokers whose pod cannot be dialed.
 
-      The admin client's host list was built purely from each
-      RedpandaBrokerPool's declared replica count, so it offered every broker
-      the spec asked for — including ones deliberately absent: a pool that was
-      just deleted, or the broker being rolled during a config change that
-      requires a restart. Whichever host a reconcile happened to pick, an absent
-      one failed the call, and the steps that gate on it made no progress as a
-      result. `reconcileDecommission` could not read cluster health, so it never
-      deleted the removed pool's StatefulSet; the maintenance-mode pass deferred
-      on an unreadable broker list instead of advancing the roll. Neither
-      recovered on its own while the host list kept offering the same absent
-      broker, so both surfaced as intermittent stalls that cleared only once the
-      pod happened to come back.
-
-      Endpoints are now filtered to pods that can accept a connection: present,
-      not terminating, and with an address assigned. Readiness is deliberately
-      not part of the test, since the operator reads a rejoining broker's
-      identity from an unready pod on purpose. When no pod looks reachable — a
-      whole-cluster outage — the full declared list is still returned, so that
-      case behaves exactly as it did before.
+      Endpoints came purely from each RedpandaBrokerPool's declared replica count, so
+      every call also tried brokers deliberately absent — a deleted pool, or the broker
+      mid-roll during a restart-requiring config change — spending the client's timeout
+      on each. Terminating, finished, and address-less pods are now skipped; when none
+      look dialable the full declared list is returned, exactly as before.
 time: 2026-08-27T12:00:00.000000000-07:00

--- a/operator/multicluster/service_per_pod.go
+++ b/operator/multicluster/service_per_pod.go
@@ -136,6 +136,25 @@ func PerPodServiceName(poolFullname string, ordinal int32) string {
 	return fmt.Sprintf("%s-%d", poolFullname, ordinal)
 }
 
+// BrokerPodSelector returns the labels identifying the broker Pods of the
+// cluster deployed under releaseName -- sc.Name for a StretchCluster. Callers
+// outside the renderer use it to list brokers without reading every other Pod in
+// the namespace.
+//
+// These are StatefulSet selector labels, so every broker Pod of a deployed
+// cluster carries them whatever operator version rendered it: a StatefulSet's
+// selector is immutable and has to match its own Pods. Stricter markers such as
+// cluster.redpanda.com/broker are deliberately left out -- they are set on the
+// Pod template rather than the selector, so a Pod rendered before such a label
+// existed would not match, and a caller filtering on the result would then drop
+// a live broker.
+func BrokerPodSelector(releaseName string) map[string]string {
+	return map[string]string{
+		labelNameKey:     labelNameValue,
+		labelInstanceKey: releaseName,
+	}
+}
+
 func perPodServicePorts(spec *redpandav1alpha2.BrokerPoolSpec) []corev1.ServicePort {
 	var ports []corev1.ServicePort
 

--- a/operator/multicluster/service_per_pod.go
+++ b/operator/multicluster/service_per_pod.go
@@ -137,17 +137,12 @@ func PerPodServiceName(poolFullname string, ordinal int32) string {
 }
 
 // BrokerPodSelector returns the labels identifying the broker Pods of the
-// cluster deployed under releaseName -- sc.Name for a StretchCluster. Callers
-// outside the renderer use it to list brokers without reading every other Pod in
-// the namespace.
+// cluster deployed under releaseName -- sc.Name for a StretchCluster.
 //
-// These are StatefulSet selector labels, so every broker Pod of a deployed
-// cluster carries them whatever operator version rendered it: a StatefulSet's
-// selector is immutable and has to match its own Pods. Stricter markers such as
-// cluster.redpanda.com/broker are deliberately left out -- they are set on the
-// Pod template rather than the selector, so a Pod rendered before such a label
-// existed would not match, and a caller filtering on the result would then drop
-// a live broker.
+// These are StatefulSet selector labels: immutable, so present on every broker
+// Pod whatever operator version rendered it. Stricter markers such as
+// cluster.redpanda.com/broker live only on the Pod template, and filtering on
+// one would drop a live broker rendered before the label existed.
 func BrokerPodSelector(releaseName string) map[string]string {
 	return map[string]string{
 		labelNameKey:     labelNameValue,

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -301,9 +301,7 @@ func (c *Factory) schemaRegistryForStretchCluster(ctx context.Context, sc *redpa
 // across all clusters known to the manager, and builds per-pod endpoint addresses
 // for the given port.
 func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alpha2.StretchCluster, port int32) ([]string, error) {
-	// declared is every endpoint the pool specs ask for; dialable is the subset
-	// whose backing pod can currently accept a connection. See the return for
-	// why both are tracked.
+	// All endpoints the pool specs declare, and the subset whose pod is dialable.
 	var declared, dialable []string
 
 	for _, clusterName := range c.mgr.GetClusterNames() {
@@ -339,9 +337,8 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 		servable, podsErr := dialablePodNames(ctx, k8sClient, sc.Namespace, sc.Name)
 		podsKnown := podsErr == nil
 		if !podsKnown {
-			// Losing the pod list costs us only the filter. Offer this
-			// cluster's endpoints unfiltered rather than fail a client
-			// construction that never needed pod state before.
+			// A failed pod list costs only the filter: offer this cluster's
+			// endpoints unfiltered rather than fail the client construction.
 			log.FromContext(ctx).V(log.DebugLevel).Info("pod list unavailable; not filtering admin endpoints for this cluster",
 				"cluster", clusterName, "error", podsErr.Error())
 		}
@@ -357,8 +354,7 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 				name := rendermulticluster.PerPodServiceName(poolFullname, j)
 				endpoint := fmt.Sprintf("%s.%s:%d", name, pool.GetNamespace(), port)
 				declared = append(declared, endpoint)
-				// A per-pod Service and its backing Pod share a name, so the
-				// endpoint host is the pod to look up.
+				// A per-pod Service and its backing Pod share a name.
 				if !podsKnown || servable[name] {
 					dialable = append(dialable, endpoint)
 				}
@@ -366,11 +362,8 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 		}
 	}
 
-	// Prefer brokers that can answer. Falling back to the declared list when
-	// none look dialable keeps a whole-cluster outage behaving as it did
-	// before, rather than failing earlier with a different error: the caller
-	// treats an empty list as fatal, and "every broker is down" is a state the
-	// admin client is expected to be built in and fail against.
+	// Prefer brokers that can answer. With none dialable (a whole-cluster
+	// outage), return the declared list so that case fails exactly as it used to.
 	if len(dialable) > 0 {
 		return dialable, nil
 	}
@@ -381,40 +374,18 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 // connection. A non-nil error means the pod state is unknown, which the caller
 // treats as "do not filter" rather than as a failure.
 //
-// The host list is otherwise built purely from each RedpandaBrokerPool's
-// declared replica count, so it offers every broker the spec asks for,
-// including ones that are deliberately absent: a pool that was just deleted, or
-// the broker being rolled during a restart-requiring config change. rpadmin
-// does not fail on such a host -- it pays for it, and the price is paid on
-// every pass, because the client is rebuilt per reconcile:
-//
-//   - A read (sendAny) shuffles the host list and tries each host in turn until
-//     one answers, so an absent broker costs a wasted attempt and its share of
-//     the client timeout.
-//   - A write (sendToLeader) -- the cluster-config PUT that reconcileClusterConfig
-//     issues, and the decommission and maintenance-mode broker calls -- first
-//     resolves the controller leader through eachBroker, which fans out to every
-//     host and waits for all of them. One host that blackholes therefore adds the
-//     whole admin client timeout to the write, and if the leader is the id that
-//     could not be mapped, sendToLeader burns three stale-leader backoffs before
-//     giving up.
-//
-// Dropping hosts that provably cannot answer keeps that budget for the brokers
-// that can. This is the same reasoning as the IsClusterReachable skip in
-// stretchClusterEndpoints, and it is bounded the same way: a pod whose node has
-// gone NotReady still holds an address and still looks dialable here, so this
-// narrows the window rather than closing it.
+// The endpoint list is otherwise built from declared replica counts alone, so
+// it offers brokers that are deliberately absent -- a just-deleted pool, a
+// broker mid-roll -- and rpadmin pays for each such host with wasted attempts,
+// timeouts, and stale-leader backoffs on every reconcile. A pod on a NotReady
+// node still holds its address and still counts as dialable, so this narrows
+// that window rather than closing it.
 func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseName string) (map[string]bool, error) {
 	listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
 	defer listCancel()
 
-	// Scoped to this cluster's brokers. A namespace can hold unrelated
-	// workloads, and reading all of them widens both this list and, on a cached
-	// client, what has to be watched to serve it. Correctness never depended on
-	// the scope -- a Pod name is unique in a namespace and a broker's Pod name is
-	// its per-pod Service name, so a name match cannot land on someone else's
-	// Pod. It does close one contrived hole: a Pod named after a broker that is
-	// itself absent would otherwise vouch for it.
+	// Scope to this cluster's brokers: the namespace can hold unrelated
+	// workloads, and on a cached client an unscoped list widens the watch.
 	var pods corev1.PodList
 	if err := k8sClient.List(listCtx, &pods,
 		client.InNamespace(ns),
@@ -432,15 +403,10 @@ func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseN
 	return dialable, nil
 }
 
-// podDialable reports whether a connection to pod can be established at all.
-//
-// Readiness is deliberately not part of this, and an unready broker stays
-// reachable in practice: the operator talks to unready brokers on purpose --
-// reconcileStaleDiskWipe reads a rejoining broker's identity through
-// RedpandaAdminClientForStretchPod -- and the per-pod Service these endpoints
-// resolve through sets PublishNotReadyAddresses. So only pods that cannot accept
-// a connection are excluded: ones that are terminating, have finished, or have
-// no address yet.
+// podDialable reports whether a connection to pod can be established at all:
+// not terminating, not finished, and holding an address. Readiness is
+// deliberately excluded -- the operator reads rejoining brokers through unready
+// pods on purpose, and the per-pod Services publish not-ready addresses.
 func podDialable(pod *corev1.Pod) bool {
 	if pod.DeletionTimestamp != nil {
 		return false

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/redpanda-data/common-go/otelutil/log"
 	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
@@ -300,7 +301,10 @@ func (c *Factory) schemaRegistryForStretchCluster(ctx context.Context, sc *redpa
 // across all clusters known to the manager, and builds per-pod endpoint addresses
 // for the given port.
 func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alpha2.StretchCluster, port int32) ([]string, error) {
-	var endpoints []string
+	// declared is every endpoint the pool specs ask for; dialable is the subset
+	// whose backing pod can currently accept a connection. See the return for
+	// why both are tracked.
+	var declared, dialable []string
 
 	for _, clusterName := range c.mgr.GetClusterNames() {
 		// Skip peers the probe has marked unreachable. Without this the List
@@ -332,6 +336,16 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 			return nil, errors.Wrapf(err, "listing RedpandaBrokerPools in cluster %s", clusterName)
 		}
 
+		servable, podsErr := dialablePodNames(ctx, k8sClient, sc.Namespace)
+		podsKnown := podsErr == nil
+		if !podsKnown {
+			// Losing the pod list costs us only the filter. Offer this
+			// cluster's endpoints unfiltered rather than fail a client
+			// construction that never needed pod state before.
+			log.FromContext(ctx).V(log.DebugLevel).Info("pod list unavailable; not filtering admin endpoints for this cluster",
+				"cluster", clusterName, "error", podsErr.Error())
+		}
+
 		for i := range brokerPoolList.Items {
 			pool := &brokerPoolList.Items[i]
 			ref := pool.Spec.ClusterRef
@@ -341,11 +355,75 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 			for j := int32(0); j < pool.GetReplicas(); j++ {
 				poolFullname := tplutil.CleanForK8s(sc.Name) + pool.Suffix()
 				name := rendermulticluster.PerPodServiceName(poolFullname, j)
-				endpoints = append(endpoints, fmt.Sprintf("%s.%s:%d", name, pool.GetNamespace(), port))
+				endpoint := fmt.Sprintf("%s.%s:%d", name, pool.GetNamespace(), port)
+				declared = append(declared, endpoint)
+				// A per-pod Service and its backing Pod share a name, so the
+				// endpoint host is the pod to look up.
+				if !podsKnown || servable[name] {
+					dialable = append(dialable, endpoint)
+				}
 			}
 		}
 	}
-	return endpoints, nil
+
+	// Prefer brokers that can answer. Falling back to the declared list when
+	// none look dialable keeps a whole-cluster outage behaving as it did
+	// before, rather than failing earlier with a different error: the caller
+	// treats an empty list as fatal, and "every broker is down" is a state the
+	// admin client is expected to be built in and fail against.
+	if len(dialable) > 0 {
+		return dialable, nil
+	}
+	return declared, nil
+}
+
+// dialablePodNames returns the names of pods in ns that can currently accept a
+// connection. A non-nil error means the pod state is unknown, which the caller
+// treats as "do not filter" rather than as a failure.
+//
+// The admin client's host list is otherwise built purely from each
+// RedpandaBrokerPool's declared replica count, so it offers every broker the
+// spec asks for, including ones that are deliberately absent: a pool that was
+// just deleted, or the broker being rolled during a restart-requiring config
+// change. Whichever host a reconcile happens to pick, an absent one fails the
+// call, and the steps that gate on it make no progress as a result --
+// reconcileDecommission cannot read cluster health, so it never deletes the
+// removed pool's StatefulSet, and the maintenance-mode pass defers on an
+// unreadable broker list instead of advancing the roll. Neither recovers on its
+// own while the host list keeps offering the same absent broker.
+func dialablePodNames(ctx context.Context, k8sClient client.Client, ns string) (map[string]bool, error) {
+	listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
+	defer listCancel()
+
+	var pods corev1.PodList
+	if err := k8sClient.List(listCtx, &pods, client.InNamespace(ns)); err != nil {
+		return nil, errors.Wrapf(err, "listing pods in namespace %s", ns)
+	}
+
+	dialable := make(map[string]bool, len(pods.Items))
+	for i := range pods.Items {
+		if podDialable(&pods.Items[i]) {
+			dialable[pods.Items[i].Name] = true
+		}
+	}
+	return dialable, nil
+}
+
+// podDialable reports whether a connection to pod can be established at all.
+//
+// Readiness is deliberately not part of this. The operator talks to unready
+// brokers on purpose -- reconcileStaleDiskWipe reads a rejoining broker's
+// identity through RedpandaAdminClientForStretchPod -- so only pods that cannot
+// accept a connection are excluded: ones that are terminating, have finished,
+// or have no address yet.
+func podDialable(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return false
+	}
+	return pod.Status.PodIP != ""
 }
 
 // stretchClusterListenerTLSConfig builds a *tls.Config for a listener if TLS

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -336,7 +336,7 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 			return nil, errors.Wrapf(err, "listing RedpandaBrokerPools in cluster %s", clusterName)
 		}
 
-		servable, podsErr := dialablePodNames(ctx, k8sClient, sc.Namespace)
+		servable, podsErr := dialablePodNames(ctx, k8sClient, sc.Namespace, sc.Name)
 		podsKnown := podsErr == nil
 		if !podsKnown {
 			// Losing the pod list costs us only the filter. Offer this
@@ -404,13 +404,23 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 // stretchClusterEndpoints, and it is bounded the same way: a pod whose node has
 // gone NotReady still holds an address and still looks dialable here, so this
 // narrows the window rather than closing it.
-func dialablePodNames(ctx context.Context, k8sClient client.Client, ns string) (map[string]bool, error) {
+func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseName string) (map[string]bool, error) {
 	listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
 	defer listCancel()
 
+	// Scoped to this cluster's brokers. A namespace can hold unrelated
+	// workloads, and reading all of them widens both this list and, on a cached
+	// client, what has to be watched to serve it. Correctness never depended on
+	// the scope -- a Pod name is unique in a namespace and a broker's Pod name is
+	// its per-pod Service name, so a name match cannot land on someone else's
+	// Pod. It does close one contrived hole: a Pod named after a broker that is
+	// itself absent would otherwise vouch for it.
 	var pods corev1.PodList
-	if err := k8sClient.List(listCtx, &pods, client.InNamespace(ns)); err != nil {
-		return nil, errors.Wrapf(err, "listing pods in namespace %s", ns)
+	if err := k8sClient.List(listCtx, &pods,
+		client.InNamespace(ns),
+		client.MatchingLabels(rendermulticluster.BrokerPodSelector(releaseName)),
+	); err != nil {
+		return nil, errors.Wrapf(err, "listing broker pods in namespace %s", ns)
 	}
 
 	dialable := make(map[string]bool, len(pods.Items))

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -381,16 +381,29 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 // connection. A non-nil error means the pod state is unknown, which the caller
 // treats as "do not filter" rather than as a failure.
 //
-// The admin client's host list is otherwise built purely from each
-// RedpandaBrokerPool's declared replica count, so it offers every broker the
-// spec asks for, including ones that are deliberately absent: a pool that was
-// just deleted, or the broker being rolled during a restart-requiring config
-// change. Whichever host a reconcile happens to pick, an absent one fails the
-// call, and the steps that gate on it make no progress as a result --
-// reconcileDecommission cannot read cluster health, so it never deletes the
-// removed pool's StatefulSet, and the maintenance-mode pass defers on an
-// unreadable broker list instead of advancing the roll. Neither recovers on its
-// own while the host list keeps offering the same absent broker.
+// The host list is otherwise built purely from each RedpandaBrokerPool's
+// declared replica count, so it offers every broker the spec asks for,
+// including ones that are deliberately absent: a pool that was just deleted, or
+// the broker being rolled during a restart-requiring config change. rpadmin
+// does not fail on such a host -- it pays for it, and the price is paid on
+// every pass, because the client is rebuilt per reconcile:
+//
+//   - A read (sendAny) shuffles the host list and tries each host in turn until
+//     one answers, so an absent broker costs a wasted attempt and its share of
+//     the client timeout.
+//   - A write (sendToLeader) -- the cluster-config PUT that reconcileClusterConfig
+//     issues, and the decommission and maintenance-mode broker calls -- first
+//     resolves the controller leader through eachBroker, which fans out to every
+//     host and waits for all of them. One host that blackholes therefore adds the
+//     whole admin client timeout to the write, and if the leader is the id that
+//     could not be mapped, sendToLeader burns three stale-leader backoffs before
+//     giving up.
+//
+// Dropping hosts that provably cannot answer keeps that budget for the brokers
+// that can. This is the same reasoning as the IsClusterReachable skip in
+// stretchClusterEndpoints, and it is bounded the same way: a pod whose node has
+// gone NotReady still holds an address and still looks dialable here, so this
+// narrows the window rather than closing it.
 func dialablePodNames(ctx context.Context, k8sClient client.Client, ns string) (map[string]bool, error) {
 	listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
 	defer listCancel()
@@ -411,11 +424,13 @@ func dialablePodNames(ctx context.Context, k8sClient client.Client, ns string) (
 
 // podDialable reports whether a connection to pod can be established at all.
 //
-// Readiness is deliberately not part of this. The operator talks to unready
-// brokers on purpose -- reconcileStaleDiskWipe reads a rejoining broker's
-// identity through RedpandaAdminClientForStretchPod -- so only pods that cannot
-// accept a connection are excluded: ones that are terminating, have finished,
-// or have no address yet.
+// Readiness is deliberately not part of this, and an unready broker stays
+// reachable in practice: the operator talks to unready brokers on purpose --
+// reconcileStaleDiskWipe reads a rejoining broker's identity through
+// RedpandaAdminClientForStretchPod -- and the per-pod Service these endpoints
+// resolve through sets PublishNotReadyAddresses. So only pods that cannot accept
+// a connection are excluded: ones that are terminating, have finished, or have
+// no address yet.
 func podDialable(pod *corev1.Pod) bool {
 	if pod.DeletionTimestamp != nil {
 		return false

--- a/operator/pkg/client/stretch_cluster_endpoints_test.go
+++ b/operator/pkg/client/stretch_cluster_endpoints_test.go
@@ -31,9 +31,8 @@ import (
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 )
 
-// pod builds a broker Pod in the shape the dialability check reads, labelled
-// the way the renderer labels brokers of the StretchCluster named "sc" so the
-// scoped list selects it.
+// pod builds a running, addressable Pod labelled as a broker of the
+// StretchCluster named "sc".
 func pod(name string, mutate ...func(*corev1.Pod)) *corev1.Pod {
 	p := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -49,10 +48,8 @@ func pod(name string, mutate ...func(*corev1.Pod)) *corev1.Pod {
 	return p
 }
 
-// TestPodDialable pins which pods are excluded from the admin client's host
-// list. Only pods that cannot accept a connection are: readiness is
-// deliberately not a factor, because the operator reads a rejoining broker's
-// identity from an unready pod on purpose.
+// TestPodDialable pins which pods are excluded from the host list: only ones
+// that cannot accept a connection. Readiness is deliberately not a factor.
 func TestPodDialable(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -112,11 +109,8 @@ func TestPodDialable(t *testing.T) {
 	}
 }
 
-// TestDialablePodNames covers the lookup that stretchClusterEndpoints filters
-// against, including the case that motivated it: a broker pool being deleted
-// leaves a terminating pod that must not be offered to the admin client, since
-// the decommission that removes its StatefulSet is itself gated on a
-// cluster-health read.
+// TestDialablePodNames covers the lookup: a deleted pool's terminating pod, a
+// pod without an address, and scoping to this cluster's brokers.
 func TestDialablePodNames(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
@@ -164,11 +158,8 @@ func TestDialablePodNames(t *testing.T) {
 	}, got)
 }
 
-// TestDialablePodNamesListFailure pins the fallback: losing the pod list must
-// cost only the filter. Reporting the state as unknown makes
-// stretchClusterEndpoints offer its endpoints unfiltered, which is how the
-// admin client behaved before the filter existed, rather than failing a
-// construction that never needed pod state.
+// TestDialablePodNamesListFailure pins the fallback: a failed pod list reports
+// the state as unknown, and the caller then skips filtering instead of failing.
 func TestDialablePodNamesListFailure(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
@@ -186,9 +177,8 @@ func TestDialablePodNamesListFailure(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-// stubCluster satisfies cluster.Cluster well enough to hand back a client. The
-// embedded interface is nil: any method this test does not exercise panics
-// rather than silently returning a zero value.
+// stubCluster hands back a client; the nil embedded interface makes any
+// unexercised method panic rather than return a zero value.
 type stubCluster struct {
 	cluster.Cluster
 	c client.Client
@@ -197,8 +187,7 @@ type stubCluster struct {
 func (s *stubCluster) GetClient() client.Client { return s.c }
 
 // stubManager satisfies multicluster.Manager for the three methods
-// stretchClusterEndpoints reaches through. Same nil-embedding contract as
-// stubCluster.
+// stretchClusterEndpoints uses; same nil-embedding contract as stubCluster.
 type stubManager struct {
 	multicluster.Manager
 	clients map[string]client.Client
@@ -247,17 +236,13 @@ func endpointsScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
-// TestStretchClusterEndpointsSkipsUndialablePods is the test that pins the fix
-// itself: the endpoint list is derived from each pool's declared replica count,
-// so without the pod filter it offers a broker that is provably absent, and the
-// steps gating on it (decommission's cluster-health read, the maintenance-mode
-// broker list) then fail on whichever host they happen to pick.
+// TestStretchClusterEndpointsSkipsUndialablePods pins the fix end to end: a
+// terminating pool's broker must not be offered to the admin client.
 func TestStretchClusterEndpointsSkipsUndialablePods(t *testing.T) {
 	scheme := endpointsScheme(t)
 	now := metav1.Now()
 
-	// Cluster one's broker is up; cluster two's pool is being deleted, which is
-	// exactly the SingleBrokerPoolDeletion shape.
+	// Cluster one's broker is up; cluster two's pool is being deleted.
 	clusterOne := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		brokerPool("pool-a", "sc"),
 		pod("sc-pool-a-0"),
@@ -286,14 +271,12 @@ func TestStretchClusterEndpointsSkipsUndialablePods(t *testing.T) {
 		"the terminating pool's broker must not be offered to the admin client")
 }
 
-// TestStretchClusterEndpointsFallsBackWhenNoneDialable pins the safety valve. A
-// whole-cluster outage must still produce a host list: the caller treats an
-// empty one as fatal, and failing there would trade a dial error for a
-// different, less informative one.
+// TestStretchClusterEndpointsFallsBackWhenNoneDialable pins the safety valve:
+// a whole-cluster outage must still produce a host list.
 func TestStretchClusterEndpointsFallsBackWhenNoneDialable(t *testing.T) {
 	scheme := endpointsScheme(t)
 
-	// Both brokers are mid-reschedule with no address assigned.
+	// The cluster's only broker is mid-reschedule with no address assigned.
 	pending := func(name string) *corev1.Pod {
 		return pod(name, func(p *corev1.Pod) {
 			p.Status.Phase = corev1.PodPending

--- a/operator/pkg/client/stretch_cluster_endpoints_test.go
+++ b/operator/pkg/client/stretch_cluster_endpoints_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package client
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
+)
+
+// pod builds a Pod in the shape the dialability check reads.
+func pod(name string, mutate ...func(*corev1.Pod)) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "redpanda"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
+	}
+	for _, m := range mutate {
+		m(p)
+	}
+	return p
+}
+
+// TestPodDialable pins which pods are excluded from the admin client's host
+// list. Only pods that cannot accept a connection are: readiness is
+// deliberately not a factor, because the operator reads a rejoining broker's
+// identity from an unready pod on purpose.
+func TestPodDialable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "running with an address",
+			pod:  pod("broker-0"),
+			want: true,
+		},
+		{
+			name: "unready but addressable is still dialable",
+			pod: pod("broker-0", func(p *corev1.Pod) {
+				p.Status.Conditions = []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				}}
+			}),
+			want: true,
+		},
+		{
+			name: "terminating",
+			pod: pod("broker-0", func(p *corev1.Pod) {
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				p.Finalizers = []string{"keep/for-fake-client"}
+			}),
+			want: false,
+		},
+		{
+			name: "unscheduled, no address yet",
+			pod: pod("broker-0", func(p *corev1.Pod) {
+				p.Status.Phase = corev1.PodPending
+				p.Status.PodIP = ""
+			}),
+			want: false,
+		},
+		{
+			name: "succeeded",
+			pod: pod("broker-0", func(p *corev1.Pod) {
+				p.Status.Phase = corev1.PodSucceeded
+			}),
+			want: false,
+		},
+		{
+			name: "failed",
+			pod: pod("broker-0", func(p *corev1.Pod) {
+				p.Status.Phase = corev1.PodFailed
+			}),
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, podDialable(tc.pod))
+		})
+	}
+}
+
+// TestDialablePodNames covers the lookup that stretchClusterEndpoints filters
+// against, including the case that motivated it: a broker pool being deleted
+// leaves a terminating pod that must not be offered to the admin client, since
+// the decommission that removes its StatefulSet is itself gated on a
+// cluster-health read.
+func TestDialablePodNames(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	now := metav1.Now()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		pod("cleanup-test-cleanup-pool-0-0"),
+		pod("cleanup-test-cleanup-pool-1-0"),
+		// The pool under deletion.
+		pod("cleanup-test-cleanup-pool-2-0", func(p *corev1.Pod) {
+			p.DeletionTimestamp = &now
+			p.Finalizers = []string{"keep/for-fake-client"}
+		}),
+		// Mid-roll, rescheduled and not yet assigned an address.
+		pod("config-sync-cfg-pool-0-0", func(p *corev1.Pod) {
+			p.Status.Phase = corev1.PodPending
+			p.Status.PodIP = ""
+		}),
+		// A pod in another namespace must not leak in.
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "elsewhere-0", Namespace: "other"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.9"},
+		},
+	).Build()
+
+	got, err := dialablePodNames(t.Context(), c, "redpanda")
+	require.NoError(t, err, "a successful list must report the pod state as known")
+	assert.Equal(t, map[string]bool{
+		"cleanup-test-cleanup-pool-0-0": true,
+		"cleanup-test-cleanup-pool-1-0": true,
+	}, got)
+}
+
+// TestDialablePodNamesListFailure pins the fallback: losing the pod list must
+// cost only the filter. Reporting the state as unknown makes
+// stretchClusterEndpoints offer its endpoints unfiltered, which is how the
+// admin client behaved before the filter existed, rather than failing a
+// construction that never needed pod state.
+func TestDialablePodNamesListFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Stands in for an unreachable or throttled apiserver.
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return errors.New("apiserver unavailable")
+			},
+		}).Build()
+
+	got, err := dialablePodNames(t.Context(), c, "redpanda")
+	require.Error(t, err, "a failed list must report the pod state as unknown")
+	assert.Nil(t, got)
+}
+
+// stubCluster satisfies cluster.Cluster well enough to hand back a client. The
+// embedded interface is nil: any method this test does not exercise panics
+// rather than silently returning a zero value.
+type stubCluster struct {
+	cluster.Cluster
+	c client.Client
+}
+
+func (s *stubCluster) GetClient() client.Client { return s.c }
+
+// stubManager satisfies multicluster.Manager for the three methods
+// stretchClusterEndpoints reaches through. Same nil-embedding contract as
+// stubCluster.
+type stubManager struct {
+	multicluster.Manager
+	clients map[string]client.Client
+}
+
+func (m *stubManager) GetClusterNames() []string {
+	names := make([]string, 0, len(m.clients))
+	for name := range m.clients {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func (m *stubManager) IsClusterReachable(string) bool { return true }
+
+func (m *stubManager) GetCluster(_ context.Context, name string) (cluster.Cluster, error) {
+	c, ok := m.clients[name]
+	if !ok {
+		return nil, errors.Newf("no cluster %q", name)
+	}
+	return &stubCluster{c: c}, nil
+}
+
+// brokerPool builds a RedpandaBrokerPool bound to sc with a single replica.
+func brokerPool(name, scName string) *redpandav1alpha2.RedpandaBrokerPool {
+	return &redpandav1alpha2.RedpandaBrokerPool{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "redpanda"},
+		Spec: redpandav1alpha2.BrokerPoolSpec{
+			EmbeddedBrokerPoolSpec: redpandav1alpha2.EmbeddedBrokerPoolSpec{
+				Replicas: ptr.To(int32(1)),
+			},
+			ClusterRef: redpandav1alpha2.ClusterRef{
+				Kind: ptr.To(redpandav1alpha2.StretchClusterRefKind),
+				Name: scName,
+			},
+		},
+	}
+}
+
+func endpointsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+	return scheme
+}
+
+// TestStretchClusterEndpointsSkipsUndialablePods is the test that pins the fix
+// itself: the endpoint list is derived from each pool's declared replica count,
+// so without the pod filter it offers a broker that is provably absent, and the
+// steps gating on it (decommission's cluster-health read, the maintenance-mode
+// broker list) then fail on whichever host they happen to pick.
+func TestStretchClusterEndpointsSkipsUndialablePods(t *testing.T) {
+	scheme := endpointsScheme(t)
+	now := metav1.Now()
+
+	// Cluster one's broker is up; cluster two's pool is being deleted, which is
+	// exactly the SingleBrokerPoolDeletion shape.
+	clusterOne := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		brokerPool("pool-a", "sc"),
+		pod("sc-pool-a-0"),
+	).Build()
+
+	clusterTwo := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		brokerPool("pool-b", "sc"),
+		pod("sc-pool-b-0", func(p *corev1.Pod) {
+			p.DeletionTimestamp = &now
+			p.Finalizers = []string{"keep/for-fake-client"}
+		}),
+	).Build()
+
+	c := &Factory{mgr: &stubManager{clients: map[string]client.Client{
+		"cluster-1": clusterOne,
+		"cluster-2": clusterTwo,
+	}}}
+
+	sc := &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sc", Namespace: "redpanda"},
+	}
+
+	endpoints, err := c.stretchClusterEndpoints(t.Context(), sc, 9644)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sc-pool-a-0.redpanda:9644"}, endpoints,
+		"the terminating pool's broker must not be offered to the admin client")
+}
+
+// TestStretchClusterEndpointsFallsBackWhenNoneDialable pins the safety valve. A
+// whole-cluster outage must still produce a host list: the caller treats an
+// empty one as fatal, and failing there would trade a dial error for a
+// different, less informative one.
+func TestStretchClusterEndpointsFallsBackWhenNoneDialable(t *testing.T) {
+	scheme := endpointsScheme(t)
+
+	// Both brokers are mid-reschedule with no address assigned.
+	pending := func(name string) *corev1.Pod {
+		return pod(name, func(p *corev1.Pod) {
+			p.Status.Phase = corev1.PodPending
+			p.Status.PodIP = ""
+		})
+	}
+
+	clusterOne := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		brokerPool("pool-a", "sc"), pending("sc-pool-a-0"),
+	).Build()
+
+	c := &Factory{mgr: &stubManager{clients: map[string]client.Client{"cluster-1": clusterOne}}}
+
+	sc := &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sc", Namespace: "redpanda"},
+	}
+
+	endpoints, err := c.stretchClusterEndpoints(t.Context(), sc, 9644)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sc-pool-a-0.redpanda:9644"}, endpoints,
+		"with nothing dialable the declared list must still be returned")
+}

--- a/operator/pkg/client/stretch_cluster_endpoints_test.go
+++ b/operator/pkg/client/stretch_cluster_endpoints_test.go
@@ -27,14 +27,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+	rendermulticluster "github.com/redpanda-data/redpanda-operator/operator/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 )
 
-// pod builds a Pod in the shape the dialability check reads.
+// pod builds a broker Pod in the shape the dialability check reads, labelled
+// the way the renderer labels brokers of the StretchCluster named "sc" so the
+// scoped list selects it.
 func pod(name string, mutate ...func(*corev1.Pod)) *corev1.Pod {
 	p := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "redpanda"},
-		Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "redpanda",
+			Labels:    rendermulticluster.BrokerPodSelector("sc"),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
 	}
 	for _, m := range mutate {
 		m(p)
@@ -133,9 +140,23 @@ func TestDialablePodNames(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "elsewhere-0", Namespace: "other"},
 			Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.9"},
 		},
+		// An unrelated workload sharing the namespace must not be read at all.
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "someone-elses-app-0", Namespace: "redpanda"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.8"},
+		},
+		// Nor must another StretchCluster's brokers in the same namespace.
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-sc-pool-0-0",
+				Namespace: "redpanda",
+				Labels:    rendermulticluster.BrokerPodSelector("other-sc"),
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.7"},
+		},
 	).Build()
 
-	got, err := dialablePodNames(t.Context(), c, "redpanda")
+	got, err := dialablePodNames(t.Context(), c, "redpanda", "sc")
 	require.NoError(t, err, "a successful list must report the pod state as known")
 	assert.Equal(t, map[string]bool{
 		"cleanup-test-cleanup-pool-0-0": true,
@@ -160,7 +181,7 @@ func TestDialablePodNamesListFailure(t *testing.T) {
 			},
 		}).Build()
 
-	got, err := dialablePodNames(t.Context(), c, "redpanda")
+	got, err := dialablePodNames(t.Context(), c, "redpanda", "sc")
 	require.Error(t, err, "a failed list must report the pod state as unknown")
 	assert.Nil(t, got)
 }

--- a/operator/pkg/client/stretch_cluster_test.go
+++ b/operator/pkg/client/stretch_cluster_test.go
@@ -389,16 +389,33 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 	s.mc.ApplyAll(t, ctx, mutatedSC)
 
 	// Verify ConfigurationApplied returns to True and the config version changed.
+	//
+	// Each unmet branch logs what it saw. A bare bool here is indistinguishable
+	// from every other way this can time out, and the failure it produces
+	// ("Condition never satisfied") says nothing about whether the roll never
+	// started, the condition went False, or the version simply never moved --
+	// which is the difference between a product bug and a slow environment.
 	require.Eventually(t, func() bool {
 		var cluster redpandav1alpha2.StretchCluster
 		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {
+			t.Logf("get StretchCluster: %v", err)
 			return false
 		}
 		cond := apimeta.FindStatusCondition(cluster.Status.Conditions, statuses.StretchClusterConfigurationApplied)
-		if cond == nil || cond.Status != metav1.ConditionTrue {
+		if cond == nil {
+			t.Logf("ConfigurationApplied absent; configVersion=%q (want != %q)", cluster.Status.ConfigVersion, initialConfigVersion)
 			return false
 		}
-		return cluster.Status.ConfigVersion != "" && cluster.Status.ConfigVersion != initialConfigVersion
+		if cond.Status != metav1.ConditionTrue {
+			t.Logf("ConfigurationApplied=%s reason=%q message=%q; configVersion=%q (want != %q)",
+				cond.Status, cond.Reason, cond.Message, cluster.Status.ConfigVersion, initialConfigVersion)
+			return false
+		}
+		if cluster.Status.ConfigVersion == "" || cluster.Status.ConfigVersion == initialConfigVersion {
+			t.Logf("ConfigurationApplied=True but configVersion=%q has not moved off %q", cluster.Status.ConfigVersion, initialConfigVersion)
+			return false
+		}
+		return true
 	}, 3*time.Minute, 5*time.Second, "ConfigurationApplied=True with new config version never appeared after config change")
 }
 

--- a/operator/pkg/client/stretch_cluster_test.go
+++ b/operator/pkg/client/stretch_cluster_test.go
@@ -389,12 +389,8 @@ func (s *StretchClusterFactorySuite) TestClusterConfigSync() {
 	s.mc.ApplyAll(t, ctx, mutatedSC)
 
 	// Verify ConfigurationApplied returns to True and the config version changed.
-	//
-	// Each unmet branch logs what it saw. A bare bool here is indistinguishable
-	// from every other way this can time out, and the failure it produces
-	// ("Condition never satisfied") says nothing about whether the roll never
-	// started, the condition went False, or the version simply never moved --
-	// which is the difference between a product bug and a slow environment.
+	// Each unmet branch logs what it saw, so a timeout says which requirement
+	// never held instead of a bare "Condition never satisfied".
 	require.Eventually(t, func() bool {
 		var cluster redpandav1alpha2.StretchCluster
 		if err := s.mc.Envs[0].Client().Get(ctx, nn, &cluster); err != nil {


### PR DESCRIPTION
## Problem

`stretchClusterEndpoints` builds the StretchCluster admin, Kafka, and Schema Registry host lists purely from each pool's declared replica count, so it also offers brokers that are deliberately absent — a just-deleted pool, or the broker mid-roll during a restart-requiring config change. rpadmin doesn't fail on such a host; it pays for it on every reconcile, because the client is rebuilt per pass:

* Reads (`sendAny`) try hosts in turn, so an absent broker wastes an attempt and its share of the 10s client timeout.
* Writes (`sendToLeader`: the cluster-config PUT, decommission, maintenance mode) first resolve the leader by fanning out to **every** host and waiting for all of them — one blackholed host adds the whole timeout, and a failed leader mapping burns three 9s stale-leader backoffs.

Both flaky multicluster tests in build 15442 sit on this path: `TestResourceCleanup/SingleBrokerPoolDeletion` timed out decommissioning against the pool it had just deleted (`pod cleanup-test-cleanup-pool-2-0 does not have a host assigned`), and `TestClusterConfigSync` re-resolves brokers while rolling them.

## Fix

Filter endpoints to pods that can accept a connection: present, not terminating, address assigned. The pod list is scoped to this cluster's brokers via StatefulSet selector labels (`BrokerPodSelector`).

Deliberately **not** readiness-gated: the operator reads a rejoining broker's identity through an unready pod on purpose, and the per-pod Services set `PublishNotReadyAddresses`. If nothing looks dialable (whole-cluster outage) or the pod list fails, the full declared list is returned so those cases behave exactly as before. This mirrors the existing `IsClusterReachable` skip in the same function, and applies in production, not just tests.

Also: `TestClusterConfigSync`'s wait now logs which requirement was unmet instead of returning a bare bool, so a timeout is diagnosable.

## Caveats

* This removes wasted timeout budget, not a hard failure — reads try every host, so an absent broker slows a reconcile rather than failing it. Whether it closes the build-15442 flake needs a rerun.
* A pod on a NotReady node keeps its address and still looks dialable; both failing runs also logged `Node is not ready`, which this filter can't see.
* Filtering down to exactly one host flips rpadmin into single-host mode (no leader resolution, HTTP retry re-enabled). A two-host floor would avoid that; not addressed here.
* `TestClusterConfigSync` allows 5 min for a cold broker start but only 3 min for a three-broker rolling restart; left as is so this PR's effect stays visible. Worth raising after this lands.

## Testing

* `TestPodDialable` — each excluded state; pins that unready-but-addressable stays dialable.
* `TestDialablePodNames` / `TestDialablePodNamesListFailure` — the scoped lookup and the don't-filter-on-error fallback.
* `TestStretchClusterEndpointsSkipsUndialablePods` — the fix end to end across two clusters; verified by mutation (accepting every endpoint fails it).
* `TestStretchClusterEndpointsFallsBackWhenNoneDialable` — the outage fallback.
* `go build ./operator/...` and `golangci-lint run ./operator/pkg/client/...` clean.
