### PR TITLE
operator: fix nightly multicluster failures — nil test factory, config-sync starvation, NotReady-node endpoints

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260903-210000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260903-210000.yaml
@@ -1,0 +1,8 @@
+project: operator
+kind: Fixed
+body: |-
+    In the multicluster operator, a persistently failing maintenance-mode,
+    stale-disk-wipe, or decommission step no longer blocks a StretchCluster's
+    cluster-config and license synchronization; previously `ConfigurationApplied`
+    could report `True` indefinitely while spec changes were never applied.
+time: 2026-09-03T21:00:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260903-210100.yaml
+++ b/.changes/unreleased/operator-Fixed-20260903-210100.yaml
@@ -1,0 +1,8 @@
+project: operator
+kind: Fixed
+body: |-
+    StretchCluster admin, Kafka, and Schema Registry clients no longer dial
+    broker pods on a node that has gone NotReady. Such pods keep their address
+    while being unreachable, previously wedging cluster-health fetches — and
+    with them decommission and pool cleanup — behind connection timeouts.
+time: 2026-09-03T21:01:00.000000-07:00

--- a/.changes/unreleased/operator-Fixed-20260904-090000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260904-090000.yaml
@@ -1,0 +1,8 @@
+project: operator
+kind: Fixed
+body: |-
+    StretchCluster clients keep at least two admin hosts: when endpoint
+    filtering leaves a single broker, the list is padded from the declared
+    endpoints so rpadmin retains leader resolution and try-every-host reads
+    instead of failing every request against one churning broker.
+time: 2026-09-04T09:00:00.000000-07:00

--- a/operator/internal/controller/redpanda/maintenance_mode_test.go
+++ b/operator/internal/controller/redpanda/maintenance_mode_test.go
@@ -31,6 +31,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/redpanda-data/redpanda-operator/operator/internal/lifecycle"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/observability"
@@ -1460,7 +1462,7 @@ func TestRedpandaReconcilerRunsMaintenanceModeBeforeDecommission(t *testing.T) {
 // ordering on the MulticlusterReconciler chain.
 func TestMulticlusterReconcilerRunsMaintenanceModeBeforeDecommission(t *testing.T) {
 	r := &MulticlusterReconciler{}
-	chain := r.clusterReconcilers()
+	chain := r.clusterRemediationReconcilers()
 	names := make([]string, len(chain))
 	for i, fn := range chain {
 		names[i] = reconcilerStepName(fn)
@@ -1480,7 +1482,7 @@ func TestMulticlusterReconcilerRunsMaintenanceModeBeforeDecommission(t *testing.
 // bad_rejoin's stuck-not-Ready pod always is (K8S-843).
 func TestMulticlusterReconcilerRunsStaleDiskWipeBeforeDecommission(t *testing.T) {
 	r := &MulticlusterReconciler{}
-	chain := r.clusterReconcilers()
+	chain := r.clusterRemediationReconcilers()
 	names := make([]string, len(chain))
 	for i, fn := range chain {
 		names[i] = reconcilerStepName(fn)
@@ -1527,7 +1529,7 @@ func TestReconcilersRunMaintenanceModeBeforeStaleDiskWipe(t *testing.T) {
 	}
 	{
 		r := &MulticlusterReconciler{}
-		chain := r.clusterReconcilers()
+		chain := r.clusterRemediationReconcilers()
 		names := make([]string, len(chain))
 		for i, fn := range chain {
 			names[i] = reconcilerStepName(fn)
@@ -1582,4 +1584,69 @@ func TestClearStuckMaintenanceModeDefersOnBrokerListFailure(t *testing.T) {
 
 	require.NoError(t, clearStuckMaintenanceMode(ctx, client, pods, 5*time.Minute, nil, testr.New(t)),
 		"an unreadable broker list must defer the pass, not abort the reconcile chain")
+}
+
+// TestMulticlusterSyncStepsAreNotBehindRemediation pins the Phase-3 group
+// membership: the declarative syncs (cluster config, license) live in the
+// independent group, not behind the fail-fast remediation chain, or a
+// persistently failing reconcileDecommission (e.g. cluster health unreachable
+// during broker churn) freezes Status.ConfigVersion while ConfigurationApplied
+// sits at a stale True.
+func TestMulticlusterSyncStepsAreNotBehindRemediation(t *testing.T) {
+	r := &MulticlusterReconciler{}
+	remNames := make([]string, 0)
+	for _, fn := range r.clusterRemediationReconcilers() {
+		remNames = append(remNames, reconcilerStepName(fn))
+	}
+	syncNames := make([]string, 0)
+	for _, fn := range r.clusterSyncReconcilers() {
+		syncNames = append(syncNames, reconcilerStepName(fn))
+	}
+	require.GreaterOrEqual(t, indexOfReconcilerStep(syncNames, "reconcileClusterConfig"), 0, "reconcileClusterConfig not in the sync group: %v", syncNames)
+	require.GreaterOrEqual(t, indexOfReconcilerStep(syncNames, "reconcileLicense"), 0, "reconcileLicense not in the sync group: %v", syncNames)
+	assert.Equal(t, -1, indexOfReconcilerStep(remNames, "reconcileClusterConfig"), "reconcileClusterConfig must not be behind the fail-fast remediation chain: %v", remNames)
+	assert.Equal(t, -1, indexOfReconcilerStep(remNames, "reconcileLicense"), "reconcileLicense must not be behind the fail-fast remediation chain: %v", remNames)
+}
+
+// TestRunOrderedStepsStopsAtFirstAbort: later remediation steps depend on
+// earlier ones, so the first error or requeue ends the group for this pass.
+func TestRunOrderedStepsStopsAtFirstAbort(t *testing.T) {
+	var ran []string
+	step := func(name string, result ctrl.Result, err error) stretchClusterReconciliationFn {
+		return func(context.Context, *stretchClusterReconciliationState, cluster.Cluster) (ctrl.Result, error) {
+			ran = append(ran, name)
+			return result, err
+		}
+	}
+	boom := errors.New("boom")
+	result, err := runOrderedSteps(t.Context(), nil, nil, []stretchClusterReconciliationFn{
+		step("a", ctrl.Result{}, nil),
+		step("b", ctrl.Result{}, boom),
+		step("c", ctrl.Result{}, nil),
+	})
+	assert.Equal(t, []string{"a", "b"}, ran, "steps after the first abort must not run")
+	assert.ErrorIs(t, err, boom)
+	assert.Zero(t, result.RequeueAfter)
+}
+
+// TestRunIndependentStepsRunsEveryStep: a failing sync step must not starve
+// the rest of the group — every step runs, errors are joined so none is
+// dropped, and the soonest requested requeue wins.
+func TestRunIndependentStepsRunsEveryStep(t *testing.T) {
+	var ran []string
+	step := func(name string, result ctrl.Result, err error) stretchClusterReconciliationFn {
+		return func(context.Context, *stretchClusterReconciliationState, cluster.Cluster) (ctrl.Result, error) {
+			ran = append(ran, name)
+			return result, err
+		}
+	}
+	boom := errors.New("boom")
+	result, err := runIndependentSteps(t.Context(), nil, nil, []stretchClusterReconciliationFn{
+		step("a", ctrl.Result{}, boom),
+		step("b", ctrl.Result{RequeueAfter: time.Minute}, nil),
+		step("c", ctrl.Result{RequeueAfter: time.Second}, nil),
+	})
+	assert.Equal(t, []string{"a", "b", "c"}, ran, "every independent step must run despite the first one failing")
+	assert.ErrorIs(t, err, boom)
+	assert.Equal(t, time.Second, result.RequeueAfter, "the soonest requested requeue must win")
 }

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -363,19 +363,28 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 		state.status.StretchClusterStatus.SetResourcesSynced(statuses.StretchClusterResourcesSyncedReasonSynced)
 	}
 
-	// Phase 3: cluster-level reconciliation (admin API, maintenance mode,
-	// stale-disk wipe, decommission, config, license) — see clusterReconcilers
-	// for ordering. Deliberately NOT gated on the pool view: these steps act
-	// through the admin API and on the pods/pools we can see, and any
-	// "no desired counterpart → drain" decision inside them is separately
-	// guarded by the per-cluster observed set threaded into
-	// FetchExistingAndDesiredPools.
-	for _, reconciler := range r.clusterReconcilers() {
-		result, err := reconciler(ctx, state, cluster)
-		if err != nil || result.RequeueAfter > 0 {
-			l.V(log.TraceLevel).Info("aborting reconciliation early", "error", err, "requeueAfter", result.RequeueAfter)
-			return r.syncStatus(ctx, cluster, state, result, err)
-		}
+	// Phase 3: cluster-level reconciliation. Deliberately NOT gated on the
+	// pool view: these steps act through the admin API and on the pods/pools
+	// we can see, and any "no desired counterpart → drain" decision inside
+	// them is separately guarded by the per-cluster observed set threaded
+	// into FetchExistingAndDesiredPools.
+	//
+	// initAdminClient gates everything below. The remediation steps run in
+	// strict order and stop at the first error or requeue (see
+	// clusterRemediationReconcilers), but the declarative syncs still run
+	// afterwards: a persistently failing remediation step — e.g.
+	// reconcileDecommission unable to fetch cluster health during broker
+	// churn — must not starve cluster-config and license sync, or
+	// ConfigurationApplied sits at a stale True while the spec has moved on.
+	phase3Result, phase3Err := r.initAdminClient(ctx, state, cluster)
+	if phase3Err == nil && phase3Result.RequeueAfter == 0 {
+		remResult, remErr := runOrderedSteps(ctx, state, cluster, r.clusterRemediationReconcilers())
+		syncResult, syncErr := runIndependentSteps(ctx, state, cluster, r.clusterSyncReconcilers())
+		phase3Result, phase3Err = soonerRequeue(remResult, syncResult), errors.Join(remErr, syncErr)
+	}
+	if phase3Err != nil || phase3Result.RequeueAfter > 0 {
+		l.V(log.TraceLevel).Info("aborting reconciliation early", "error", phase3Err, "requeueAfter", phase3Result.RequeueAfter)
+		return r.syncStatus(ctx, cluster, state, phase3Result, phase3Err)
 	}
 
 	// we're at the end of reconciliation, so sync back our status.
@@ -399,11 +408,11 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 	return r.syncStatus(ctx, cluster, state, pollResult, nil)
 }
 
-// clusterReconcilers returns the ordered cluster-level reconcile steps
-// (admin API, maintenance mode, stale-disk wipe, decommission, config, license).
-// Order matters: any step returning a non-zero RequeueAfter or an error aborts
-// the rest of the chain for this pass, so a step whose completion is a
-// precondition for another must come first.
+// clusterRemediationReconcilers returns the ordered remediation steps
+// (maintenance mode, stale-disk wipe, decommission). Order matters: any step
+// returning a non-zero RequeueAfter or an error stops the rest of this group
+// for the pass, so a step whose completion is a precondition for another must
+// come first. initAdminClient runs before this group in Reconcile.
 //
 // reconcileMaintenanceMode must precede reconcileDecommission specifically:
 // reconcileDecommission requeues for as long as a decommission it started is
@@ -413,21 +422,70 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 //
 // reconcileStaleDiskWipe must precede reconcileDecommission: reconcileDecommission
 // runs the rolling-restart pre-check and requeues (aborting the rest of the
-// chain) whenever HasRecentlyReplacedPods() is true — i.e. while any recently
+// group) whenever HasRecentlyReplacedPods() is true — i.e. while any recently
 // replaced pod is still not-Ready. A decommissioned-broker bad_rejoin (K8S-843)
 // is exactly that state (its pod is stuck not-Ready), so if the wipe step were
 // ordered after reconcileDecommission it would never run to recover the very
 // bad_rejoin it exists for. Running it first lets it destroy the stale disk and
 // unblock the pod before the roll-loop deferral aborts the pass.
-func (r *MulticlusterReconciler) clusterReconcilers() []stretchClusterReconciliationFn {
+func (r *MulticlusterReconciler) clusterRemediationReconcilers() []stretchClusterReconciliationFn {
 	return []stretchClusterReconciliationFn{
-		r.initAdminClient,
 		r.reconcileMaintenanceMode,
 		r.reconcileStaleDiskWipe,
 		r.reconcileDecommission,
+	}
+}
+
+// clusterSyncReconcilers returns the declarative sync steps (license, cluster
+// config). They run every pass once the admin client is initialized — even
+// when a remediation step failed or requeued, and independently of each other
+// — because they share no preconditions with the remediation group and
+// skipping them turns any persistent remediation failure into a silent config
+// and license freeze.
+func (r *MulticlusterReconciler) clusterSyncReconcilers() []stretchClusterReconciliationFn {
+	return []stretchClusterReconciliationFn{
 		r.reconcileLicense,
 		r.reconcileClusterConfig,
 	}
+}
+
+// runOrderedSteps runs steps in order, stopping at the first error or
+// non-zero requeue: later steps depend on earlier ones having completed.
+func runOrderedSteps(ctx context.Context, state *stretchClusterReconciliationState, cluster cluster.Cluster, steps []stretchClusterReconciliationFn) (ctrl.Result, error) {
+	for _, step := range steps {
+		result, err := step(ctx, state, cluster)
+		if err != nil || result.RequeueAfter > 0 {
+			log.FromContext(ctx).V(log.TraceLevel).Info("stopping ordered steps early", "error", err, "requeueAfter", result.RequeueAfter)
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// runIndependentSteps runs every step even when an earlier one fails, joining
+// errors and keeping the soonest requested requeue: the steps don't depend on
+// one another, and stopping early would starve the rest behind a persistent
+// failure.
+func runIndependentSteps(ctx context.Context, state *stretchClusterReconciliationState, cluster cluster.Cluster, steps []stretchClusterReconciliationFn) (ctrl.Result, error) {
+	var combined ctrl.Result
+	var errs error
+	for _, step := range steps {
+		result, err := step(ctx, state, cluster)
+		errs = errors.Join(errs, err)
+		combined = soonerRequeue(combined, result)
+	}
+	return combined, errs
+}
+
+// soonerRequeue merges two results, keeping the soonest non-zero RequeueAfter.
+func soonerRequeue(a, b ctrl.Result) ctrl.Result {
+	if a.RequeueAfter == 0 {
+		return b
+	}
+	if b.RequeueAfter != 0 && b.RequeueAfter < a.RequeueAfter {
+		return b
+	}
+	return a
 }
 
 // findAliveCluster checks whether the StretchCluster exists and is NOT being
@@ -2008,6 +2066,12 @@ func (r *MulticlusterReconciler) setupLicense(ctx context.Context, sc *redpandav
 }
 
 func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, redpandaImage lifecycle.Image, sidecarImage lifecycle.Image, cloudSecrets lifecycle.CloudSecretsFlags, factory *internalclient.Factory, reconcileTimeout time.Duration, brokerPodNodeUnavailableToleration time.Duration, postRestartCaughtUpPercent int, waitForSchemaRegistrySync bool, clearMaintenanceModeAfter time.Duration, staleDiskWipeNotReadyThreshold time.Duration) error {
+	// A nil factory survives until the first reconcile that builds an admin
+	// client, then panics on every such pass (Factory methods dispatch fine on
+	// a nil receiver until the first field access). Refuse it at startup.
+	if factory == nil {
+		return errors.New("SetupMulticlusterController requires a non-nil client factory")
+	}
 	return mcbuilder.ControllerManagedBy(mgr).WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
 		// NB: This is gross, but currently the multicluster runtime doesn't hand this global option off to the controller
 		// registration properly, so we can't boot multiple controllers in test without doing this.

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/redpanda-data/redpanda-operator/operator/internal/statuses"
 	"github.com/redpanda-data/redpanda-operator/operator/internal/testenv"
 	rendermulticluster "github.com/redpanda-data/redpanda-operator/operator/multicluster"
+	internalclient "github.com/redpanda-data/redpanda-operator/operator/pkg/client"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster/bootstrap"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
@@ -100,7 +101,10 @@ func (s *MulticlusterControllerSuite) SetupSuite() {
 		WatchAllNamespaces: true,
 		InstallCertManager: true,
 		SetupFn: func(mgr multicluster.Manager) error {
-			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, nil, 0, 0, 100 /* post-restart caught-up % */, false /* wait-for-schema-registry-sync (factory is nil here) */, 5*time.Minute /* clear-maintenance-mode-after */, 0 /* wipe-stale-disk-after (default) */)
+			// A real factory, as in cmd/multicluster: a nil one panics the
+			// reconciler on the first admin-client build.
+			factory := internalclient.NewFactory(mgr, nil)
+			return redpanda.SetupMulticlusterController(s.ctx, mgr, redpandaImage, sidecarImage, cloudSecrets, factory, 0, 0, 100 /* post-restart caught-up % */, false /* wait-for-schema-registry-sync */, 5*time.Minute /* clear-maintenance-mode-after */, 0 /* wipe-stale-disk-after (default) */)
 		},
 	})
 }

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -377,9 +377,7 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 // The endpoint list is otherwise built from declared replica counts alone, so
 // it offers brokers that are deliberately absent -- a just-deleted pool, a
 // broker mid-roll -- and rpadmin pays for each such host with wasted attempts,
-// timeouts, and stale-leader backoffs on every reconcile. A pod on a NotReady
-// node still holds its address and still counts as dialable, so this narrows
-// that window rather than closing it.
+// timeouts, and stale-leader backoffs on every reconcile.
 func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseName string) (map[string]bool, error) {
 	listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
 	defer listCancel()
@@ -403,16 +401,29 @@ func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseN
 	return dialable, nil
 }
 
+// podReasonNodeNotReady is the Ready-condition reason the node lifecycle
+// controller stamps on every pod of a node that stopped reporting
+// (MarkPodsNotReady in k8s.io/kubernetes/pkg/controller/nodelifecycle).
+const podReasonNodeNotReady = "NodeNotReady"
+
 // podDialable reports whether a connection to pod can be established at all:
-// not terminating, not finished, and holding an address. Readiness is
-// deliberately excluded -- the operator reads rejoining brokers through unready
-// pods on purpose, and the per-pod Services publish not-ready addresses.
+// not terminating, not finished, holding an address, and not sitting on a
+// NotReady node. App-level readiness is deliberately excluded -- the operator
+// reads rejoining brokers through unready pods on purpose, and the per-pod
+// Services publish not-ready addresses -- but a pod whose NODE is gone keeps
+// its address while being unreachable, so offering it wedges health fetches
+// (and with them decommission) behind connection timeouts.
 func podDialable(pod *corev1.Pod) bool {
 	if pod.DeletionTimestamp != nil {
 		return false
 	}
 	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionFalse && cond.Reason == podReasonNodeNotReady {
+			return false
+		}
 	}
 	return pod.Status.PodIP != ""
 }

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -301,8 +301,10 @@ func (c *Factory) schemaRegistryForStretchCluster(ctx context.Context, sc *redpa
 // across all clusters known to the manager, and builds per-pod endpoint addresses
 // for the given port.
 func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alpha2.StretchCluster, port int32) ([]string, error) {
-	// All endpoints the pool specs declare, and the subset whose pod is dialable.
-	var declared, dialable []string
+	// All endpoints the pool specs declare, the subset whose pod is dialable,
+	// and the subset with no backing pod at all (candidates for padding: the
+	// dialer rejects them instantly, unlike a pod that holds a dead address).
+	var declared, dialable, absent []string
 
 	for _, clusterName := range c.mgr.GetClusterNames() {
 		// Skip peers the probe has marked unreachable. Without this the List
@@ -334,7 +336,7 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 			return nil, errors.Wrapf(err, "listing RedpandaBrokerPools in cluster %s", clusterName)
 		}
 
-		servable, podsErr := dialablePodNames(ctx, k8sClient, sc.Namespace, sc.Name)
+		servable, podsErr := podDialability(ctx, k8sClient, sc.Namespace, sc.Name)
 		podsKnown := podsErr == nil
 		if !podsKnown {
 			// A failed pod list costs only the filter: offer this cluster's
@@ -355,30 +357,56 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 				endpoint := fmt.Sprintf("%s.%s:%d", name, pool.GetNamespace(), port)
 				declared = append(declared, endpoint)
 				// A per-pod Service and its backing Pod share a name.
-				if !podsKnown || servable[name] {
+				canDial, exists := servable[name]
+				switch {
+				case !podsKnown || canDial:
 					dialable = append(dialable, endpoint)
+				case !exists:
+					absent = append(absent, endpoint)
 				}
 			}
 		}
 	}
 
-	// Prefer brokers that can answer. With none dialable (a whole-cluster
-	// outage), return the declared list so that case fails exactly as it used to.
-	if len(dialable) > 0 {
-		return dialable, nil
-	}
-	return declared, nil
+	return pickAdminEndpoints(declared, dialable, absent), nil
 }
 
-// dialablePodNames returns the names of pods in ns that can currently accept a
-// connection. A non-nil error means the pod state is unknown, which the caller
-// treats as "do not filter" rather than as a failure.
+// pickAdminEndpoints chooses the hosts offered to rpadmin. The dialable
+// subset wins outright when it holds at least two hosts. A single-URL list
+// flips rpadmin into single-host mode — no leader resolution, no
+// try-every-host reads (#1783) — so one churning broker would fail every
+// request; pad back up to two from the declared list, preferring an endpoint
+// whose pod is gone entirely (the dialer rejects those instantly, while a pod
+// on a NotReady node holds its address and costs a connect timeout). With
+// nothing dialable (a whole-cluster outage) return the declared list so that
+// case fails exactly as it always has.
+func pickAdminEndpoints(declared, dialable, absent []string) []string {
+	if len(dialable) == 0 {
+		return declared
+	}
+	if len(dialable) >= 2 {
+		return dialable
+	}
+	for _, candidates := range [][]string{absent, declared} {
+		for _, ep := range candidates {
+			if ep != dialable[0] {
+				return append(dialable, ep)
+			}
+		}
+	}
+	return dialable
+}
+
+// podDialability maps each of this cluster's broker pods in ns to whether it
+// can currently accept a connection. A declared endpoint missing from the map
+// has no backing pod at all. A non-nil error means the pod state is unknown,
+// which the caller treats as "do not filter" rather than as a failure.
 //
 // The endpoint list is otherwise built from declared replica counts alone, so
 // it offers brokers that are deliberately absent -- a just-deleted pool, a
 // broker mid-roll -- and rpadmin pays for each such host with wasted attempts,
 // timeouts, and stale-leader backoffs on every reconcile.
-func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseName string) (map[string]bool, error) {
+func podDialability(ctx context.Context, k8sClient client.Client, ns, releaseName string) (map[string]bool, error) {
 	listCtx, listCancel := context.WithTimeout(ctx, lifecycle.RemoteCallTimeout)
 	defer listCancel()
 
@@ -394,9 +422,7 @@ func dialablePodNames(ctx context.Context, k8sClient client.Client, ns, releaseN
 
 	dialable := make(map[string]bool, len(pods.Items))
 	for i := range pods.Items {
-		if podDialable(&pods.Items[i]) {
-			dialable[pods.Items[i].Name] = true
-		}
+		dialable[pods.Items[i].Name] = podDialable(&pods.Items[i])
 	}
 	return dialable, nil
 }

--- a/operator/pkg/client/stretch_cluster_endpoints_test.go
+++ b/operator/pkg/client/stretch_cluster_endpoints_test.go
@@ -72,6 +72,20 @@ func TestPodDialable(t *testing.T) {
 			want: true,
 		},
 		{
+			// The node lifecycle controller stamps this reason when the pod's
+			// node stops reporting; the pod keeps its address but nothing
+			// answers on it, so it must not be offered as an endpoint.
+			name: "unready because its node is gone",
+			pod: pod("broker-0", func(p *corev1.Pod) {
+				p.Status.Conditions = []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+					Reason: "NodeNotReady",
+				}}
+			}),
+			want: false,
+		},
+		{
 			name: "terminating",
 			pod: pod("broker-0", func(p *corev1.Pod) {
 				now := metav1.Now()

--- a/operator/pkg/client/stretch_cluster_endpoints_test.go
+++ b/operator/pkg/client/stretch_cluster_endpoints_test.go
@@ -123,9 +123,11 @@ func TestPodDialable(t *testing.T) {
 	}
 }
 
-// TestDialablePodNames covers the lookup: a deleted pool's terminating pod, a
-// pod without an address, and scoping to this cluster's brokers.
-func TestDialablePodNames(t *testing.T) {
+// TestPodDialability covers the lookup: a deleted pool's terminating pod, a
+// pod without an address, and scoping to this cluster's brokers. Every broker
+// pod appears in the map so callers can tell "exists but undialable" from
+// "no pod at all".
+func TestPodDialability(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 
@@ -164,17 +166,19 @@ func TestDialablePodNames(t *testing.T) {
 		},
 	).Build()
 
-	got, err := dialablePodNames(t.Context(), c, "redpanda", "sc")
+	got, err := podDialability(t.Context(), c, "redpanda", "sc")
 	require.NoError(t, err, "a successful list must report the pod state as known")
 	assert.Equal(t, map[string]bool{
 		"cleanup-test-cleanup-pool-0-0": true,
 		"cleanup-test-cleanup-pool-1-0": true,
+		"cleanup-test-cleanup-pool-2-0": false,
+		"config-sync-cfg-pool-0-0":      false,
 	}, got)
 }
 
-// TestDialablePodNamesListFailure pins the fallback: a failed pod list reports
+// TestPodDialabilityListFailure pins the fallback: a failed pod list reports
 // the state as unknown, and the caller then skips filtering instead of failing.
-func TestDialablePodNamesListFailure(t *testing.T) {
+func TestPodDialabilityListFailure(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 
@@ -186,7 +190,7 @@ func TestDialablePodNamesListFailure(t *testing.T) {
 			},
 		}).Build()
 
-	got, err := dialablePodNames(t.Context(), c, "redpanda", "sc")
+	got, err := podDialability(t.Context(), c, "redpanda", "sc")
 	require.Error(t, err, "a failed list must report the pod state as unknown")
 	assert.Nil(t, got)
 }
@@ -251,15 +255,18 @@ func endpointsScheme(t *testing.T) *runtime.Scheme {
 }
 
 // TestStretchClusterEndpointsSkipsUndialablePods pins the fix end to end: a
-// terminating pool's broker must not be offered to the admin client.
+// terminating pool's broker must not be offered to the admin client while
+// enough dialable brokers remain.
 func TestStretchClusterEndpointsSkipsUndialablePods(t *testing.T) {
 	scheme := endpointsScheme(t)
 	now := metav1.Now()
 
-	// Cluster one's broker is up; cluster two's pool is being deleted.
+	// Cluster one's two brokers are up; cluster two's pool is being deleted.
 	clusterOne := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		brokerPool("pool-a", "sc"),
 		pod("sc-pool-a-0"),
+		brokerPool("pool-c", "sc"),
+		pod("sc-pool-c-0"),
 	).Build()
 
 	clusterTwo := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
@@ -281,8 +288,93 @@ func TestStretchClusterEndpointsSkipsUndialablePods(t *testing.T) {
 
 	endpoints, err := c.stretchClusterEndpoints(t.Context(), sc, 9644)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"sc-pool-a-0.redpanda:9644"}, endpoints,
+	assert.ElementsMatch(t, []string{"sc-pool-a-0.redpanda:9644", "sc-pool-c-0.redpanda:9644"}, endpoints,
 		"the terminating pool's broker must not be offered to the admin client")
+}
+
+// TestStretchClusterEndpointsTwoHostFloor pins the floor end to end: with one
+// dialable broker left, the list is padded back to two so rpadmin keeps
+// leader resolution and try-every-host reads, preferring a pod-less endpoint
+// (instant dialer rejection) over one whose pod holds a dead address.
+func TestStretchClusterEndpointsTwoHostFloor(t *testing.T) {
+	scheme := endpointsScheme(t)
+	now := metav1.Now()
+
+	// Cluster one: one broker up, one terminating (pod still present).
+	clusterOne := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		brokerPool("pool-a", "sc"),
+		pod("sc-pool-a-0"),
+		brokerPool("pool-b", "sc"),
+		pod("sc-pool-b-0", func(p *corev1.Pod) {
+			p.DeletionTimestamp = &now
+			p.Finalizers = []string{"keep/for-fake-client"}
+		}),
+	).Build()
+
+	// Cluster two: the pool is declared but its pod is gone entirely.
+	clusterTwo := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		brokerPool("pool-c", "sc"),
+	).Build()
+
+	c := &Factory{mgr: &stubManager{clients: map[string]client.Client{
+		"cluster-1": clusterOne,
+		"cluster-2": clusterTwo,
+	}}}
+
+	sc := &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sc", Namespace: "redpanda"},
+	}
+
+	endpoints, err := c.stretchClusterEndpoints(t.Context(), sc, 9644)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sc-pool-a-0.redpanda:9644", "sc-pool-c-0.redpanda:9644"}, endpoints,
+		"one dialable broker must be padded with the pod-less endpoint, not the terminating pod")
+}
+
+// TestPickAdminEndpoints pins the host-list decision table, the two-host
+// floor included.
+func TestPickAdminEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		declared, dialable, absent []string
+		want                       []string
+	}{
+		{
+			name:     "nothing dialable falls back to declared",
+			declared: []string{"a", "b", "c"},
+			want:     []string{"a", "b", "c"},
+		},
+		{
+			name:     "two or more dialable stand alone",
+			declared: []string{"a", "b", "c"},
+			dialable: []string{"a", "b"},
+			absent:   []string{"c"},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "one dialable pads with an absent endpoint first",
+			declared: []string{"a", "b", "c"},
+			dialable: []string{"b"},
+			absent:   []string{"c"},
+			want:     []string{"b", "c"},
+		},
+		{
+			name:     "one dialable without absent pads from declared",
+			declared: []string{"a", "b"},
+			dialable: []string{"b"},
+			want:     []string{"b", "a"},
+		},
+		{
+			name:     "a single declared broker cannot be padded",
+			declared: []string{"a"},
+			dialable: []string{"a"},
+			want:     []string{"a"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pickAdminEndpoints(tc.declared, tc.dialable, tc.absent))
+		})
+	}
 }
 
 // TestStretchClusterEndpointsFallsBackWhenNoneDialable pins the safety valve:


### PR DESCRIPTION
**What broke**: nightly build 15561 (k3s 1.33.12, redpanda-unstable v26.2.1-rc6) failed all three multicluster targets — the drift test, `TestClusterConfigSync` (6/6 attempts), and `TestResourceCleanup` pool deletion. Build 15614 on this branch then surfaced one residual `SingleBrokerPoolDeletion` flake (300s timeout, passed on rerun).

**Why**, one cause per failure:
- The controller test suite passed `factory: nil` to `SetupMulticlusterController`; any reconcile reaching `initAdminClient` panicked, and the recovered-panic churn on the single worker starved the drift test's status writes.
- Phase 3 aborted at the first failing step, so persistent health-fetch errors during broker churn meant config/license sync never ran — `Status.ConfigVersion` froze (`d884b5186b651429` = FNV-64 of `{}`) while `ConfigurationApplied` reported a stale `True`.
- A pod on a NotReady node keeps its address, so the endpoint filter offered it and health fetches — and with them decommission and pool cleanup — wedged behind connection timeouts (#1783's named caveat).
- The residual flake is #1783's other caveat: filtering down to one host flips rpadmin into single-host mode (no leader resolution, no try-every-host reads), so the lone surviving broker's restart churn failed every health fetch for the full window.

**The fix**, one commit each:
1. The suite wires a real factory like `cmd/multicluster`; `SetupMulticlusterController` refuses nil at startup.
2. Remediation (maintenance → stale-disk wipe → decommission) keeps strict order and fail-fast; license and cluster-config sync now run every pass once the admin client is up, errors joined, soonest requeue kept.
3. `podDialable` excludes pods stamped `Ready=False/NodeNotReady`; app-level unreadiness stays dialable.
4. Two-host floor: a filtered list of one is padded back to two from the declared endpoints, preferring an endpoint with no backing pod (instant dialer rejection) over one holding a dead address. Healthy clusters are unaffected; a whole-cluster outage still falls back to the full declared list.

**Testing**: each decision is pinned by unit tests (chain grouping, step runner, `podDialable`/`podDialability`, `pickAdminEndpoints` plus end-to-end fake-cluster endpoint tests); `go build ./operator/...` and `golangci-lint` clean on touched packages. The multicluster suites need CI's k3d — build 15614 ran the first three commits green, with the targets passing first try.

Follow-up, deliberately out of scope: the single-cluster `RedpandaReconciler` has the same fail-fast chain shape (`redpanda_controller.go`).
