### PR TITLE
testenv: multicluster failure diagnostics and kube-default node health

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260906-090000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260906-090000.yaml
@@ -1,0 +1,8 @@
+project: operator
+kind: Fixed
+body: |-
+    Deleting a Redpanda or StretchCluster no longer waits for the 3-minute
+    periodic requeue before its finalizer is removed. While owned resources
+    are still being deleted the controller requeues every 10s instead of
+    relying on an incidental event.
+time: 2026-09-06T09:00:00.000000-07:00

--- a/acceptance/features/broker-crd-migration.feature
+++ b/acceptance/features/broker-crd-migration.feature
@@ -12,8 +12,9 @@ Feature: Broker CRD migration from StatefulSet
         image: ${DEFAULT_REDPANDA_REPO}
         version: ${DEFAULT_REDPANDA_TAG}
         replicas: 3
-        # The harpoon k3d cluster defaults not-ready/unreachable tolerations
-        # to 10s (pkg/k3d) so node-failure tests evict fast. These scenarios
+        # The harpoon k3d cluster sets not-ready/unreachable tolerations to
+        # 10s (k3d.WithFastNodeFailureDetection) so node-failure tests evict
+        # fast. These scenarios
         # assert pod-UID stability — a transient agent-node blip must NOT
         # evict brokers mid-scenario.
         tolerations:

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -68,12 +68,22 @@ var setupSuite = sync.OnceValues(func() (*framework.Suite, error) {
 	steps.DefaultRedpandaTag = os.Getenv("TEST_REDPANDA_VERSION")
 	steps.OperatorNamespace = sharedOperatorNamespace
 
+	// Fast (10s) node-failure detection is only for the acceptance suite's
+	// "Tolerating Node Failure" scenario. The multicluster suite must keep the
+	// Kubernetes defaults: on its shared k3d cluster the 10s grace flaps
+	// loaded nodes and tears down vclusters. HARPOON_GROUPS=multicluster is how
+	// the multicluster acceptance job selects itself.
+	k3dProvider := providers.NewK3D(5).RetainCluster()
+	if !strings.Contains(os.Getenv("HARPOON_GROUPS"), "multicluster") {
+		k3dProvider = k3dProvider.WithFastNodeFailureDetection()
+	}
+
 	builder := framework.SuiteBuilderFromFlags().
 		Strict().
 		RegisterProvider("eks", framework.NoopProvider).
 		RegisterProvider("gke", framework.NoopProvider).
 		RegisterProvider("aks", framework.NoopProvider).
-		RegisterProvider("k3d", providers.NewK3D(5).RetainCluster()).
+		RegisterProvider("k3d", k3dProvider).
 		WithDefaultProvider("k3d").
 		WithImportedImages([]string{
 			imageRepo + ":" + imageTag,

--- a/acceptance/steps/stretch.go
+++ b/acceptance/steps/stretch.go
@@ -198,8 +198,13 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 					t.Logf("[multicluster-diagnostics] failed to get logs for %s: %v", pod.Name, err)
 					continue
 				}
-				logBytes, _ := io.ReadAll(logStream)
-				_ = logStream.Close()
+				logBytes, err := io.ReadAll(logStream)
+				if err != nil {
+					t.Logf("[multicluster-diagnostics] failed to read logs for %s: %v", pod.Name, err)
+				}
+				if err := logStream.Close(); err != nil {
+					t.Logf("[multicluster-diagnostics] failed to close log stream for %s: %v", pod.Name, err)
+				}
 
 				logStr := string(logBytes)
 				dumpLayeredControllerLogs(t, pod.Name, logStr)
@@ -286,8 +291,13 @@ func dumpVClusterContainerLog(ctx context.Context, t framework.TestingT, k8sClie
 		t.Logf("[multicluster-diagnostics] failed to get logs for %s: %v", name, err)
 		return
 	}
-	logBytes, _ := io.ReadAll(stream)
-	_ = stream.Close()
+	logBytes, err := io.ReadAll(stream)
+	if err != nil {
+		t.Logf("[multicluster-diagnostics] failed to read logs for %s: %v", name, err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Logf("[multicluster-diagnostics] failed to close log stream for %s: %v", name, err)
+	}
 	t.Logf("[multicluster-diagnostics] === logs %s (last %d lines) ===\n%s", name, tailLines, logBytes)
 }
 

--- a/acceptance/steps/stretch.go
+++ b/acceptance/steps/stretch.go
@@ -11,6 +11,7 @@ package steps
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -62,37 +63,32 @@ const (
 
 type vclusterNodes []*vclusterNode
 
-// dumpDiagnostics logs pod statuses and events from each vcluster to aid
-// debugging when multicluster tests fail.
+// dumpDiagnostics logs the host nodes and, for each vcluster, pod statuses,
+// events, workload objects and container logs to aid debugging when
+// multicluster tests fail.
 func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) {
-	diagCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	diagCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	hostClient, err := client.New(t.RestConfig(), client.Options{})
+	if err != nil {
+		t.Logf("[multicluster-diagnostics] failed to create host client: %v", err)
+	} else {
+		dumpHostNodes(diagCtx, t, hostClient)
+	}
 
 	for _, node := range v {
 		t.Logf("[multicluster-diagnostics] === vcluster %s (host namespace: %s) ===", node.Name(), node.Name())
 
 		// Dump pods from the host namespace (where vcluster components run).
-		hostClient, err := client.New(t.RestConfig(), client.Options{})
-		if err != nil {
-			t.Logf("[multicluster-diagnostics] failed to create host client: %v", err)
-			continue
-		}
-		var hostPods corev1.PodList
-		if err := hostClient.List(diagCtx, &hostPods, client.InNamespace(node.Name())); err != nil {
-			t.Logf("[multicluster-diagnostics] failed to list host pods: %v", err)
-		} else {
-			for _, pod := range hostPods.Items {
-				t.Logf("[multicluster-diagnostics] host pod %s: phase=%s", pod.Name, pod.Status.Phase)
-				for _, cs := range pod.Status.ContainerStatuses {
-					if cs.State.Waiting != nil {
-						t.Logf("[multicluster-diagnostics]   container %s: waiting reason=%s", cs.Name, cs.State.Waiting.Reason)
-					}
-					if cs.State.Terminated != nil {
-						t.Logf("[multicluster-diagnostics]   container %s: terminated exitCode=%d reason=%s", cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
-					}
-					if cs.RestartCount > 0 {
-						t.Logf("[multicluster-diagnostics]   container %s: restarts=%d", cs.Name, cs.RestartCount)
-					}
+		if hostClient != nil {
+			var hostPods corev1.PodList
+			if err := hostClient.List(diagCtx, &hostPods, client.InNamespace(node.Name())); err != nil {
+				t.Logf("[multicluster-diagnostics] failed to list host pods: %v", err)
+			} else {
+				for _, pod := range hostPods.Items {
+					t.Logf("[multicluster-diagnostics] host pod %s: phase=%s node=%s", pod.Name, pod.Status.Phase, pod.Spec.NodeName)
+					logContainerStatuses(t, pod.Status.ContainerStatuses)
 				}
 			}
 		}
@@ -104,17 +100,7 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 		} else {
 			for _, pod := range vcPods.Items {
 				t.Logf("[multicluster-diagnostics] vcluster pod %s/%s: phase=%s", pod.Namespace, pod.Name, pod.Status.Phase)
-				for _, cs := range pod.Status.ContainerStatuses {
-					if cs.State.Waiting != nil {
-						t.Logf("[multicluster-diagnostics]   container %s: waiting reason=%s", cs.Name, cs.State.Waiting.Reason)
-					}
-					if cs.State.Terminated != nil {
-						t.Logf("[multicluster-diagnostics]   container %s: terminated exitCode=%d reason=%s", cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
-					}
-					if cs.RestartCount > 0 {
-						t.Logf("[multicluster-diagnostics]   container %s: restarts=%d", cs.Name, cs.RestartCount)
-					}
-				}
+				logContainerStatuses(t, pod.Status.ContainerStatuses)
 			}
 		}
 
@@ -194,30 +180,115 @@ func (v vclusterNodes) dumpDiagnostics(_ context.Context, t framework.TestingT) 
 		// reconciles before we even get to anything else. We also surface the
 		// subset filtered by layered-CR controller names so the actual error
 		// the Topic/User/Role/etc. reconciler hit is easy to find.
+		//
+		// Every other pod gets the tail of its broker containers and of any
+		// container that restarted, including the previous instance — the
+		// only place a CrashLoopBackOff broker's crash reason is recorded.
 		k8sClient, err := kubernetes.NewForConfig(node.RESTConfig())
 		if err != nil {
 			t.Logf("[multicluster-diagnostics] failed to create k8s client for logs: %v", err)
 			continue
 		}
 		for _, pod := range vcPods.Items {
-			if !strings.Contains(pod.Name, "operator") {
-				continue
-			}
-			tailLines := int64(4000)
-			req := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{TailLines: &tailLines})
-			logStream, err := req.Stream(diagCtx)
-			if err != nil {
-				t.Logf("[multicluster-diagnostics] failed to get logs for %s: %v", pod.Name, err)
-				continue
-			}
-			logBytes, _ := io.ReadAll(logStream)
-			_ = logStream.Close()
+			if strings.Contains(pod.Name, "operator") {
+				tailLines := int64(4000)
+				req := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{TailLines: &tailLines})
+				logStream, err := req.Stream(diagCtx)
+				if err != nil {
+					t.Logf("[multicluster-diagnostics] failed to get logs for %s: %v", pod.Name, err)
+					continue
+				}
+				logBytes, _ := io.ReadAll(logStream)
+				_ = logStream.Close()
 
-			logStr := string(logBytes)
-			dumpLayeredControllerLogs(t, pod.Name, logStr)
-			t.Logf("[multicluster-diagnostics] === operator logs %s (last 4000 lines) ===\n%s", pod.Name, logStr)
+				logStr := string(logBytes)
+				dumpLayeredControllerLogs(t, pod.Name, logStr)
+				t.Logf("[multicluster-diagnostics] === operator logs %s (last 4000 lines) ===\n%s", pod.Name, logStr)
+				continue
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				broker := cs.Name == "redpanda" || cs.Name == "sidecar"
+				if !broker && cs.RestartCount == 0 && cs.State.Waiting == nil {
+					continue
+				}
+				dumpVClusterContainerLog(diagCtx, t, k8sClient, pod, cs.Name, false)
+				if cs.RestartCount > 0 {
+					dumpVClusterContainerLog(diagCtx, t, k8sClient, pod, cs.Name, true)
+				}
+			}
 		}
 	}
+}
+
+// dumpHostNodes logs every host node's readiness, taints, allocatable
+// capacity and pod count. Stretch features pin their vclusters to host nodes,
+// so a saturated or NotReady node is a root cause the per-vcluster view
+// cannot show.
+func dumpHostNodes(ctx context.Context, t framework.TestingT, hostClient client.Client) {
+	var nodes corev1.NodeList
+	if err := hostClient.List(ctx, &nodes); err != nil {
+		t.Logf("[multicluster-diagnostics] failed to list host nodes: %v", err)
+		return
+	}
+	var pods corev1.PodList
+	if err := hostClient.List(ctx, &pods); err != nil {
+		t.Logf("[multicluster-diagnostics] failed to list host pods: %v", err)
+	}
+	podsPerNode := countPodsPerNode(pods.Items)
+	for _, node := range nodes.Items {
+		ready := "<none>"
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady {
+				ready = fmt.Sprintf("%s reason=%s since=%s", cond.Status, cond.Reason, cond.LastTransitionTime.UTC().Format(time.RFC3339))
+			}
+		}
+		taints := make([]string, 0, len(node.Spec.Taints))
+		for _, taint := range node.Spec.Taints {
+			taints = append(taints, taint.ToString())
+		}
+		t.Logf("[multicluster-diagnostics] host node %s: ready=%s taints=%v pods=%d/%s allocatable cpu=%s memory=%s",
+			node.Name, ready, taints, podsPerNode[node.Name], node.Status.Allocatable.Pods().String(), node.Status.Allocatable.Cpu().String(), node.Status.Allocatable.Memory().String())
+	}
+}
+
+// logContainerStatuses logs each container's state and restart count and,
+// after a restart, how the previous instance ended — the exit code and reason
+// a container in CrashLoopBackOff otherwise hides.
+func logContainerStatuses(t framework.TestingT, statuses []corev1.ContainerStatus) {
+	for _, cs := range statuses {
+		if cs.State.Waiting != nil {
+			t.Logf("[multicluster-diagnostics]   container %s: waiting reason=%s", cs.Name, cs.State.Waiting.Reason)
+		}
+		if cs.State.Terminated != nil {
+			t.Logf("[multicluster-diagnostics]   container %s: terminated exitCode=%d reason=%s", cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
+		}
+		if cs.RestartCount > 0 {
+			t.Logf("[multicluster-diagnostics]   container %s: restarts=%d", cs.Name, cs.RestartCount)
+		}
+		if last := cs.LastTerminationState.Terminated; last != nil {
+			t.Logf("[multicluster-diagnostics]   container %s: last terminated exitCode=%d reason=%s at=%s", cs.Name, last.ExitCode, last.Reason, last.FinishedAt.UTC().Format(time.RFC3339))
+		}
+	}
+}
+
+func dumpVClusterContainerLog(ctx context.Context, t framework.TestingT, k8sClient kubernetes.Interface, pod corev1.Pod, container string, previous bool) {
+	const tailLines = int64(300)
+	name := pod.Namespace + "/" + pod.Name + "/" + container
+	if previous {
+		name += " (previous)"
+	}
+	stream, err := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: container,
+		Previous:  previous,
+		TailLines: ptr.To(tailLines),
+	}).Stream(ctx)
+	if err != nil {
+		t.Logf("[multicluster-diagnostics] failed to get logs for %s: %v", name, err)
+		return
+	}
+	logBytes, _ := io.ReadAll(stream)
+	_ = stream.Close()
+	t.Logf("[multicluster-diagnostics] === logs %s (last %d lines) ===\n%s", name, tailLines, logBytes)
 }
 
 // dumpLayeredCRs lists each layered CR kind and emits its conditions. The
@@ -871,37 +942,74 @@ func createVClusters(ctx context.Context, t framework.TestingT, clusters int32, 
 	return nodes
 }
 
-// pickK3dAgentNodes returns `clusters` worker-node hostnames from the host
-// k3d cluster so each vcluster can be pinned to a distinct host node. Uses
-// the built-in `kubernetes.io/hostname` label — no extra labeling needed.
-// Skips the control-plane node and fails if there are not enough workers.
+// pickK3dAgentNodes returns the `clusters` host worker nodes to pin this
+// feature's vclusters to: Ready, schedulable workers, least loaded first, so
+// parallel features spread over every agent. Fails if there are not enough
+// eligible workers.
 func pickK3dAgentNodes(ctx context.Context, t framework.TestingT, clusters int32) []string {
 	hostClient, err := client.New(t.RestConfig(), client.Options{})
 	require.NoError(t, err)
 
 	var nodeList corev1.NodeList
 	require.NoError(t, hostClient.List(ctx, &nodeList))
+	var podList corev1.PodList
+	require.NoError(t, hostClient.List(ctx, &podList))
 
-	var workerNodes []corev1.Node
-	for _, n := range nodeList.Items {
-		if _, isControlPlane := n.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
+	ranked := rankWorkerNodes(nodeList.Items, podList.Items)
+	require.GreaterOrEqual(t, int32(len(ranked)), clusters,
+		"need at least %d Ready worker nodes in host cluster, got %d", clusters, len(ranked))
+	names := ranked[:clusters]
+	t.Logf("pinning %d vclusters to the least-loaded host nodes %v", clusters, names)
+	return names
+}
+
+// rankWorkerNodes returns the Ready, schedulable worker node names ordered by
+// the number of pods they run (Succeeded/Failed excluded), ties by name.
+func rankWorkerNodes(nodes []corev1.Node, pods []corev1.Pod) []string {
+	podsPerNode := countPodsPerNode(pods)
+
+	var workers []corev1.Node
+	for _, node := range nodes {
+		if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
 			continue
 		}
-		workerNodes = append(workerNodes, n)
+		if node.Spec.Unschedulable || !nodeReady(node) {
+			continue
+		}
+		workers = append(workers, node)
 	}
-	require.GreaterOrEqual(t, int32(len(workerNodes)), clusters,
-		"need at least %d worker nodes in host cluster, got %d", clusters, len(workerNodes))
-
-	// Sort for deterministic assignment within a single test run.
-	slices.SortFunc(workerNodes, func(a, b corev1.Node) int {
+	slices.SortFunc(workers, func(a, b corev1.Node) int {
+		if c := cmp.Compare(podsPerNode[a.Name], podsPerNode[b.Name]); c != 0 {
+			return c
+		}
 		return strings.Compare(a.Name, b.Name)
 	})
 
-	names := make([]string, clusters)
-	for i := int32(0); i < clusters; i++ {
-		names[i] = workerNodes[i].Name
+	names := make([]string, len(workers))
+	for i, node := range workers {
+		names[i] = node.Name
 	}
 	return names
+}
+
+func countPodsPerNode(pods []corev1.Pod) map[string]int {
+	counts := map[string]int{}
+	for _, pod := range pods {
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		counts[pod.Spec.NodeName]++
+	}
+	return counts
+}
+
+func nodeReady(node corev1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // pinningValues returns vcluster helm values that pin the control plane pod

--- a/acceptance/steps/stretch_test.go
+++ b/acceptance/steps/stretch_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package steps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRankWorkerNodes(t *testing.T) {
+	node := func(name string, ready corev1.ConditionStatus, labels map[string]string) corev1.Node {
+		return corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+			Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: ready}}},
+		}
+	}
+	pod := func(nodeName string, phase corev1.PodPhase) corev1.Pod {
+		return corev1.Pod{Spec: corev1.PodSpec{NodeName: nodeName}, Status: corev1.PodStatus{Phase: phase}}
+	}
+
+	nodes := []corev1.Node{
+		node("k3d-harpoon-server-0", corev1.ConditionTrue, map[string]string{"node-role.kubernetes.io/control-plane": "true"}),
+		node("k3d-harpoon-agent-0", corev1.ConditionTrue, nil),
+		node("k3d-harpoon-agent-1", corev1.ConditionFalse, nil),
+		node("k3d-harpoon-agent-2", corev1.ConditionTrue, nil),
+		node("k3d-harpoon-agent-3", corev1.ConditionTrue, nil),
+	}
+	pods := []corev1.Pod{
+		pod("k3d-harpoon-agent-0", corev1.PodRunning),
+		pod("k3d-harpoon-agent-0", corev1.PodRunning),
+		pod("k3d-harpoon-agent-0", corev1.PodPending),
+		pod("k3d-harpoon-agent-2", corev1.PodRunning),
+		pod("k3d-harpoon-agent-2", corev1.PodSucceeded),
+		pod("k3d-harpoon-agent-2", corev1.PodFailed),
+		pod("k3d-harpoon-server-0", corev1.PodRunning),
+	}
+
+	// The control-plane node and the NotReady agent are excluded; the rest
+	// are ordered by live pods, so an idle agent beats a busy lower-numbered one.
+	require.Equal(t, []string{"k3d-harpoon-agent-3", "k3d-harpoon-agent-2", "k3d-harpoon-agent-0"}, rankWorkerNodes(nodes, pods))
+
+	// Idle nodes fall back to name order for a deterministic choice.
+	require.Equal(t, []string{"k3d-harpoon-agent-0", "k3d-harpoon-agent-2", "k3d-harpoon-agent-3"}, rankWorkerNodes(nodes, nil))
+}

--- a/harpoon/providers/k3d.go
+++ b/harpoon/providers/k3d.go
@@ -31,6 +31,7 @@ type K3DProvider struct {
 	retainCluster            bool
 	fastNodeFailureDetection bool
 	configPath               string
+	importedImages           []string
 }
 
 func (p *K3DProvider) RetainCluster() *K3DProvider {
@@ -89,6 +90,7 @@ func (p *K3DProvider) LoadImages(_ context.Context, images []string) error {
 	if len(images) == 0 {
 		return nil
 	}
+	p.importedImages = append(p.importedImages, images...)
 	return p.cluster.ImportImage(images...)
 }
 
@@ -97,7 +99,17 @@ func (p *K3DProvider) DeleteNode(_ context.Context, name string) error {
 }
 
 func (p *K3DProvider) AddNode(_ context.Context, name string) error {
-	return p.cluster.CreateNodeWithName(name)
+	if err := p.cluster.CreateNodeWithName(name); err != nil {
+		return err
+	}
+	// A node created after setup has none of the images LoadImages imported, so
+	// a pod scheduled onto it (e.g. the node-failure scenario's replacement
+	// broker) would hit ImagePullBackOff pulling localhost/... images that never
+	// came from a registry. Re-import the suite's images onto the new node.
+	if len(p.importedImages) == 0 {
+		return nil
+	}
+	return p.cluster.ImportImage(p.importedImages...)
 }
 
 func (p *K3DProvider) GetBaseContext() context.Context {

--- a/harpoon/providers/k3d.go
+++ b/harpoon/providers/k3d.go
@@ -26,14 +26,25 @@ func NewK3D(nodes int) *K3DProvider {
 }
 
 type K3DProvider struct {
-	nodes         int
-	cluster       *k3d.Cluster
-	retainCluster bool
-	configPath    string
+	nodes                    int
+	cluster                  *k3d.Cluster
+	retainCluster            bool
+	fastNodeFailureDetection bool
+	configPath               string
 }
 
 func (p *K3DProvider) RetainCluster() *K3DProvider {
 	p.retainCluster = true
+	return p
+}
+
+// WithFastNodeFailureDetection shortens the node-failure grace/tolerations to
+// ~10s so a suite that kills a node sees the eviction quickly. Only enable it
+// for such suites: the 10s grace flaps momentarily-loaded nodes, which is fatal
+// to workloads like vclusters. The cluster gets its own name so a retained
+// cluster's baked-in flags are never reused by a suite that wants the defaults.
+func (p *K3DProvider) WithFastNodeFailureDetection() *K3DProvider {
+	p.fastNodeFailureDetection = true
 	return p
 }
 
@@ -42,7 +53,13 @@ func (p *K3DProvider) Initialize() error {
 }
 
 func (p *K3DProvider) Setup(_ context.Context) error {
-	cluster, err := k3d.GetOrCreate("harpoon", k3d.WithServerNoSchedule(), k3d.WithFastNodeFailureDetection(), k3d.SkipManifestInstallation(), k3d.WithAgents(p.nodes))
+	name := "harpoon"
+	opts := []k3d.ClusterOpt{k3d.WithServerNoSchedule(), k3d.SkipManifestInstallation(), k3d.WithAgents(p.nodes)}
+	if p.fastNodeFailureDetection {
+		name = "harpoon-nodefailure"
+		opts = append(opts, k3d.WithFastNodeFailureDetection())
+	}
+	cluster, err := k3d.GetOrCreate(name, opts...)
 	if err != nil {
 		return err
 	}

--- a/harpoon/providers/k3d.go
+++ b/harpoon/providers/k3d.go
@@ -42,7 +42,7 @@ func (p *K3DProvider) Initialize() error {
 }
 
 func (p *K3DProvider) Setup(_ context.Context) error {
-	cluster, err := k3d.GetOrCreate("harpoon", k3d.WithServerNoSchedule(), k3d.SkipManifestInstallation(), k3d.WithAgents(p.nodes))
+	cluster, err := k3d.GetOrCreate("harpoon", k3d.WithServerNoSchedule(), k3d.WithFastNodeFailureDetection(), k3d.SkipManifestInstallation(), k3d.WithAgents(p.nodes))
 	if err != nil {
 		return err
 	}

--- a/operator/internal/controller/pvcunbinder/pvcunbinder_test.go
+++ b/operator/internal/controller/pvcunbinder/pvcunbinder_test.go
@@ -139,7 +139,7 @@ func TestIntegrationPVCUnbinder(t *testing.T) {
 	log.SetGlobals(logger)
 	ctx = log.IntoContext(ctx, logger)
 
-	cluster, err := k3d.NewCluster(t.Name())
+	cluster, err := k3d.NewCluster(t.Name(), k3d.WithFastNodeFailureDetection())
 	require.NoError(t, err)
 	t.Logf("created cluster %T %q", cluster, cluster.Name)
 

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -275,9 +275,12 @@ func (r *MulticlusterReconciler) Reconcile(ctx context.Context, req mcreconcile.
 			return r.syncStatus(ctx, cluster, state, ctrl.Result{RequeueAfter: requeueTimeout}, nil)
 		}
 
-		// All clusters are deleting — safe to proceed with cleanup.
+		// All clusters are deleting — safe to proceed with cleanup. Requeue
+		// while resources are still going away: nothing this controller
+		// watches fires when a Pod or StatefulSet finally disappears, so a
+		// bare result would fall through to the 3m periodicRequeue.
 		if deleted, err := r.LifecycleClient.DeleteAll(ctx, state.cluster); deleted || err != nil {
-			return r.syncStatus(ctx, cluster, state, ctrl.Result{}, err)
+			return r.syncStatus(ctx, cluster, state, ctrl.Result{RequeueAfter: requeueTimeout}, err)
 		}
 		if controllerutil.RemoveFinalizer(stretchCluster, FinalizerKey) {
 			if err := k8sClient.Update(ctx, stretchCluster); err != nil {

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -288,9 +288,12 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 
 	// Examine if the object is under deletion
 	if !rp.ObjectMeta.DeletionTimestamp.IsZero() {
-		// clean up all dependant resources
+		// clean up all dependant resources, requeueing while they are still
+		// going away: no watched object fires when a Pod or StatefulSet
+		// finally disappears, so a bare result would fall through to the 3m
+		// periodicRequeue.
 		if deleted, err := r.LifecycleClient.DeleteAll(ctx, state.cluster); deleted || err != nil {
-			return r.syncStatus(ctx, cluster, state, reconcile.Result{}, err)
+			return r.syncStatus(ctx, cluster, state, reconcile.Result{RequeueAfter: requeueTimeout}, err)
 		}
 		if controllerutil.RemoveFinalizer(rp, FinalizerKey) {
 			if err := k8sClient.Update(ctx, rp); err != nil {

--- a/operator/internal/controller/redpanda/redpanda_controller.go
+++ b/operator/internal/controller/redpanda/redpanda_controller.go
@@ -289,9 +289,11 @@ func (r *RedpandaReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 	// Examine if the object is under deletion
 	if !rp.ObjectMeta.DeletionTimestamp.IsZero() {
 		// clean up all dependant resources, requeueing while they are still
-		// going away: no watched object fires when a Pod or StatefulSet
-		// finally disappears, so a bare result would fall through to the 3m
-		// periodicRequeue.
+		// going away: Pod and PVC removals are not mapped to this CR, and the
+		// owned StatefulSet's delete event can race a stale informer cache
+		// (the triggered reconcile may still see the StatefulSet, and no
+		// further event ever comes). Without a requeue the fallback is the
+		// 3m periodicRequeue.
 		if deleted, err := r.LifecycleClient.DeleteAll(ctx, state.cluster); deleted || err != nil {
 			return r.syncStatus(ctx, cluster, state, reconcile.Result{RequeueAfter: requeueTimeout}, err)
 		}

--- a/operator/internal/testenv/multicluster.go
+++ b/operator/internal/testenv/multicluster.go
@@ -11,6 +11,7 @@ package testenv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -120,6 +121,10 @@ func NewMulticluster(t *testing.T, ctx context.Context, opts MulticlusterOptions
 			k3dOpts := []k3d.ClusterOpt{
 				k3d.WithAgents(1),
 				k3d.WithNetwork(opts.Name),
+				// The server container also runs the k3s control plane; a
+				// busy-polling broker scheduled next to it competes with the
+				// apiserver for the same CPU budget.
+				k3d.WithServerNoSchedule(),
 			}
 			// Non-overlapping CIDRs so pods can communicate across clusters.
 			k3dOpts = append(k3dOpts, k3d.WithCIDRs(
@@ -263,7 +268,12 @@ func (m *MulticlusterEnv) CreateTestNamespace(t *testing.T) *MulticlusterTestNam
 		nsClient := client.NewNamespacedClient(rawClient, tn.Name)
 		clients = append(clients, nsClient)
 
+		env.recordLogs(t, tn.Name)
+
 		t.Cleanup(func() {
+			if t.Failed() {
+				env.diagnosticsFor(t, tn.Name).dump()
+			}
 			if !testutil.Retain() {
 				_ = rawClient.Delete(context.Background(), ns)
 			}
@@ -351,8 +361,7 @@ func (m *MulticlusterEnv) DialContext(ctx context.Context, network, address stri
 				if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" {
 					// Found the pod — dial it via this cluster's PodDialer.
 					podAddress := net.JoinHostPort(addr.TargetRef.Name+"."+ns, port)
-					dialer := kube.NewPodDialer(m.Envs[i].RESTConfig())
-					return dialer.DialContext(ctx, network, podAddress)
+					return m.dialPod(ctx, i, network, podAddress)
 				}
 			}
 		}
@@ -363,24 +372,35 @@ func (m *MulticlusterEnv) DialContext(ctx context.Context, network, address stri
 				podName, podClusterIdx := m.findPodByIP(ctx, ns, addr.IP)
 				if podName != "" {
 					podAddress := net.JoinHostPort(podName+"."+ns, port)
-					dialer := kube.NewPodDialer(m.Envs[podClusterIdx].RESTConfig())
-					return dialer.DialContext(ctx, network, podAddress)
+					return m.dialPod(ctx, podClusterIdx, network, podAddress)
 				}
 			}
 		}
 	}
 
-	// Fallback: try each cluster's PodDialer directly (maybe the service name IS the pod name).
-	var lastErr error
-	for _, env := range m.Envs {
-		dialer := kube.NewPodDialer(env.RESTConfig())
-		conn, err := dialer.DialContext(ctx, network, address)
+	// Fallback: try each cluster's PodDialer directly (maybe the service name
+	// IS the pod name). The pod lives on exactly one cluster, so its error is
+	// the one that matters; report every cluster's rather than letting a
+	// peer's "not found" mask it.
+	var errs []error
+	for i := range m.Envs {
+		conn, err := m.dialPod(ctx, i, network, address)
 		if err == nil {
 			return conn, nil
 		}
-		lastErr = err
+		errs = append(errs, err)
 	}
-	return nil, fmt.Errorf("multicluster dial failed for %s: %w", address, lastErr)
+	return nil, fmt.Errorf("multicluster dial failed for %s: %w", address, errors.Join(errs...))
+}
+
+// dialPod port-forwards to a pod through cluster idx's API server, naming the
+// cluster in any error.
+func (m *MulticlusterEnv) dialPod(ctx context.Context, idx int, network, podAddress string) (net.Conn, error) {
+	conn, err := kube.NewPodDialer(m.Envs[idx].RESTConfig()).DialContext(ctx, network, podAddress)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", m.Envs[idx].Name, err)
+	}
+	return conn, nil
 }
 
 // findPodByIP searches all clusters for a pod with the given IP in the given namespace.

--- a/operator/internal/testenv/testenv.go
+++ b/operator/internal/testenv/testenv.go
@@ -10,35 +10,48 @@
 package testenv
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/redpanda-data/common-go/kube"
 	"github.com/redpanda-data/common-go/otelutil/otelkube"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	goclientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	redpandav1alpha2 "github.com/redpanda-data/redpanda-operator/operator/api/redpanda/v1alpha2"
 	"github.com/redpanda-data/redpanda-operator/pkg/k3d"
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
@@ -58,6 +71,9 @@ type Env struct {
 	client             client.Client
 	watchAllNamespaces bool
 	Name               string
+
+	recordersMu sync.Mutex
+	recorders   map[string]*podLogRecorder
 }
 
 type Options struct {
@@ -210,10 +226,12 @@ func New(t *testing.T, options Options) *Env {
 		t.Logf("Executing in namespace '%s'", ns.Name)
 	}
 
+	env.recordLogs(t, ns.Name)
+
 	t.Cleanup(func() {
 		// Dump diagnostics before cleanup if the test failed.
 		if t.Failed() {
-			env.dumpDiagnostics()
+			env.diagnosticsFor(t, ns.Name).dump()
 		}
 
 		env.cancel()
@@ -279,11 +297,11 @@ func (e *Env) CreateTestNamespace(t *testing.T) *TestNamespace {
 
 	nsClient := otelkube.NewClient(client.NewNamespacedClient(rawClient, ns.Name))
 
+	e.recordLogs(t, ns.Name)
+
 	t.Cleanup(func() {
 		if t.Failed() {
-			// Dump diagnostics for this namespace.
-			envCopy := &Env{t: t, client: nsClient, namespace: ns}
-			envCopy.dumpDiagnostics()
+			e.diagnosticsFor(t, ns.Name).dump()
 		}
 		if !testutil.Retain() {
 			if err := rawClient.Delete(context.Background(), ns); err != nil {
@@ -381,73 +399,497 @@ func (e *Env) SetupManager(serviceAccount string, fn func(multicluster.Manager) 
 	<-manager.Elected()
 }
 
-// dumpDiagnostics collects Kubernetes state from the test namespace to help
-// debug failures. If INTEGRATION_ARTIFACTS_DIR is set, output is written to
-// files; otherwise it is logged via t.Log.
-func (e *Env) dumpDiagnostics() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+// diagnosticsLogTailLines bounds every log tail captured on failure: enough
+// to see a broker's last state transitions without flooding the test output.
+const diagnosticsLogTailLines = 100
+
+// nodeHealthLogPattern picks the kubelet and node-controller lines out of a
+// k3d node container's k3s log: readiness transitions, status/lease posting
+// and taint-based eviction. That log is the only place the reason for a
+// NotReady transition is recorded.
+var nodeHealthLogPattern = regexp.MustCompile(`(?i)nodenotready|nodeready|node status|not ready|pleg|lease|evict|taint|oom|deadline exceeded`)
+
+// diagnostics dumps the state relevant to a failed test for one cluster: the
+// test namespace's pods, events and workload objects, the cluster's node
+// conditions and node events, the tail of every container log and the
+// node-health lines of the k3d node containers. Output goes to t.Log and, when
+// INTEGRATION_ARTIFACTS_DIR is set, to files under <dir>/<test>/<cluster>/.
+type diagnostics struct {
+	t         testing.TB
+	cluster   string
+	host      *k3d.Cluster
+	config    *rest.Config
+	scheme    *runtime.Scheme
+	namespace string
+	recorder  *podLogRecorder
+
+	files map[string]*strings.Builder
+}
+
+func (e *Env) diagnosticsFor(t testing.TB, namespace string) *diagnostics {
+	return &diagnostics{
+		t:         t,
+		cluster:   e.Name,
+		host:      e.host,
+		config:    e.config,
+		scheme:    e.scheme,
+		namespace: namespace,
+		recorder:  e.recorderFor(namespace),
+		files:     map[string]*strings.Builder{},
+	}
+}
+
+func (d *diagnostics) dump() {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	namespace := e.Namespace()
-	testName := e.t.Name()
-	e.t.Logf("=== DIAGNOSTICS for %s (namespace=%s) ===", testName, namespace)
+	d.t.Logf("=== DIAGNOSTICS for %s (cluster=%s namespace=%s) ===", d.t.Name(), d.cluster, d.namespace)
 
-	// Collect pod statuses.
+	c, err := client.New(d.config, client.Options{Scheme: d.scheme})
+	if err != nil {
+		d.t.Logf("[diagnostics] error creating client: %v", err)
+		return
+	}
+
+	pods := d.dumpPods(ctx, c)
+	d.dumpObjects(ctx, c)
+	d.dumpEvents(ctx, c)
+	d.dumpNodes(ctx, c)
+	d.dumpContainerLogs(ctx, pods)
+	d.dumpNodeContainerLogs()
+	d.writeArtifacts()
+}
+
+func (d *diagnostics) dumpPods(ctx context.Context, c client.Client) []corev1.Pod {
 	var podList corev1.PodList
-	if err := e.client.List(ctx, &podList, client.InNamespace(namespace)); err != nil {
-		e.t.Logf("[diagnostics] error listing pods: %v", err)
-	} else {
-		for _, pod := range podList.Items {
-			e.t.Logf("[diagnostics/pod] %s phase=%s reason=%s", pod.Name, pod.Status.Phase, pod.Status.Reason)
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.State.Waiting != nil {
-					e.t.Logf("[diagnostics/pod] %s/%s waiting: %s - %s", pod.Name, cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
-				}
-				if cs.State.Terminated != nil {
-					e.t.Logf("[diagnostics/pod] %s/%s terminated: exitCode=%d reason=%s", pod.Name, cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
-				}
+	if err := c.List(ctx, &podList, client.InNamespace(d.namespace)); err != nil {
+		d.t.Logf("[diagnostics] error listing pods: %v", err)
+		return nil
+	}
+	for _, pod := range podList.Items {
+		ready := "<none>"
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady {
+				ready = fmt.Sprintf("%s reason=%s since=%s", cond.Status, cond.Reason, cond.LastTransitionTime.UTC().Format(time.RFC3339))
+			}
+		}
+		d.line("pod", "%s phase=%s reason=%s node=%s ready=%s", pod.Name, pod.Status.Phase, pod.Status.Reason, pod.Spec.NodeName, ready)
+		for _, cs := range pod.Status.ContainerStatuses {
+			d.line("pod", "%s/%s ready=%t restarts=%d", pod.Name, cs.Name, cs.Ready, cs.RestartCount)
+			if cs.State.Waiting != nil {
+				d.line("pod", "%s/%s waiting: %s - %s", pod.Name, cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+			}
+			if cs.State.Terminated != nil {
+				d.line("pod", "%s/%s terminated: exitCode=%d reason=%s", pod.Name, cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
+			}
+			if last := cs.LastTerminationState.Terminated; last != nil {
+				d.line("pod", "%s/%s last terminated: exitCode=%d reason=%s at=%s", pod.Name, cs.Name, last.ExitCode, last.Reason, last.FinishedAt.UTC().Format(time.RFC3339))
 			}
 		}
 	}
+	return podList.Items
+}
 
-	// Collect events.
+// dumpObjects lists the workload objects in the namespace with the fields that
+// gate deletion: finalizers, deletion timestamps and StatefulSet replica
+// counts. Redpanda CRDs are listed only when the env's scheme knows them.
+func (d *diagnostics) dumpObjects(ctx context.Context, c client.Client) {
+	var sets appsv1.StatefulSetList
+	if err := c.List(ctx, &sets, client.InNamespace(d.namespace)); err != nil {
+		d.t.Logf("[diagnostics] error listing statefulsets: %v", err)
+	}
+	for _, set := range sets.Items {
+		d.line("object", "StatefulSet/%s replicas=%d status.replicas=%d ready=%d updateRevision=%s deletionTimestamp=%s finalizers=%v",
+			set.Name, ptr.Deref(set.Spec.Replicas, 1), set.Status.Replicas, set.Status.ReadyReplicas, set.Status.UpdateRevision, formatTime(set.DeletionTimestamp), set.Finalizers)
+	}
+
+	gv := schema.GroupVersion{Group: redpandav1alpha2.GroupVersion.Group, Version: redpandav1alpha2.GroupVersion.Version}
+	for _, kind := range []string{"StretchCluster", "RedpandaBrokerPool", "Redpanda", "NodePool"} {
+		if !d.scheme.Recognizes(gv.WithKind(kind)) {
+			continue
+		}
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gv.WithKind(kind + "List"))
+		if err := c.List(ctx, list, client.InNamespace(d.namespace)); err != nil {
+			d.t.Logf("[diagnostics] error listing %s: %v", kind, err)
+			continue
+		}
+		for _, obj := range list.Items {
+			d.line("object", "%s/%s deletionTimestamp=%s finalizers=%v", kind, obj.GetName(), formatTime(obj.GetDeletionTimestamp()), obj.GetFinalizers())
+		}
+	}
+}
+
+func formatTime(t *metav1.Time) string {
+	if t == nil {
+		return "<none>"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func (d *diagnostics) dumpEvents(ctx context.Context, c client.Client) {
 	var eventList corev1.EventList
-	if err := e.client.List(ctx, &eventList, client.InNamespace(namespace)); err != nil {
-		e.t.Logf("[diagnostics] error listing events: %v", err)
-	} else {
-		for _, event := range eventList.Items {
-			e.t.Logf("[diagnostics/event] %s %s/%s: %s (count=%d)", event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message, event.Count)
+	if err := c.List(ctx, &eventList, client.InNamespace(d.namespace)); err != nil {
+		d.t.Logf("[diagnostics] error listing events: %v", err)
+		return
+	}
+	d.lineEvents("event", eventList.Items)
+}
+
+// dumpNodes records every node's Ready condition and taints plus the Node
+// events, which carry the NodeNotReady/NodeReady transitions and their times.
+func (d *diagnostics) dumpNodes(ctx context.Context, c client.Client) {
+	var nodeList corev1.NodeList
+	if err := c.List(ctx, &nodeList); err != nil {
+		d.t.Logf("[diagnostics] error listing nodes: %v", err)
+	}
+	for _, node := range nodeList.Items {
+		ready := "<none>"
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady {
+				ready = fmt.Sprintf("%s reason=%s since=%s", cond.Status, cond.Reason, cond.LastTransitionTime.UTC().Format(time.RFC3339))
+			}
+		}
+		taints := make([]string, 0, len(node.Spec.Taints))
+		for _, taint := range node.Spec.Taints {
+			taints = append(taints, taint.ToString())
+		}
+		d.line("node", "%s ready=%s taints=%v", node.Name, ready, taints)
+	}
+
+	var eventList corev1.EventList
+	if err := c.List(ctx, &eventList, client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector("involvedObject.kind", "Node")}); err != nil {
+		d.t.Logf("[diagnostics] error listing node events: %v", err)
+		return
+	}
+	d.lineEvents("node-event", eventList.Items)
+}
+
+// dumpContainerLogs prints the tail of every container log the recorder
+// followed — including pods that no longer exist, which is where a broker's
+// shutdown is logged — and fetches live tails for anything it never saw. The
+// sidecar's log is where the readiness probe explains why a broker is unready.
+func (d *diagnostics) dumpContainerLogs(ctx context.Context, pods []corev1.Pod) {
+	recorded := map[string][]string{}
+	if d.recorder != nil {
+		var errs []string
+		recorded, errs = d.recorder.snapshot()
+		for _, e := range errs {
+			d.t.Logf("[diagnostics] log recorder: %s", e)
+		}
+		keys := make([]string, 0, len(recorded))
+		for key := range recorded {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			d.logBlock(key, recorded[key])
 		}
 	}
 
-	// Write to artifact directory if configured.
+	if len(pods) == 0 {
+		return
+	}
+	ctl, err := kube.FromRESTConfig(d.config)
+	if err != nil {
+		d.t.Logf("[diagnostics] error creating kube client for logs: %v", err)
+		return
+	}
+	for i := range pods {
+		pod := &pods[i]
+		for _, cs := range pod.Status.ContainerStatuses {
+			if _, ok := recorded[containerLogKey(pod.Name, cs.Name, cs.RestartCount)]; ok {
+				continue
+			}
+			d.containerLog(ctx, ctl, pod, cs.Name, false)
+			if cs.RestartCount > 0 {
+				d.containerLog(ctx, ctl, pod, cs.Name, true)
+			}
+		}
+	}
+}
+
+func (d *diagnostics) containerLog(ctx context.Context, ctl *kube.Ctl, pod *corev1.Pod, container string, previous bool) {
+	name := pod.Name + "/" + container
+	if previous {
+		name += ".previous"
+	}
+	stream, err := ctl.Logs(ctx, pod, corev1.PodLogOptions{
+		Container: container,
+		Previous:  previous,
+		TailLines: ptr.To(int64(diagnosticsLogTailLines)),
+	})
+	if err != nil {
+		d.t.Logf("[diagnostics] error fetching logs of %s: %v", name, err)
+		return
+	}
+	defer stream.Close()
+	logs, err := io.ReadAll(stream)
+	if err != nil {
+		d.t.Logf("[diagnostics] error reading logs of %s: %v", name, err)
+		return
+	}
+	d.logBlock(name, strings.Split(strings.TrimRight(string(logs), "\n"), "\n"))
+}
+
+func (d *diagnostics) logBlock(name string, lines []string) {
+	d.t.Logf("[diagnostics/log] %s (last %d lines):\n%s", name, len(lines), strings.Join(lines, "\n"))
+	file := strings.NewReplacer("/", "-", "#", ".").Replace(name)
+	d.file(filepath.Join("logs", file+".log"), strings.Join(lines, "\n")+"\n")
+}
+
+// dumpNodeContainerLogs pulls the node-health lines out of each k3d node
+// container's k3s log; kubelet and the node controller both log there.
+func (d *diagnostics) dumpNodeContainerLogs() {
+	if d.host == nil {
+		return
+	}
+	out, err := exec.Command("docker", "ps", "--filter", "name=^k3d-"+d.host.Name+"-", "--format", "{{.Names}}").Output()
+	if err != nil {
+		d.t.Logf("[diagnostics] error listing k3d node containers: %v", err)
+		return
+	}
+	for _, container := range strings.Fields(string(out)) {
+		if strings.Contains(container, "-serverlb") {
+			continue
+		}
+		logs, err := exec.Command("docker", "logs", "--tail", "2000", container).CombinedOutput()
+		if err != nil {
+			d.t.Logf("[diagnostics] error reading logs of %s: %v", container, err)
+			continue
+		}
+		var matched []string
+		for _, line := range strings.Split(string(logs), "\n") {
+			if nodeHealthLogPattern.MatchString(line) {
+				matched = append(matched, line)
+			}
+		}
+		if len(matched) > diagnosticsLogTailLines {
+			matched = matched[len(matched)-diagnosticsLogTailLines:]
+		}
+		d.t.Logf("[diagnostics/k3d] %s node-health log lines (%d):\n%s", container, len(matched), strings.Join(matched, "\n"))
+		d.file(filepath.Join("k3d", container+".log"), string(logs))
+	}
+}
+
+func (d *diagnostics) lineEvents(kind string, events []corev1.Event) {
+	sort.Slice(events, func(i, j int) bool {
+		return eventTime(events[i]).Before(eventTime(events[j]))
+	})
+	for _, event := range events {
+		d.line(kind, "%s %s %s/%s: %s (reason=%s count=%d)", eventTime(event).UTC().Format(time.RFC3339), event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message, event.Reason, event.Count)
+	}
+}
+
+// eventTime is the most recent occurrence of an event, whichever of the
+// legacy and events.k8s.io fields the reporter populated.
+func eventTime(event corev1.Event) time.Time {
+	switch {
+	case !event.LastTimestamp.IsZero():
+		return event.LastTimestamp.Time
+	case !event.EventTime.IsZero():
+		return event.EventTime.Time
+	default:
+		return event.CreationTimestamp.Time
+	}
+}
+
+func (d *diagnostics) line(kind, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	d.t.Logf("[diagnostics/%s] %s", kind, msg)
+	d.file(kind+".txt", msg+"\n")
+}
+
+func (d *diagnostics) file(name, content string) {
+	b, ok := d.files[name]
+	if !ok {
+		b = &strings.Builder{}
+		d.files[name] = b
+	}
+	b.WriteString(content)
+}
+
+func (d *diagnostics) writeArtifacts() {
 	artifactsDir := os.Getenv("INTEGRATION_ARTIFACTS_DIR")
 	if artifactsDir == "" {
 		return
 	}
-
-	dir := filepath.Join(artifactsDir, sanitizeTestName(testName))
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		e.t.Logf("[diagnostics] failed to create artifacts directory: %v", err)
-		return
-	}
-
-	// Dump pod descriptions.
-	var podDescs []byte
-	for _, pod := range podList.Items {
-		podDescs = append(podDescs, []byte(fmt.Sprintf("--- Pod: %s (phase=%s) ---\n", pod.Name, pod.Status.Phase))...)
-		for _, cs := range pod.Status.ContainerStatuses {
-			podDescs = append(podDescs, []byte(fmt.Sprintf("  container %s: ready=%v restarts=%d\n", cs.Name, cs.Ready, cs.RestartCount))...)
+	dir := filepath.Join(artifactsDir, sanitizeTestName(d.t.Name()), d.cluster)
+	for name, content := range d.files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			d.t.Logf("[diagnostics] failed to create artifacts directory %s: %v", filepath.Dir(path), err)
+			return
+		}
+		if err := os.WriteFile(path, []byte(content.String()), 0o600); err != nil {
+			d.t.Logf("[diagnostics] failed to write %s: %v", path, err)
 		}
 	}
-	_ = os.WriteFile(filepath.Join(dir, "pods.txt"), podDescs, 0o600)
+}
 
-	// Dump events.
-	var eventDescs []byte
-	for _, event := range eventList.Items {
-		eventDescs = append(eventDescs, []byte(fmt.Sprintf("%s %s/%s: %s (count=%d)\n", event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message, event.Count))...)
+// recordLogs follows the container logs of every pod in namespace until t
+// ends, so a later dump can show what pods logged before they were deleted.
+func (e *Env) recordLogs(t testing.TB, namespace string) {
+	recorder, err := startPodLogRecorder(e.config, e.scheme, namespace)
+	if err != nil {
+		t.Logf("[diagnostics] not recording pod logs for %s on %s: %v", namespace, e.Name, err)
+		return
 	}
-	_ = os.WriteFile(filepath.Join(dir, "events.txt"), eventDescs, 0o600)
+	e.recordersMu.Lock()
+	if e.recorders == nil {
+		e.recorders = map[string]*podLogRecorder{}
+	}
+	e.recorders[namespace] = recorder
+	e.recordersMu.Unlock()
+
+	// Registered before the dump cleanup so (LIFO) it runs after the dump.
+	t.Cleanup(func() {
+		recorder.stop()
+		e.recordersMu.Lock()
+		delete(e.recorders, namespace)
+		e.recordersMu.Unlock()
+	})
+}
+
+func (e *Env) recorderFor(namespace string) *podLogRecorder {
+	e.recordersMu.Lock()
+	defer e.recordersMu.Unlock()
+	return e.recorders[namespace]
+}
+
+// podLogRecorder follows every container log in a namespace for the life of a
+// test, keeping the last diagnosticsLogTailLines lines per container instance,
+// so the diagnostics dump can show what a pod logged before it was deleted.
+// It never logs through testing.TB: its goroutines outlive individual tests.
+type podLogRecorder struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	client client.WithWatch
+	ctl    *kube.Ctl
+	ns     string
+
+	mu        sync.Mutex
+	following map[string]bool
+	logs      map[string][]string
+	errs      []string
+}
+
+func startPodLogRecorder(config *rest.Config, scheme *runtime.Scheme, namespace string) (*podLogRecorder, error) {
+	c, err := client.NewWithWatch(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+	ctl, err := kube.FromRESTConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &podLogRecorder{
+		ctx:       ctx,
+		cancel:    cancel,
+		client:    c,
+		ctl:       ctl,
+		ns:        namespace,
+		following: map[string]bool{},
+		logs:      map[string][]string{},
+	}
+	go r.run()
+	return r, nil
+}
+
+func (r *podLogRecorder) stop() {
+	r.cancel()
+}
+
+// run keeps a pod watch open on the namespace and starts following each
+// container instance the first time it is seen running or terminated.
+func (r *podLogRecorder) run() {
+	for r.ctx.Err() == nil {
+		w, err := r.client.Watch(r.ctx, &corev1.PodList{}, client.InNamespace(r.ns))
+		if err != nil {
+			r.noteErr(fmt.Sprintf("watching pods: %v", err))
+		} else {
+			for event := range w.ResultChan() {
+				if pod, ok := event.Object.(*corev1.Pod); ok {
+					r.followNewContainers(pod)
+				}
+			}
+			w.Stop()
+		}
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (r *podLogRecorder) followNewContainers(pod *corev1.Pod) {
+	statuses := append(append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...)
+	for _, cs := range statuses {
+		if cs.State.Running == nil && cs.State.Terminated == nil {
+			continue
+		}
+		key := containerLogKey(pod.Name, cs.Name, cs.RestartCount)
+		r.mu.Lock()
+		seen := r.following[key]
+		r.following[key] = true
+		r.mu.Unlock()
+		if !seen {
+			go r.follow(pod.DeepCopy(), cs.Name, key)
+		}
+	}
+}
+
+// follow streams one container instance's log until it ends (the container
+// exited, the pod is gone or the recorder stopped).
+func (r *podLogRecorder) follow(pod *corev1.Pod, container, key string) {
+	stream, err := r.ctl.Logs(r.ctx, pod, corev1.PodLogOptions{Container: container, Follow: true})
+	if err != nil {
+		if r.ctx.Err() == nil {
+			r.noteErr(fmt.Sprintf("following %s: %v", key, err))
+		}
+		r.mu.Lock()
+		delete(r.following, key)
+		r.mu.Unlock()
+		return
+	}
+	defer stream.Close()
+	scanner := bufio.NewScanner(stream)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		r.mu.Lock()
+		lines := append(r.logs[key], scanner.Text())
+		if len(lines) > diagnosticsLogTailLines {
+			lines = lines[len(lines)-diagnosticsLogTailLines:]
+		}
+		r.logs[key] = lines
+		r.mu.Unlock()
+	}
+}
+
+func (r *podLogRecorder) noteErr(msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.errs) < 20 {
+		r.errs = append(r.errs, msg)
+	}
+}
+
+// snapshot returns copies of the recorded log tails keyed by
+// pod/container#restartCount, and the recorder's own errors.
+func (r *podLogRecorder) snapshot() (map[string][]string, []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	logs := make(map[string][]string, len(r.logs))
+	for key, lines := range r.logs {
+		logs[key] = append([]string(nil), lines...)
+	}
+	return logs, append([]string(nil), r.errs...)
+}
+
+func containerLogKey(pod, container string, restartCount int32) string {
+	return fmt.Sprintf("%s/%s#%d", pod, container, restartCount)
 }
 
 func sanitizeTestName(name string) string {

--- a/operator/pkg/client/stretch_cluster.go
+++ b/operator/pkg/client/stretch_cluster.go
@@ -351,6 +351,15 @@ func (c *Factory) stretchClusterEndpoints(ctx context.Context, sc *redpandav1alp
 			if !ref.IsStretchCluster() || ref.Name != sc.Name {
 				continue
 			}
+			// A pool being deleted has a broker the operator is tearing down; its
+			// admin API goes away (io.EOF, surfaced by rpadmin as "expected a tls
+			// connection") mid-decommission. Keep it out of the admin endpoint set
+			// so cluster-health and decommission reads route through surviving
+			// brokers rather than the one being removed — otherwise the pool's own
+			// StatefulSet cleanup can wedge on a read to its dying broker.
+			if !pool.GetDeletionTimestamp().IsZero() {
+				continue
+			}
 			for j := int32(0); j < pool.GetReplicas(); j++ {
 				poolFullname := tplutil.CleanForK8s(sc.Name) + pool.Suffix()
 				name := rendermulticluster.PerPodServiceName(poolFullname, j)

--- a/operator/pkg/client/stretch_cluster_endpoints_test.go
+++ b/operator/pkg/client/stretch_cluster_endpoints_test.go
@@ -292,6 +292,37 @@ func TestStretchClusterEndpointsSkipsUndialablePods(t *testing.T) {
 		"the terminating pool's broker must not be offered to the admin client")
 }
 
+// TestStretchClusterEndpointsSkipsDeletingPool pins the pool-level skip: a pool
+// with a deletion timestamp is left out of the admin endpoints even when its
+// pod is still dialable, so the decommission/health reads that clean the pool
+// up never route through the broker being removed.
+func TestStretchClusterEndpointsSkipsDeletingPool(t *testing.T) {
+	scheme := endpointsScheme(t)
+	now := metav1.Now()
+
+	deletingPool := brokerPool("pool-b", "sc")
+	deletingPool.DeletionTimestamp = &now
+	deletingPool.Finalizers = []string{"keep/for-fake-client"}
+
+	c := &Factory{mgr: &stubManager{clients: map[string]client.Client{
+		"cluster-1": fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			brokerPool("pool-a", "sc"), pod("sc-pool-a-0"),
+			brokerPool("pool-c", "sc"), pod("sc-pool-c-0"),
+			// pool-b is being deleted, but its pod is still Running (dialable).
+			deletingPool, pod("sc-pool-b-0"),
+		).Build(),
+	}}}
+
+	sc := &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sc", Namespace: "redpanda"},
+	}
+
+	endpoints, err := c.stretchClusterEndpoints(t.Context(), sc, 9644)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"sc-pool-a-0.redpanda:9644", "sc-pool-c-0.redpanda:9644"}, endpoints,
+		"a pool with a deletion timestamp must not be offered even if its pod is dialable")
+}
+
 // TestStretchClusterEndpointsTwoHostFloor pins the floor end to end: with one
 // dialable broker left, the list is padded back to two so rpadmin keeps
 // leader resolution and try-every-host reads, preferring a pod-less endpoint

--- a/pkg/k3d/k3d.go
+++ b/pkg/k3d/k3d.go
@@ -84,17 +84,18 @@ func (c clusterOpt) apply(config *clusterConfig) {
 }
 
 type clusterConfig struct {
-	agents           int
-	timeout          time.Duration
-	image            string
-	skipManifests    bool
-	serverNoSchedule bool
-	network          string
-	domain           string
-	port             int
-	portMappings     []PortMapping
-	clusterCIDR      string
-	serviceCIDR      string
+	agents                   int
+	timeout                  time.Duration
+	image                    string
+	skipManifests            bool
+	serverNoSchedule         bool
+	fastNodeFailureDetection bool
+	network                  string
+	domain                   string
+	port                     int
+	portMappings             []PortMapping
+	clusterCIDR              string
+	serviceCIDR              string
 }
 
 func defaultClusterConfig() *clusterConfig {
@@ -119,6 +120,18 @@ func WithAgents(agents int) clusterOpt {
 func WithServerNoSchedule() clusterOpt {
 	return func(config *clusterConfig) {
 		config.serverNoSchedule = true
+	}
+}
+
+// WithFastNodeFailureDetection drops the node-monitor grace period and the
+// not-ready/unreachable eviction tolerations from their kube defaults (40s and
+// 5m) to 10s so tests that kill nodes see pods evicted quickly. The grace
+// period then equals the kubelet's 10s heartbeat interval, so any late
+// heartbeat flaps the node NotReady; only enable it in suites that actually
+// delete or stop nodes.
+func WithFastNodeFailureDetection() clusterOpt {
+	return func(config *clusterConfig) {
+		config.fastNodeFailureDetection = true
 	}
 }
 
@@ -325,70 +338,7 @@ Use testutils.SkipIfNotIntegration or testutils.SkipIfNotAcceptance to gate test
 		opt.apply(config)
 	}
 
-	args := []string{
-		"cluster",
-		"create",
-		name,
-		fmt.Sprintf("--agents=%d", config.agents),
-		fmt.Sprintf("--timeout=%s", config.timeout),
-		fmt.Sprintf("--image=%s", config.image),
-		// If k3d cluster create will fail please uncomment no-rollback flag
-		// "--no-rollback",
-		// See also https://github.com/k3d-io/k3d/blob/main/docs/faq/faq.md#passing-additional-argumentsflags-to-k3s-and-on-to-eg-the-kube-apiserver
-		// As the formatting is QUITE finicky.
-		// Halve the node-monitor-grace-period to speed up tests that rely on dead node detection.
-		`--k3s-arg`, `--kube-controller-manager-arg=node-monitor-grace-period=10s@server:*`,
-		// Dramatically decrease (5m -> 10s) the default tolerations to ensure
-		// Pod eviction happens in a timely fashion.
-		`--k3s-arg`, `--kube-apiserver-arg=default-not-ready-toleration-seconds=10@server:*`,
-		`--k3s-arg`, `--kube-apiserver-arg=default-unreachable-toleration-seconds=10@server:*`,
-		// Disable bundled k3s components that we don't use in tests.
-		`--k3s-arg`, `--disable=traefik@server:*`,
-		`--k3s-arg`, `--disable=servicelb@server:*`,
-		// Raise kubelet image-pull rate limits and allow parallel pulls. The
-		// kubelet defaults (registry-qps=5, registry-burst=10,
-		// serialize-image-pulls=true) throttle the burst of pulls when many
-		// pods start at once (e.g. several multicluster acceptance features
-		// each launching vclusters + Redpanda), surfacing as "pull QPS
-		// exceeded" events and slow/crashlooping pods. Apply to both server and
-		// agent kubelets since pods may schedule on either.
-		`--k3s-arg`, `--kubelet-arg=registry-qps=20@server:*`,
-		`--k3s-arg`, `--kubelet-arg=registry-burst=40@server:*`,
-		`--k3s-arg`, `--kubelet-arg=serialize-image-pulls=false@server:*`,
-		`--k3s-arg`, `--kubelet-arg=registry-qps=20@agent:*`,
-		`--k3s-arg`, `--kubelet-arg=registry-burst=40@agent:*`,
-		`--k3s-arg`, `--kubelet-arg=serialize-image-pulls=false@agent:*`,
-		`--network`, config.network,
-		`--verbose`,
-	}
-
-	for _, mapping := range config.portMappings {
-		args = append(args, `--port`, fmt.Sprintf("%d:%d@loadbalancer", mapping.Host, mapping.Target))
-	}
-
-	if config.domain != "" {
-		args = append(args, `--k3s-arg`, `--cluster-domain=`+config.domain+"@server:*")
-	}
-
-	if config.port != 0 {
-		args = append(args, `--api-port`, strconv.Itoa(config.port))
-	}
-
-	if config.clusterCIDR != "" {
-		args = append(args, `--k3s-arg`, `--cluster-cidr=`+config.clusterCIDR+`@server:*`)
-	}
-	if config.serviceCIDR != "" {
-		args = append(args, `--k3s-arg`, `--service-cidr=`+config.serviceCIDR+`@server:*`)
-	}
-
-	if config.serverNoSchedule {
-		args = append(args, []string{
-			// This can be useful for tests in which we don't want to accidentally
-			// kill the API server when we delete arbitrary nodes to simulate
-			// hardware failures
-			`--k3s-arg`, `--node-taint=server=true:NoSchedule@server:*`,
-		}...)
-	}
+	args := clusterCreateArgs(name, config)
 
 	// When Docker Hub credentials are available (CI), authenticate the
 	// cluster's containerd against docker.io so in-cluster image pulls
@@ -429,6 +379,77 @@ Use testutils.SkipIfNotIntegration or testutils.SkipIfNotAcceptance to gate test
 	clearImageMarkers(name)
 
 	return loadCluster(name, config)
+}
+
+func clusterCreateArgs(name string, config *clusterConfig) []string {
+	args := []string{
+		"cluster",
+		"create",
+		name,
+		fmt.Sprintf("--agents=%d", config.agents),
+		fmt.Sprintf("--timeout=%s", config.timeout),
+		fmt.Sprintf("--image=%s", config.image),
+		// If k3d cluster create will fail please uncomment no-rollback flag
+		// "--no-rollback",
+		// See also https://github.com/k3d-io/k3d/blob/main/docs/faq/faq.md#passing-additional-argumentsflags-to-k3s-and-on-to-eg-the-kube-apiserver
+		// As the formatting is QUITE finicky.
+		// Disable bundled k3s components that we don't use in tests.
+		`--k3s-arg`, `--disable=traefik@server:*`,
+		`--k3s-arg`, `--disable=servicelb@server:*`,
+		// Raise kubelet image-pull rate limits and allow parallel pulls. The
+		// kubelet defaults (registry-qps=5, registry-burst=10,
+		// serialize-image-pulls=true) throttle the burst of pulls when many
+		// pods start at once (e.g. several multicluster acceptance features
+		// each launching vclusters + Redpanda), surfacing as "pull QPS
+		// exceeded" events and slow/crashlooping pods. Apply to both server and
+		// agent kubelets since pods may schedule on either.
+		`--k3s-arg`, `--kubelet-arg=registry-qps=20@server:*`,
+		`--k3s-arg`, `--kubelet-arg=registry-burst=40@server:*`,
+		`--k3s-arg`, `--kubelet-arg=serialize-image-pulls=false@server:*`,
+		`--k3s-arg`, `--kubelet-arg=registry-qps=20@agent:*`,
+		`--k3s-arg`, `--kubelet-arg=registry-burst=40@agent:*`,
+		`--k3s-arg`, `--kubelet-arg=serialize-image-pulls=false@agent:*`,
+		`--network`, config.network,
+		`--verbose`,
+	}
+
+	if config.fastNodeFailureDetection {
+		args = append(args,
+			`--k3s-arg`, `--kube-controller-manager-arg=node-monitor-grace-period=10s@server:*`,
+			`--k3s-arg`, `--kube-apiserver-arg=default-not-ready-toleration-seconds=10@server:*`,
+			`--k3s-arg`, `--kube-apiserver-arg=default-unreachable-toleration-seconds=10@server:*`,
+		)
+	}
+
+	for _, mapping := range config.portMappings {
+		args = append(args, `--port`, fmt.Sprintf("%d:%d@loadbalancer", mapping.Host, mapping.Target))
+	}
+
+	if config.domain != "" {
+		args = append(args, `--k3s-arg`, `--cluster-domain=`+config.domain+"@server:*")
+	}
+
+	if config.port != 0 {
+		args = append(args, `--api-port`, strconv.Itoa(config.port))
+	}
+
+	if config.clusterCIDR != "" {
+		args = append(args, `--k3s-arg`, `--cluster-cidr=`+config.clusterCIDR+`@server:*`)
+	}
+	if config.serviceCIDR != "" {
+		args = append(args, `--k3s-arg`, `--service-cidr=`+config.serviceCIDR+`@server:*`)
+	}
+
+	if config.serverNoSchedule {
+		args = append(args, []string{
+			// This can be useful for tests in which we don't want to accidentally
+			// kill the API server when we delete arbitrary nodes to simulate
+			// hardware failures
+			`--k3s-arg`, `--node-taint=server=true:NoSchedule@server:*`,
+		}...)
+	}
+
+	return args
 }
 
 func loadCluster(name string, config *clusterConfig) (*Cluster, error) {

--- a/pkg/k3d/k3d_test.go
+++ b/pkg/k3d/k3d_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/testutil"
 )
@@ -56,4 +57,28 @@ func TestIntegrationMultiInstance(t *testing.T) {
 	}
 
 	assert.NoError(t, errors.Join(errs...))
+}
+
+func TestClusterCreateArgs(t *testing.T) {
+	fastDetectionArgs := []string{
+		`--kube-controller-manager-arg=node-monitor-grace-period=10s@server:*`,
+		`--kube-apiserver-arg=default-not-ready-toleration-seconds=10@server:*`,
+		`--kube-apiserver-arg=default-unreachable-toleration-seconds=10@server:*`,
+	}
+
+	t.Run("kube default node health unless opted in", func(t *testing.T) {
+		args := clusterCreateArgs("test", defaultClusterConfig())
+		for _, arg := range fastDetectionArgs {
+			require.NotContains(t, args, arg)
+		}
+	})
+
+	t.Run("WithFastNodeFailureDetection", func(t *testing.T) {
+		config := defaultClusterConfig()
+		WithFastNodeFailureDetection().apply(config)
+		args := clusterCreateArgs("test", config)
+		for _, arg := range fastDetectionArgs {
+			require.Contains(t, args, arg)
+		}
+	})
 }


### PR DESCRIPTION
Multicluster build 15638 failed `TestResourceCleanup/SingleBrokerPoolDeletion` 3/3 with only cluster-0 evidence to go on: `MulticlusterEnv.CreateTestNamespace` registered the failure dump on `Envs[0]` alone, the dialer reported a peer's `pods "…" not found` in place of the home cluster's error, and nothing captured node conditions or container logs. This PR first made failures root-causable and removed two test-infra amplifiers; its own multicluster run (build 15653) then showed no node flap at all, `SingleBrokerPoolDeletion` green, and a new `FullDeletion` failure whose cause is fixed here too. The acceptance-multicluster nightly (build 15704) exposed the same blind spots in harpoon's diagnostics and a node-pinning imbalance, also addressed here.

**Operator**
- Both deletion paths (`RedpandaReconciler`, `MulticlusterReconciler`) returned a bare result after `DeleteAll` removed resources, which the Reconcile defer turns into the 3m `periodicRequeue`. Neither controller watches Pods or StatefulSets, so finalizer removal waited the full 3m unless an unrelated event arrived — build 15653's `FullDeletion` failed at exactly that boundary (181.7s vs. a 3m wait) and passed on re-run in 22s. They now requeue every 10s while cleanup is in progress. Changelog entry included.
- `stretchClusterEndpoints` offered a per-pod admin endpoint for pools that were mid-deletion. A pool being torn down still has a Running (dialable) broker pod, so `SingleBrokerPoolDeletion`'s decommission/health reads routed through the broker being removed and hit `io.EOF`, which rpadmin mislabels as `expected a tls connection` — wedging the pool's own StatefulSet cleanup (build 15762). Pools carrying a deletion timestamp are now skipped when building the admin endpoint set, so those reads land on surviving brokers. Regression test included.

**Test infrastructure (testenv, multicluster suites)**
- Every multicluster member dumps its pods (node, restarts, conditions), timestamped events, node conditions and Node events, StatefulSets and Redpanda CRDs with finalizers/deletion timestamps, container log tails, and the node-health lines of its k3d node containers; `INTEGRATION_ARTIFACTS_DIR` gets the same per cluster.
- Each test namespace gets a log recorder that follows every container log for the life of the test (last 100 lines per container instance), so a teardown failure still shows what the brokers logged before their pods disappeared — build 15653's pods burned the full 90s termination grace and left no logs to explain why.
- `MulticlusterEnv.DialContext` joins per-cluster errors instead of returning the last one.
- k3d's `node-monitor-grace-period=10s` and 10s not-ready/unreachable tolerations become `k3d.WithFastNodeFailureDetection()`, enabled only where a suite deliberately kills a node: the PVC-unbinder integration test and the acceptance suite's "Tolerating Node Failure" scenario. The multicluster suites (integration and acceptance) and the shared `testenv` cluster keep kube defaults (40s / 5m) — the 10s grace flaps a momentarily-loaded node, which tears down vclusters. In the harpoon provider the flag is gated on `HARPOON_GROUPS` (off for the multicluster acceptance job) and the fast-eviction cluster is named separately so a retained cluster's flags never leak between suites.
- `NewMulticluster` taints the k3s server node so brokers never share a container with the control plane.
- The harpoon K3D provider re-imports the suite's images onto a node it recreates (`AddNode`). A node the acceptance "Tolerating Node Failure" scenario deletes and re-adds came up without the images imported at setup, so the replacement broker hit `Init:ImagePullBackOff` on `localhost/redpanda-operator:dev` and `helm install --wait` timed out (build 15750).

**Acceptance (stretch features)**
- `pickK3dAgentNodes` sorted the harpoon workers by name and took the first three, so with `-parallel 3` every stretch feature pinned its vclusters onto agents 0–2 while agents 3–4 idled. Nightly 15704 lost `stretch-cluster-operator-upgrade`'s baseline cluster that way (broker CrashLoopBackOff, vc-1's node reporting `Insufficient cpu, Insufficient memory, Too many pods`), and both re-runs then timed out creating a vcluster on the same saturated node. Vclusters are now pinned to Ready, schedulable workers with the fewest pods (ties by name; unit-tested).
- The multicluster diagnostics knew only that a container was in CrashLoopBackOff. They now log the previous instance's exit code/reason, the `redpanda`/`sidecar` log tails plus the previous instance of anything that restarted, and every host node's readiness, taints, allocatable capacity and pod count.

Not changed: the preStop drain on full-cluster teardown (survivors already skip it at ≤2 replicas; the departing broker's Secret is GC'd before it dies).

In the multicluster integration job `FullDeletion` went from a 3m timeout to 57s and the whole job ran without a single gotestsum re-run.

Build 15721 then showed the acceptance-multicluster suite failing `stretch-cluster-operator-upgrade` with node-NotReady flapping (30 `Node is not ready` events, zero resource-exhaustion) that killed vclusters after they had come up — the earlier commit had handed harpoon's fast-eviction flags to that suite. Gating the flag off the multicluster job (above) removes that failure mode while keeping the pinning fix.

Build 15750's acceptance `Tolerating Node Failure` failure was a third, unrelated flake — the replacement broker's node lacked the imported images — fixed by the re-import above.

Build 15762's `SingleBrokerPoolDeletion` failure was the deleting-pool admin-endpoint bug — the decommission read routed through the dying broker — fixed by the endpoint skip above.
