### PR TITLE
operator: report experimental Broker CR mode in telemetry

### DIFF
--- a/.changes/unreleased/operator-Added-20260831-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260831-120000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: "Anonymous operator telemetry now reports the experimental Broker CR mode: the new `broker` section carries `enabled` (the operator's `--enable-broker` flag - whether the Broker controller runs at all) and `count` (the number of Broker CRs, i.e. broker pods managed as Broker CRs instead of by a StatefulSet), so `enabled: true` with `count: 0` reads as available but unused and `count > 0` as in use; Broker CRs are only ever created by the Redpanda and Cluster controllers, so their existence is direct evidence of use. Installs without the experimental Broker CRD, or without RBAC to list it, report `count: 0` and still send the rest of the report"
+time: 2026-08-31T12:00:00+02:00

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -840,6 +840,7 @@ func Run(
 			IDHash:              idHash,
 			Features:            features,
 			ConnectDefaultImage: opts.connectDefaultImage,
+			BrokerCREnabled:     opts.enableBrokerController,
 			Period:              opts.telemetryPeriod,
 		})
 		if err != nil {

--- a/operator/internal/telemetry/collector.go
+++ b/operator/internal/telemetry/collector.go
@@ -73,6 +73,10 @@ type Collector struct {
 	// key embedded in common-go, and committing a real token to satisfy it is
 	// not an option.
 	ParseLicense func([]byte) (license.RedpandaLicense, error)
+	// BrokerCREnabled is the operator's --enable-broker flag, reported as
+	// broker.enabled. Configuration rather than cluster shape, so it is
+	// passed in rather than discovered.
+	BrokerCREnabled bool
 	// ConnectDefaultImage is the operator-level Connect image override (the
 	// --connect-default-image flag / connectController.image chart values).
 	// Needed to resolve the effective image of Pipelines that don't pin
@@ -229,6 +233,11 @@ func (c *Collector) Collect(ctx context.Context) (*Payload, error) {
 		if payload.IDHash == "" && len(checksums) == 1 {
 			payload.IDHash = checksums[0]
 		}
+	}
+
+	payload.Broker.Enabled = c.BrokerCREnabled
+	if err := c.count(ctx, redpandav1alpha2.SchemeGroupVersion.WithKind("BrokerList"), &payload.Broker.Count); err != nil {
+		return nil, err
 	}
 
 	// Supporting CR-type counts. Metadata-only lists: we only need len(), so

--- a/operator/internal/telemetry/collector_test.go
+++ b/operator/internal/telemetry/collector_test.go
@@ -120,6 +120,14 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 				},
 			},
 		},
+		&redpandav1alpha2.Broker{
+			ObjectMeta: metav1.ObjectMeta{Name: "rp-1-0", Namespace: "default"},
+			Spec:       redpandav1alpha2.BrokerSpec{ClusterRef: redpandav1alpha2.ClusterRef{Name: "rp-1"}},
+		},
+		&redpandav1alpha2.Broker{
+			ObjectMeta: metav1.ObjectMeta{Name: "rp-1-1", Namespace: "default"},
+			Spec:       redpandav1alpha2.BrokerSpec{ClusterRef: redpandav1alpha2.ClusterRef{Name: "rp-1"}},
+		},
 		&redpandav1alpha2.Redpanda{
 			ObjectMeta: metav1.ObjectMeta{Name: "rp-1", Namespace: "default"},
 			Spec: redpandav1alpha2.RedpandaSpec{
@@ -183,6 +191,7 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 		OperatorVersion: "v26.2.0",
 		IDHash:          "deadbeefcafe",
 		Features:        map[string]bool{"pvcUnbinder": true},
+		BrokerCREnabled: true,
 		Discovery:       fakeServerVersion{info: &version.Info{GitVersion: "v1.32.0"}},
 	}
 
@@ -247,6 +256,11 @@ func TestCollect_PopulatedCluster(t *testing.T) {
 	require.Equal(t, 1, payload.Console.HTTPRoute)
 	require.Equal(t, 1, payload.Console.Ingress)
 
+	// Broker CR mode: the controller is enabled and rp-1's two brokers are
+	// managed as Broker CRs.
+	require.True(t, payload.Broker.Enabled)
+	require.Equal(t, 2, payload.Broker.Count)
+
 	require.Equal(t, 1, payload.CRDCount)
 	// PVC Unbinder usage is reported via the features map, not a dedicated field.
 	require.True(t, payload.Features["pvcUnbinder"])
@@ -303,6 +317,8 @@ func TestCollect_EmptyCluster(t *testing.T) {
 	require.Empty(t, payload.Storage.CSIDrivers)
 	require.Equal(t, 0, payload.Resources.Topics)
 	require.Equal(t, 0, payload.CRDCount)
+	require.False(t, payload.Broker.Enabled)
+	require.Equal(t, 0, payload.Broker.Count)
 }
 
 // TestAggregateRedpandas_GatewayCountRequiresParentRefs locks the telemetry
@@ -911,4 +927,78 @@ func TestAggregatePipelines_ImageResolution(t *testing.T) {
 	payload = &Payload{}
 	c.aggregatePipelines(payload, pipelines)
 	require.Contains(t, payload.Connect.Versions, imageVersion(redpandav1alpha2.PipelineDefaultImage))
+}
+
+// TestCollect_BrokerModeToleratesMissingBrokerCRD locks in that the Broker CR
+// count degrades to zero on an install that runs the Broker controller but
+// never applied the experimental Broker CRD, rather than dropping the whole
+// telemetry document. The reported flag is unaffected by the failed read.
+func TestCollect_BrokerModeToleratesMissingBrokerCRD(t *testing.T) {
+	scheme := testScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&redpandav1alpha2.Redpanda{ObjectMeta: metav1.ObjectMeta{Name: "rp-1", Namespace: "default"}},
+	).Build()
+
+	// Tracked so a mistyped list kind can't make this test pass by accident.
+	var brokersListed bool
+	reader := stubReader{
+		Reader: base,
+		listErr: func(list client.ObjectList) error {
+			if l, ok := list.(*metav1.PartialObjectMetadataList); ok && l.GroupVersionKind().Kind == "BrokerList" {
+				brokersListed = true
+				// Experimental CRD never applied -> RESTMapper no-match.
+				return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: redpandaCRDGroup, Kind: "Broker"}}
+			}
+			return nil
+		},
+	}
+
+	raw, err := (&Collector{Reader: reader, BrokerCREnabled: true}).Collect(t.Context())
+	require.NoError(t, err) // tolerated: the document is still sent
+
+	require.True(t, brokersListed)
+	require.True(t, raw.Broker.Enabled)
+	require.Equal(t, 0, raw.Broker.Count)
+	require.Equal(t, 1, raw.Redpanda.Count, "the rest of the report is unaffected")
+}
+
+// TestCollect_BrokerEnabledTracksFlagNotUsage pins the two broker fields as
+// independent axes: enabled mirrors --enable-broker (configuration) and count
+// mirrors the Broker CRs that exist (usage). All four combinations are
+// reachable, including Broker CRs left over from a rollback on an operator that
+// no longer runs the controller.
+func TestCollect_BrokerEnabledTracksFlagNotUsage(t *testing.T) {
+	scheme := testScheme(t)
+
+	for _, tc := range []struct {
+		name    string
+		flag    bool
+		brokers []client.Object
+		count   int
+	}{
+		{name: "unavailable", flag: false},
+		{name: "available but unused", flag: true},
+		{
+			name:    "in use",
+			flag:    true,
+			brokers: []client.Object{&redpandav1alpha2.Broker{ObjectMeta: metav1.ObjectMeta{Name: "rp-1-0", Namespace: "default"}}},
+			count:   1,
+		},
+		{
+			name:    "in use with the controller turned off",
+			flag:    false,
+			brokers: []client.Object{&redpandav1alpha2.Broker{ObjectMeta: metav1.ObjectMeta{Name: "rp-1-0", Namespace: "default"}}},
+			count:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.brokers...).Build()
+
+			raw, err := (&Collector{Reader: c, BrokerCREnabled: tc.flag}).Collect(t.Context())
+			require.NoError(t, err)
+
+			require.Equal(t, tc.flag, raw.Broker.Enabled)
+			require.Equal(t, tc.count, raw.Broker.Count)
+		})
+	}
 }

--- a/operator/internal/telemetry/payload.go
+++ b/operator/internal/telemetry/payload.go
@@ -116,6 +116,23 @@ type Payload struct {
 		BrokerSizes    []string `json:"brokerSizes,omitempty"`
 	} `json:"vectorizedClusters"`
 
+	// Broker reports the experimental Broker CR mode. The fields are
+	// independent axes, so enabled=false with count>0 is a valid shape
+	// (rollback leftovers, or a collector that never runs the Broker
+	// controller — the multicluster command).
+	Broker struct {
+		// Enabled is the operator's --enable-broker flag: configuration,
+		// not usage.
+		Enabled bool `json:"enabled"`
+		// Count is the number of Broker CRs — broker pods managed in broker
+		// mode rather than by a StatefulSet. Only controllers create Broker
+		// CRs, so their existence is direct evidence of use. Slightly
+		// overcounts live brokers during disk-loss recovery: a disk-lost
+		// Broker lingers as its node_id's decommission record while the
+		// replacement reuses the pod name.
+		Count int `json:"count"`
+	} `json:"broker"`
+
 	Storage struct {
 		CSIDrivers []string `json:"csiDrivers"`
 	} `json:"storage"`

--- a/operator/internal/telemetry/runnable.go
+++ b/operator/internal/telemetry/runnable.go
@@ -49,6 +49,9 @@ type Options struct {
 	// they neither list a type their scheme deliberately omits nor spend an API
 	// server round trip on it.
 	SkipV1Collection bool
+	// BrokerCREnabled is the operator's --enable-broker flag, reported as
+	// broker.enabled.
+	BrokerCREnabled bool
 	// Delay is the wait before the first report; zero means the shared library default (5m).
 	Delay  time.Duration
 	Period time.Duration
@@ -93,6 +96,7 @@ func NewRunnable(reader client.Reader, disco discovery.ServerVersionInterface, l
 		Discovery:           disco,
 		ConnectDefaultImage: opts.ConnectDefaultImage,
 		SkipV1Collection:    opts.SkipV1Collection,
+		BrokerCREnabled:     opts.BrokerCREnabled,
 	}
 
 	return &Runnable{reporter: &commontelemetry.Reporter{


### PR DESCRIPTION
Anonymous operator telemetry gained a `broker` section with two independent axes: `enabled` mirrors the operator's --enable-broker flag (whether the Broker controller runs at all), and `count` is the number of Broker CRs — the broker pods actually managed as Broker CRs instead of by a StatefulSet. So enabled=true with count=0 reads as "available but unused" and count>0 as "in use". enabled=false with count>0 is reachable too (a rollback, or the flag dropped from a running install), which is why the flag is recorded before the count read and outside its error path.

Broker CRs are created by the Redpanda and Cluster controllers, never by hand, so their existence is direct evidence of use. The use-broker-cr annotation is deliberately not consulted: it is user intent rather than fact, and it goes away once broker mode becomes the default path.

The experimental Broker CRD may not be installed at all, and the operator may not hold RBAC to list brokers; both degrade the count to zero through the collector's existing per-field NoMatch/Forbidden tolerance instead of dropping the whole report.