### PR TITLE
operator: harden Broker CR rollback

### DIFF
--- a/operator/internal/brokerset/aggregator.go
+++ b/operator/internal/brokerset/aggregator.go
@@ -43,9 +43,9 @@ func NewMigrationAggregator() *MigrationAggregator {
 }
 
 // PoolReporter returns the MigrationReporter for one pool. Report calls
-// accumulate (last report per pool wins); NeedsCompletion delegates to
-// inner, which keeps the underlying condition as the source of truth for
-// "was a migration ever recorded".
+// accumulate (last report per pool wins); the ShouldReport* predicates
+// delegate to inner, which keeps the underlying condition as the source of
+// truth for "was a migration ever recorded".
 func (a *MigrationAggregator) PoolReporter(pool string, inner MigrationReporter) MigrationReporter {
 	a.expected++
 	return &poolReporter{agg: a, pool: pool, inner: inner}
@@ -100,6 +100,10 @@ func (r *poolReporter) Report(_ context.Context, status corev1.ConditionStatus, 
 	r.agg.reports[r.pool] = poolReport{status: status, reason: reason, message: message}
 }
 
-func (r *poolReporter) NeedsCompletion(ctx context.Context) bool {
-	return r.inner.NeedsCompletion(ctx)
+func (r *poolReporter) ShouldReportComplete(ctx context.Context) bool {
+	return r.inner.ShouldReportComplete(ctx)
+}
+
+func (r *poolReporter) ShouldReportRolledBack(ctx context.Context) bool {
+	return r.inner.ShouldReportRolledBack(ctx)
 }

--- a/operator/internal/brokerset/aggregator_test.go
+++ b/operator/internal/brokerset/aggregator_test.go
@@ -17,10 +17,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type staticNeedsCompletion bool
+type staticReporter bool
 
-func (s staticNeedsCompletion) Report(context.Context, corev1.ConditionStatus, string, string) {}
-func (s staticNeedsCompletion) NeedsCompletion(context.Context) bool                           { return bool(s) }
+func (s staticReporter) Report(context.Context, corev1.ConditionStatus, string, string) {}
+func (s staticReporter) ShouldReportComplete(context.Context) bool                      { return bool(s) }
+func (s staticReporter) ShouldReportRolledBack(context.Context) bool                    { return bool(s) }
 
 // TestMigrationAggregator pins the flap fix: a pool that finished migrating
 // must never flip the cluster-scoped condition to Complete while another
@@ -34,7 +35,7 @@ func TestMigrationAggregator(t *testing.T) {
 		if reason == MigrationReasonComplete {
 			status = corev1.ConditionTrue
 		}
-		agg.PoolReporter(pool, staticNeedsCompletion(true)).Report(ctx, status, reason, message)
+		agg.PoolReporter(pool, staticReporter(true)).Report(ctx, status, reason, message)
 	}
 
 	t.Run("one complete one blocked stays blocked", func(t *testing.T) {
@@ -76,8 +77,8 @@ func TestMigrationAggregator(t *testing.T) {
 
 	t.Run("no reports means no write", func(t *testing.T) {
 		agg := NewMigrationAggregator()
-		agg.PoolReporter("blue-a", staticNeedsCompletion(false))
-		agg.PoolReporter("blue-b", staticNeedsCompletion(false))
+		agg.PoolReporter("blue-a", staticReporter(false))
+		agg.PoolReporter("blue-b", staticReporter(false))
 
 		_, _, _, ok := agg.Aggregate()
 		require.False(t, ok, "quiescent pools must not dirty the condition")
@@ -86,7 +87,7 @@ func TestMigrationAggregator(t *testing.T) {
 	t.Run("partial reports mean no write", func(t *testing.T) {
 		agg := NewMigrationAggregator()
 		report(agg, "blue-a", MigrationReasonInProgress, "creating shadow Broker CRs")
-		agg.PoolReporter("blue-b", staticNeedsCompletion(true)) // constructed, never reported
+		agg.PoolReporter("blue-b", staticReporter(true)) // constructed, never reported
 
 		_, _, _, ok := agg.Aggregate()
 		require.False(t, ok, "a pool that errored before reporting must not cause a flap on stale data")
@@ -94,7 +95,7 @@ func TestMigrationAggregator(t *testing.T) {
 
 	t.Run("last report per pool wins", func(t *testing.T) {
 		agg := NewMigrationAggregator()
-		rep := agg.PoolReporter("blue-a", staticNeedsCompletion(true))
+		rep := agg.PoolReporter("blue-a", staticReporter(true))
 		rep.Report(ctx, corev1.ConditionFalse, MigrationReasonInProgress, "creating shadow Broker CRs")
 		rep.Report(ctx, corev1.ConditionFalse, MigrationReasonBlocked, "cluster is restarting")
 

--- a/operator/internal/brokerset/brokerset.go
+++ b/operator/internal/brokerset/brokerset.go
@@ -116,10 +116,19 @@ type MigrationReporter interface {
 	// Report records the given condition value. Implementations should
 	// de-duplicate writes when nothing changed.
 	Report(ctx context.Context, status corev1.ConditionStatus, reason, message string)
-	// NeedsCompletion reports whether migration progress was previously
-	// recorded and not yet marked complete. Steady state promotes such a
-	// record to Complete; clusters that never migrated never get one.
-	NeedsCompletion(ctx context.Context) bool
+	// ShouldReportComplete reports whether migration progress was previously
+	// recorded and the condition has not yet reached Complete. Steady state
+	// promotes such a record to Complete; clusters that never migrated never
+	// get one.
+	ShouldReportComplete(ctx context.Context) bool
+	// ShouldReportRolledBack reports whether migration progress was
+	// previously recorded and the condition has not yet reached RolledBack.
+	// Rollback's steady state promotes such a record to RolledBack — like
+	// Complete, the terminal state is observed, not recorded, so a report
+	// lost between the last rollback action and its persistence
+	// (status-write conflict, crash) is re-derived instead of gone. Clusters
+	// that never migrated never get one.
+	ShouldReportRolledBack(ctx context.Context) bool
 }
 
 // BrokerSet manages the Broker CRs of one node pool on behalf of an owning
@@ -215,7 +224,7 @@ func (s *BrokerSet) ensureBrokers(ctx context.Context, l logr.Logger, desiredSTS
 	// Migration completion is observed, not recorded: reaching steady state
 	// (no StatefulSet left) IS completion. Only progress an existing
 	// condition — clusters that never migrated don't get one.
-	if s.Reporter != nil && s.Reporter.NeedsCompletion(ctx) {
+	if s.Reporter != nil && s.Reporter.ShouldReportComplete(ctx) {
 		s.report(ctx, corev1.ConditionTrue,
 			MigrationReasonComplete, "StatefulSet removed; Broker CRs manage all pods")
 	}

--- a/operator/internal/brokerset/migration.go
+++ b/operator/internal/brokerset/migration.go
@@ -34,6 +34,17 @@ func migrationBackupName(ownerName string) string {
 	return fmt.Sprintf("%s-migration-backup", ownerName)
 }
 
+func backupStatefulSetPayload(sts *appsv1.StatefulSet) ([]byte, error) {
+	return json.Marshal(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        sts.Name,
+			Labels:      sts.Labels,
+			Annotations: sts.Annotations,
+		},
+		Spec: sts.Spec,
+	})
+}
+
 // ensureMigration runs the StatefulSet→Broker CR migration state machine.
 //
 // State 0→1: Create shadow Broker CRs + back up STS spec to ConfigMap.
@@ -253,18 +264,7 @@ func (s *BrokerSet) ensureBackupConfigMap(ctx context.Context, l logr.Logger, st
 	cmName := migrationBackupName(s.Owner.GetName())
 	poolKey := fmt.Sprintf("%s.json", s.PoolName)
 
-	// Store only what restoreStatefulSetsFromBackup consumes. Marshaling the
-	// live object verbatim would embed resourceVersion/status churn and make
-	// the staleness comparison below dirty on every pass.
-	backup := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        sts.Name,
-			Labels:      sts.Labels,
-			Annotations: sts.Annotations,
-		},
-		Spec: sts.Spec,
-	}
-	data, err := json.Marshal(backup)
+	data, err := backupStatefulSetPayload(sts)
 	if err != nil {
 		return err
 	}

--- a/operator/internal/brokerset/rollback.go
+++ b/operator/internal/brokerset/rollback.go
@@ -71,16 +71,6 @@ func (cfg *RollbackConfig) report(ctx context.Context, status corev1.ConditionSt
 	}
 }
 
-// VerifyRollbackPreconditions blocks rollback while a rotation or
-// decommission is mid-flight, reading only the Broker CRs: no Broker may be
-// mid-decommission and no Broker may hold an unexpired roll-grant (an
-// actively progressing rotation always holds one). Fully Decommissioned
-// brokers (scale-down leftovers) are inert and do not block. A missing pod
-// deliberately does NOT block: with no unexpired grant it is an abandoned
-// rotation (e.g. a wedged Broker controller) or a manual deletion, and the
-// restored StatefulSet recreates the pod — whose postStart hook clears
-// maintenance mode — so proceeding recovers toward a working cluster where
-// waiting would deadlock on the very controller being rolled away from.
 func VerifyRollbackPreconditions(l logr.Logger, brokers []redpandav1alpha2.Broker) error {
 	block := func(reason string) error {
 		l.Info("rollback blocked, waiting for in-flight operations to finish", "reason", reason)
@@ -141,15 +131,6 @@ func restoreStatefulSetsFromBackup(ctx context.Context, cfg RollbackConfig, cm *
 
 // Rollback cleans up Broker CRs when the migration annotation is removed,
 // allowing the StatefulSet to re-adopt pods. It returns true when it acted.
-//
-// Rollback is resumable at any point: a transient error aborts the pass and
-// bubbles out of the owning Reconcile, which requeues; the retry re-derives
-// everything from world state, and every mutation is idempotent. The backup
-// ConfigMap is the resume marker for the tail of the flow — it is deleted
-// only after the restored StatefulSets have re-adopted the pods, so a pass
-// interrupted after the last Broker CR was deleted still finishes the
-// restore-and-verify phase on the next reconcile (finalizeRollback keys on
-// the ConfigMap's existence, not on Broker CRs remaining).
 func Rollback(ctx context.Context, cfg RollbackConfig) (bool, error) {
 	c, l := cfg.Client, cfg.Logger
 
@@ -174,8 +155,8 @@ func Rollback(ctx context.Context, cfg RollbackConfig) (bool, error) {
 
 		l.Info("rollback: cleaning up Broker CRs", "count", len(brokers))
 
-		// Strip Broker CR ownerRefs from pods and PVCs so the STS can
-		// re-adopt. A strategic-merge $patch:delete keyed on the Broker's
+		// Strip Broker CR ownerRefs from pods so the STS can re-adopt.
+		// A strategic-merge $patch:delete keyed on the Broker's
 		// UID is a no-op when the object or the ref is already gone, and
 		// unlike a read-modify-Update it cannot conflict with concurrent
 		// writers (the Broker controller keeps reconciling until its CR is
@@ -186,24 +167,8 @@ func Rollback(ctx context.Context, cfg RollbackConfig) (bool, error) {
 			if err := stripOwnerRef(ctx, c, pod, b.UID); err != nil {
 				return acted, errors.Wrapf(err, "stripping Broker ownerRef from pod %s", pod.Name)
 			}
-			for _, ec := range b.Spec.Storage.ExistingClaims {
-				pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: ec.Name, Namespace: cfg.Owner.GetNamespace()}}
-				if err := stripOwnerRef(ctx, c, pvc, b.UID); err != nil {
-					return acted, errors.Wrapf(err, "stripping Broker ownerRef from PVC %s", ec.Name)
-				}
-			}
 		}
 
-		// Delete Broker CRs with orphan propagation, leaving each CR's
-		// finalizer alone: the Broker controller removes its own finalizer in
-		// reconcileDelete — the pod's ownerRef was stripped above, so it takes
-		// the no-decommission rollback branch (raw CR deletion never
-		// decommissions, RFC Q2). Removing the finalizer from here instead
-		// would race the Broker controller, which re-adds it on every
-		// reconcile of a live CR — a conflict tug-of-war that stalled
-		// rollback for minutes. Orphan propagation prevents the GC from
-		// cascade-deleting pods that the Broker controller re-adopted between
-		// our ownerRef strip above and the delete here.
 		for i := range brokers {
 			b := &brokers[i]
 			if b.DeletionTimestamp.IsZero() {
@@ -253,14 +218,7 @@ func finalizeRollback(ctx context.Context, cfg RollbackConfig, cleanedThisPass b
 			return err
 		}
 		if !cleanedThisPass {
-			// Steady state: no Broker CRs and no pending restore. The terminal
-			// RolledBack report from the pass that finished the rollback rides
-			// the owner's status write, which may never land (conflict, crash)
-			// — and the backup ConfigMap, the resume marker, is already gone
-			// by then. So, like migration Complete, the terminal state is
-			// observed rather than recorded: promote a lingering non-terminal
-			// condition here until the write sticks. Clusters that never
-			// migrated have no condition and report nothing.
+			// Steady state: no Broker CRs and no pending restore.
 			if cfg.Reporter != nil && cfg.Reporter.ShouldReportRolledBack(ctx) {
 				cfg.report(ctx, corev1.ConditionTrue,
 					MigrationReasonRolledBack, "Broker CRs removed; StatefulSet manages all pods")
@@ -319,28 +277,6 @@ func finalizeRollback(ctx context.Context, cfg RollbackConfig, cleanedThisPass b
 				return errors.Wrapf(err, "re-stripping Broker ownerRef from pod %s", pod.Name)
 			}
 		}
-		for _, vol := range pod.Spec.Volumes {
-			if vol.PersistentVolumeClaim == nil {
-				continue
-			}
-			var pvc corev1.PersistentVolumeClaim
-			if err := c.Get(ctx, types.NamespacedName{Name: vol.PersistentVolumeClaim.ClaimName, Namespace: pod.Namespace}, &pvc); err != nil {
-				if apierrors.IsNotFound(err) {
-					// Not rollback's doing and nothing to strip, but a pod
-					// referencing a claim that does not exist is anomalous
-					// enough to surface.
-					l.Info("rollback: WARNING pod references a claim that does not exist", "pod", pod.Name, "pvc", vol.PersistentVolumeClaim.ClaimName)
-					continue
-				}
-				return errors.Wrapf(err, "checking claim %s for Broker ownerRefs", vol.PersistentVolumeClaim.ClaimName)
-			}
-			if owner := metav1.GetControllerOf(&pvc); owner != nil && owner.Kind == redpandav1alpha2.BrokerKind {
-				l.Info("rollback: re-stripping Broker ownerRef from claim", "pvc", pvc.Name)
-				if err := stripOwnerRef(ctx, c, &pvc, owner.UID); err != nil {
-					return errors.Wrapf(err, "re-stripping Broker ownerRef from claim %s", pvc.Name)
-				}
-			}
-		}
 		owner := metav1.GetControllerOf(pod)
 		if owner == nil || owner.Kind != "StatefulSet" {
 			msg := fmt.Sprintf("waiting for the StatefulSet to adopt pod %s", pod.Name)
@@ -349,14 +285,8 @@ func finalizeRollback(ctx context.Context, cfg RollbackConfig, cleanedThisPass b
 		}
 		// Pods the BROKER controller created (rotations, decommission
 		// replacements) carry no controller-revision-hash — only the
-		// StatefulSet controller stamps it, and under OnDelete it never
-		// re-labels adopted pods — so the revision-based roll planners would
-		// treat every such pod as outdated and restart the fleet right after
-		// rollback. Hand them over as CURRENT by stamping the restored
-		// StatefulSet's revision: the backup is the state being rolled back
-		// TO, and any genuine drift from the next render re-rolls through
-		// the ordinary health-gated flow. Stamped before the backup
-		// ConfigMap is deleted, so an interrupted pass resumes here.
+		// StatefulSet controller stamps it. We need to stamp them here,
+		// so in case of rollback, there's no pod rotation triggered by cluster (or Redpanda) controller.
 		if pod.Labels[appsv1.StatefulSetRevisionLabel] == "" {
 			rev, ok := revisions[owner.Name]
 			if !ok {

--- a/operator/internal/brokerset/rollback.go
+++ b/operator/internal/brokerset/rollback.go
@@ -23,6 +23,7 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -42,6 +43,26 @@ type RollbackConfig struct {
 	// Reporter records rollback progress. Optional.
 	Reporter MigrationReporter
 	Logger   logr.Logger
+}
+
+func (cfg *RollbackConfig) listOwnedBrokers(ctx context.Context) ([]redpandav1alpha2.Broker, error) {
+	var brokers []redpandav1alpha2.Broker
+	var brokerList redpandav1alpha2.BrokerList
+	if err := cfg.Client.List(ctx, &brokerList, &k8sclient.ListOptions{
+		LabelSelector: cfg.ClusterSelector,
+		Namespace:     cfg.Owner.GetNamespace(),
+	}); err != nil {
+		return nil, err
+	}
+
+	for i := range brokerList.Items {
+		// this check is needed because Brokers can be owned either by v1 resource (Cluster)
+		// or v2 (Redpanda). We need to make sure we're only rolling back Brokers that are owned by cfg.Owner
+		if metav1.IsControlledBy(&brokerList.Items[i], cfg.Owner) {
+			brokers = append(brokers, brokerList.Items[i])
+		}
+	}
+	return brokers, nil
 }
 
 func (cfg *RollbackConfig) report(ctx context.Context, status corev1.ConditionStatus, reason, message string) {
@@ -119,32 +140,39 @@ func restoreStatefulSetsFromBackup(ctx context.Context, cfg RollbackConfig, cm *
 }
 
 // Rollback cleans up Broker CRs when the migration annotation is removed,
-// allowing the StatefulSet to re-adopt pods.
-func Rollback(ctx context.Context, cfg RollbackConfig) error {
+// allowing the StatefulSet to re-adopt pods. It returns true when it acted.
+//
+// Rollback is resumable at any point: a transient error aborts the pass and
+// bubbles out of the owning Reconcile, which requeues; the retry re-derives
+// everything from world state, and every mutation is idempotent. The backup
+// ConfigMap is the resume marker for the tail of the flow — it is deleted
+// only after the restored StatefulSets have re-adopted the pods, so a pass
+// interrupted after the last Broker CR was deleted still finishes the
+// restore-and-verify phase on the next reconcile (finalizeRollback keys on
+// the ConfigMap's existence, not on Broker CRs remaining).
+func Rollback(ctx context.Context, cfg RollbackConfig) (bool, error) {
 	c, l := cfg.Client, cfg.Logger
 
-	var brokerList redpandav1alpha2.BrokerList
-	if err := c.List(ctx, &brokerList, &k8sclient.ListOptions{
-		LabelSelector: cfg.ClusterSelector,
-		Namespace:     cfg.Owner.GetNamespace(),
-	}); err != nil {
-		return err
+	brokers, err := cfg.listOwnedBrokers(ctx)
+	if err != nil {
+		return false, err
 	}
 
-	if len(brokerList.Items) > 0 {
+	acted := len(brokers) > 0
+	if acted {
 		// Rollback is gated on LOCAL state only — never on admin-API health.
 		// It is the escape hatch and must stay available on a degraded
 		// cluster; it is blocked only while another disruptive operation is
 		// mid-flight.
-		if err := VerifyRollbackPreconditions(l, brokerList.Items); err != nil {
+		if err := VerifyRollbackPreconditions(l, brokers); err != nil {
 			var requeueErr *RequeueAfterError
 			if errors.As(err, &requeueErr) {
 				cfg.report(ctx, corev1.ConditionFalse, MigrationReasonBlocked, requeueErr.Msg)
 			}
-			return err
+			return acted, err
 		}
 
-		l.Info("rollback: cleaning up Broker CRs", "count", len(brokerList.Items))
+		l.Info("rollback: cleaning up Broker CRs", "count", len(brokers))
 
 		// Strip Broker CR ownerRefs from pods and PVCs so the STS can
 		// re-adopt. A strategic-merge $patch:delete keyed on the Broker's
@@ -152,22 +180,32 @@ func Rollback(ctx context.Context, cfg RollbackConfig) error {
 		// unlike a read-modify-Update it cannot conflict with concurrent
 		// writers (the Broker controller keeps reconciling until its CR is
 		// deleted below).
-		for i := range brokerList.Items {
-			b := &brokerList.Items[i]
+		for i := range brokers {
+			b := &brokers[i]
 			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: b.PodName(), Namespace: cfg.Owner.GetNamespace()}}
 			if err := stripOwnerRef(ctx, c, pod, b.UID); err != nil {
-				return errors.Wrapf(err, "stripping Broker ownerRef from pod %s", pod.Name)
+				return acted, errors.Wrapf(err, "stripping Broker ownerRef from pod %s", pod.Name)
 			}
 			for _, ec := range b.Spec.Storage.ExistingClaims {
 				pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: ec.Name, Namespace: cfg.Owner.GetNamespace()}}
 				if err := stripOwnerRef(ctx, c, pvc, b.UID); err != nil {
-					return errors.Wrapf(err, "stripping Broker ownerRef from PVC %s", ec.Name)
+					return acted, errors.Wrapf(err, "stripping Broker ownerRef from PVC %s", ec.Name)
 				}
 			}
 		}
 
-		for i := range brokerList.Items {
-			b := &brokerList.Items[i]
+		// Delete Broker CRs with orphan propagation, leaving each CR's
+		// finalizer alone: the Broker controller removes its own finalizer in
+		// reconcileDelete — the pod's ownerRef was stripped above, so it takes
+		// the no-decommission rollback branch (raw CR deletion never
+		// decommissions, RFC Q2). Removing the finalizer from here instead
+		// would race the Broker controller, which re-adds it on every
+		// reconcile of a live CR — a conflict tug-of-war that stalled
+		// rollback for minutes. Orphan propagation prevents the GC from
+		// cascade-deleting pods that the Broker controller re-adopted between
+		// our ownerRef strip above and the delete here.
+		for i := range brokers {
+			b := &brokers[i]
 			if b.DeletionTimestamp.IsZero() {
 				if b.IsDiskLost() && b.Status.BrokerID != nil {
 					// The tombstone's dead-id decommission will never run now.
@@ -179,7 +217,7 @@ func Rollback(ctx context.Context, cfg RollbackConfig) error {
 				}
 				l.Info("rollback: deleting Broker CR", "name", b.Name)
 				if err := c.Delete(ctx, b, k8sclient.PropagationPolicy(metav1.DeletePropagationOrphan)); err != nil && !apierrors.IsNotFound(err) {
-					return errors.Wrapf(err, "deleting Broker CR %s", b.Name)
+					return acted, errors.Wrapf(err, "deleting Broker CR %s", b.Name)
 				}
 				continue
 			}
@@ -190,18 +228,21 @@ func Rollback(ctx context.Context, cfg RollbackConfig) error {
 				controllerutil.RemoveFinalizer(stripped, BrokerDecommissionFinalizer)
 				patch, err := json.Marshal(map[string]any{"metadata": map[string]any{"finalizers": stripped.Finalizers}})
 				if err != nil {
-					return err
+					return acted, err
 				}
 				if err := c.Patch(ctx, b, k8sclient.RawPatch(types.MergePatchType, patch)); err != nil && !apierrors.IsNotFound(err) {
-					return errors.Wrapf(err, "stripping finalizer from Broker CR %s", b.Name)
+					return acted, errors.Wrapf(err, "stripping finalizer from Broker CR %s", b.Name)
 				}
 			}
 		}
 	}
 
-	return finalizeRollback(ctx, cfg, len(brokerList.Items) > 0)
+	return acted, finalizeRollback(ctx, cfg, acted)
 }
 
+// finalizeRollback restores the pre-migration StatefulSets from the backup
+// ConfigMap, waits for them to re-adopt the pods, and only then deletes the
+// backup and reports success.
 func finalizeRollback(ctx context.Context, cfg RollbackConfig, cleanedThisPass bool) error {
 	c, l := cfg.Client, cfg.Logger
 
@@ -212,7 +253,18 @@ func finalizeRollback(ctx context.Context, cfg RollbackConfig, cleanedThisPass b
 			return err
 		}
 		if !cleanedThisPass {
-			// Steady state: no Broker CRs and no pending restore.
+			// Steady state: no Broker CRs and no pending restore. The terminal
+			// RolledBack report from the pass that finished the rollback rides
+			// the owner's status write, which may never land (conflict, crash)
+			// — and the backup ConfigMap, the resume marker, is already gone
+			// by then. So, like migration Complete, the terminal state is
+			// observed rather than recorded: promote a lingering non-terminal
+			// condition here until the write sticks. Clusters that never
+			// migrated have no condition and report nothing.
+			if cfg.Reporter != nil && cfg.Reporter.ShouldReportRolledBack(ctx) {
+				cfg.report(ctx, corev1.ConditionTrue,
+					MigrationReasonRolledBack, "Broker CRs removed; StatefulSet manages all pods")
+			}
 			return nil
 		}
 		// No backup exists (a broker-born cluster was never migrated from a
@@ -240,12 +292,95 @@ func finalizeRollback(ctx context.Context, cfg RollbackConfig, cleanedThisPass b
 	}); err != nil {
 		return err
 	}
+
+	// Make sure we act only on the pods that belong to THIS rollback:
+	// gated on the ordinal names of the backup's StatefulSets.
+	expected := map[string]bool{}
+	for _, data := range cm.Data {
+		var backup appsv1.StatefulSet
+		if err := json.Unmarshal([]byte(data), &backup); err != nil {
+			continue // restoreStatefulSetsFromBackup already reported this
+		}
+		for i := int32(0); i < ptr.Deref(backup.Spec.Replicas, 1); i++ {
+			expected[fmt.Sprintf("%s-%d", backup.Name, i)] = true
+		}
+	}
+
+	revisions := map[string]string{}
 	for i := range pods.Items {
-		owner := metav1.GetControllerOf(&pods.Items[i])
+		pod := &pods.Items[i]
+		if !expected[pod.Name] {
+			continue
+		}
+
+		if owner := metav1.GetControllerOf(pod); owner != nil && owner.Kind == redpandav1alpha2.BrokerKind {
+			l.Info("rollback: re-stripping Broker ownerRef from re-adopted pod", "pod", pod.Name)
+			if err := stripOwnerRef(ctx, c, pod, owner.UID); err != nil {
+				return errors.Wrapf(err, "re-stripping Broker ownerRef from pod %s", pod.Name)
+			}
+		}
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim == nil {
+				continue
+			}
+			var pvc corev1.PersistentVolumeClaim
+			if err := c.Get(ctx, types.NamespacedName{Name: vol.PersistentVolumeClaim.ClaimName, Namespace: pod.Namespace}, &pvc); err != nil {
+				if apierrors.IsNotFound(err) {
+					// Not rollback's doing and nothing to strip, but a pod
+					// referencing a claim that does not exist is anomalous
+					// enough to surface.
+					l.Info("rollback: WARNING pod references a claim that does not exist", "pod", pod.Name, "pvc", vol.PersistentVolumeClaim.ClaimName)
+					continue
+				}
+				return errors.Wrapf(err, "checking claim %s for Broker ownerRefs", vol.PersistentVolumeClaim.ClaimName)
+			}
+			if owner := metav1.GetControllerOf(&pvc); owner != nil && owner.Kind == redpandav1alpha2.BrokerKind {
+				l.Info("rollback: re-stripping Broker ownerRef from claim", "pvc", pvc.Name)
+				if err := stripOwnerRef(ctx, c, &pvc, owner.UID); err != nil {
+					return errors.Wrapf(err, "re-stripping Broker ownerRef from claim %s", pvc.Name)
+				}
+			}
+		}
+		owner := metav1.GetControllerOf(pod)
 		if owner == nil || owner.Kind != "StatefulSet" {
-			msg := fmt.Sprintf("waiting for the StatefulSet to adopt pod %s", pods.Items[i].Name)
+			msg := fmt.Sprintf("waiting for the StatefulSet to adopt pod %s", pod.Name)
 			cfg.report(ctx, corev1.ConditionFalse, MigrationReasonInProgress, msg)
 			return &RequeueAfterError{RequeueAfter: RequeueDuration, Msg: "rollback: " + msg}
+		}
+		// Pods the BROKER controller created (rotations, decommission
+		// replacements) carry no controller-revision-hash — only the
+		// StatefulSet controller stamps it, and under OnDelete it never
+		// re-labels adopted pods — so the revision-based roll planners would
+		// treat every such pod as outdated and restart the fleet right after
+		// rollback. Hand them over as CURRENT by stamping the restored
+		// StatefulSet's revision: the backup is the state being rolled back
+		// TO, and any genuine drift from the next render re-rolls through
+		// the ordinary health-gated flow. Stamped before the backup
+		// ConfigMap is deleted, so an interrupted pass resumes here.
+		if pod.Labels[appsv1.StatefulSetRevisionLabel] == "" {
+			rev, ok := revisions[owner.Name]
+			if !ok {
+				var sts appsv1.StatefulSet
+				if err := c.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: cfg.Owner.GetNamespace()}, &sts); err != nil {
+					return errors.Wrapf(err, "fetching restored StatefulSet %s for revision stamping", owner.Name)
+				}
+				rev = sts.Status.UpdateRevision
+				revisions[owner.Name] = rev
+			}
+			if rev == "" {
+				msg := fmt.Sprintf("waiting for the restored StatefulSet %s to publish its revision", owner.Name)
+				cfg.report(ctx, corev1.ConditionFalse, MigrationReasonInProgress, msg)
+				return &RequeueAfterError{RequeueAfter: RequeueDuration, Msg: "rollback: " + msg}
+			}
+			podPatch := k8sclient.MergeFrom(pod.DeepCopy())
+			if pod.Labels == nil {
+				pod.Labels = map[string]string{}
+			}
+			pod.Labels[appsv1.StatefulSetRevisionLabel] = rev
+			l.Info("rollback: stamping restored StatefulSet revision onto Broker-created pod", "pod", pod.Name, "revision", rev)
+			if err := c.Patch(ctx, pod, podPatch); err != nil {
+				return errors.Wrapf(err, "stamping revision label on pod %s", pod.Name)
+			}
 		}
 	}
 

--- a/operator/internal/brokerset/rollback_test.go
+++ b/operator/internal/brokerset/rollback_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package brokerset
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
+)
+
+type recordingReporter struct {
+	reason  string
+	reports []string
+}
+
+func (r *recordingReporter) Report(_ context.Context, _ corev1.ConditionStatus, reason, _ string) {
+	r.reports = append(r.reports, reason)
+	r.reason = reason
+}
+
+func (r *recordingReporter) shouldReport(terminalReason string) bool {
+	return r.reason != "" && r.reason != terminalReason
+}
+
+func (r *recordingReporter) ShouldReportComplete(context.Context) bool {
+	return r.shouldReport(MigrationReasonComplete)
+}
+
+func (r *recordingReporter) ShouldReportRolledBack(context.Context) bool {
+	return r.shouldReport(MigrationReasonRolledBack)
+}
+
+func TestRollbackTouchesOnlyOwnedBrokers(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "rp", Namespace: "test", UID: "owner-uid"}}
+	foreignOwner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "other-cluster", Namespace: "test", UID: "foreign-uid"}}
+
+	foreign := &redpandav1alpha2.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-cluster-broker-0",
+			Namespace: "test",
+			// Labels that match the rollback's selector (Everything() here;
+			// in production: copyable name-based owner labels).
+			Labels: map[string]string{"app": "redpanda"},
+		},
+		Spec: redpandav1alpha2.BrokerSpec{
+			ClusterRef:   redpandav1alpha2.ClusterRef{Name: "other-cluster"},
+			NetworkIndex: ptr.To(int32(0)),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(foreignOwner, foreign, scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner, foreignOwner, foreign).Build()
+
+	acted, err := Rollback(ctx, RollbackConfig{
+		Client:          c,
+		Scheme:          scheme,
+		Owner:           owner,
+		ClusterSelector: k8slabels.Everything(),
+		Logger:          logr.Discard(),
+	})
+	require.NoError(t, err)
+	require.False(t, acted, "a foreign Broker must not count as this owner's rollback work")
+
+	var still redpandav1alpha2.Broker
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: foreign.Name, Namespace: "test"}, &still),
+		"rollback deleted a Broker CR controlled by a different owner")
+	require.Zero(t, still.DeletionTimestamp, "rollback must not delete a Broker CR it does not own")
+}
+
+func TestRollbackRederivesLostTerminalReport(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+
+	// Steady state: no Broker CRs, no backup ConfigMap.
+	rollback := func(t *testing.T, rep *recordingReporter) {
+		acted, err := Rollback(context.Background(), RollbackConfig{
+			Client:          fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Scheme:          scheme,
+			Owner:           &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "rp", Namespace: "test", UID: "owner-uid"}},
+			ClusterSelector: k8slabels.Everything(),
+			Reporter:        rep,
+			Logger:          logr.Discard(),
+		})
+		require.NoError(t, err)
+		require.False(t, acted)
+	}
+
+	t.Run("lost RolledBack is re-reported", func(t *testing.T) {
+		rep := &recordingReporter{reason: MigrationReasonInProgress}
+		rollback(t, rep)
+		require.Equal(t, []string{MigrationReasonRolledBack}, rep.reports,
+			"a rollback whose terminal report never persisted must be promoted to RolledBack in steady state")
+	})
+
+	t.Run("never-migrated cluster reports nothing", func(t *testing.T) {
+		rep := &recordingReporter{}
+		rollback(t, rep)
+		require.Empty(t, rep.reports, "a cluster with no migration condition must not get one")
+	})
+
+	t.Run("already rolled back reports nothing", func(t *testing.T) {
+		rep := &recordingReporter{reason: MigrationReasonRolledBack}
+		rollback(t, rep)
+		require.Empty(t, rep.reports, "a persisted RolledBack must not be re-written every pass")
+	})
+}
+
+func TestFinalizeRollbackIgnoresForeignPods(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, redpandav1alpha2.Install(scheme))
+
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "rp", Namespace: "test", UID: "owner-uid"}}
+
+	backup, err := json.Marshal(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "rp", Namespace: "test"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+	})
+	require.NoError(t, err)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: migrationBackupName(owner.Name), Namespace: "test"},
+		Data:       map[string]string{"rp.json": string(backup)},
+	}
+
+	// This rollback's pod: StatefulSet-owned and already carrying a revision
+	// label, so the flow can complete in one pass.
+	adopted := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rp-0",
+			Namespace: "test",
+			Labels:    map[string]string{appsv1.StatefulSetRevisionLabel: "rp-abc"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "StatefulSet", Name: "rp", UID: "sts-uid", Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	// A label-matching pod from ANOTHER cluster, still owned by its Broker CR.
+	foreignBrokerRef := metav1.OwnerReference{
+		APIVersion: redpandav1alpha2.GroupVersion.String(),
+		Kind:       redpandav1alpha2.BrokerKind,
+		Name:       "other-cluster-broker-0",
+		UID:        "foreign-broker-uid",
+		Controller: ptr.To(true),
+	}
+	foreignPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-cluster-0", Namespace: "test", OwnerReferences: []metav1.OwnerReference{foreignBrokerRef}},
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{{
+			Name:         "datadir",
+			VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "datadir-other-cluster-0"}},
+		}}},
+	}
+	foreignPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadir-other-cluster-0", Namespace: "test", OwnerReferences: []metav1.OwnerReference{foreignBrokerRef}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owner, cm, adopted, foreignPod, foreignPVC).Build()
+
+	_, err = Rollback(ctx, RollbackConfig{
+		Client:          c,
+		Scheme:          scheme,
+		Owner:           owner,
+		ClusterSelector: k8slabels.Everything(),
+		Logger:          logr.Discard(),
+	})
+	require.NoError(t, err, "a foreign pod must not wedge the rollback at the adoption wait")
+
+	var gone corev1.ConfigMap
+	require.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Name: cm.Name, Namespace: "test"}, &gone)),
+		"rollback must complete (backup deleted) despite the foreign pod")
+
+	var pod corev1.Pod
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: foreignPod.Name, Namespace: "test"}, &pod))
+	require.Equal(t, []metav1.OwnerReference{foreignBrokerRef}, pod.OwnerReferences,
+		"rollback stripped the Broker ownerRef from a pod it does not own")
+	require.Empty(t, pod.Labels[appsv1.StatefulSetRevisionLabel],
+		"rollback stamped a revision label onto a pod it does not own")
+
+	var pvc corev1.PersistentVolumeClaim
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: foreignPVC.Name, Namespace: "test"}, &pvc))
+	require.Equal(t, []metav1.OwnerReference{foreignBrokerRef}, pvc.OwnerReferences,
+		"rollback stripped the Broker ownerRef from a claim it does not own")
+}

--- a/operator/internal/controller/redpanda/broker_controller.go
+++ b/operator/internal/controller/redpanda/broker_controller.go
@@ -393,6 +393,11 @@ func (r *BrokerReconciler) reconcilePod(ctx context.Context, state *brokerReconc
 				return ctrl.Result{}, nil
 			}
 		}
+		if adoptionBarredByRollback(ctx, k8sClient, broker) {
+			l.Info("owning cluster left broker mode; not creating a pod", "name", podName)
+			state.phase = redpandav1alpha2.BrokerPhasePending
+			return ctrl.Result{RequeueAfter: requeueShort}, nil
+		}
 		l.Info("creating pod (no existing pod found)", "name", podName)
 		newPod := broker.BuildPod(podName)
 		if err := controllerutil.SetControllerReference(broker, newPod, scheme); err != nil {

--- a/operator/internal/controller/redpanda/broker_controller.go
+++ b/operator/internal/controller/redpanda/broker_controller.go
@@ -595,7 +595,7 @@ func (r *BrokerReconciler) dismantleDiskLost(ctx context.Context, l logr.Logger,
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: broker.Namespace}, &pvc)
 			switch {
 			case err == nil:
-				if owner := metav1.GetControllerOf(&pvc); owner == nil || metav1.IsControlledBy(&pvc, broker) {
+				if metav1.GetControllerOf(&pvc) == nil {
 					l.Info("pvc still terminating", "pvc", name)
 					return ctrl.Result{RequeueAfter: requeueShort}, nil // still terminating, requeue
 				}

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -577,8 +577,24 @@ func (p *PoolTracker) PodsToRoll() []*MulticlusterPod {
 		for _, withOrdinals := range existing.pods {
 			// the CurrentRevision on the StatefulSet can't be used here due to leveraging onDelete
 			if len(existing.revisions) == 0 {
-				// we have no revisions, just assume this needs to be rolled
-				pods = append(pods, newMulticlusterPod(withOrdinals.pod.DeepCopy(), existing.set.clusterName, existing.set.canonicalClusterName))
+				// No owned ControllerRevisions means we cannot KNOW whether a
+				// pod is outdated — and "can't know" must not mean "restart
+				// the fleet". This state is transient (the StatefulSet
+				// controller mints the revision at creation; a StatefulSet
+				// restored by a Broker-CR rollback additionally has to adopt
+				// the orphaned revisions of its predecessor), and assuming
+				// roll here sent freshly re-adopted pods straight to the roll
+				// loop. Skip; genuine drift computes once revisions appear.
+				continue
+			} else if withOrdinals.pod.Labels[appsv1.StatefulSetRevisionLabel] == "" {
+				// No revision label: this pod was ADOPTED, not created, by
+				// the StatefulSet (under OnDelete, kube labels pods only at
+				// creation) — a Broker-CR rollback hands such pods over. An
+				// empty label says nothing about outdatedness, and rolling
+				// on "can't know" restarted every adopted pod. The rollback
+				// stamps the restored revision onto them; until that write
+				// is visible here, leave them alone.
+				continue
 			} else {
 				lastRevision := existing.revisions[len(existing.revisions)-1]
 				if withOrdinals.pod.Labels[appsv1.StatefulSetRevisionLabel] != lastRevision.Name {

--- a/operator/internal/lifecycle/pool.go
+++ b/operator/internal/lifecycle/pool.go
@@ -578,22 +578,12 @@ func (p *PoolTracker) PodsToRoll() []*MulticlusterPod {
 			// the CurrentRevision on the StatefulSet can't be used here due to leveraging onDelete
 			if len(existing.revisions) == 0 {
 				// No owned ControllerRevisions means we cannot KNOW whether a
-				// pod is outdated — and "can't know" must not mean "restart
-				// the fleet". This state is transient (the StatefulSet
-				// controller mints the revision at creation; a StatefulSet
-				// restored by a Broker-CR rollback additionally has to adopt
-				// the orphaned revisions of its predecessor), and assuming
-				// roll here sent freshly re-adopted pods straight to the roll
-				// loop. Skip; genuine drift computes once revisions appear.
+				// pod is outdated — skip.
 				continue
 			} else if withOrdinals.pod.Labels[appsv1.StatefulSetRevisionLabel] == "" {
 				// No revision label: this pod was ADOPTED, not created, by
 				// the StatefulSet (under OnDelete, kube labels pods only at
-				// creation) — a Broker-CR rollback hands such pods over. An
-				// empty label says nothing about outdatedness, and rolling
-				// on "can't know" restarted every adopted pod. The rollback
-				// stamps the restored revision onto them; until that write
-				// is visible here, leave them alone.
+				// creation) — a Broker-CR rollback hands such pods over. Skip.
 				continue
 			} else {
 				lastRevision := existing.revisions[len(existing.revisions)-1]

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -1072,8 +1072,32 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 				revisions: pool1Revisions,
 			}},
 		},
+		// A pod WITHOUT a revision label was adopted, not created, by the
+		// StatefulSet (under OnDelete kube labels pods only at creation) —
+		// the Broker-CR rollback hands such pods over and stamps them one
+		// pass later. Unknowable-from-label must not mean "roll": rolling
+		// here restarted every adopted pod right after rollback.
+		"adopted-pod-without-revision-label": {
+			expectedPodsToRoll: nil,
+			existingPools: []*poolWithOrdinals{{
+				pods: []*podsWithOrdinals{{
+					pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pod-1",
+						},
+					},
+				}},
+				set:       pool1,
+				revisions: pool1Revisions,
+			}},
+		},
+		// No owned ControllerRevisions means outdatedness is UNKNOWABLE, and
+		// unknowable must not restart the fleet: the state is transient (the
+		// StatefulSet controller mints the revision at creation; a StatefulSet
+		// restored by rollback has to adopt its predecessor's orphaned
+		// revisions first), so nothing rolls until revisions appear.
 		"no-revisions": {
-			expectedPodsToRoll: []string{"canonical-1//pod-1", "canonical-1//pod-2"},
+			expectedPodsToRoll: nil,
 			existingPools: []*poolWithOrdinals{{
 				pods: []*podsWithOrdinals{{
 					pod: &corev1.Pod{

--- a/operator/internal/lifecycle/pool_test.go
+++ b/operator/internal/lifecycle/pool_test.go
@@ -1072,11 +1072,6 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 				revisions: pool1Revisions,
 			}},
 		},
-		// A pod WITHOUT a revision label was adopted, not created, by the
-		// StatefulSet (under OnDelete kube labels pods only at creation) —
-		// the Broker-CR rollback hands such pods over and stamps them one
-		// pass later. Unknowable-from-label must not mean "roll": rolling
-		// here restarted every adopted pod right after rollback.
 		"adopted-pod-without-revision-label": {
 			expectedPodsToRoll: nil,
 			existingPools: []*poolWithOrdinals{{
@@ -1091,11 +1086,6 @@ func TestPoolTrackerPodsToRoll(t *testing.T) {
 				revisions: pool1Revisions,
 			}},
 		},
-		// No owned ControllerRevisions means outdatedness is UNKNOWABLE, and
-		// unknowable must not restart the fleet: the state is transient (the
-		// StatefulSet controller mints the revision at creation; a StatefulSet
-		// restored by rollback has to adopt its predecessor's orphaned
-		// revisions first), so nothing rolls until revisions appear.
 		"no-revisions": {
 			expectedPodsToRoll: nil,
 			existingPools: []*poolWithOrdinals{{

--- a/operator/pkg/resources/brokerset.go
+++ b/operator/pkg/resources/brokerset.go
@@ -113,6 +113,8 @@ func NewBrokerSet(
 	}
 }
 
+// Key exists solely to satisfy the [Resource] interface.
+// Don't use it.
 func (r *BrokerSetResource) Key() types.NamespacedName {
 	return types.NamespacedName{
 		Name:      fmt.Sprintf("brokerset-%s", r.nodePool.Name),
@@ -257,7 +259,7 @@ func MarkBrokersForRestart(ctx context.Context, c k8sclient.Client, cluster *vec
 // RollbackBrokerCRs cleans up Broker CRs when the migration annotation is
 // removed, allowing the StatefulSet to re-adopt pods.
 func RollbackBrokerCRs(ctx context.Context, c k8sclient.Client, scheme *runtime.Scheme, cluster *vectorizedv1alpha1.Cluster, l logr.Logger) error {
-	return brokerset.Rollback(ctx, brokerset.RollbackConfig{
+	_, err := brokerset.Rollback(ctx, brokerset.RollbackConfig{
 		Client:          c,
 		Scheme:          scheme,
 		Owner:           cluster,
@@ -269,12 +271,13 @@ func RollbackBrokerCRs(ctx context.Context, c k8sclient.Client, scheme *runtime.
 		},
 		Logger: l,
 	})
+	return err
 }
 
 // NewMigrationPoolReporter returns the migration reporter for one node pool:
 // reports accumulate into agg (the cluster controller flushes one aggregate
-// after all pools reconcile), while NeedsCompletion keeps reading the
-// Cluster's BrokerMigration condition.
+// after all pools reconcile), while the ShouldReport* predicates keep
+// reading the Cluster's BrokerMigration condition.
 func NewMigrationPoolReporter(agg *brokerset.MigrationAggregator, pool string, c k8sclient.Client, cluster *vectorizedv1alpha1.Cluster, l logr.Logger) brokerset.MigrationReporter {
 	return agg.PoolReporter(pool, &v1MigrationReporter{client: c, cluster: cluster, logger: l})
 }
@@ -307,9 +310,21 @@ func (rep *v1MigrationReporter) Report(ctx context.Context, status corev1.Condit
 	setMigrationCondition(ctx, rep.client, rep.cluster, rep.logger, status, reason, message)
 }
 
-func (rep *v1MigrationReporter) NeedsCompletion(context.Context) bool {
+// shouldReport reports whether migration progress was previously recorded
+// on the Cluster's BrokerMigration condition and the condition has not yet
+// reached the given terminal reason. Clusters that never migrated have no
+// condition and must never gain one from a steady-state promotion.
+func (rep *v1MigrationReporter) shouldReport(terminalReason string) bool {
 	cond := rep.cluster.Status.GetCondition(vectorizedv1alpha1.BrokerMigrationConditionType)
-	return cond != nil && cond.Reason != brokerset.MigrationReasonComplete
+	return cond != nil && cond.Reason != terminalReason
+}
+
+func (rep *v1MigrationReporter) ShouldReportComplete(context.Context) bool {
+	return rep.shouldReport(brokerset.MigrationReasonComplete)
+}
+
+func (rep *v1MigrationReporter) ShouldReportRolledBack(context.Context) bool {
+	return rep.shouldReport(brokerset.MigrationReasonRolledBack)
 }
 
 // setMigrationCondition records STS→Broker migration progress on the Cluster

--- a/operator/pkg/resources/brokerset_test.go
+++ b/operator/pkg/resources/brokerset_test.go
@@ -530,13 +530,23 @@ func TestRollbackRestoresStatefulSetFromBackup(t *testing.T) {
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "rp-migration-backup", Namespace: "test"}, &kept),
 		"backup ConfigMap must survive until the pods are adopted")
 
-	// Simulate the StatefulSet controller adopting the pod, then finish.
+	// Simulate the StatefulSet controller adopting the pod and publishing
+	// its revision, then finish.
 	var pod corev1.Pod
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "rp-0", Namespace: "test"}, &pod))
 	require.NoError(t, controllerutil.SetControllerReference(&restored, &pod, r.scheme))
 	require.NoError(t, c.Update(ctx, &pod))
+	restored.Status.UpdateRevision = "rp-restored-revision"
+	require.NoError(t, c.Status().Update(ctx, &restored))
 
 	require.NoError(t, RollbackBrokerCRs(ctx, c, r.scheme, r.pandaCluster, ctrl.Log))
+
+	// Broker-created pods carry no controller-revision-hash; the handover
+	// must stamp the restored StatefulSet's revision so the revision-based
+	// roll planners don't restart the fleet right after rollback.
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "rp-0", Namespace: "test"}, &pod))
+	assert.Equal(t, "rp-restored-revision", pod.Labels[appsv1.StatefulSetRevisionLabel],
+		"adopted pod must be handed over as current")
 
 	var gone corev1.ConfigMap
 	err = c.Get(ctx, types.NamespacedName{Name: "rp-migration-backup", Namespace: "test"}, &gone)


### PR DESCRIPTION
Rollback (removing the use-broker-cr annotation) gets four fixes:

1. Broker-created pods (rotations, decommission replacements) carry no controller-revision-hash, and under OnDelete the StatefulSet controller labels pods only at creation — so after rollback the revision-based roll planners restarted the whole fleet. finalizeRollback now stamps the restored StatefulSet's revision onto adopted pods before deleting the backup, and PodsToRoll treats "no revisions" / "no revision label" as unknowable (skip) instead of "roll".
2. Rollback acts only on Broker CRs controlled by the owner and, in the finalize pod/PVC loop, only on the ordinal pod names derived from the backup's StatefulSets: the label selector alone (name-based, copyable labels) must not decide what gets ownerRef-stripped or deleted, and a label-matching foreign pod must not wedge the rollback at the adoption wait.
3. The terminal RolledBack report is re-derived in steady state (like migration Complete): the pass that finishes the rollback deletes the resume marker first, so a lost status write left the condition stuck InProgress forever.
4. Rollback returns whether it acted, so callers can hold off StatefulSet mutations computed from a pre-rollback view of the world.