### PR TITLE
operator: tolerate a disabled Schema Registry listener in the v2 client factory

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260901-140000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260901-140000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Fixed
+body: User, Role, and Group resources now reconcile on clusters with `listeners.schemaRegistry.enabled=false`. The Schema Registry client is no longer resolved via DNS SRV lookup (which always failed with the listener disabled, blocking all ACL syncs); a disabled listener is treated as "Schema Registry not configured", matching v1 clusters.
+time: 2026-09-01T14:00:00-07:00

--- a/operator/pkg/client/cluster.go
+++ b/operator/pkg/client/cluster.go
@@ -81,6 +81,13 @@ func (c *Factory) redpandaAdminForV1Cluster(ctx context.Context, cluster *vector
 
 // schemaRegistryForCluster returns a simple sr.Client able to communicate with the given cluster specified via a Redpanda cluster.
 func (c *Factory) schemaRegistryForCluster(ctx context.Context, cluster *redpandav1alpha2.Redpanda, clusterName string) (*sr.Client, error) {
+	// A disabled listener publishes no _schemaregistry._tcp SRV record, so
+	// endpoint resolution below can only NXDOMAIN. Return the sentinel that
+	// isSchemaRegistryNotConfigured tolerates instead (#1793).
+	if !redpandaSchemaRegistryEnabled(cluster) {
+		return nil, NoSchemaRegistryAPI
+	}
+
 	config, err := c.GetConfig(ctx, clusterName)
 	if err != nil {
 		return nil, err

--- a/operator/pkg/client/schema_registry_probe_internal_test.go
+++ b/operator/pkg/client/schema_registry_probe_internal_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 )
@@ -113,4 +115,25 @@ func TestSchemaRegistryProbeUniform(t *testing.T) {
 		})
 		assert.True(t, uniform, reason)
 	})
+}
+
+// TestSchemaRegistryDisabledSentinel covers #1793: a v2 cluster with the
+// Schema Registry listener disabled yields the not-configured sentinel (and
+// a nil ACL client) instead of a failed SRV lookup that bricks User/Role/
+// Group reconciliation. Runs on a zero Factory: the gate must trip before
+// any config or DNS access.
+func TestSchemaRegistryDisabledSentinel(t *testing.T) {
+	cluster := &redpandav1alpha2.Redpanda{
+		Spec: redpandav1alpha2.RedpandaSpec{ClusterSpec: &redpandav1alpha2.RedpandaClusterSpec{
+			Listeners: &redpandav1alpha2.Listeners{SchemaRegistry: &redpandav1alpha2.SchemaRegistry{
+				Listener: redpandav1alpha2.Listener{Enabled: ptr.To(false)},
+			}},
+		}},
+	}
+
+	f := &Factory{}
+	_, err := f.SchemaRegistryClientForCluster(t.Context(), cluster, mcmanager.LocalCluster)
+	require.ErrorIs(t, err, NoSchemaRegistryAPI)
+	// SchemaRegistryACLClientForCluster maps this to (nil, nil).
+	require.True(t, isSchemaRegistryNotConfigured(err))
 }


### PR DESCRIPTION
Fixes #1793.

`schemaRegistryForCluster` resolved v2 endpoints via DNS SRV even with `listeners.schemaRegistry.enabled=false`, where the chart omits the port from the headless Service and no SRV record exists. The NXDOMAIN isn't tolerated by `isSchemaRegistryNotConfigured`, so every User/Role/Group reconcile failed (`Synced=False`, `UnexpectedError`) before any Kafka ACL work — reproduced locally on k3d with operator 26.2.2 in under a minute (broker healthy, Kafka-only User CR).

Fix is the issue's option 2: check the listener spec (existing `redpandaSchemaRegistryEnabled` helper) before resolving and return the existing `NoSchemaRegistryAPI` sentinel, matching the v1 path and skipping the per-reconcile DNS round-trip. Regression test runs on a zero `Factory`, proving the gate trips before any config or DNS access.
