### PR TITLE
charts/redpanda: Add address config to allow listen on ::, instead of 0.0.0.0

### DIFF
--- a/.changes/unreleased/charts-redpanda-Added-20260901-142100.yaml
+++ b/.changes/unreleased/charts-redpanda-Added-20260901-142100.yaml
@@ -1,0 +1,4 @@
+project: charts/redpanda
+kind: Added
+body: 'Added ability to override redpanda listen address using address value in listeners to enable IPv6 address :: to be used for listening, instead of IPv4-only 0.0.0.0 default'
+time: 2026-09-01T14:21:00+00:00

--- a/charts/redpanda/chart/README.md
+++ b/charts/redpanda/chart/README.md
@@ -331,7 +331,7 @@ Listener settings.  Override global settings configured above for individual lis
 **Default:**
 
 ```
-{"admin":{"external":{"default":{"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}},"port":9644,"tls":{"cert":"default","requireClientAuth":false}},"http":{"authenticationMethod":null,"enabled":true,"external":{"default":{"advertisedPorts":[30082],"authenticationMethod":null,"port":8083,"tls":{"cert":"external","requireClientAuth":false}}},"port":8082,"tls":{"cert":"default","requireClientAuth":false}},"kafka":{"authenticationMethod":null,"external":{"default":{"advertisedPorts":[31092],"authenticationMethod":null,"port":9094,"tls":{"cert":"external"}}},"port":9093,"tls":{"cert":"default","requireClientAuth":false}},"rpc":{"port":33145,"tls":{"cert":"default","requireClientAuth":false}},"schemaRegistry":{"authenticationMethod":null,"enabled":true,"external":{"default":{"advertisedPorts":[30081],"authenticationMethod":null,"port":8084,"tls":{"cert":"external","requireClientAuth":false}}},"port":8081,"tls":{"cert":"default","requireClientAuth":false}}}
+{"admin":{"address":null,"external":{"default":{"address":null,"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}},"port":9644,"tls":{"cert":"default","requireClientAuth":false}},"http":{"address":null,"authenticationMethod":null,"enabled":true,"external":{"default":{"address":null,"advertisedPorts":[30082],"authenticationMethod":null,"port":8083,"tls":{"cert":"external","requireClientAuth":false}}},"port":8082,"tls":{"cert":"default","requireClientAuth":false}},"kafka":{"address":null,"authenticationMethod":null,"external":{"default":{"address":null,"advertisedPorts":[31092],"authenticationMethod":null,"port":9094,"tls":{"cert":"external"}}},"port":9093,"tls":{"cert":"default","requireClientAuth":false}},"rpc":{"address":null,"port":33145,"tls":{"cert":"default","requireClientAuth":false}},"schemaRegistry":{"address":null,"authenticationMethod":null,"enabled":true,"external":{"default":{"address":null,"advertisedPorts":[30081],"authenticationMethod":null,"port":8084,"tls":{"cert":"external","requireClientAuth":false}}},"port":8081,"tls":{"cert":"default","requireClientAuth":false}}}
 ```
 
 ### [listeners.admin](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.admin)
@@ -341,8 +341,14 @@ Admin API listener (only one).
 **Default:**
 
 ```
-{"external":{"default":{"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}},"port":9644,"tls":{"cert":"default","requireClientAuth":false}}
+{"address":null,"external":{"default":{"address":null,"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}},"port":9644,"tls":{"cert":"default","requireClientAuth":false}}
 ```
+
+### [listeners.admin.address](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.admin.address)
+
+The address to bind to, default is 0.0.0.0
+
+**Default:** `nil`
 
 ### [listeners.admin.external](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.admin.external)
 
@@ -351,7 +357,7 @@ Optional external access settings.
 **Default:**
 
 ```
-{"default":{"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}}
+{"default":{"address":null,"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}}
 ```
 
 ### [listeners.admin.external.default](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.admin.external.default)
@@ -361,7 +367,7 @@ Name of the external listener.
 **Default:**
 
 ```
-{"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}
+{"address":null,"advertisedPorts":[31644],"port":9645,"tls":{"cert":"external"}}
 ```
 
 ### [listeners.admin.external.default.tls](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.admin.external.default.tls)
@@ -405,8 +411,14 @@ HTTP API listeners (aka PandaProxy).
 **Default:**
 
 ```
-{"authenticationMethod":null,"enabled":true,"external":{"default":{"advertisedPorts":[30082],"authenticationMethod":null,"port":8083,"tls":{"cert":"external","requireClientAuth":false}}},"port":8082,"tls":{"cert":"default","requireClientAuth":false}}
+{"address":null,"authenticationMethod":null,"enabled":true,"external":{"default":{"address":null,"advertisedPorts":[30082],"authenticationMethod":null,"port":8083,"tls":{"cert":"external","requireClientAuth":false}}},"port":8082,"tls":{"cert":"default","requireClientAuth":false}}
 ```
+
+### [listeners.http.address](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.http.address)
+
+The address to bind to, default is 0.0.0.0
+
+**Default:** `nil`
 
 ### [listeners.kafka](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.kafka)
 
@@ -415,8 +427,20 @@ Kafka API listeners.
 **Default:**
 
 ```
-{"authenticationMethod":null,"external":{"default":{"advertisedPorts":[31092],"authenticationMethod":null,"port":9094,"tls":{"cert":"external"}}},"port":9093,"tls":{"cert":"default","requireClientAuth":false}}
+{"address":null,"authenticationMethod":null,"external":{"default":{"address":null,"advertisedPorts":[31092],"authenticationMethod":null,"port":9094,"tls":{"cert":"external"}}},"port":9093,"tls":{"cert":"default","requireClientAuth":false}}
 ```
+
+### [listeners.kafka.address](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.kafka.address)
+
+The address to bind to, default is 0.0.0.0
+
+**Default:** `nil`
+
+### [listeners.kafka.external.default.address](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.kafka.external.default.address)
+
+The address to bind to, default is 0.0.0.0
+
+**Default:** `nil`
 
 ### [listeners.kafka.external.default.advertisedPorts](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.kafka.external.default.advertisedPorts)
 
@@ -443,8 +467,14 @@ RPC listener (this is never externally accessible).
 **Default:**
 
 ```
-{"port":33145,"tls":{"cert":"default","requireClientAuth":false}}
+{"address":null,"port":33145,"tls":{"cert":"default","requireClientAuth":false}}
 ```
+
+### [listeners.rpc.address](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.rpc.address)
+
+The address to bind to, default is 0.0.0.0
+
+**Default:** `nil`
 
 ### [listeners.schemaRegistry](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.schemaRegistry)
 
@@ -453,8 +483,14 @@ Schema registry listeners.
 **Default:**
 
 ```
-{"authenticationMethod":null,"enabled":true,"external":{"default":{"advertisedPorts":[30081],"authenticationMethod":null,"port":8084,"tls":{"cert":"external","requireClientAuth":false}}},"port":8081,"tls":{"cert":"default","requireClientAuth":false}}
+{"address":null,"authenticationMethod":null,"enabled":true,"external":{"default":{"address":null,"advertisedPorts":[30081],"authenticationMethod":null,"port":8084,"tls":{"cert":"external","requireClientAuth":false}}},"port":8081,"tls":{"cert":"default","requireClientAuth":false}}
 ```
+
+### [listeners.schemaRegistry.address](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=listeners.schemaRegistry.address)
+
+The address to bind to, default is 0.0.0.0
+
+**Default:** `nil`
 
 ### [logging](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=logging)
 

--- a/charts/redpanda/chart/templates/_configmap.go.tpl
+++ b/charts/redpanda/chart/templates/_configmap.go.tpl
@@ -615,8 +615,13 @@
 {{- $state := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
+{{- $m := (dict "address" "0.0.0.0" "port" ($state.Values.listeners.rpc.port | int)) -}}
+{{- $addr_15 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $state.Values.listeners.address "")))) "r") -}}
+{{- if (ne $addr_15 "") -}}
+{{- $_ := (set $m "address" $addr_15) -}}
+{{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (dict "address" "0.0.0.0" "port" ($state.Values.listeners.rpc.port | int))) | toJson -}}
+{{- (dict "r" $m) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -655,19 +660,19 @@
 {{- end -}}
 {{- $enabledOptions := (dict "true" true "1" true "" true) -}}
 {{- $lockMemory := false -}}
-{{- $_712_value_15_ok_16 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $flags "--lock-memory" "")))) "r") -}}
-{{- $value_15 := (index $_712_value_15_ok_16 0) -}}
-{{- $ok_16 := (index $_712_value_15_ok_16 1) -}}
-{{- if $ok_16 -}}
-{{- $lockMemory = (ternary (index $enabledOptions $value_15) false (hasKey $enabledOptions $value_15)) -}}
+{{- $_717_value_16_ok_17 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $flags "--lock-memory" "")))) "r") -}}
+{{- $value_16 := (index $_717_value_16_ok_17 0) -}}
+{{- $ok_17 := (index $_717_value_16_ok_17 1) -}}
+{{- if $ok_17 -}}
+{{- $lockMemory = (ternary (index $enabledOptions $value_16) false (hasKey $enabledOptions $value_16)) -}}
 {{- $_ := (unset $flags "--lock-memory") -}}
 {{- end -}}
 {{- $overprovisioned := false -}}
-{{- $_719_value_17_ok_18 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $flags "--overprovisioned" "")))) "r") -}}
-{{- $value_17 := (index $_719_value_17_ok_18 0) -}}
-{{- $ok_18 := (index $_719_value_17_ok_18 1) -}}
-{{- if $ok_18 -}}
-{{- $overprovisioned = (ternary (index $enabledOptions $value_17) false (hasKey $enabledOptions $value_17)) -}}
+{{- $_724_value_18_ok_19 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $flags "--overprovisioned" "")))) "r") -}}
+{{- $value_18 := (index $_724_value_18_ok_19 0) -}}
+{{- $ok_19 := (index $_724_value_18_ok_19 1) -}}
+{{- if $ok_19 -}}
+{{- $overprovisioned = (ternary (index $enabledOptions $value_18) false (hasKey $enabledOptions $value_18)) -}}
 {{- $_ := (unset $flags "--overprovisioned") -}}
 {{- end -}}
 {{- $keys := (keys $flags) -}}

--- a/charts/redpanda/chart/templates/_values.go.tpl
+++ b/charts/redpanda/chart/templates/_values.go.tpl
@@ -684,9 +684,9 @@
 {{- $seen := (dict) -}}
 {{- $deduped := (coalesce nil) -}}
 {{- range $_, $item := $items -}}
-{{- $_1225___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
-{{- $_ := (index $_1225___ok_11 0) -}}
-{{- $ok_11 := (index $_1225___ok_11 1) -}}
+{{- $_1226___ok_11 := (get (fromJson (include "_shims.dicttest" (dict "a" (list $seen $item.key false)))) "r") -}}
+{{- $_ := (index $_1226___ok_11 0) -}}
+{{- $ok_11 := (index $_1226___ok_11 1) -}}
 {{- if $ok_11 -}}
 {{- continue -}}
 {{- end -}}
@@ -909,9 +909,9 @@
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_1513_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
-{{- $cert := (index $_1513_cert_ok 0) -}}
-{{- $ok := (index $_1513_cert_ok 1) -}}
+{{- $_1514_cert_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (dict "enabled" (coalesce nil) "caEnabled" false "applyInternalDNSNames" (coalesce nil) "duration" "" "issuerRef" (coalesce nil) "secretRef" (coalesce nil) "clientSecretRef" (coalesce nil)))))) "r") -}}
+{{- $cert := (index $_1514_cert_ok 0) -}}
+{{- $ok := (index $_1514_cert_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
@@ -1222,7 +1222,7 @@
 {{- $auth = $authAStr -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "enabled" false "external" (coalesce nil) "port" 0 "tls" (dict "enabled" (coalesce nil) "cert" "" "requireClientAuth" false "trustStore" (coalesce nil))) (dict "enabled" $l.enabled "external" $ext "port" ($l.port | int) "tls" $l.tls "appProtocol" $l.appProtocol "authenticationMethod" $auth))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "enabled" false "external" (coalesce nil) "port" 0 "tls" (dict "enabled" (coalesce nil) "cert" "" "requireClientAuth" false "trustStore" (coalesce nil))) (dict "enabled" $l.enabled "external" $ext "port" ($l.port | int) "tls" $l.tls "address" $l.address "appProtocol" $l.appProtocol "authenticationMethod" $auth))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -1284,10 +1284,14 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $internal := (dict "name" "internal" "address" "0.0.0.0" "port" ($l.port | int)) -}}
+{{- $addr_13 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.address "")))) "r") -}}
+{{- if (ne $addr_13 "") -}}
+{{- $_ := (set $internal "address" $addr_13) -}}
+{{- end -}}
 {{- $defaultAuth := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $auth "")))) "r") -}}
-{{- $am_13 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod $defaultAuth)))) "r") -}}
-{{- if (ne $am_13 "") -}}
-{{- $_ := (set $internal "authentication_method" $am_13) -}}
+{{- $am_14 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod $defaultAuth)))) "r") -}}
+{{- if (ne $am_14 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_14) -}}
 {{- end -}}
 {{- $listeners := (list $internal) -}}
 {{- range $k, $l := $l.external -}}
@@ -1295,9 +1299,13 @@
 {{- continue -}}
 {{- end -}}
 {{- $listener := (dict "name" $k "port" ($l.port | int) "address" "0.0.0.0") -}}
-{{- $am_14 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod $defaultAuth)))) "r") -}}
-{{- if (ne $am_14 "") -}}
-{{- $_ := (set $listener "authentication_method" $am_14) -}}
+{{- $addr_15 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.address "")))) "r") -}}
+{{- if (ne $addr_15 "") -}}
+{{- $_ := (set $listener "address" $addr_15) -}}
+{{- end -}}
+{{- $am_16 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod $defaultAuth)))) "r") -}}
+{{- if (ne $am_16 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_16) -}}
 {{- end -}}
 {{- $listeners = (concat (default (list) $listeners) (list $listener)) -}}
 {{- end -}}
@@ -1347,7 +1355,7 @@
 {{- $auth = $authAStr -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "enabled" (coalesce nil) "advertisedPorts" (coalesce nil) "port" 0 "nodePort" (coalesce nil) "tls" (coalesce nil)) (dict "enabled" $l.enabled "advertisedPorts" $l.advertisedPorts "port" ($l.port | int) "nodePort" $l.nodePort "tls" $l.tls "authenticationMethod" $auth "prefixTemplate" $l.prefixTemplate "type" $l.type "host" $l.host "hostTemplate" $l.hostTemplate))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "enabled" (coalesce nil) "advertisedPorts" (coalesce nil) "port" 0 "nodePort" (coalesce nil) "tls" (coalesce nil)) (dict "enabled" $l.enabled "advertisedPorts" $l.advertisedPorts "port" ($l.port | int) "nodePort" $l.nodePort "tls" $l.tls "address" $l.address "authenticationMethod" $auth "prefixTemplate" $l.prefixTemplate "type" $l.type "host" $l.host "hostTemplate" $l.hostTemplate))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -1403,10 +1411,10 @@
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $_2084___ok_15 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
-{{- $_ := ((index $_2084___ok_15 0) | float64) -}}
-{{- $ok_15 := (index $_2084___ok_15 1) -}}
-{{- if $ok_15 -}}
+{{- $_2097___ok_17 := (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v)))) "r") -}}
+{{- $_ := ((index $_2097___ok_17 0) | float64) -}}
+{{- $ok_17 := (index $_2097___ok_17 1) -}}
+{{- if $ok_17 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}{{- if (kindIs "bool" $v) -}}
 {{- $_ := (set $result $k $v) -}}
@@ -1431,11 +1439,11 @@
 {{- $_is_returning := false -}}
 {{- $result := (dict) -}}
 {{- range $k, $v := $c -}}
-{{- $_2104_b_16_ok_17 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
-{{- $b_16 := (index $_2104_b_16_ok_17 0) -}}
-{{- $ok_17 := (index $_2104_b_16_ok_17 1) -}}
-{{- if $ok_17 -}}
-{{- $_ := (set $result $k $b_16) -}}
+{{- $_2117_b_18_ok_19 := (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false)))) "r") -}}
+{{- $b_18 := (index $_2117_b_18_ok_19 0) -}}
+{{- $ok_19 := (index $_2117_b_18_ok_19 1) -}}
+{{- if $ok_19 -}}
+{{- $_ := (set $result $k $b_18) -}}
 {{- continue -}}
 {{- end -}}
 {{- if (not (empty $v)) -}}
@@ -1476,15 +1484,15 @@
 {{- $config := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_2149___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_2149___hasAccessKey 0) -}}
-{{- $hasAccessKey := (index $_2149___hasAccessKey 1) -}}
-{{- $_2150___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_2150___hasSecretKey 0) -}}
-{{- $hasSecretKey := (index $_2150___hasSecretKey 1) -}}
-{{- $_2151___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_2151___hasSharedKey 0) -}}
-{{- $hasSharedKey := (index $_2151___hasSharedKey 1) -}}
+{{- $_2162___hasAccessKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_access_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_2162___hasAccessKey 0) -}}
+{{- $hasAccessKey := (index $_2162___hasAccessKey 1) -}}
+{{- $_2163___hasSecretKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_secret_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_2163___hasSecretKey 0) -}}
+{{- $hasSecretKey := (index $_2163___hasSecretKey 1) -}}
+{{- $_2164___hasSharedKey := (get (fromJson (include "_shims.dicttest" (dict "a" (list $config "cloud_storage_azure_shared_key" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_2164___hasSharedKey 0) -}}
+{{- $hasSharedKey := (index $_2164___hasSharedKey 1) -}}
 {{- $envvars := (coalesce nil) -}}
 {{- if (and (not $hasAccessKey) (get (fromJson (include "redpanda.SecretRef.IsValid" (dict "a" (list $tsc.accessKey)))) "r")) -}}
 {{- $envvars = (concat (default (list) $envvars) (list (mustMergeOverwrite (dict "name" "") (dict "name" "REDPANDA_CLOUD_STORAGE_ACCESS_KEY" "valueFrom" (get (fromJson (include "redpanda.SecretRef.AsSource" (dict "a" (list $tsc.accessKey)))) "r"))))) -}}
@@ -1507,12 +1515,12 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_2187___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_2187___containerExists 0) -}}
-{{- $containerExists := (index $_2187___containerExists 1) -}}
-{{- $_2188___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
-{{- $_ := (index $_2188___accountExists 0) -}}
-{{- $accountExists := (index $_2188___accountExists 1) -}}
+{{- $_2200___containerExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_container" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_2200___containerExists 0) -}}
+{{- $containerExists := (index $_2200___containerExists 1) -}}
+{{- $_2201___accountExists := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c "cloud_storage_azure_storage_account" (coalesce nil))))) "r") -}}
+{{- $_ := (index $_2201___accountExists 0) -}}
+{{- $accountExists := (index $_2201___accountExists 1) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (and $containerExists $accountExists)) | toJson -}}
 {{- break -}}
@@ -1523,9 +1531,9 @@
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $_2193_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
-{{- $value := (index $_2193_value_ok 0) -}}
-{{- $ok := (index $_2193_value_ok 1) -}}
+{{- $_2206_value_ok := (get (fromJson (include "_shims.dicttest" (dict "a" (list $c `cloud_storage_cache_size` (coalesce nil))))) "r") -}}
+{{- $value := (index $_2206_value_ok 0) -}}
+{{- $ok := (index $_2206_value_ok 1) -}}
 {{- if (not $ok) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}
@@ -1551,9 +1559,9 @@
 {{- if $_is_returning -}}
 {{- break -}}
 {{- end -}}
-{{- $size_18 := (get (fromJson (include "redpanda.TieredStorageConfig.CloudStorageCacheSize" (dict "a" (list (deepCopy $c))))) "r") -}}
-{{- if (ne (toJson $size_18) "null") -}}
-{{- $_ := (set $config "cloud_storage_cache_size" ((get (fromJson (include "_shims.resource_Value" (dict "a" (list $size_18)))) "r") | int64)) -}}
+{{- $size_20 := (get (fromJson (include "redpanda.TieredStorageConfig.CloudStorageCacheSize" (dict "a" (list (deepCopy $c))))) "r") -}}
+{{- if (ne (toJson $size_20) "null") -}}
+{{- $_ := (set $config "cloud_storage_cache_size" ((get (fromJson (include "_shims.resource_Value" (dict "a" (list $size_20)))) "r") | int64)) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (list $config $fixups)) | toJson -}}

--- a/charts/redpanda/chart/values.schema.json
+++ b/charts/redpanda/chart/values.schema.json
@@ -4701,9 +4701,15 @@
     "listeners": {
       "additionalProperties": false,
       "properties": {
+        "address": {
+          "type": "string"
+        },
         "admin": {
           "additionalProperties": false,
           "properties": {
+            "address": {
+              "type": "string"
+            },
             "appProtocol": {
               "type": "string"
             },
@@ -4726,6 +4732,9 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "additionalProperties": false,
                   "properties": {
+                    "address": {
+                      "type": "string"
+                    },
                     "advertisedPorts": {
                       "items": {
                         "type": "integer"
@@ -4899,6 +4908,9 @@
         "http": {
           "additionalProperties": false,
           "properties": {
+            "address": {
+              "type": "string"
+            },
             "appProtocol": {
               "type": "string"
             },
@@ -4925,6 +4937,9 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "additionalProperties": false,
                   "properties": {
+                    "address": {
+                      "type": "string"
+                    },
                     "advertisedPorts": {
                       "items": {
                         "type": "integer"
@@ -5102,6 +5117,9 @@
         "kafka": {
           "additionalProperties": false,
           "properties": {
+            "address": {
+              "type": "string"
+            },
             "appProtocol": {
               "type": "string"
             },
@@ -5129,6 +5147,9 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "additionalProperties": false,
                   "properties": {
+                    "address": {
+                      "type": "string"
+                    },
                     "advertisedPorts": {
                       "items": {
                         "type": "integer"
@@ -5377,6 +5398,9 @@
         "schemaRegistry": {
           "additionalProperties": false,
           "properties": {
+            "address": {
+              "type": "string"
+            },
             "appProtocol": {
               "type": "string"
             },
@@ -5399,6 +5423,9 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "additionalProperties": false,
                   "properties": {
+                    "address": {
+                      "type": "string"
+                    },
                     "advertisedPorts": {
                       "items": {
                         "type": "integer"

--- a/charts/redpanda/chart/values.yaml
+++ b/charts/redpanda/chart/values.yaml
@@ -869,6 +869,8 @@ tuning:
 listeners:
   # -- Admin API listener (only one).
   admin:
+    # -- The address to bind to, default is 0.0.0.0
+    address: null
     # -- The port for both internal and external connections to the Admin API.
     port: 9644
     # -- Optional instrumentation hint - https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
@@ -877,6 +879,7 @@ listeners:
     external:
       # -- Name of the external listener.
       default:
+        address: null
         port: 9645
         # Override the global `external.enabled` for only this listener.
         # enabled: true
@@ -899,6 +902,8 @@ listeners:
       requireClientAuth: false
   # -- Kafka API listeners.
   kafka:
+    # -- The address to bind to, default is 0.0.0.0
+    address: null
     # -- The port for internal client connections.
     port: 9093
     # default is "sasl"
@@ -911,6 +916,8 @@ listeners:
     external:
       default:
         # enabled: true
+        # -- The address to bind to, default is 0.0.0.0
+        address: null
         # -- The port used for external client connections.
         port: 9094
         # prefixTemplate: ""
@@ -936,6 +943,8 @@ listeners:
         # hostTemplate: redpanda-$POD_ORDINAL-broker.example.com
   # -- RPC listener (this is never externally accessible).
   rpc:
+    # -- The address to bind to, default is 0.0.0.0
+    address: null
     port: 33145
     tls:
       # Optional flag to override the global TLS enabled flag.
@@ -945,6 +954,8 @@ listeners:
   # -- Schema registry listeners.
   schemaRegistry:
     enabled: true
+    # -- The address to bind to, default is 0.0.0.0
+    address: null
     port: 8081
     # default is "http_basic"
     authenticationMethod:
@@ -956,6 +967,7 @@ listeners:
     external:
       default:
         # enabled: true
+        address: null
         port: 8084
         advertisedPorts:
         - 30081
@@ -968,6 +980,8 @@ listeners:
   # -- HTTP API listeners (aka PandaProxy).
   http:
     enabled: true
+    # -- The address to bind to, default is 0.0.0.0
+    address: null
     port: 8082
     # default is "http_basic"
     authenticationMethod:
@@ -979,6 +993,7 @@ listeners:
     external:
       default:
         # enabled: true
+        address: null
         port: 8083
         # prefixTemplate: ""
         advertisedPorts:

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -646,10 +646,14 @@ func rpcListenersTLS(state *RenderState) map[string]any {
 }
 
 func rpcListeners(state *RenderState) map[string]any {
-	return map[string]any{
+	m := map[string]any{
 		"address": "0.0.0.0",
 		"port":    state.Values.Listeners.RPC.Port,
 	}
+	if addr := ptr.Deref(state.Values.Listeners.Address, ""); addr != "" {
+		m["address"] = addr
+	}
+	return m
 }
 
 // First parameter defaultTLSEnabled must come from `state.Values.tls.enabled`.

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -1083,6 +1083,7 @@ type Listeners struct {
 		Port int32       `json:"port" jsonschema:"required"`
 		TLS  InternalTLS `json:"tls" jsonschema:"required"`
 	} `json:"rpc" jsonschema:"required"`
+	Address        *string                                   `json:"address,omitempty"`
 }
 
 // InUseServerCerts returns a set of names (As a sorted slice) of all TLS
@@ -1813,6 +1814,7 @@ type ListenerConfig[T ~string] struct {
 	External map[string]ExternalListener[T] `json:"external"`
 	Port     int32                          `json:"port" jsonschema:"required"`
 	TLS      InternalTLS                    `json:"tls" jsonschema:"required"`
+	Address  *string                        `json:"address,omitempty"`
 
 	AppProtocol          *string `json:"appProtocol,omitempty"`
 	AuthenticationMethod *T      `json:"authenticationMethod,omitempty"`
@@ -1835,6 +1837,7 @@ func (l *ListenerConfig[T]) AsString() ListenerConfig[string] {
 		External:             ext,
 		Port:                 l.Port,
 		TLS:                  l.TLS,
+		Address:              l.Address,
 		AppProtocol:          l.AppProtocol,
 		AuthenticationMethod: auth,
 	}
@@ -1912,6 +1915,9 @@ func (l *ListenerConfig[T]) Listeners(auth *T) []map[string]any {
 		"address": "0.0.0.0",
 		"port":    l.Port,
 	}
+	if addr := ptr.Deref(l.Address, ""); addr != "" {
+		internal["address"] = addr
+	}
 
 	defaultAuth := ptr.Deref(auth, "")
 
@@ -1932,6 +1938,9 @@ func (l *ListenerConfig[T]) Listeners(auth *T) []map[string]any {
 			"name":    k,
 			"port":    l.Port,
 			"address": "0.0.0.0",
+		}
+		if addr := ptr.Deref(l.Address, ""); addr != "" {
+			listener["address"] = addr
 		}
 
 		if am := ptr.Deref(l.AuthenticationMethod, defaultAuth); am != "" {
@@ -1979,6 +1988,7 @@ type ExternalListener[T ~string] struct {
 	// TODO CHECK NODE PORT USAGE
 	NodePort *int32       `json:"nodePort"`
 	TLS      *ExternalTLS `json:"tls"`
+	Address  *string      `json:"address,omitempty"`
 
 	AuthenticationMethod *T      `json:"authenticationMethod,omitempty"`
 	PrefixTemplate       *string `json:"prefixTemplate,omitempty"`
@@ -2018,6 +2028,7 @@ func (l *ExternalListener[T]) AsString() ExternalListener[string] {
 		Port:                 l.Port,
 		NodePort:             l.NodePort,
 		TLS:                  l.TLS,
+		Address:              l.Address,
 		AuthenticationMethod: auth,
 		PrefixTemplate:       l.PrefixTemplate,
 		Type:                 l.Type,

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -238,6 +238,7 @@ type PartialListeners struct {
 		Port *int32              "json:\"port,omitempty\" jsonschema:\"required\""
 		TLS  *PartialInternalTLS "json:\"tls,omitempty\" jsonschema:\"required\""
 	} "json:\"rpc,omitempty\" jsonschema:\"required\""
+	Address *string "json:\"address,omitempty\""
 }
 
 type PartialConfig struct {
@@ -343,6 +344,7 @@ type PartialListenerConfig[T ~string] struct {
 	External             map[string]PartialExternalListener[T] "json:\"external,omitempty\""
 	Port                 *int32                                "json:\"port,omitempty\" jsonschema:\"required\""
 	TLS                  *PartialInternalTLS                   "json:\"tls,omitempty\" jsonschema:\"required\""
+	Address              *string                               "json:\"address,omitempty\""
 	AppProtocol          *string                               "json:\"appProtocol,omitempty\""
 	AuthenticationMethod *T                                    "json:\"authenticationMethod,omitempty\""
 }
@@ -430,6 +432,7 @@ type PartialExternalListener[T ~string] struct {
 	Port                 *int32              "json:\"port,omitempty\" jsonschema:\"required\""
 	NodePort             *int32              "json:\"nodePort,omitempty\""
 	TLS                  *PartialExternalTLS "json:\"tls,omitempty\""
+	Address              *string             "json:\"address,omitempty\""
 	AuthenticationMethod *T                  "json:\"authenticationMethod,omitempty\""
 	PrefixTemplate       *string             "json:\"prefixTemplate,omitempty\""
 	Type                 *string             "json:\"type,omitempty\" jsonschema:\"enum=tlsroute\""


### PR DESCRIPTION
In some kubernetes deployments, the in-cluster traffic is only possible using
IPv6, with no in-cluster IPv4 available. Currently redpanda starts, but operator
cannot reach it, nor the brokers can reach each other.
    
Set to `address: "::"`, to use IPv6

https://github.com/redpanda-data/redpanda-operator/issues/1855