### PR TITLE
DEVPROD-4558 Stop pushing to vectorized and repoint to correct dockerhub

### DIFF
--- a/operator/config/e2e-tests/kustomization.yaml
+++ b/operator/config/e2e-tests/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: vectorized/redpanda-operator
+  - name: redpandadata/redpanda-operator
     newName: localhost/redpanda-operator
     newTag: dev
 resources:

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: vectorized/redpanda-operator
-  newName: vectorized/redpanda-operator
+- name: redpandadata/redpanda-operator
+  newName: redpandadata/redpanda-operator
   newTag: latest

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: vectorized/redpanda-operator:2021022-e853bf3
+        image: redpandadata/redpanda-operator:latest
         name: manager
         ports: []
         securityContext:

--- a/operator/config/samples/console.yaml
+++ b/operator/config/samples/console.yaml
@@ -11,7 +11,7 @@ spec:
     name: cluster
     namespace: default
   deployment:
-    image: vectorized/console:master-173596f
+    image: redpandadata/console:v2.8.16
   connect:
     enabled: true
     clusters:

--- a/operator/config/samples/external_connectivity.yaml
+++ b/operator/config/samples/external_connectivity.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: external-connectivity
 spec:
-  image: "vectorized/redpanda"
+  image: "redpandadata/redpanda"
   version: "latest"
   replicas: 3
   resources:

--- a/operator/config/samples/mtls.yaml
+++ b/operator/config/samples/mtls.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-sample-mtls
 spec:
-  image: "vectorized/redpanda"
+  image: "redpandadata/redpanda"
   version: "latest"
   replicas: 1
   resources:

--- a/operator/config/samples/one_node_external.yaml
+++ b/operator/config/samples/one_node_external.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: one-node-external
 spec:
-  image: "vectorized/redpanda"
+  image: "redpandadata/redpanda"
   version: "latest"
   replicas: 1
   resources:

--- a/operator/config/samples/sasl.yaml
+++ b/operator/config/samples/sasl.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-sample-sasl
 spec:
-  image: "vectorized/redpanda"
+  image: "redpandadata/redpanda"
   version: "latest"
   replicas: 1
   kafkaEnableAuthorization: true

--- a/operator/config/samples/tls.yaml
+++ b/operator/config/samples/tls.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-sample-tls
 spec:
-  image: "vectorized/redpanda"
+  image: "redpandadata/redpanda"
   version: "latest"
   replicas: 1
   resources:

--- a/operator/internal/controller/vectorized/test/suite_test.go
+++ b/operator/internal/controller/vectorized/test/suite_test.go
@@ -158,7 +158,7 @@ var _ = BeforeSuite(func(suiteCtx SpecContext) {
 		DecommissionWaitInterval:       100 * time.Millisecond,
 		ConfigurationReassertionPeriod: driftCheckPeriod,
 	}).WithClusterDomain("cluster.local").WithConfiguratorSettings(resources.ConfiguratorSettings{
-		ConfiguratorBaseImage: "redpanda-data/redpanda-operator",
+		ConfiguratorBaseImage: "redpandadata/redpanda-operator",
 		ConfiguratorTag:       "latest",
 		ImagePullPolicy:       "Always",
 	}).SetupWithManager(k8sManager)

--- a/operator/pkg/resources/featuregates/featuregates_test.go
+++ b/operator/pkg/resources/featuregates/featuregates_test.go
@@ -38,7 +38,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			version:   "dev",
 			supported: true,
 		},
-		// Versions from: https://hub.docker.com/r/vectorized/redpanda/tags
+		// Versions from: https://hub.docker.com/r/redpandadata/redpanda/tags
 		{
 			version:   "latest",
 			supported: true,
@@ -47,7 +47,7 @@ func TestFeatureGates(t *testing.T) { //nolint:funlen // table tests can be long
 			version:   "v23.2.3-arm64",
 			supported: true,
 		},
-		// Versions from: https://hub.docker.com/r/vectorized/redpanda-nightly/tags
+		// Versions from: https://hub.docker.com/r/redpandadata/redpanda-nightly/tags
 		{
 			version:   "v0.0.0-20221006git23a658b",
 			supported: true,

--- a/operator/pkg/resources/resource_integration_test.go
+++ b/operator/pkg/resources/resource_integration_test.go
@@ -100,7 +100,7 @@ func TestEnsure_StatefulSet(t *testing.T) {
 		TestAdminTLSConfigProvider{},
 		"",
 		res.ConfiguratorSettings{
-			ConfiguratorBaseImage: "redpanda-data/redpanda-operator",
+			ConfiguratorBaseImage: "redpandadata/redpanda-operator",
 			ConfiguratorTag:       "latest",
 			ImagePullPolicy:       "Always",
 		},

--- a/operator/pkg/resources/statefulset_test.go
+++ b/operator/pkg/resources/statefulset_test.go
@@ -179,7 +179,7 @@ func TestEnsure(t *testing.T) {
 				TestAdminTLSConfigProvider{},
 				"",
 				resources.ConfiguratorSettings{
-					ConfiguratorBaseImage:  "redpanda-data/redpanda-operator",
+					ConfiguratorBaseImage:  "redpandadata/redpanda-operator",
 					ConfiguratorTag:        "latest",
 					ImagePullPolicy:        "Always",
 					CloudSecretsEnabled:    true,
@@ -304,7 +304,7 @@ func defaultNodePoolstsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *ap
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{{
 						Name:  "redpanda-configurator",
-						Image: "vectorized/redpanda-operator:latest",
+						Image: "redpandadata/redpanda-operator:latest",
 						Resources: corev1.ResourceRequirements{
 							Limits:   pandaCluster.Spec.Resources.Limits,
 							Requests: pandaCluster.Spec.Resources.Requests,
@@ -402,7 +402,7 @@ func stsFromCluster(pandaCluster *vectorizedv1alpha1.Cluster) *appsv1.StatefulSe
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{{
 						Name:  "redpanda-configurator",
-						Image: "vectorized/redpanda-operator:latest",
+						Image: "redpandadata/redpanda-operator:latest",
 						Resources: corev1.ResourceRequirements{
 							Limits:   pandaCluster.Spec.NodePools[0].Resources.Limits,
 							Requests: pandaCluster.Spec.NodePools[0].Resources.Requests,
@@ -677,7 +677,7 @@ func TestCurrentVersion(t *testing.T) {
 				TestAdminTLSConfigProvider{},
 				"",
 				resources.ConfiguratorSettings{
-					ConfiguratorBaseImage: "redpanda-data/redpanda-operator",
+					ConfiguratorBaseImage: "redpandadata/redpanda-operator",
 					ConfiguratorTag:       "latest",
 					ImagePullPolicy:       "Always",
 				},

--- a/taskfiles/ci.yml
+++ b/taskfiles/ci.yml
@@ -190,7 +190,6 @@ tasks:
       - task: :build:operator-image
         vars:
           TAGS:
-          - docker.io/vectorized/redpanda-operator:{{.OPERATOR_VERSION}}
           - docker.io/redpandadata/redpanda-operator:{{.OPERATOR_VERSION}}
           PLATFORMS:
           - linux/amd64


### PR DESCRIPTION
Refs: https://redpandadata.atlassian.net/browse/DEVPROD-4558
Companion: redpanda-data/cloudv2-infra#3816

## What

`publish-operator-image` pushed every release to both `docker.io/vectorized/redpanda-operator`
and `docker.io/redpandadata/redpanda-operator`. The `vectorized` repo is private, last pulled
2025-02-21. This drops that tag and repoints the remaining `config/` and sample references.

No consumer impact: nothing outside CI could pull from `vectorized`, and every released operator
already defaults to `docker.redpanda.com/redpandadata/redpanda-operator`.

`config/manager/` and `config/e2e-tests/kustomization.yaml` have to move together — both select
the manager image by name, and kustomize silently ignores an `images` entry that no longer
matches, so renaming one alone makes e2e stop using `localhost/redpanda-operator:dev`.

## Known, accepted

- `config/default` renders `redpandadata/redpanda-operator:latest`, which isn't published. Not a
  regression, and nothing consumes that overlay.
- ~20 `vectorized/redpanda` strings remain as envtest fixtures — nothing pulls there.
- `ci/scripts/install-task.sh:14` uses `vectorized-public.s3…` — not Docker Hub, out of scope.
