### PR TITLE
Substantially speed up `task generate`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,13 @@ formatters:
       no-prefix-comments: false
   exclusions:
     generated: strict
+    paths:
+    # gotohelm's rewrite tests assert on these files' contents, import
+    # grouping included, so they must not be reformatted. `golangci-lint run`
+    # skips them anyway (it can't typecheck example.com/example), but `fmt` is
+    # syntactic and would. .licenseupdater.yaml ignores them for the same
+    # reason.
+    - gotohelm/testdata/
 
 linters:
   default: none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ A healthy controller **quiesces**: once a resource matches its desired state, `R
 ## CI Lint Flow
 
 The CI lint step (`taskfiles/ci.yml`) runs:
-1. `task :generate` — regenerates ALL generated files (CRDs, RBAC, templates, schemas, partials, licenses, changelog, buildkite pipelines, then `lint-fix`)
+1. `task :generate` — regenerates ALL generated files (CRDs, RBAC, templates, schemas, partials, licenses, changelog, buildkite pipelines, then `fmt:fix`)
 2. `task :lint` — runs `golangci-lint run`, `helm lint --strict`, and `actionlint`
 3. `git diff --exit-code` — fails if any generated file doesn't match what's committed
 
@@ -52,6 +52,23 @@ The CI lint step (`taskfiles/ci.yml`) runs:
 - Adding dependencies without updating `licenses/third_party.md`
 - Changing kubebuilder RBAC markers without running `controller-gen`
 - Import ordering violations caught by `gci` formatter
+
+`generate` ends with `fmt:fix` (`golangci-lint fmt`), which runs the formatters
+only. `lint-fix` is an alias of it, so it no longer auto-fixes analysis-linter
+findings in hand-written code — step 2 reports those instead. For the old
+behavior, `task lint -- --fix`.
+
+### Generation task caching
+
+Generators in `taskfiles/k8s.yml` and `taskfiles/charts.yml` declare
+`sources:`/`generates:`, so `task generate` skips whatever is current: ~4s for
+a no-op and ~12s after editing one controller, against ~50s from scratch.
+**Give any new generator a fingerprint**, and `exclude:` its own output from
+`sources:` or it dirties itself every run.
+
+This only helps locally. CI starts with an empty `.task/` and ends with
+`git diff --exit-code`, so it regenerates everything and catches a glob that
+missed a real input. `rm -rf .task` forces a full local rebuild.
 
 ## Golden Test Files
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,7 +10,9 @@ vars:
   SRC_DIR:
     sh: 'realpath {{default "." .SRC_DIR}}'
   BUILD_ROOT:
-    sh: 'realpath {{default ".build" .BUILD_ROOT}}'
+    # Ensure BUILD_ROOT exists. Fresh non-CI clones (e.g. Claude worktrees)
+    # need something to create this directory.
+    sh: 'mkdir -p {{default ".build" .BUILD_ROOT}} && realpath {{default ".build" .BUILD_ROOT}}'
   TIMESTAMP: # Timestamp used for any build artifacts.
     # MacOS' man page isn't helpful. https://man7.org/linux/man-pages/man1/date.1.html
     # Roughly ISO 8601
@@ -54,13 +56,6 @@ tasks:
       - helm lint --strict ./charts/console/chart ./charts/connectors ./charts/redpanda/chart ./operator/chart/
       - actionlint
 
-  lint-fix:
-    desc: "equivalent to task lint -- --fix"
-    cmds:
-      - task: lint
-        vars:
-          CLI_ARGS: "--fix"
-
   mod:tidy:
     desc: "Runs go mod tidy on all go modules in this repo"
     # This isn't the most accurate check as any new imports in go files may
@@ -96,34 +91,82 @@ tasks:
     cmds:
       - gofumpt -w ./
 
+  fmt:fix:
+    desc: "Apply the golangci-lint formatters (gci, gofumpt) to all go code"
+    # Kept as the lint-fix alias since that's the name in shell history, but
+    # it no longer loads the analysis linters. For that: `task lint -- --fix`.
+    aliases:
+    - lint-fix
+    vars:
+      _PKG:
+        sh: go work edit -json | jq -j '.Use.[].DiskPath + "/... "'
+      PKG: '{{ .PKG | default ._PKG }}'
+    cmds:
+      - golangci-lint fmt {{.PKG}} {{.CLI_ARGS}}
+
   generate:
     desc: "[re]generate all generated files"
     cmds:
       - task: mod:tidy
-      # update-licenses may update licenses/boilerplate.go.txt which is used
-      # for _some_ of k8s:generate. For simplicity, we just run update-licenses
-      # twice.
+      # boilerplate.go.txt feeds nearly every generator below, so header
+      # updates settle first.
       - task: dev:update-licenses
+      # Writes into ./operator/api/redpanda/v1alpha2, so it precedes every
+      # generator that typechecks that package.
       - task: generate:applyconfig-copy
-      - task: k8s:generate
-      - task: dev:update-licenses
+      - task: generate:parallelizable
+      # charts:generate embeds the itemized RBAC that k8s:generate writes into
+      # charts/redpanda/chart/files, so it has to follow it.
       - task: charts:generate
-      - task: generate:third-party-licenses-list
-      - task: generate:changelog
-      - task: generate:buildkite-pipelines
-      - buf generate
-      - task: lint-fix
+      - task: fmt:fix # Format any newly generated files.
       - nix fmt . # Ensure flake.nix has been formatted.
+
+  # Stages that share no inputs or outputs, fanned out.
+  #
+  # A separate task rather than `deps:` on generate: deps run before cmds, and
+  # these have to follow mod:tidy and update-licenses.
+  generate:parallelizable:
+    internal: true
+    deps:
+    - k8s:generate
+    - generate:third-party-licenses-list
+    - generate:changelog
+    - generate:buildkite-pipelines
+    - generate:protos
+
+  generate:protos:
+    sources:
+    - ./buf.gen.yaml
+    - ./pkg/multicluster/leaderelection/proto/**/*.proto
+    generates:
+    - ./pkg/multicluster/leaderelection/proto/gen/**/*.go
+    cmds:
+    - buf generate
 
   generate:buildkite-pipelines:
     deps:
     - build:gen
+    sources:
+    - ./gen/pipeline/**/*.go
+    - ./.buildkite/pipeline.yml
+    generates:
+    - ./.buildkite/testsuite.yml
     cmds:
     - gen pipeline testsuite > .buildkite/testsuite.yml
 
   generate:applyconfig-copy:
     deps:
     - build:gen
+    sources:
+    - ./gen/applyconfig-copy/**/*.go
+    - ./licenses/boilerplate.go.txt
+    # The struct being copied comes from client-go, so a dependency bump
+    # changes the output even when nothing in this repo did.
+    - ./gen/go.sum
+    - ./go.work.sum
+    generates:
+    - ./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy.go
+    - ./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy_test.go
     cmds:
     - gen applyconfig-copy --header "licenses/boilerplate.go.txt" --package "v1alpha2" --out "./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy.go"  --test "./operator/api/redpanda/v1alpha2/zz_generated.applyconfigcopy_test.go" --struct "PodSpecApplyConfiguration" k8s.io/client-go/applyconfigurations/core/v1
 

--- a/licensereport/main.go
+++ b/licensereport/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -493,8 +494,27 @@ func buildURL(info *proxyInfo, licenseRelPath string, m module, name string, fal
 			// produce 404s; the only reliable option is to ask the
 			// source-of-truth host (github, gitiles, gitlab, etc.).
 			candidates := candidateRepoPaths(info.Origin.Subdir, m.Path, licenseRelPath)
-			for _, p := range candidates {
-				url := blobURL(repoURL, ref, p)
+			urls := make([]string, len(candidates))
+			for i, p := range candidates {
+				urls[i] = blobURL(repoURL, ref, p)
+			}
+
+			// Reuse what the previous run resolved (--fallback-from seeded it)
+			// before probing. Otherwise every module whose most-specific
+			// candidate is a virtual /vN dir or a slash-containing subdir tag
+			// pays a serial round trip to 404 before reaching the root URL
+			// already sitting in third_party.md.
+			//
+			// This trusts the table over specificity: a candidate that would
+			// newly 200 loses to a later one already committed.
+			// --validate-full skips the seed and re-derives from scratch.
+			for _, url := range urls {
+				if exists, _ := peekURLExists(url); exists {
+					return url
+				}
+			}
+
+			for _, url := range urls {
 				if urlExists(url) {
 					return url
 				}
@@ -503,7 +523,7 @@ func buildURL(info *proxyInfo, licenseRelPath string, m module, name string, fal
 			// the safest fallback (license inherited from root is the
 			// most common scenario when subdir lookups fail).
 			fmt.Fprintf(os.Stderr, "licensereport: no working URL for %s@%s (tried %d candidates)\n", m.Path, m.Version, len(candidates))
-			return blobURL(repoURL, ref, candidates[len(candidates)-1])
+			return urls[len(urls)-1]
 		}
 	}
 	// No Origin — fall back to a previously-committed URL. Verify it works;
@@ -644,13 +664,21 @@ var (
 	urlExistsCacheMu sync.Mutex
 )
 
-func urlExists(url string) bool {
+// peekURLExists reports whether url is already cached, and whether it was
+// cached at all, without issuing a request. Both are needed: the candidate
+// pre-pass wants known-good only, while urlExists must also honour a cached
+// 404 rather than re-probing it.
+func peekURLExists(url string) (exists, cached bool) {
 	urlExistsCacheMu.Lock()
-	if v, ok := urlExistsCache[url]; ok {
-		urlExistsCacheMu.Unlock()
-		return v
+	defer urlExistsCacheMu.Unlock()
+	exists, cached = urlExistsCache[url]
+	return exists, cached
+}
+
+func urlExists(url string) bool {
+	if exists, cached := peekURLExists(url); cached {
+		return exists
 	}
-	urlExistsCacheMu.Unlock()
 
 	req, _ := http.NewRequest("HEAD", url, nil) //nolint:gosec // url is built from constant origin + sanitized path
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -718,6 +746,15 @@ func listPackages(dir string) ([]goListPackage, error) {
 }
 
 func fetchInfo(m module) (*proxyInfo, error) {
+	// listPackages already made the go command download the whole build list,
+	// so this hits for every module in practice.
+	if body := readCached(m, ".info"); body != nil {
+		var info proxyInfo
+		if err := json.Unmarshal(body, &info); err == nil {
+			return &info, nil
+		}
+	}
+
 	url := fmt.Sprintf("%s/%s/@v/%s.info", proxyBase, escapePath(m.Path), m.Version)
 	resp, err := http.Get(url) //nolint:gosec // url is built from constant proxy base + sanitized module path
 	if err != nil {
@@ -735,6 +772,12 @@ func fetchInfo(m module) (*proxyInfo, error) {
 }
 
 func fetchZip(m module) (*zip.Reader, error) {
+	if body := readCached(m, ".zip"); body != nil {
+		if r, err := zip.NewReader(bytes.NewReader(body), int64(len(body))); err == nil {
+			return r, nil
+		}
+	}
+
 	url := fmt.Sprintf("%s/%s/@v/%s.zip", proxyBase, escapePath(m.Path), m.Version)
 	resp, err := http.Get(url) //nolint:gosec // url is built from constant proxy base + sanitized module path
 	if err != nil {
@@ -810,3 +853,44 @@ func die(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "licensereport: "+format+"\n", args...)
 	os.Exit(1)
 }
+
+// readCached reads m's <ext> artifact from the module cache, or returns nil.
+// Any error is a miss; the caller falls back to the proxy.
+func readCached(m module, ext string) []byte {
+	p := cachePath(m, ext)
+	if p == "" {
+		return nil
+	}
+	body, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	return body
+}
+
+// cachePath returns where the module cache would hold m's <ext> artifact, or
+// "" if there's no usable cache. Path and version both take the proxy's case
+// encoding, matching the on-disk layout.
+func cachePath(m module, ext string) string {
+	dir := modCacheDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, filepath.FromSlash(escapePath(m.Path)), "@v", escapePath(m.Version)+ext)
+}
+
+// modCacheDir returns $GOMODCACHE/cache/download, the go command's local
+// mirror of the proxy. It holds byte-identical .info and .zip artifacts under
+// the same "!<lower>"-escaped layout, Origin field included. Empty if `go env`
+// fails, which degrades every lookup to a proxy fetch.
+var modCacheDir = sync.OnceValue(func() string {
+	out, err := exec.Command("go", "env", "GOMODCACHE").Output()
+	if err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "cache", "download")
+})

--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -128,7 +128,10 @@ tasks:
     # gotohelm invocations)
     # `go build -n` reports all commands to build without running them. When a
     # rebuild is required, the final lines will contain: 'mv $WORK/<somepath> < -o flag >'.
-    # Negating the output of grep effectively indicates if go thinks a rebuild
-    # is required. Command must be encased in "s as the negation operator (!)
-    # is otherwise consumed during YAML parsing.
-    - "! go build -C {{ .DIR }} -n -ldflags='{{ .LD_FLAGS }}' -o ../.build/{{ .DIR }} {{ .PACKAGE }} 2>&1 | grep 'mv $WORK'"
+    # An empty grep therefore means go considers the binary current.
+    #
+    # Do not rewrite this as `! go build -n ... | grep ...`: Task runs status
+    # through mvdan/sh, where `!` binds to the pipeline's first command rather
+    # than the pipeline, so the status took grep's exit code (1 == no match)
+    # as "needs rebuild" and never once reported up-to-date.
+    - 'test -z "$(go build -C {{ .DIR }} -n -ldflags=''{{ .LD_FLAGS }}'' -o ../.build/{{ .DIR }} {{ .PACKAGE }} 2>&1 | grep ''mv $WORK'')"'

--- a/taskfiles/charts.yml
+++ b/taskfiles/charts.yml
@@ -3,20 +3,40 @@ version: '3'
 tasks:
   generate:
     desc: "Run all file generation tasks"
+    deps:
+      # console, operator and connectors share no inputs, so they can be
+      # generated in parallel.
+    - generate:console
+    - generate:operator
+    - generate:connectors
     cmds:
-      - task: generate:console
-      - task: generate:operator
       - task: generate:redpanda
-      - task: generate:connectors
-      # Generate chart README.md's
-      - helm-docs --chart-to-generate charts/connectors,charts/console/chart,operator/chart,charts/redpanda/chart
+      - task: generate:readmes
+
+  # Generate chart README.md's
+  generate:readmes:
+    internal: true
+    sources:
+    - ./charts/connectors/*.yaml
+    - ./charts/connectors/README.md.gotmpl
+    - ./charts/console/chart/*.yaml
+    - ./charts/console/chart/README.md.gotmpl
+    - ./charts/redpanda/chart/*.yaml
+    - ./charts/redpanda/chart/README.md.gotmpl
+    - ./operator/chart/*.yaml
+    - ./operator/chart/README.md.gotmpl
+    generates:
+    - ./charts/connectors/README.md
+    - ./charts/console/chart/README.md
+    - ./charts/redpanda/chart/README.md
+    - ./operator/chart/README.md
+    cmds:
+    - helm-docs --chart-to-generate charts/connectors,charts/console/chart,operator/chart,charts/redpanda/chart
 
   generate:console:
     desc: "Generate files for the console Helm chart"
-    deps:
-    - task: :build:gen
     cmds:
-    - cmd: cd charts/console && gen partial --out zz_generated.config.go --package console --struct Config github.com/redpanda-data/console/backend/pkg/config
+    - task: generate:console:config
     - task: genpartial
       vars: { CHART: console, STRUCT: RenderValues }
     - task: genpartial
@@ -25,6 +45,23 @@ tasks:
       vars: { CHART: console, DIR: charts/console/chart }
     - task: gotohelm
       vars: { CHART: console/chart, BUNDLE: ['github.com/redpanda-data/redpanda-operator/charts/console/v3'] }
+
+  # A partial of Console's own Config struct. Unlike genpartial it takes no
+  # --header, and its input is an external package -- hence a fingerprint on
+  # the console module's version rather than on any file here.
+  generate:console:config:
+    internal: true
+    deps:
+    - task: :build:gen
+    dir: charts/console
+    sources:
+    - ./go.mod
+    - ./go.sum
+    - ../../gen/partial/*.go
+    generates:
+    - ./zz_generated.config.go
+    cmds:
+    - gen partial --out zz_generated.config.go --package console --struct Config github.com/redpanda-data/console/backend/pkg/config
 
   generate:operator:
     desc: "Generate files for the operator Helm chart"
@@ -84,9 +121,11 @@ tasks:
     sources:
     - ./*.go
     - ./**/*.go
-    - exclude: ./values_partial.gen.go
+    - '{{ .SRC_DIR }}/licenses/boilerplate.go.txt'
+    - exclude: ./{{ .STRUCT | lower }}_partial.gen.go
+    - exclude: ./**/zz_*.go
     generates:
-    - ./values_partial.gen.go
+    - ./{{ .STRUCT | lower }}_partial.gen.go
     cmds:
     - gen partial --header {{ .SRC_DIR }}/licenses/boilerplate.go.txt --out ./{{ .STRUCT | lower }}_partial.gen.go --struct {{ .STRUCT }} .
 

--- a/taskfiles/k8s.yml
+++ b/taskfiles/k8s.yml
@@ -1,142 +1,257 @@
 version: '3'
 
+# Each task here is an input-fingerprinted wrapper around one generator, so a
+# no-op run does nothing and editing one controller regenerates one artifact.
+#
+# Source globs exclude generated output; a task that lists its own output
+# dirties itself every run. The cost is that hand-editing a generated file goes
+# unnoticed locally -- CI starts with an empty .task dir and ends with
+# `git diff --exit-code`, so it catches the drift.
+
+# Inputs for generators that walk the whole module looking for markers.
+x-operator-sources: &operator-sources
+- ./**/*.go
+- ../licenses/boilerplate.go.txt
+- exclude: ./**/zz_*.go
+- exclude: ./**/*.gen.go
+- exclude: ./api/applyconfiguration/**/*.go
+
+# Narrower set for generators pointed only at ./api, so editing a controller
+# doesn't re-run them.
+x-operator-api-sources: &operator-api-sources
+- ./api/**/*.go
+- ../licenses/boilerplate.go.txt
+- exclude: ./api/**/zz_*.go
+- exclude: ./api/applyconfiguration/**/*.go
+
 tasks:
 
   generate:
-    dir: 'operator'
     aliases:
     - generate-controller-code
     - generate-manifests
     cmds:
-      # Generates SchemaBuilders and automatically registers CRs with it.
-      - register-gen --go-header-file "../licenses/boilerplate.go.txt" --output-file 'zz_generated.register.go' ./api/redpanda/... ./api/vectorized/...
+    # register and objects write into ./api, so they precede everything that
+    # typechecks it.
+    - task: generate:register
+    - task: generate:objects
+    - task: generate:statuses
+    - task: generate:deprecations
+    - task: generate:crd-docs
+    - task: generate:rbac:itemized
+    - task: generate:rbac:embedded
+    - task: generate:rbac:testdata
+    - task: generate:applyconfiguration
+    - task: generate:conversions
 
-      # Generate the full RBAC bundle for kustomize and the operator chart, CRD
-      # manifests, and deep copy methods.
-      - |
-        controller-gen \
-          object:headerFile="../licenses/boilerplate.go.txt" \
-          paths='./...' \
-          crd \
-          webhook \
-          rbac:roleName=manager-role \
-          output:crd:artifacts:config=config/crd/bases \
-          output:rbac:artifacts:config=config/rbac/bases/operator
+  # Generates SchemaBuilders and automatically registers CRs with it.
+  generate:register:
+    internal: true
+    dir: 'operator'
+    sources: *operator-api-sources
+    generates:
+    - ./api/redpanda/**/zz_generated.register.go
+    - ./api/vectorized/**/zz_generated.register.go
+    cmds:
+    - register-gen --go-header-file "../licenses/boilerplate.go.txt" --output-file 'zz_generated.register.go' ./api/redpanda/... ./api/vectorized/...
 
-      - task: generate:statuses
-      - task: generate:deprecations
-      - task: generate:crd-docs
+  # Generate the full RBAC bundle for kustomize and the operator chart, CRD
+  # manifests, and deep copy methods.
+  generate:objects:
+    internal: true
+    dir: 'operator'
+    sources: *operator-sources
+    generates:
+    - ./config/crd/bases/*.yaml
+    - ./config/rbac/bases/operator/*.yaml
+    - ./api/**/zz_generated.deepcopy.go
+    cmds:
+    - |
+      controller-gen \
+        object:headerFile="../licenses/boilerplate.go.txt" \
+        paths='./...' \
+        crd \
+        webhook \
+        rbac:roleName=manager-role \
+        output:crd:artifacts:config=config/crd/bases \
+        output:rbac:artifacts:config=config/rbac/bases/operator
 
-      # For each controller (or really itemizable RBAC source), generate an
-      # isolated rbac bundle. These are used by the helm charts to check
-      # whether or not permissions are correctly in sync. As we allow VERY
-      # granular toggling at the moment it's critical to upkeep this bookkeeping.
-      - for:
-        - NAME: rpk-debug-bundle
-          PATH: ./internal/controller/rpkdebugbundle
-        - NAME: rack-awareness
-          PATH: ./internal/controller/rackawareness
-        - NAME: stretch-rack-awareness
-          PATH: ./internal/controller/stretchrackawareness
-        - NAME: old-decommission
-          PATH: ./internal/controller/olddecommission
-        - NAME: pvcunbinder
-          PATH: ./internal/controller/pvcunbinder
-        - NAME: v2-manager
-          PATH: ./internal/controller/redpanda
-        - NAME: console
-          PATH: ./internal/controller/console
-        - NAME: pipeline
-          PATH: ./internal/controller/pipeline
-        - NAME: v1-manager
-          PATH: ./internal/controller/vectorized
-        - NAME: decommission
-          PATH: ./internal/controller/decommissioning
-        - NAME: sidecar
-          PATH: ./cmd/sidecar
-        - NAME: leader-election
-          PATH: ./cmd/run
-        - NAME: crd-installation
-          PATH: ./cmd/crd
-        - NAME: multicluster-manager
-          PATH: ./cmd/multicluster
-        cmd: |
-          controller-gen \
-            paths={{ .ITEM.PATH }} \
-            rbac:roleName={{ .ITEM.NAME }} \
-            output:rbac:stdout > config/rbac/itemized/{{ .ITEM.NAME }}.yaml
+  # For each controller (or really itemizable RBAC source), generate an
+  # isolated rbac bundle. These are used by the helm charts to check
+  # whether or not permissions are correctly in sync. As we allow VERY
+  # granular toggling at the moment it's critical to upkeep this bookkeeping.
+  #
+  # Fanned out rather than looped: one controller-gen process each, ~150MB and
+  # under half the cores apiece, so concurrency takes ~10s down to ~4s.
+  generate:rbac:itemized:
+    internal: true
+    deps:
+    - { task: generate:rbac:bundle, vars: { NAME: rpk-debug-bundle, PACKAGE: ./internal/controller/rpkdebugbundle } }
+    - { task: generate:rbac:bundle, vars: { NAME: rack-awareness, PACKAGE: ./internal/controller/rackawareness } }
+    - { task: generate:rbac:bundle, vars: { NAME: stretch-rack-awareness, PACKAGE: ./internal/controller/stretchrackawareness } }
+    - { task: generate:rbac:bundle, vars: { NAME: old-decommission, PACKAGE: ./internal/controller/olddecommission } }
+    - { task: generate:rbac:bundle, vars: { NAME: pvcunbinder, PACKAGE: ./internal/controller/pvcunbinder } }
+    - { task: generate:rbac:bundle, vars: { NAME: v2-manager, PACKAGE: ./internal/controller/redpanda } }
+    - { task: generate:rbac:bundle, vars: { NAME: console, PACKAGE: ./internal/controller/console } }
+    - { task: generate:rbac:bundle, vars: { NAME: pipeline, PACKAGE: ./internal/controller/pipeline } }
+    - { task: generate:rbac:bundle, vars: { NAME: v1-manager, PACKAGE: ./internal/controller/vectorized } }
+    - { task: generate:rbac:bundle, vars: { NAME: decommission, PACKAGE: ./internal/controller/decommissioning } }
+    - { task: generate:rbac:bundle, vars: { NAME: sidecar, PACKAGE: ./cmd/sidecar } }
+    - { task: generate:rbac:bundle, vars: { NAME: leader-election, PACKAGE: ./cmd/run } }
+    - { task: generate:rbac:bundle, vars: { NAME: crd-installation, PACKAGE: ./cmd/crd } }
+    - { task: generate:rbac:bundle, vars: { NAME: multicluster-manager, PACKAGE: ./cmd/multicluster } }
 
-      # Collect all permissions relevant for the redpanda chart and drop them into ./files, separated by kind.
-      # The chart embeds these permissions so they can't get out of sync with the operator.
-      - rm ../charts/redpanda/chart/files/*.yaml
-      - |
-        yq e \
-          --split-exp '"../charts/redpanda/chart/files/\( .metadata.name ).\( .kind ).yaml"' \
-          '.' \
-          ./config/rbac/itemized/decommission.yaml \
-          ./config/rbac/itemized/pvcunbinder.yaml \
-          ./config/rbac/itemized/sidecar.yaml \
-          ./config/rbac/itemized/rpk-debug-bundle.yaml \
-          ./config/rbac/itemized/rack-awareness.yaml
+  generate:rbac:bundle:
+    internal: true
+    run: when_changed
+    label: "generate:rbac:bundle:{{ .NAME }}"
+    dir: 'operator'
+    requires:
+      vars: [NAME, PACKAGE]
+    # `paths` has no `/...`, so only this directory's markers are read.
+    sources:
+    - '{{ .PACKAGE }}/*.go'
+    generates:
+    - ./config/rbac/itemized/{{ .NAME }}.yaml
+    cmds:
+    - |
+      controller-gen \
+        paths={{ .PACKAGE }} \
+        rbac:roleName={{ .NAME }} \
+        output:rbac:stdout > config/rbac/itemized/{{ .NAME }}.yaml
 
-      # And once more for the Operator's chart.
-      - mkdir -p chart/files/rbac/ && (rm chart/files/rbac/*.yaml || true)
-      - |
-        yq e \
-          --split-exp '"chart/files/rbac/\( .metadata.name ).\( .kind ).yaml"' \
-          '.' \
-          ./config/rbac/itemized/decommission.yaml \
-          ./config/rbac/itemized/leader-election.yaml \
-          ./config/rbac/itemized/old-decommission.yaml \
-          ./config/rbac/itemized/pvcunbinder.yaml \
-          ./config/rbac/itemized/rack-awareness.yaml \
-          ./config/rbac/itemized/stretch-rack-awareness.yaml \
-          ./config/rbac/itemized/rpk-debug-bundle.yaml \
-          ./config/rbac/itemized/sidecar.yaml \
-          ./config/rbac/itemized/crd-installation.yaml \
-          ./config/rbac/itemized/multicluster-manager.yaml \
-          ./config/rbac/itemized/pipeline.yaml \
-          ./config/rbac/itemized/v1-manager.yaml \
-          ./config/rbac/itemized/v2-manager.yaml \
-          ./config/rbac/itemized/console.yaml
+  # Collect all permissions relevant for the redpanda chart and drop them into ./files, separated by kind.
+  # The chart embeds these permissions so they can't get out of sync with the operator.
+  generate:rbac:embedded:
+    internal: true
+    dir: 'operator'
+    sources:
+    - ./config/rbac/itemized/*.yaml
+    generates:
+    - ../charts/redpanda/chart/files/*.yaml
+    - ./chart/files/rbac/*.yaml
+    cmds:
+    - rm ../charts/redpanda/chart/files/*.yaml
+    - |
+      yq e \
+        --split-exp '"../charts/redpanda/chart/files/\( .metadata.name ).\( .kind ).yaml"' \
+        '.' \
+        ./config/rbac/itemized/decommission.yaml \
+        ./config/rbac/itemized/pvcunbinder.yaml \
+        ./config/rbac/itemized/sidecar.yaml \
+        ./config/rbac/itemized/rpk-debug-bundle.yaml \
+        ./config/rbac/itemized/rack-awareness.yaml
 
-      # Some integration tests use their RBAC declarations but generally
-      # require some additional permissions (e.g. leader election, running
-      # multiple controllers)
-      - |
-        controller-gen \
-          paths=./cmd/run \
-          paths=./internal/controller/decommissioning \
-          rbac:roleName=decommissioning \
-          output:rbac:stdout > ./internal/controller/decommissioning/testdata/role.yaml
+    # And once more for the Operator's chart.
+    - mkdir -p chart/files/rbac/ && (rm chart/files/rbac/*.yaml || true)
+    - |
+      yq e \
+        --split-exp '"chart/files/rbac/\( .metadata.name ).\( .kind ).yaml"' \
+        '.' \
+        ./config/rbac/itemized/decommission.yaml \
+        ./config/rbac/itemized/leader-election.yaml \
+        ./config/rbac/itemized/old-decommission.yaml \
+        ./config/rbac/itemized/pvcunbinder.yaml \
+        ./config/rbac/itemized/rack-awareness.yaml \
+        ./config/rbac/itemized/stretch-rack-awareness.yaml \
+        ./config/rbac/itemized/rpk-debug-bundle.yaml \
+        ./config/rbac/itemized/sidecar.yaml \
+        ./config/rbac/itemized/crd-installation.yaml \
+        ./config/rbac/itemized/multicluster-manager.yaml \
+        ./config/rbac/itemized/pipeline.yaml \
+        ./config/rbac/itemized/v1-manager.yaml \
+        ./config/rbac/itemized/v2-manager.yaml \
+        ./config/rbac/itemized/console.yaml
 
-      - |
-        controller-gen \
-          paths=./cmd/run \
-          paths=./cmd/multicluster \
-          paths=./internal/controller/redpanda \
-          paths=./internal/controller/rackawareness \
-          paths=./internal/controller/rpkdebugbundle \
-          paths=./internal/controller/olddecommission \
-          rbac:roleName=manager \
-          output:rbac:stdout > ./internal/controller/redpanda/testdata/role.yaml
+  # Some integration tests use their RBAC declarations but generally
+  # require some additional permissions (e.g. leader election, running
+  # multiple controllers)
+  generate:rbac:testdata:
+    internal: true
+    deps:
+    - generate:rbac:testdata:decommissioning
+    - generate:rbac:testdata:manager
 
-      - |
-        applyconfiguration-gen \
-        --go-header-file "../licenses/boilerplate.go.txt" \
-        --output-dir "api/applyconfiguration" \
-        --output-pkg "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration" \
-        ./api/redpanda/v1alpha2
-      - find ./api/applyconfiguration/redpanda/v1alpha2 -type f -exec sed -i'' 's/"redpanda\/v1/"cluster.redpanda.com\/v1/g' {} \;
-      - rm -rf api/applyconfiguration/utils.go api/applyconfiguration/internal
+  generate:rbac:testdata:decommissioning:
+    internal: true
+    dir: 'operator'
+    sources:
+    - ./cmd/run/*.go
+    - ./internal/controller/decommissioning/*.go
+    generates:
+    - ./internal/controller/decommissioning/testdata/role.yaml
+    cmds:
+    - |
+      controller-gen \
+        paths=./cmd/run \
+        paths=./internal/controller/decommissioning \
+        rbac:roleName=decommissioning \
+        output:rbac:stdout > ./internal/controller/decommissioning/testdata/role.yaml
 
-      # Generate rote conversion functions.
-      # Must run after deepcopy is generated.
-      - goverter gen ./api/redpanda/v1alpha2/
+  generate:rbac:testdata:manager:
+    internal: true
+    dir: 'operator'
+    sources:
+    - ./cmd/run/*.go
+    - ./cmd/multicluster/*.go
+    - ./internal/controller/redpanda/*.go
+    - ./internal/controller/rackawareness/*.go
+    - ./internal/controller/rpkdebugbundle/*.go
+    - ./internal/controller/olddecommission/*.go
+    generates:
+    - ./internal/controller/redpanda/testdata/role.yaml
+    cmds:
+    - |
+      controller-gen \
+        paths=./cmd/run \
+        paths=./cmd/multicluster \
+        paths=./internal/controller/redpanda \
+        paths=./internal/controller/rackawareness \
+        paths=./internal/controller/rpkdebugbundle \
+        paths=./internal/controller/olddecommission \
+        rbac:roleName=manager \
+        output:rbac:stdout > ./internal/controller/redpanda/testdata/role.yaml
+
+  generate:applyconfiguration:
+    internal: true
+    dir: 'operator'
+    sources: *operator-api-sources
+    generates:
+    - ./api/applyconfiguration/**/*.go
+    cmds:
+    - |
+      applyconfiguration-gen \
+      --go-header-file "../licenses/boilerplate.go.txt" \
+      --output-dir "api/applyconfiguration" \
+      --output-pkg "github.com/redpanda-data/redpanda-operator/operator/api/applyconfiguration" \
+      ./api/redpanda/v1alpha2
+    - find ./api/applyconfiguration/redpanda/v1alpha2 -type f -exec sed -i'' 's/"redpanda\/v1/"cluster.redpanda.com\/v1/g' {} \;
+    - rm -rf api/applyconfiguration/utils.go api/applyconfiguration/internal
+
+  # Generate rote conversion functions.
+  # Must run after deepcopy is generated, hence its position after
+  # generate:objects above.
+  generate:conversions:
+    internal: true
+    dir: 'operator'
+    sources: *operator-api-sources
+    generates:
+    - ./api/redpanda/v1alpha2/zz_generated.conversion.go
+    cmds:
+    - goverter gen ./api/redpanda/v1alpha2/
 
   generate:crd-docs:
     desc: Generates an example ascii doc from our crd-ref-docs configuration.
     dir: 'operator'
+    sources:
+    - ./api/redpanda/v1alpha2/*.go
+    # Only the hand-written types reach the doc; the zz_* files alongside them
+    # would just dirty this task whenever they're regenerated.
+    - exclude: ./api/redpanda/v1alpha2/zz_*.go
+    - ./crd-ref-docs-config.yaml
+    - ./crd-docs-templates/*
+    generates:
+    - ./api/redpanda/v1alpha2/testdata/crd-docs.adoc
     cmds:
     - |
       crd-ref-docs \
@@ -148,6 +263,11 @@ tasks:
   generate:deprecations:
     label: "generate:deprecations"
     desc: "Generate the deprecation tests for our deprecation warnings."
+    sources:
+    - ./operator/api/redpanda/v1alpha2/*.go
+    - exclude: ./operator/api/redpanda/v1alpha2/zz_*.go
+    generates:
+    - ./operator/api/redpanda/v1alpha2/zz_generated.deprecations_test.go
     cmds:
     - rp-controller-gen deprecations --directory ./operator/api/redpanda/v1alpha2
 


### PR DESCRIPTION
**build: fingerprint and parallelize `task generate`**
Cold run 2m18s -> 57s

Reorders the dependency graph to be as parallel as possible, reduces
duplication in some cases, fixes subtly incorrect fingerprinting, adds
fingerprinting where possible, and uses `golangci-lint fmt` instead of
`run`.

**licensereport: use cached resolutions**
licensereport needlessly hit the network on every run.

`listPackages` downloads all modules into $GOMODCACHE/cache/download.
When present, .info and .zip files will be pulled from it.

Licenses were previously re-resolved every run; often serially hitting
404s. Instead use `third_party.md` as a cache. `--validate-full` will
still re-derive the entire list from scratch. As CI has no go module
caching, it acts as a safety net.

These changes drop runs from 26.3s -> 2.5s