### PR TITLE
docs: point the chart values.yaml links at this repository

### DIFF
--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -5,7 +5,7 @@ description: Find the default values and descriptions of settings in the Redpand
 
 ![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.31](https://img.shields.io/badge/AppVersion-v1.0.31-informational?style=flat-square)
 
-This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
+This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/kubernetes/k-deploy-connectors/).
 

--- a/charts/connectors/README.md.gotmpl
+++ b/charts/connectors/README.md.gotmpl
@@ -6,7 +6,7 @@ description: Find the default values and descriptions of settings in the Redpand
 {{- end -}}
 
 {{ define "chart.description" -}}
-This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
+This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/kubernetes/k-deploy-connectors/).
 {{ end -}}

--- a/charts/console/chart/README.md
+++ b/charts/console/chart/README.md
@@ -5,7 +5,7 @@ description: Find the default values and descriptions of settings in the Redpand
 
 ![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.9.0](https://img.shields.io/badge/AppVersion-v3.9.0-informational?style=flat-square)
 
-This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml).
+This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/charts/console/chart/values.yaml).
 Each of the settings is listed and described on this page, along with any default values.
 
 The Redpanda Console Helm chart is included as a subchart in the Redpanda Helm chart so that you can deploy and configure Redpanda and Redpanda Console together.

--- a/charts/console/chart/README.md.gotmpl
+++ b/charts/console/chart/README.md.gotmpl
@@ -6,7 +6,7 @@ description: Find the default values and descriptions of settings in the Redpand
 {{- end -}}
 
 {{ define "chart.description" -}}
-This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml).
+This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/charts/console/chart/values.yaml).
 Each of the settings is listed and described on this page, along with any default values.
 
 The Redpanda Console Helm chart is included as a subchart in the Redpanda Helm chart so that you can deploy and configure Redpanda and Redpanda Console together.

--- a/charts/redpanda/chart/README.md
+++ b/charts/redpanda/chart/README.md
@@ -5,7 +5,7 @@ description: Find the default values and descriptions of settings in the Redpand
 
 ![Version: 26.2.1](https://img.shields.io/badge/Version-26.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.2.1](https://img.shields.io/badge/AppVersion-v26.2.1-informational?style=flat-square)
 
-This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/chart/values.yaml). Each of the settings is listed and described on this page, along with any default values.
+This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/charts/redpanda/chart/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-deploy/).
 

--- a/charts/redpanda/chart/README.md.gotmpl
+++ b/charts/redpanda/chart/README.md.gotmpl
@@ -6,7 +6,7 @@ description: Find the default values and descriptions of settings in the Redpand
 {{- end -}}
 
 {{ define "chart.description" -}}
-This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/chart/values.yaml). Each of the settings is listed and described on this page, along with any default values.
+This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/charts/redpanda/chart/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-deploy/).
 {{ end -}}

--- a/operator/chart/README.md
+++ b/operator/chart/README.md
@@ -5,7 +5,7 @@ description: Find the default values and descriptions of settings in the Redpand
 
 ![Version: 26.2.1](https://img.shields.io/badge/Version-26.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.2.1](https://img.shields.io/badge/AppVersion-v26.2.1-informational?style=flat-square)
 
-This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](./values.yaml). Each of the settings is listed and described on this page, along with any default values.
+This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/operator/chart/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-deploy/).
 

--- a/operator/chart/README.md.gotmpl
+++ b/operator/chart/README.md.gotmpl
@@ -6,7 +6,7 @@ description: Find the default values and descriptions of settings in the Redpand
 {{- end -}}
 
 {{ define "chart.description" -}}
-This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](./values.yaml). Each of the settings is listed and described on this page, along with any default values.
+This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/redpanda-operator/blob/main/operator/chart/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-deploy/).
 {{ end -}}


### PR DESCRIPTION
Every chart README template links its own `values.yaml` in `redpanda-data/helm-charts`, which no longer holds the charts, so all three 404. The operator chart uses a repo-relative `./values.yaml` instead, which is worse in a subtle way: it resolves fine on GitHub but resolves against `docs.redpanda.com` once the template is rendered into the published helm spec page, where there is no `values.yaml` to resolve to.

| Chart | Was | Now |
|---|---|---|
| `charts/redpanda/chart` | `helm-charts/blob/main/charts/redpanda/chart/values.yaml` | `redpanda-operator/blob/main/charts/redpanda/chart/values.yaml` |
| `charts/console/chart` | `helm-charts/blob/main/charts/console/values.yaml` | `redpanda-operator/blob/main/charts/console/chart/values.yaml` |
| `charts/connectors` | `helm-charts/blob/main/charts/connectors/values.yaml` | `redpanda-operator/blob/main/charts/connectors/values.yaml` |
| `operator/chart` | `./values.yaml` | `redpanda-operator/blob/main/operator/chart/values.yaml` |

The console one had two problems: the wrong repo *and* a missing `/chart/` path segment. All four new targets were verified with a live request.

## Why this matters beyond the 404

These templates generate the `k-redpanda-helm-spec`, `k-console-helm-spec`, `k-connector-helm-spec` and `k-operator-helm-spec` reference pages on docs.redpanda.com, which is where the dead links were reported ([redpanda-data/docs-site#211](https://github.com/redpanda-data/docs-site/issues/211)).

Someone has already hand-corrected the published pages in the `docs` repo. Because the correction was not made here, the next `doc-tools gen-helm` run would put the dead links straight back. Fixing the template is what makes that stick.

## Generated files

`README.md` regenerated with the same `helm-docs` invocation `taskfiles/charts.yml` uses:

```
helm-docs --chart-to-generate charts/connectors,charts/console/chart,operator/chart,charts/redpanda/chart
```

The only line that changed in each rendered README is the one in the table above; the diff is 8 lines across 8 files, half templates and half their output.

## Scope

`main` only. The same dead URL is on `release/v26.2.x`, `release/v26.1.x` and `release/v25.3.x`, but the docs versions built from those are frozen and are not being edited.
