### PR TITLE
operator: add more leader election arguments (#1790 re-land)

### DIFF
--- a/.changes/unreleased/operator-Added-20260831-233316.yaml
+++ b/.changes/unreleased/operator-Added-20260831-233316.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: 'The single-cluster operator now supports --leader-election-lease-duration, --leader-election-renew-deadline, and --leader-election-retry-period for tuning leader election. The existing 15s, 10s, and 2s defaults remain unchanged.'
+time: 2026-08-31T23:33:16+02:00

--- a/operator/cmd/run/run.go
+++ b/operator/cmd/run/run.go
@@ -176,6 +176,9 @@ func (o *RunOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.managerOptions.LeaderElectionID, "leader-election-id", "aa9fc693.vectorized.io", "Sets the ID used for the leader election process.")
 	// NB: The default behavior here is in the controller-runtime, pretty deep. It reads the namespace file that's created when mounting a service account token.
 	cmd.Flags().StringVar(&o.managerOptions.LeaderElectionNamespace, "leader-election-namespace", "", "Sets the namespace that leader election resources will be created within. If not specified, defaults the value of --namespace or the namespace this Pod is running in.")
+	o.managerOptions.LeaseDuration = cmd.Flags().Duration("leader-election-lease-duration", 15*time.Second, "Duration that non-leader candidates wait before forcing acquisition of the leader election lease")
+	o.managerOptions.RenewDeadline = cmd.Flags().Duration("leader-election-renew-deadline", 10*time.Second, "Duration that the acting leader retries refreshing leadership before giving up")
+	o.managerOptions.RetryPeriod = cmd.Flags().Duration("leader-election-retry-period", 2*time.Second, "Duration that leader election clients wait between attempts")
 	cmd.Flags().StringVar(&o.managerOptions.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	cmd.Flags().StringVar(&o.managerOptions.PprofBindAddress, "pprof-bind-address", ":8082", "The address the metric endpoint binds to. Set to '' or 0 to disable")
 	cmd.Flags().StringVar(&o.namespace, "namespace", "", "If namespace is set to not empty value, it changes scope of Redpanda operator to work in single namespace")

--- a/operator/cmd/run/run_flags_test.go
+++ b/operator/cmd/run/run_flags_test.go
@@ -11,8 +11,11 @@ package run
 
 import (
 	"testing"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/leaderelection"
 )
 
 // TestWipeStaleDiskAfterDefaultsDisabled pins the single-cluster operator's
@@ -25,4 +28,64 @@ func TestWipeStaleDiskAfterDefaultsDisabled(t *testing.T) {
 	f := Command().Flags().Lookup("wipe-stale-disk-after")
 	require.NotNil(t, f, "run command must define --wipe-stale-disk-after")
 	require.Equal(t, "0s", f.DefValue, "the single-cluster stale-disk wipe must be disabled (opt-in) by default")
+}
+
+// TestLeaderElectionTimingFlags pins the leader-election tunables
+// (--leader-election-lease-duration, --leader-election-renew-deadline,
+// --leader-election-retry-period): their defaults must equal
+// controller-runtime's shipped values, so that an unset flag changes no
+// behavior, and parsed values must actually land in the ctrl.Options handed
+// to the manager — the flags bind ctrl.Options' *time.Duration fields
+// directly via Flags().Duration, a different idiom from the DurationVar
+// calls around them, and one a refactor could silently break.
+func TestLeaderElectionTimingFlags(t *testing.T) {
+	t.Run("defaults match controller-runtime", func(t *testing.T) {
+		for flag, def := range map[string]string{
+			"leader-election-lease-duration": "15s",
+			"leader-election-renew-deadline": "10s",
+			"leader-election-retry-period":   "2s",
+		} {
+			f := Command().Flags().Lookup(flag)
+			require.NotNil(t, f, "run command must define --%s", flag)
+			require.Equal(t, def, f.DefValue, "--%s must default to controller-runtime's shipped value", flag)
+		}
+	})
+
+	t.Run("parsed values reach the manager options", func(t *testing.T) {
+		var options RunOptions
+		cmd := &cobra.Command{}
+		options.BindFlags(cmd)
+
+		require.NoError(t, cmd.ParseFlags([]string{
+			"--leader-election-lease-duration=45s",
+			"--leader-election-renew-deadline=30s",
+			"--leader-election-retry-period=5s",
+		}))
+
+		require.NotNil(t, options.managerOptions.LeaseDuration)
+		require.NotNil(t, options.managerOptions.RenewDeadline)
+		require.NotNil(t, options.managerOptions.RetryPeriod)
+		require.Equal(t, 45*time.Second, *options.managerOptions.LeaseDuration)
+		require.Equal(t, 30*time.Second, *options.managerOptions.RenewDeadline)
+		require.Equal(t, 5*time.Second, *options.managerOptions.RetryPeriod)
+	})
+
+	// client-go's leader elector rejects its config at manager start unless
+	// leaseDuration > renewDeadline and renewDeadline > JitterFactor *
+	// retryPeriod. There is no fail-fast validation on the flags (a bad combo
+	// surfaces as a manager start error), so at minimum the shipped defaults
+	// must satisfy the invariants.
+	t.Run("defaults satisfy the client-go invariants", func(t *testing.T) {
+		var options RunOptions
+		cmd := &cobra.Command{}
+		options.BindFlags(cmd)
+		require.NoError(t, cmd.ParseFlags(nil))
+
+		lease := *options.managerOptions.LeaseDuration
+		renew := *options.managerOptions.RenewDeadline
+		retry := *options.managerOptions.RetryPeriod
+		require.Greater(t, lease, renew, "client-go requires leaseDuration > renewDeadline")
+		require.Greater(t, float64(renew), leaderelection.JitterFactor*float64(retry),
+			"client-go requires renewDeadline > JitterFactor * retryPeriod")
+	})
 }


### PR DESCRIPTION
Re-lands #1790 from an in-repo branch so the full Buildkite suite runs (fork PRs only get the GitHub-side checks). All credit to @dzsibi — the original commit and authorship are preserved unchanged; this branch adds only a maintainer test commit on top.

## Original description (from #1790)

We would like to make the leader election parameters of the operator tunable - in our cluster, we regularly see container restarts due to renewal failures during periods of increased control plane strain. This PR exposes the three related parameters as arguments, keeping their current default values.

## Review notes

- The `Flags().Duration(...)` pointer-assignment is the right idiom for `ctrl.Options`' `*time.Duration` fields, and the 15s/10s/2s defaults match controller-runtime's shipped values, so an unset flag changes no behavior.
- Tests added in `run_flags_test.go`: the flags' defaults are pinned to controller-runtime's values, parsed values are asserted to reach the `ctrl.Options` handed to the manager, and the defaults are checked against client-go's leader-election invariants (`leaseDuration > renewDeadline > JitterFactor × retryPeriod`) — there is no fail-fast flag validation, so a bad combo surfaces as a manager start error.
- Verified locally: full `operator/cmd/run` package suite passes; the built binary shows all three flags in `run --help` and parses custom values cleanly.

Closes #1790.
