### PR TITLE
docs: document every chart value and CRD field that ships blank

### DIFF
--- a/.changes/unreleased/charts-connectors-Added-20260907-130000.yaml
+++ b/.changes/unreleased/charts-connectors-Added-20260907-130000.yaml
@@ -1,0 +1,16 @@
+project: charts/connectors
+kind: Added
+body: |-
+    Descriptions for the 30 values that shipped blank in the Helm reference
+
+      Includes `connectors.schemaRegistryURL`, the `connectors.secretManager` group,
+      `connectors.brokerTLS.enabled`, `container.javaGCLogEnabled`, `deployment.create`,
+      `deployment.strategy`, `deployment.schedulerName`, `readinessProbe`,
+      `deployment.topologySpreadConstraints`, `deployment.securityContext`,
+      `deployment.terminationGracePeriodSeconds`, `deployment.restartPolicy`,
+      `storage.volume`, `storage.volumeMounts` and `test.create`.
+
+      `deployment.budget.maxUnavailable` is deliberately left undocumented: it is
+      declared in the values schema but this chart renders no PodDisruptionBudget, so
+      the value currently has no effect.
+time: 2026-09-07T13:00:00.000000-07:00

--- a/.changes/unreleased/charts-console-Added-20260907-130001.yaml
+++ b/.changes/unreleased/charts-console-Added-20260907-130001.yaml
@@ -1,0 +1,18 @@
+project: charts/console
+kind: Added
+body: |-
+    Descriptions for the 36 values that shipped blank in the Helm reference
+
+      Includes `replicaCount`, `podAnnotations`, `podLabels`, `podSecurityContext`,
+      `securityContext`, the `service`, `ingress`, `autoscaling` and `monitoring`
+      groups, `resources`, `nodeSelector`, `tolerations`, `affinity`,
+      `topologySpreadConstraints`, `readinessProbe`, `strategy`, `configmap.create` and
+      `deployment.create`.
+
+      Values that only apply when a sibling is enabled now say so, for example
+      `replicaCount` is ignored when `autoscaling.enabled` is `true`.
+
+      `tests.enabled` is deliberately left undocumented: it is declared in the values
+      schema but this chart has no test hook template, so the value currently has no
+      effect.
+time: 2026-09-07T13:00:01.000000-07:00

--- a/.changes/unreleased/charts-redpanda-Added-20260907-130002.yaml
+++ b/.changes/unreleased/charts-redpanda-Added-20260907-130002.yaml
@@ -1,0 +1,15 @@
+project: charts/redpanda
+kind: Added
+body: |-
+    Descriptions for the 20 values that shipped blank in the Helm reference
+
+      Includes `post_install_job.enabled`, `statefulset.updateStrategy`,
+      `statefulset.budget.maxUnavailable`, the `statefulset.sideCars` image,
+      `pvcUnbinder`, `brokerDecommissioner`, `configWatcher` and `controllers`
+      settings, the `statefulset.initContainers` settings, and
+      `statefulset.initContainerImage`.
+
+      `tests.enabled` is deliberately left undocumented: it is declared in the values
+      schema but this chart has no test hook template, so the value currently has no
+      effect.
+time: 2026-09-07T13:00:02.000000-07:00

--- a/.changes/unreleased/operator-Added-20260907-130003.yaml
+++ b/.changes/unreleased/operator-Added-20260907-130003.yaml
@@ -1,0 +1,10 @@
+project: operator
+kind: Added
+body: |-
+    Descriptions for the 30 Tiered Storage fields of `StretchTieredConfig`
+
+      Every field shipped blank in the CRD reference and in `kubectl explain`. The text
+      is the description already published in the object storage property reference for
+      the same cluster property, so the two references now agree. Affects the
+      StretchCluster and RedpandaBrokerPool CRDs, which share the type.
+time: 2026-09-07T13:00:03.000000-07:00

--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -88,6 +88,8 @@ The name of the secret where client signed certificate is located
 
 ### [connectors.brokerTLS.enabled](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.brokerTLS.enabled)
 
+Whether Kafka Connect connects to the Redpanda brokers over TLS. Sets the `CONNECT_TLS_ENABLED` environment variable.
+
 **Default:** `false`
 
 ### [connectors.brokerTLS.key.secretNameOverwrite](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.brokerTLS.key.secretNameOverwrite)
@@ -128,21 +130,31 @@ The port on which the Kafka Connect REST API listens. The API is used for admini
 
 ### [connectors.schemaRegistryURL](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.schemaRegistryURL)
 
+A comma-separated list of Schema Registry addresses in the format IP:Port or DNS:Port. The Schema Registry is a service that manages the schemas used by producers and consumers.
+
 **Default:** `""`
 
 ### [connectors.secretManager.connectorsPrefix](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.connectorsPrefix)
+
+Second part of that secret name prefix, appended to `consolePrefix`.
 
 **Default:** `""`
 
 ### [connectors.secretManager.consolePrefix](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.consolePrefix)
 
+First part of the prefix that every secret name is looked up under. Concatenated with `connectorsPrefix` to form `config.providers.secretsManager.param.secret.prefix`.
+
 **Default:** `""`
 
 ### [connectors.secretManager.enabled](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.enabled)
 
+Whether to register the AWS Secrets Manager config provider with Kafka Connect, so that connector configurations can reference secrets held in Secrets Manager instead of inlining them.
+
 **Default:** `false`
 
 ### [connectors.secretManager.region](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.region)
+
+AWS region that Secrets Manager is read from. Sets `config.providers.secretsManager.param.aws.region`.
 
 **Default:** `""`
 
@@ -216,6 +228,8 @@ The name of the internal topic that Kafka Connect uses to store connector and ta
 
 ### [container.javaGCLogEnabled](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=container.javaGCLogEnabled)
 
+Whether Kafka Connect writes Java garbage-collection logs. Sets the `CONNECT_GC_LOG_ENABLED` environment variable.
+
 **Default:** `"false"`
 
 ### [container.resources](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=container.resources)
@@ -255,6 +269,8 @@ Additional annotations to apply to the Pods of this Deployment.
 **Default:** `1`
 
 ### [deployment.create](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.create)
+
+Whether to render the Deployment. Set to `false` to install the chart's other resources without running Kafka Connect.
 
 **Default:** `true`
 
@@ -344,27 +360,19 @@ The maximum time in seconds for a deployment to make progress before it is consi
 
 **Default:** `600`
 
-### [deployment.readinessProbe.failureThreshold](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.readinessProbe.failureThreshold)
+### [deployment.readinessProbe](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.readinessProbe)
 
-**Default:** `2`
+Adjust the period for your probes to meet your needs. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
 
-### [deployment.readinessProbe.initialDelaySeconds](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.readinessProbe.initialDelaySeconds)
+**Default:**
 
-**Default:** `60`
-
-### [deployment.readinessProbe.periodSeconds](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.readinessProbe.periodSeconds)
-
-**Default:** `10`
-
-### [deployment.readinessProbe.successThreshold](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.readinessProbe.successThreshold)
-
-**Default:** `3`
-
-### [deployment.readinessProbe.timeoutSeconds](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.readinessProbe.timeoutSeconds)
-
-**Default:** `5`
+```
+{"failureThreshold":2,"initialDelaySeconds":60,"periodSeconds":10,"successThreshold":3,"timeoutSeconds":5}
+```
 
 ### [deployment.restartPolicy](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.restartPolicy)
+
+Restart policy for the Pods of this Deployment.
 
 **Default:** `"Always"`
 
@@ -376,25 +384,29 @@ The number of old ReplicaSets to retain to allow rollback. This is a pointer to 
 
 ### [deployment.schedulerName](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.schedulerName)
 
+Name of the scheduler used to place the Pods of this Deployment. Leave empty to use the default scheduler.
+
 **Default:** `""`
 
-### [deployment.securityContext.fsGroup](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.securityContext.fsGroup)
+### [deployment.securityContext](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.securityContext)
 
-**Default:** `101`
+Pod-level security context for the Pods of this Deployment. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
-### [deployment.securityContext.fsGroupChangePolicy](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.securityContext.fsGroupChangePolicy)
+**Default:**
 
-**Default:** `"OnRootMismatch"`
+```
+{"fsGroup":101,"fsGroupChangePolicy":"OnRootMismatch","runAsUser":101}
+```
 
-### [deployment.securityContext.runAsUser](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.securityContext.runAsUser)
+### [deployment.strategy](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.strategy)
 
-**Default:** `101`
+Update strategy for this Deployment. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
 
-### [deployment.strategy.type](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.strategy.type)
-
-**Default:** `"RollingUpdate"`
+**Default:** `{"type":"RollingUpdate"}`
 
 ### [deployment.terminationGracePeriodSeconds](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.terminationGracePeriodSeconds)
+
+How long Kubernetes waits for a Pod of this Deployment to shut down cleanly before killing it.
 
 **Default:** `30`
 
@@ -404,21 +416,15 @@ Taints to be tolerated by Pods of this Deployment. These tolerations override th
 
 **Default:** `[]`
 
-### [deployment.topologySpreadConstraints[0].maxSkew](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.topologySpreadConstraints[0].maxSkew)
+### [deployment.topologySpreadConstraints](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.topologySpreadConstraints)
 
-**Default:** `1`
-
-### [deployment.topologySpreadConstraints[0].topologyKey](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.topologySpreadConstraints[0].topologyKey)
+Constraints on how the Pods of this Deployment are spread across failure domains. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
 
 **Default:**
 
 ```
-"topology.kubernetes.io/zone"
+[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]
 ```
-
-### [deployment.topologySpreadConstraints[0].whenUnsatisfiable](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.topologySpreadConstraints[0].whenUnsatisfiable)
-
-**Default:** `"ScheduleAnyway"`
 
 ### [fullnameOverride](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=fullnameOverride)
 
@@ -548,27 +554,29 @@ The name of the ServiceAccount to use. If not set and `serviceAccount.create` is
 
 **Default:** `""`
 
-### [storage.volumeMounts[0].mountPath](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volumeMounts[0].mountPath)
+### [storage.volume](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volume)
 
-**Default:** `"/tmp"`
+Volumes to add to the Pods of this Deployment. The default provides the writable `/tmp` that Kafka Connect needs when the root filesystem is read-only.
 
-### [storage.volumeMounts[0].name](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volumeMounts[0].name)
+**Default:**
 
-**Default:** `"rp-connect-tmp"`
+```
+[{"emptyDir":{"medium":"Memory","sizeLimit":"5Mi"},"name":"rp-connect-tmp"}]
+```
 
-### [storage.volume[0].emptyDir.medium](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volume[0].emptyDir.medium)
+### [storage.volumeMounts](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volumeMounts)
 
-**Default:** `"Memory"`
+Where the volumes above are mounted in the Kafka Connect container.
 
-### [storage.volume[0].emptyDir.sizeLimit](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volume[0].emptyDir.sizeLimit)
+**Default:**
 
-**Default:** `"5Mi"`
-
-### [storage.volume[0].name](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volume[0].name)
-
-**Default:** `"rp-connect-tmp"`
+```
+[{"mountPath":"/tmp","name":"rp-connect-tmp"}]
+```
 
 ### [test.create](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=test.create)
+
+Whether to render the chart's Helm test resources, which run a MirrorMaker 2 smoke test against the cluster when `helm test` is invoked.
 
 **Default:** `true`
 

--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -136,13 +136,13 @@ A comma-separated list of Schema Registry addresses in the format IP:Port or DNS
 
 ### [connectors.secretManager.connectorsPrefix](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.connectorsPrefix)
 
-Second part of that secret name prefix, appended to `consolePrefix`.
+Second part of that lookup prefix, appended to `consolePrefix`. Applies only when `connectors.secretManager.enabled` is `true`.
 
 **Default:** `""`
 
 ### [connectors.secretManager.consolePrefix](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.consolePrefix)
 
-First part of the prefix that every secret name is looked up under. Concatenated with `connectorsPrefix` to form `config.providers.secretsManager.param.secret.prefix`.
+First part of the prefix that every secret name is looked up under. Concatenated with `connectorsPrefix` to form `config.providers.secretsManager.param.secret.prefix`. Applies only when `connectors.secretManager.enabled` is `true`.
 
 **Default:** `""`
 
@@ -154,7 +154,7 @@ Whether to register the AWS Secrets Manager config provider with Kafka Connect, 
 
 ### [connectors.secretManager.region](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=connectors.secretManager.region)
 
-AWS region that Secrets Manager is read from. Sets `config.providers.secretsManager.param.aws.region`.
+AWS region that Secrets Manager is read from. Sets `config.providers.secretsManager.param.aws.region`. Applies only when `connectors.secretManager.enabled` is `true`.
 
 **Default:** `""`
 
@@ -372,7 +372,7 @@ Adjust the period for your probes to meet your needs. For details, see the [Kube
 
 ### [deployment.restartPolicy](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.restartPolicy)
 
-Restart policy for the Pods of this Deployment.
+Restart policy for the Pods of this Deployment. Kubernetes requires `Always` for Pods managed by a Deployment.
 
 **Default:** `"Always"`
 
@@ -566,7 +566,7 @@ Volumes to add to the Pods of this Deployment. The default provides the writable
 
 ### [storage.volumeMounts](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=storage.volumeMounts)
 
-Where the volumes above are mounted in the Kafka Connect container.
+Where the volumes declared in `storage.volume` are mounted inside the Kafka Connect container.
 
 **Default:**
 

--- a/charts/connectors/values.yaml
+++ b/charts/connectors/values.yaml
@@ -73,14 +73,17 @@ connectors:
     # Connect, so that connector configurations can reference secrets held in
     # Secrets Manager instead of inlining them.
     enabled: false
-    # -- AWS region that Secrets Manager is read from.
-    # Sets `config.providers.secretsManager.param.aws.region`.
+    # -- AWS region that Secrets Manager is read from. Sets
+    # `config.providers.secretsManager.param.aws.region`. Applies only when
+    # `connectors.secretManager.enabled` is `true`.
     region: ""
     # -- First part of the prefix that every secret name is looked up under.
     # Concatenated with `connectorsPrefix` to form
-    # `config.providers.secretsManager.param.secret.prefix`.
+    # `config.providers.secretsManager.param.secret.prefix`. Applies only when
+    # `connectors.secretManager.enabled` is `true`.
     consolePrefix: ""
-    # -- Second part of that secret name prefix, appended to `consolePrefix`.
+    # -- Second part of that lookup prefix, appended to `consolePrefix`.
+    # Applies only when `connectors.secretManager.enabled` is `true`.
     connectorsPrefix: ""
   # -- The number of bytes of records a producer will attempt to batch together before sending to Redpanda. Batching improves throughput.
   producerBatchSize: 131072
@@ -308,7 +311,8 @@ deployment:
   # -- How long Kubernetes waits for a Pod of this Deployment to shut down
   # cleanly before killing it.
   terminationGracePeriodSeconds: 30
-  # -- Restart policy for the Pods of this Deployment.
+  # -- Restart policy for the Pods of this Deployment. Kubernetes requires
+  # `Always` for Pods managed by a Deployment.
   restartPolicy: Always
 
 storage:
@@ -320,7 +324,8 @@ storage:
       medium: Memory
       sizeLimit: 5Mi
     name: rp-connect-tmp
-  # -- Where the volumes above are mounted in the Kafka Connect container.
+  # -- Where the volumes declared in `storage.volume` are mounted inside the
+  # Kafka Connect container.
   volumeMounts:
   - mountPath: /tmp
     name: rp-connect-tmp

--- a/charts/connectors/values.yaml
+++ b/charts/connectors/values.yaml
@@ -55,6 +55,8 @@ image:
 imagePullSecrets: []
 
 test:
+  # -- Whether to render the chart's Helm test resources, which run a
+  # MirrorMaker 2 smoke test against the cluster when `helm test` is invoked.
   create: true
 
 connectors:
@@ -62,14 +64,23 @@ connectors:
   restPort: 8083
   # -- A comma-separated list of Redpanda broker addresses in the format of IP:Port or DNS:Port. Kafka Connect uses this to connect to the Redpanda/Kafka cluster.
   bootstrapServers: ""
-  # A comma-separated list of Schema Registry addresses in the format IP:Port or DNS:Port. The Schema Registry is a service that manages the schemas used by producers and consumers.
+  # -- A comma-separated list of Schema Registry addresses in the format IP:Port or DNS:Port. The Schema Registry is a service that manages the schemas used by producers and consumers.
   schemaRegistryURL: ""
   # -- A placeholder for any Java configuration settings for Kafka Connect that are not explicitly defined in this Helm chart. Java configuration settings are passed to the Kafka Connect startup script.
   additionalConfiguration: ""
   secretManager:
+    # -- Whether to register the AWS Secrets Manager config provider with Kafka
+    # Connect, so that connector configurations can reference secrets held in
+    # Secrets Manager instead of inlining them.
     enabled: false
+    # -- AWS region that Secrets Manager is read from.
+    # Sets `config.providers.secretsManager.param.aws.region`.
     region: ""
+    # -- First part of the prefix that every secret name is looked up under.
+    # Concatenated with `connectorsPrefix` to form
+    # `config.providers.secretsManager.param.secret.prefix`.
     consolePrefix: ""
+    # -- Second part of that secret name prefix, appended to `consolePrefix`.
     connectorsPrefix: ""
   # -- The number of bytes of records a producer will attempt to batch together before sending to Redpanda. Batching improves throughput.
   producerBatchSize: 131072
@@ -104,6 +115,8 @@ connectors:
   # -- A unique string that identifies the Kafka Connect cluster. It's used in the formation of the internal topic names, ensuring that multiple Kafka Connect clusters can connect to the same Redpanda cluster without interfering with each other.
   groupID: connectors-cluster
   brokerTLS:
+    # -- Whether Kafka Connect connects to the Redpanda brokers over TLS.
+    # Sets the `CONNECT_TLS_ENABLED` environment variable.
     enabled: false
     ca:
       # -- The name of the Secret where the ca.crt file content is located.
@@ -170,17 +183,26 @@ container:
       memory: 2350Mi
     # -- Java maximum heap size must not be greater than `container.resources.limits.memory`.
     javaMaxHeapSize: 2G
+  # -- Whether Kafka Connect writes Java garbage-collection logs.
+  # Sets the `CONNECT_GC_LOG_ENABLED` environment variable.
   javaGCLogEnabled: "false"
 
 deployment:
   # Replicas can be used to scale Deployment
   # replicas
 
+  # -- Whether to render the Deployment. Set to `false` to install the chart's
+  # other resources without running Kafka Connect.
   create: true
   # Customize the command to use as the entrypoint of the Deployment.
   # command: []
+  # -- Update strategy for this Deployment.
+  # For details,
+  # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
   strategy:
     type: RollingUpdate
+  # -- Name of the scheduler used to place the Pods of this Deployment.
+  # Leave empty to use the default scheduler.
   schedulerName: ""
   budget:
     maxUnavailable: 1
@@ -195,6 +217,9 @@ deployment:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  # -- Adjust the period for your probes to meet your needs.
+  # For details,
+  # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
   readinessProbe:
     initialDelaySeconds: 60
     failureThreshold: 2
@@ -265,25 +290,37 @@ deployment:
   # For details,
   # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
   tolerations: []
+  # -- Constraints on how the Pods of this Deployment are spread across
+  # failure domains.
   # For details,
   # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
   topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
+  # -- Pod-level security context for the Pods of this Deployment.
+  # For details,
+  # see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   securityContext:
     fsGroup: 101
     runAsUser: 101
     fsGroupChangePolicy: OnRootMismatch
+  # -- How long Kubernetes waits for a Pod of this Deployment to shut down
+  # cleanly before killing it.
   terminationGracePeriodSeconds: 30
+  # -- Restart policy for the Pods of this Deployment.
   restartPolicy: Always
 
 storage:
+  # -- Volumes to add to the Pods of this Deployment. The default provides the
+  # writable `/tmp` that Kafka Connect needs when the root filesystem is
+  # read-only.
   volume:
   - emptyDir:
       medium: Memory
       sizeLimit: 5Mi
     name: rp-connect-tmp
+  # -- Where the volumes above are mounted in the Kafka Connect container.
   volumeMounts:
   - mountPath: /tmp
     name: rp-connect-tmp

--- a/charts/console/chart/README.md
+++ b/charts/console/chart/README.md
@@ -27,6 +27,8 @@ Kubernetes: `>= 1.25.0-0`
 
 ### [affinity](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=affinity)
 
+Affinity rules for scheduling the Console Pods.
+
 **Default:** `{}`
 
 ### [annotations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=annotations)
@@ -43,21 +45,31 @@ Automount API credentials for the Service Account into the pod. Console does not
 
 ### [autoscaling.enabled](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.enabled)
 
+Whether to create a HorizontalPodAutoscaler for the Console Deployment.
+
 **Default:** `false`
 
 ### [autoscaling.maxReplicas](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.maxReplicas)
+
+Maximum number of Console Pods the autoscaler scales up to.
 
 **Default:** `100`
 
 ### [autoscaling.minReplicas](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.minReplicas)
 
+Minimum number of Console Pods the autoscaler scales down to.
+
 **Default:** `1`
 
 ### [autoscaling.targetCPUUtilizationPercentage](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.targetCPUUtilizationPercentage)
 
+Average CPU utilization the autoscaler targets, as a percentage of the CPU request.
+
 **Default:** `80`
 
 ### [commonLabels](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=commonLabels)
+
+Common labels to add to all the pods
 
 **Default:** `{}`
 
@@ -69,9 +81,13 @@ Settings for the `Config.yaml` (required). For a reference of configuration sett
 
 ### [configmap.create](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=configmap.create)
 
+Whether to render the ConfigMap that holds Console's configuration.
+
 **Default:** `true`
 
 ### [deployment.create](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=deployment.create)
+
+Whether to render the Console Deployment.
 
 **Default:** `true`
 
@@ -175,25 +191,29 @@ Pull secrets may be used to provide credentials to image repositories See https:
 
 ### [ingress.annotations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.annotations)
 
+Annotations to add to the Ingress, for example to select an ingress controller or request a certificate.
+
 **Default:** `{}`
 
 ### [ingress.enabled](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.enabled)
 
+Whether to create an Ingress for Console.
+
 **Default:** `false`
 
-### [ingress.hosts[0].host](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.hosts[0].host)
+### [ingress.hosts](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.hosts)
 
-**Default:** `"chart-example.local"`
+Hosts and paths that the Ingress routes to Console.
 
-### [ingress.hosts[0].paths[0].path](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.hosts[0].paths[0].path)
+**Default:**
 
-**Default:** `"/"`
-
-### [ingress.hosts[0].paths[0].pathType](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.hosts[0].paths[0].pathType)
-
-**Default:** `"ImplementationSpecific"`
+```
+[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]
+```
 
 ### [ingress.tls](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.tls)
+
+TLS configuration for the Ingress.
 
 **Default:** `[]`
 
@@ -221,13 +241,19 @@ Settings for liveness and readiness probes. For details, see the [Kubernetes doc
 
 ### [monitoring.enabled](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=monitoring.enabled)
 
+Whether to create a ServiceMonitor for Console's metrics endpoint.
+
 **Default:** `false`
 
 ### [monitoring.labels](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=monitoring.labels)
 
+Labels to add to the ServiceMonitor, so that a Prometheus instance can select it.
+
 **Default:** `{}`
 
 ### [monitoring.scrapeInterval](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=monitoring.scrapeInterval)
+
+How often Prometheus scrapes that endpoint.
 
 **Default:** `"1m"`
 
@@ -239,27 +265,31 @@ Override `console.name` template.
 
 ### [nodeSelector](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=nodeSelector)
 
+Node labels that the Console Pods must match to be scheduled.
+
 **Default:** `{}`
 
 ### [podAnnotations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=podAnnotations)
+
+Annotations to add to the Console Pods.
 
 **Default:** `{}`
 
 ### [podLabels](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=podLabels)
 
+Labels to add to the Console Pods.
+
 **Default:** `{}`
 
-### [podSecurityContext.fsGroup](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=podSecurityContext.fsGroup)
+### [podSecurityContext](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=podSecurityContext)
 
-**Default:** `99`
+Pod-level security context for the Console Pods. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
-### [podSecurityContext.fsGroupChangePolicy](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=podSecurityContext.fsGroupChangePolicy)
+**Default:**
 
-**Default:** `"Always"`
-
-### [podSecurityContext.runAsUser](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=podSecurityContext.runAsUser)
-
-**Default:** `99`
+```
+{"fsGroup":99,"fsGroupChangePolicy":"Always","runAsUser":99}
+```
 
 ### [priorityClassName](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=priorityClassName)
 
@@ -267,9 +297,15 @@ PriorityClassName given to Pods. For details, see the [Kubernetes documentation]
 
 **Default:** `""`
 
-### [readinessProbe.failureThreshold](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=readinessProbe.failureThreshold)
+### [readinessProbe](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=readinessProbe)
 
-**Default:** `3`
+Readiness probe for the Console container. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+
+**Default:**
+
+```
+{"failureThreshold":3,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}
+```
 
 ### [readinessProbe.initialDelaySeconds](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=readinessProbe.initialDelaySeconds)
 
@@ -277,23 +313,15 @@ Grant time to test connectivity to upstream services such as Kafka and Schema Re
 
 **Default:** `10`
 
-### [readinessProbe.periodSeconds](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=readinessProbe.periodSeconds)
-
-**Default:** `10`
-
-### [readinessProbe.successThreshold](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=readinessProbe.successThreshold)
-
-**Default:** `1`
-
-### [readinessProbe.timeoutSeconds](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=readinessProbe.timeoutSeconds)
-
-**Default:** `1`
-
 ### [replicaCount](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=replicaCount)
+
+Number of Console Pods to run.
 
 **Default:** `1`
 
 ### [resources](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=resources)
+
+Compute resources for the Console container. Left empty so the chart runs on small clusters; see the commented example below.
 
 **Default:** `{}`
 
@@ -319,9 +347,11 @@ SecretMounts is an abstraction to make a Secret available in the container's fil
 
 **Default:** `[]`
 
-### [securityContext.runAsNonRoot](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=securityContext.runAsNonRoot)
+### [securityContext](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=securityContext)
 
-**Default:** `true`
+Container-level security context for the Console container.
+
+**Default:** `{"runAsNonRoot":true}`
 
 ### [service.annotations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=service.annotations)
 
@@ -331,9 +361,13 @@ Override the value in `console.config.server.listenPort` if not `nil` targetPort
 
 ### [service.port](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=service.port)
 
+Port that the Console Service listens on.
+
 **Default:** `8080`
 
 ### [service.type](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=service.type)
+
+Type of Service created for Console.
 
 **Default:** `"ClusterIP"`
 
@@ -363,6 +397,8 @@ The name of the service account to use. If not set and `serviceAccount.create` i
 
 ### [strategy](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=strategy)
 
+Update strategy for the Console Deployment.
+
 **Default:** `{}`
 
 ### [tests.enabled](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=tests.enabled)
@@ -371,9 +407,13 @@ The name of the service account to use. If not set and `serviceAccount.create` i
 
 ### [tolerations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=tolerations)
 
+Taints that the Console Pods tolerate.
+
 **Default:** `[]`
 
 ### [topologySpreadConstraints](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=topologySpreadConstraints)
+
+Constraints on how the Console Pods are spread across failure domains.
 
 **Default:** `[]`
 

--- a/charts/console/chart/README.md
+++ b/charts/console/chart/README.md
@@ -27,7 +27,7 @@ Kubernetes: `>= 1.25.0-0`
 
 ### [affinity](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=affinity)
 
-Affinity rules for scheduling the Console Pods.
+Affinity rules for scheduling the Console Pods. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
 
 **Default:** `{}`
 
@@ -51,25 +51,25 @@ Whether to create a HorizontalPodAutoscaler for the Console Deployment.
 
 ### [autoscaling.maxReplicas](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.maxReplicas)
 
-Maximum number of Console Pods the autoscaler scales up to.
+Maximum number of Console Pods the autoscaler scales up to. Applies only when `autoscaling.enabled` is `true`.
 
 **Default:** `100`
 
 ### [autoscaling.minReplicas](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.minReplicas)
 
-Minimum number of Console Pods the autoscaler scales down to.
+Minimum number of Console Pods the autoscaler scales down to. Applies only when `autoscaling.enabled` is `true`.
 
 **Default:** `1`
 
 ### [autoscaling.targetCPUUtilizationPercentage](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=autoscaling.targetCPUUtilizationPercentage)
 
-Average CPU utilization the autoscaler targets, as a percentage of the CPU request.
+Average CPU utilization the autoscaler targets, as a percentage of the CPU request. Applies only when `autoscaling.enabled` is `true`.
 
 **Default:** `80`
 
 ### [commonLabels](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=commonLabels)
 
-Common labels to add to all the pods
+Common labels to add to all the Pods.
 
 **Default:** `{}`
 
@@ -191,7 +191,7 @@ Pull secrets may be used to provide credentials to image repositories See https:
 
 ### [ingress.annotations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.annotations)
 
-Annotations to add to the Ingress, for example to select an ingress controller or request a certificate.
+Annotations to add to the Ingress, for example to select an ingress controller or request a certificate. Applies only when `ingress.enabled` is `true`.
 
 **Default:** `{}`
 
@@ -203,7 +203,7 @@ Whether to create an Ingress for Console.
 
 ### [ingress.hosts](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.hosts)
 
-Hosts and paths that the Ingress routes to Console.
+Hosts and paths that the Ingress routes to Console. Applies only when `ingress.enabled` is `true`.
 
 **Default:**
 
@@ -213,7 +213,7 @@ Hosts and paths that the Ingress routes to Console.
 
 ### [ingress.tls](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=ingress.tls)
 
-TLS configuration for the Ingress.
+TLS certificates for the Ingress, each entry naming a Secret and the hosts it covers. Applies only when `ingress.enabled` is `true`.
 
 **Default:** `[]`
 
@@ -247,13 +247,13 @@ Whether to create a ServiceMonitor for Console's metrics endpoint.
 
 ### [monitoring.labels](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=monitoring.labels)
 
-Labels to add to the ServiceMonitor, so that a Prometheus instance can select it.
+Labels to add to the ServiceMonitor, so that a Prometheus instance can select it. Applies only when `monitoring.enabled` is `true`.
 
 **Default:** `{}`
 
 ### [monitoring.scrapeInterval](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=monitoring.scrapeInterval)
 
-How often Prometheus scrapes that endpoint.
+How often Prometheus scrapes Console's metrics endpoint. Applies only when `monitoring.enabled` is `true`.
 
 **Default:** `"1m"`
 
@@ -315,13 +315,13 @@ Grant time to test connectivity to upstream services such as Kafka and Schema Re
 
 ### [replicaCount](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=replicaCount)
 
-Number of Console Pods to run.
+Number of Console Pods to run. Ignored when `autoscaling.enabled` is `true`, in which case the HorizontalPodAutoscaler sets the count.
 
 **Default:** `1`
 
 ### [resources](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=resources)
 
-Compute resources for the Console container. Left empty so the chart runs on small clusters; see the commented example below.
+Compute resources for the Console container. Left empty by default so that the chart runs on clusters with little capacity, which means Console runs without requests or limits until you set them.
 
 **Default:** `{}`
 
@@ -349,7 +349,7 @@ SecretMounts is an abstraction to make a Secret available in the container's fil
 
 ### [securityContext](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=securityContext)
 
-Container-level security context for the Console container.
+Container-level security context for the Console container. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 **Default:** `{"runAsNonRoot":true}`
 
@@ -367,7 +367,7 @@ Port that the Console Service listens on.
 
 ### [service.type](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=service.type)
 
-Type of Service created for Console.
+Type of Service created for Console. One of `ClusterIP`, `NodePort`, or `LoadBalancer`. `nodePort` applies only when this is `NodePort`.
 
 **Default:** `"ClusterIP"`
 
@@ -397,7 +397,7 @@ The name of the service account to use. If not set and `serviceAccount.create` i
 
 ### [strategy](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=strategy)
 
-Update strategy for the Console Deployment.
+Update strategy for the Console Deployment. Leave empty to use the Kubernetes default, `RollingUpdate`. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
 
 **Default:** `{}`
 
@@ -407,13 +407,13 @@ Update strategy for the Console Deployment.
 
 ### [tolerations](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=tolerations)
 
-Taints that the Console Pods tolerate.
+Taints that the Console Pods tolerate. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
 **Default:** `[]`
 
 ### [topologySpreadConstraints](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=topologySpreadConstraints)
 
-Constraints on how the Console Pods are spread across failure domains.
+Constraints on how the Console Pods are spread across failure domains. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
 
 **Default:** `[]`
 

--- a/charts/console/chart/values.yaml
+++ b/charts/console/chart/values.yaml
@@ -17,6 +17,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of Console Pods to run.
 replicaCount: 1
 
 # -- Redpanda Console Docker image settings.
@@ -59,21 +60,27 @@ serviceAccount:
   # a name is generated using the `console.fullname` template
   name: ""
 
-# Common labels to add to all the pods
+# -- Common labels to add to all the pods
 commonLabels: {}
 
 # -- Annotations to add to the deployment.
 annotations: {}
 
+# -- Annotations to add to the Console Pods.
 podAnnotations: {}
 
+# -- Labels to add to the Console Pods.
 podLabels: {}
 
+# -- Pod-level security context for the Console Pods.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 podSecurityContext:
   runAsUser: 99
   fsGroup: 99
   fsGroupChangePolicy: 'Always'
 
+# -- Container-level security context for the Console container.
 securityContext:
   runAsNonRoot: true
   # capabilities:
@@ -84,7 +91,9 @@ securityContext:
   # runAsUser: 1000
 
 service:
+  # -- Type of Service created for Console.
   type: ClusterIP
+  # -- Port that the Console Service listens on.
   port: 8080
   # nodePort: 30001
   # -- Override the value in `console.config.server.listenPort` if not `nil`
@@ -92,16 +101,21 @@ service:
   annotations: {}
 
 ingress:
+  # -- Whether to create an Ingress for Console.
   enabled: false
   # className:
+  # -- Annotations to add to the Ingress, for example to select an ingress
+  # controller or request a certificate.
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # -- Hosts and paths that the Ingress routes to Console.
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
+  # -- TLS configuration for the Ingress.
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -124,6 +138,8 @@ gateway:
   # -- One of Exact, PathPrefix, or RegularExpression.
   pathType: PathPrefix
 
+# -- Compute resources for the Console container. Left empty so the chart
+# runs on small clusters; see the commented example below.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -137,18 +153,27 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
+  # -- Whether to create a HorizontalPodAutoscaler for the Console Deployment.
   enabled: false
+  # -- Minimum number of Console Pods the autoscaler scales down to.
   minReplicas: 1
+  # -- Maximum number of Console Pods the autoscaler scales up to.
   maxReplicas: 100
+  # -- Average CPU utilization the autoscaler targets, as a percentage of the
+  # CPU request.
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# -- Node labels that the Console Pods must match to be scheduled.
 nodeSelector: {}
 
+# -- Taints that the Console Pods tolerate.
 tolerations: []
 
+# -- Affinity rules for scheduling the Console Pods.
 affinity: {}
 
+# -- Constraints on how the Console Pods are spread across failure domains.
 topologySpreadConstraints: []
 
 # -- PriorityClassName given to Pods.
@@ -278,6 +303,9 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 3
 
+# -- Readiness probe for the Console container.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
 readinessProbe:
   # -- Grant time to test connectivity to upstream services such as Kafka and Schema Registry.
   initialDelaySeconds: 10
@@ -287,16 +315,23 @@ readinessProbe:
   failureThreshold: 3
 
 configmap:
+  # -- Whether to render the ConfigMap that holds Console's configuration.
   create: true
 deployment:
+  # -- Whether to render the Console Deployment.
   create: true
 
+# -- Update strategy for the Console Deployment.
 strategy: {}
 
 tests:
   enabled: true
 
 monitoring:
+  # -- Whether to create a ServiceMonitor for Console's metrics endpoint.
   enabled: false
+  # -- How often Prometheus scrapes that endpoint.
   scrapeInterval: "1m"
+  # -- Labels to add to the ServiceMonitor, so that a Prometheus instance can
+  # select it.
   labels: {}

--- a/charts/console/chart/values.yaml
+++ b/charts/console/chart/values.yaml
@@ -17,7 +17,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- Number of Console Pods to run.
+# -- Number of Console Pods to run. Ignored when `autoscaling.enabled` is
+# `true`, in which case the HorizontalPodAutoscaler sets the count.
 replicaCount: 1
 
 # -- Redpanda Console Docker image settings.
@@ -60,7 +61,7 @@ serviceAccount:
   # a name is generated using the `console.fullname` template
   name: ""
 
-# -- Common labels to add to all the pods
+# -- Common labels to add to all the Pods.
 commonLabels: {}
 
 # -- Annotations to add to the deployment.
@@ -81,6 +82,8 @@ podSecurityContext:
   fsGroupChangePolicy: 'Always'
 
 # -- Container-level security context for the Console container.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 securityContext:
   runAsNonRoot: true
   # capabilities:
@@ -91,7 +94,8 @@ securityContext:
   # runAsUser: 1000
 
 service:
-  # -- Type of Service created for Console.
+  # -- Type of Service created for Console. One of `ClusterIP`, `NodePort`, or
+  # `LoadBalancer`. `nodePort` applies only when this is `NodePort`.
   type: ClusterIP
   # -- Port that the Console Service listens on.
   port: 8080
@@ -105,17 +109,20 @@ ingress:
   enabled: false
   # className:
   # -- Annotations to add to the Ingress, for example to select an ingress
-  # controller or request a certificate.
+  # controller or request a certificate. Applies only when `ingress.enabled`
+  # is `true`.
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  # -- Hosts and paths that the Ingress routes to Console.
+  # -- Hosts and paths that the Ingress routes to Console. Applies only when
+  # `ingress.enabled` is `true`.
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
-  # -- TLS configuration for the Ingress.
+  # -- TLS certificates for the Ingress, each entry naming a Secret and the
+  # hosts it covers. Applies only when `ingress.enabled` is `true`.
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -138,8 +145,9 @@ gateway:
   # -- One of Exact, PathPrefix, or RegularExpression.
   pathType: PathPrefix
 
-# -- Compute resources for the Console container. Left empty so the chart
-# runs on small clusters; see the commented example below.
+# -- Compute resources for the Console container. Left empty by default so
+# that the chart runs on clusters with little capacity, which means Console
+# runs without requests or limits until you set them.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -155,12 +163,14 @@ resources: {}
 autoscaling:
   # -- Whether to create a HorizontalPodAutoscaler for the Console Deployment.
   enabled: false
-  # -- Minimum number of Console Pods the autoscaler scales down to.
+  # -- Minimum number of Console Pods the autoscaler scales down to. Applies
+  # only when `autoscaling.enabled` is `true`.
   minReplicas: 1
-  # -- Maximum number of Console Pods the autoscaler scales up to.
+  # -- Maximum number of Console Pods the autoscaler scales up to. Applies
+  # only when `autoscaling.enabled` is `true`.
   maxReplicas: 100
   # -- Average CPU utilization the autoscaler targets, as a percentage of the
-  # CPU request.
+  # CPU request. Applies only when `autoscaling.enabled` is `true`.
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
@@ -168,12 +178,18 @@ autoscaling:
 nodeSelector: {}
 
 # -- Taints that the Console Pods tolerate.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 tolerations: []
 
 # -- Affinity rules for scheduling the Console Pods.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
 affinity: {}
 
 # -- Constraints on how the Console Pods are spread across failure domains.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
 topologySpreadConstraints: []
 
 # -- PriorityClassName given to Pods.
@@ -321,7 +337,10 @@ deployment:
   # -- Whether to render the Console Deployment.
   create: true
 
-# -- Update strategy for the Console Deployment.
+# -- Update strategy for the Console Deployment. Leave empty to use the
+# Kubernetes default, `RollingUpdate`.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
 strategy: {}
 
 tests:
@@ -330,8 +349,9 @@ tests:
 monitoring:
   # -- Whether to create a ServiceMonitor for Console's metrics endpoint.
   enabled: false
-  # -- How often Prometheus scrapes that endpoint.
+  # -- How often Prometheus scrapes Console's metrics endpoint. Applies only
+  # when `monitoring.enabled` is `true`.
   scrapeInterval: "1m"
   # -- Labels to add to the ServiceMonitor, so that a Prometheus instance can
-  # select it.
+  # select it. Applies only when `monitoring.enabled` is `true`.
   labels: {}

--- a/charts/redpanda/chart/README.md
+++ b/charts/redpanda/chart/README.md
@@ -524,6 +524,8 @@ Pull secrets may be used to provide credentials to image repositories See the [K
 
 ### [post_install_job.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=post_install_job.enabled)
 
+Whether to run the post-install and post-upgrade Job, which syncs the cluster configuration and the users listed under `auth.sasl` into the running cluster.
+
 **Default:** `true`
 
 ### [post_install_job.podTemplate.annotations](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=post_install_job.podTemplate.annotations)
@@ -723,25 +725,37 @@ Additional labels to be added to statefulset label selector. For example, `my.k8
 
 ### [statefulset.budget.maxUnavailable](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.budget.maxUnavailable)
 
+Maximum number of brokers the rendered PodDisruptionBudget allows to be unavailable at once during a voluntary disruption, such as a node drain.
+
 **Default:** `1`
 
 ### [statefulset.initContainerImage.repository](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainerImage.repository)
+
+Repository of the image used for the chart's own init containers.
 
 **Default:** `"busybox"`
 
 ### [statefulset.initContainerImage.tag](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainerImage.tag)
 
+Tag of the image used for the chart's own init containers.
+
 **Default:** `"latest"`
 
 ### [statefulset.initContainers.configurator.additionalCLIArgs](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainers.configurator.additionalCLIArgs)
+
+Additional command-line arguments passed to the configurator init container.
 
 **Default:** `[]`
 
 ### [statefulset.initContainers.fsValidator.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainers.fsValidator.enabled)
 
+Whether to run the filesystem-validator init container, which refuses to start a broker whose data directory is not on the expected filesystem.
+
 **Default:** `false`
 
 ### [statefulset.initContainers.fsValidator.expectedFS](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainers.fsValidator.expectedFS)
+
+Filesystem the validator requires on the data directory.
 
 **Default:** `"xfs"`
 
@@ -839,17 +853,25 @@ Number of Redpanda brokers (Redpanda Data recommends setting this to the number 
 
 ### [statefulset.sideCars.brokerDecommissioner.decommissionAfter](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.brokerDecommissioner.decommissionAfter)
 
+How long a broker must keep being detected as invalid before the decommission operation starts.
+
 **Default:** `"60s"`
 
 ### [statefulset.sideCars.brokerDecommissioner.decommissionRequeueTimeout](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.brokerDecommissioner.decommissionRequeueTimeout)
+
+How often the decommissioner rechecks a cluster that has a broker flagged as invalid.
 
 **Default:** `"10s"`
 
 ### [statefulset.sideCars.brokerDecommissioner.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.brokerDecommissioner.enabled)
 
+Whether to run the BrokerDecommissioner sidecar controller.
+
 **Default:** `false`
 
 ### [statefulset.sideCars.configWatcher.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.configWatcher.enabled)
+
+Whether to run the config-watcher sidecar.
 
 **Default:** `true`
 
@@ -861,17 +883,25 @@ DEPRECATED: Use `rbac.enabled` to control RBAC chart wide or control RBAC by sel
 
 ### [statefulset.sideCars.controllers.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.enabled)
 
+Whether to run the sidecar controllers.
+
 **Default:** `false`
 
 ### [statefulset.sideCars.controllers.healthProbeAddress](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.healthProbeAddress)
+
+Address on which the sidecar controllers serve health probes.
 
 **Default:** `":8085"`
 
 ### [statefulset.sideCars.controllers.metricsAddress](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.metricsAddress)
 
+Address on which the sidecar controllers serve Prometheus metrics.
+
 **Default:** `":9082"`
 
 ### [statefulset.sideCars.controllers.pprofAddress](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.pprofAddress)
+
+Address on which the sidecar controllers serve pprof profiles.
 
 **Default:** `":9083"`
 
@@ -883,6 +913,8 @@ DEPRECATED: Please use statefulset.sideCars.brokerDecommissioner and statefulset
 
 ### [statefulset.sideCars.image.repository](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.image.repository)
 
+Repository of the sidecar container image.
+
 **Default:**
 
 ```
@@ -890,6 +922,8 @@ DEPRECATED: Please use statefulset.sideCars.brokerDecommissioner and statefulset
 ```
 
 ### [statefulset.sideCars.image.tag](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.image.tag)
+
+Tag of the sidecar container image.
 
 **Default:** `"v26.2.1"`
 
@@ -907,6 +941,8 @@ Enables the PVCUnbinder sidecar controller. Note: with `rbac.enabled`, this rend
 
 ### [statefulset.sideCars.pvcUnbinder.unbindAfter](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.pvcUnbinder.unbindAfter)
 
+How long a broker Pod must stay in `Pending` before the PVCUnbinder deletes its PersistentVolumeClaim to re-trigger volume provisioning.
+
 **Default:** `"60s"`
 
 ### [statefulset.sideCars.rpkProfileWatcher](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.rpkProfileWatcher)
@@ -915,9 +951,11 @@ Keeps the in-pod rpk configuration fresh after node operations (scale, NodePool 
 
 **Default:** `{"enabled":true}`
 
-### [statefulset.updateStrategy.type](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.updateStrategy.type)
+### [statefulset.updateStrategy](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.updateStrategy)
 
-**Default:** `"RollingUpdate"`
+Update strategy for the StatefulSet. For details, see the [Kubernetes documentation](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update).
+
+**Default:** `{"type":"RollingUpdate"}`
 
 ### [storage](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=storage)
 

--- a/charts/redpanda/chart/README.md
+++ b/charts/redpanda/chart/README.md
@@ -755,7 +755,7 @@ Whether to run the filesystem-validator init container, which refuses to start a
 
 ### [statefulset.initContainers.fsValidator.expectedFS](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainers.fsValidator.expectedFS)
 
-Filesystem the validator requires on the data directory.
+Filesystem the validator requires on the data directory, for example `xfs`. Applies only when `fsValidator.enabled` is `true`.
 
 **Default:** `"xfs"`
 
@@ -853,13 +853,13 @@ Number of Redpanda brokers (Redpanda Data recommends setting this to the number 
 
 ### [statefulset.sideCars.brokerDecommissioner.decommissionAfter](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.brokerDecommissioner.decommissionAfter)
 
-How long a broker must keep being detected as invalid before the decommission operation starts.
+How long a broker must keep being detected as invalid before the decommission operation starts. Applies only when `brokerDecommissioner.enabled` is `true`.
 
 **Default:** `"60s"`
 
 ### [statefulset.sideCars.brokerDecommissioner.decommissionRequeueTimeout](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.brokerDecommissioner.decommissionRequeueTimeout)
 
-How often the decommissioner rechecks a cluster that has a broker flagged as invalid.
+How often the decommissioner rechecks a cluster that has a broker flagged as invalid. Applies only when `brokerDecommissioner.enabled` is `true`.
 
 **Default:** `"10s"`
 
@@ -889,19 +889,19 @@ Whether to run the sidecar controllers.
 
 ### [statefulset.sideCars.controllers.healthProbeAddress](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.healthProbeAddress)
 
-Address on which the sidecar controllers serve health probes.
+Address on which the sidecar controllers serve health probes. Applies only when `controllers.enabled` is `true`.
 
 **Default:** `":8085"`
 
 ### [statefulset.sideCars.controllers.metricsAddress](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.metricsAddress)
 
-Address on which the sidecar controllers serve Prometheus metrics.
+Address on which the sidecar controllers serve Prometheus metrics. Applies only when `controllers.enabled` is `true`.
 
 **Default:** `":9082"`
 
 ### [statefulset.sideCars.controllers.pprofAddress](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.controllers.pprofAddress)
 
-Address on which the sidecar controllers serve pprof profiles.
+Address on which the sidecar controllers serve pprof profiles. Applies only when `controllers.enabled` is `true`.
 
 **Default:** `":9083"`
 
@@ -941,7 +941,7 @@ Enables the PVCUnbinder sidecar controller. Note: with `rbac.enabled`, this rend
 
 ### [statefulset.sideCars.pvcUnbinder.unbindAfter](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.sideCars.pvcUnbinder.unbindAfter)
 
-How long a broker Pod must stay in `Pending` before the PVCUnbinder deletes its PersistentVolumeClaim to re-trigger volume provisioning.
+How long a broker Pod must stay in `Pending` before the PVCUnbinder deletes its PersistentVolumeClaim to re-trigger volume provisioning. Applies only when `pvcUnbinder.enabled` is `true`.
 
 **Default:** `"60s"`
 

--- a/charts/redpanda/chart/values.yaml
+++ b/charts/redpanda/chart/values.yaml
@@ -574,6 +574,9 @@ storage:
       cloud_storage_cache_size: 5368709120
 
 post_install_job:
+  # -- Whether to run the post-install and post-upgrade Job, which syncs the
+  # cluster configuration and the users listed under `auth.sasl` into the
+  # running cluster.
   enabled: true
   # Resource requests and limits for the post-install batch job
   # resources:
@@ -603,6 +606,9 @@ post_install_job:
 statefulset:
   # -- Number of Redpanda brokers (Redpanda Data recommends setting this to the number of worker nodes in the cluster)
   replicas: 3
+  # -- Update strategy for the StatefulSet.
+  # For details,
+  # see the [Kubernetes documentation](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update).
   updateStrategy:
     type: RollingUpdate
   # -- Controls the lifecycle of PersistentVolumeClaims created from the StatefulSet's
@@ -615,6 +621,9 @@ statefulset:
     whenDeleted: Retain
     whenScaled: Retain
   budget:
+    # -- Maximum number of brokers the rendered PodDisruptionBudget allows to
+    # be unavailable at once during a voluntary disruption, such as a node
+    # drain.
     maxUnavailable: 1
   # -- Additional labels to be added to statefulset label selector.
   # For example, `my.k8s.service: redpanda`.
@@ -703,7 +712,9 @@ statefulset:
     custom: {}
   sideCars:
     image:
+      # -- Tag of the sidecar container image.
       tag: v26.2.1
+      # -- Repository of the sidecar container image.
       repository: docker.redpanda.com/redpandadata/redpanda-operator
     # Additional arguments to pass to the sidecar command. Reserved for internal testing.
     # @ignored
@@ -716,6 +727,8 @@ statefulset:
       # ClusterRole that grants the Pod's ServiceAccount cluster-wide read access to Nodes,
       # regardless of the other pvcUnbinder settings.
       enabled: false
+      # -- How long a broker Pod must stay in `Pending` before the PVCUnbinder
+      # deletes its PersistentVolumeClaim to re-trigger volume provisioning.
       unbindAfter: 60s
       # -- Renders `--disable-pvc-rebinding-gate-exemption`: turns off the pvc-rebinding gate's
       # stuck-claim exemption (an escape hatch if its proof chain misfires in your environment)
@@ -727,10 +740,16 @@ statefulset:
     # multiple times across the `decommissionAfter` window. A `decommissionRequeueTimeout` values can be specified to override how
     # often the decommissioner rechecks a cluster that has a broker which has been flagged as invalid. 
     brokerDecommissioner:
+      # -- Whether to run the BrokerDecommissioner sidecar controller.
       enabled: false
+      # -- How long a broker must keep being detected as invalid before the
+      # decommission operation starts.
       decommissionAfter: 60s
+      # -- How often the decommissioner rechecks a cluster that has a broker
+      # flagged as invalid.
       decommissionRequeueTimeout: 10s
     configWatcher:
+      # -- Whether to run the config-watcher sidecar.
       enabled: true
     # -- Keeps the in-pod rpk configuration fresh after node operations
     # (scale, NodePool swap) without a pod restart (K8S-755). Enabled by
@@ -738,12 +757,16 @@ statefulset:
     rpkProfileWatcher:
       enabled: true
     controllers:
+      # -- Whether to run the sidecar controllers.
       enabled: false
       # -- DEPRECATED: Use `rbac.enabled` to control RBAC chart wide or control RBAC by selectively enabling/disabling specific sidecar controllers.
       # Setting this field has no effect.
       createRBAC: true
+      # -- Address on which the sidecar controllers serve health probes.
       healthProbeAddress: ":8085"
+      # -- Address on which the sidecar controllers serve Prometheus metrics.
       metricsAddress: ":9082"
+      # -- Address on which the sidecar controllers serve pprof profiles.
       pprofAddress: ":9083"
       # -- DEPRECATED: Please use statefulset.sideCars.brokerDecommissioner and statefulset.sideCars.pvcUnbinder
       # Setting this field has no effect.
@@ -751,16 +774,24 @@ statefulset:
         - all
   initContainers:
     fsValidator:
+      # -- Whether to run the filesystem-validator init container, which
+      # refuses to start a broker whose data directory is not on the expected
+      # filesystem.
       enabled: false
+      # -- Filesystem the validator requires on the data directory.
       expectedFS: xfs
     setDataDirOwnership:
       # -- In environments where root is not allowed, you cannot change the ownership of files and directories.
       # Enable `setDataDirOwnership` when using default minikube cluster configuration.
       enabled: false
     configurator:
+      # -- Additional command-line arguments passed to the configurator init
+      # container.
       additionalCLIArgs: []
   initContainerImage:
+    # -- Repository of the image used for the chart's own init containers.
     repository: busybox
+    # -- Tag of the image used for the chart's own init containers.
     tag: latest
   # -- Additional flags to pass to redpanda,
   additionalRedpandaCmdFlags: []

--- a/charts/redpanda/chart/values.yaml
+++ b/charts/redpanda/chart/values.yaml
@@ -729,6 +729,7 @@ statefulset:
       enabled: false
       # -- How long a broker Pod must stay in `Pending` before the PVCUnbinder
       # deletes its PersistentVolumeClaim to re-trigger volume provisioning.
+      # Applies only when `pvcUnbinder.enabled` is `true`.
       unbindAfter: 60s
       # -- Renders `--disable-pvc-rebinding-gate-exemption`: turns off the pvc-rebinding gate's
       # stuck-claim exemption (an escape hatch if its proof chain misfires in your environment)
@@ -743,10 +744,12 @@ statefulset:
       # -- Whether to run the BrokerDecommissioner sidecar controller.
       enabled: false
       # -- How long a broker must keep being detected as invalid before the
-      # decommission operation starts.
+      # decommission operation starts. Applies only when
+      # `brokerDecommissioner.enabled` is `true`.
       decommissionAfter: 60s
       # -- How often the decommissioner rechecks a cluster that has a broker
-      # flagged as invalid.
+      # flagged as invalid. Applies only when `brokerDecommissioner.enabled`
+      # is `true`.
       decommissionRequeueTimeout: 10s
     configWatcher:
       # -- Whether to run the config-watcher sidecar.
@@ -763,10 +766,13 @@ statefulset:
       # Setting this field has no effect.
       createRBAC: true
       # -- Address on which the sidecar controllers serve health probes.
+      # Applies only when `controllers.enabled` is `true`.
       healthProbeAddress: ":8085"
       # -- Address on which the sidecar controllers serve Prometheus metrics.
+      # Applies only when `controllers.enabled` is `true`.
       metricsAddress: ":9082"
       # -- Address on which the sidecar controllers serve pprof profiles.
+      # Applies only when `controllers.enabled` is `true`.
       pprofAddress: ":9083"
       # -- DEPRECATED: Please use statefulset.sideCars.brokerDecommissioner and statefulset.sideCars.pvcUnbinder
       # Setting this field has no effect.
@@ -778,7 +784,8 @@ statefulset:
       # refuses to start a broker whose data directory is not on the expected
       # filesystem.
       enabled: false
-      # -- Filesystem the validator requires on the data directory.
+      # -- Filesystem the validator requires on the data directory, for
+      # example `xfs`. Applies only when `fsValidator.enabled` is `true`.
       expectedFS: xfs
     setDataDirOwnership:
       # -- In environments where root is not allowed, you cannot change the ownership of files and directories.

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_types.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_types.go
@@ -228,36 +228,106 @@ type StretchTiered struct {
 // replaced *apiutil.JSONBoolean with *bool for CloudStorageEnabled (JSONBoolean was a
 // Helm-era hack to handle "true" vs true in values files).
 type StretchTieredConfig struct {
-	CloudStorageEnabled                     *bool   `json:"cloud_storage_enabled,omitempty"`
-	CloudStorageAPIEndpoint                 *string `json:"cloud_storage_api_endpoint,omitempty"`
-	CloudStorageAPIEndpointPort             *int    `json:"cloud_storage_api_endpoint_port,omitempty"`
-	CloudStorageBucket                      *string `json:"cloud_storage_bucket,omitempty"`
-	CloudStorageAzureContainer              *string `json:"cloud_storage_azure_container,omitempty"`
-	CloudStorageAzureManagedIdentityID      *string `json:"cloud_storage_azure_managed_identity_id,omitempty"`
-	CloudStorageAzureStorageAccount         *string `json:"cloud_storage_azure_storage_account,omitempty"`
-	CloudStorageAzureSharedKey              *string `json:"cloud_storage_azure_shared_key,omitempty"`
-	CloudStorageAzureADLSEndpoint           *string `json:"cloud_storage_azure_adls_endpoint,omitempty"`
-	CloudStorageAzureADLSPort               *int    `json:"cloud_storage_azure_adls_port,omitempty"`
-	CloudStorageCacheCheckInterval          *int    `json:"cloud_storage_cache_check_interval,omitempty"`
-	CloudStorageCacheDirectory              *string `json:"cloud_storage_cache_directory,omitempty"`
-	CloudStorageCacheSize                   *string `json:"cloud_storage_cache_size,omitempty"`
-	CloudStorageCredentialsSource           *string `json:"cloud_storage_credentials_source,omitempty"`
-	CloudStorageDisableTLS                  *bool   `json:"cloud_storage_disable_tls,omitempty"`
-	CloudStorageEnableRemoteRead            *bool   `json:"cloud_storage_enable_remote_read,omitempty"`
-	CloudStorageEnableRemoteWrite           *bool   `json:"cloud_storage_enable_remote_write,omitempty"`
-	CloudStorageInitialBackoffMs            *int    `json:"cloud_storage_initial_backoff_ms,omitempty"`
-	CloudStorageManifestUploadTimeoutMs     *int    `json:"cloud_storage_manifest_upload_timeout_ms,omitempty"`
-	CloudStorageMaxConnectionIdleTimeMs     *int    `json:"cloud_storage_max_connection_idle_time_ms,omitempty"`
-	CloudStorageMaxConnections              *int    `json:"cloud_storage_max_connections,omitempty"`
-	CloudStorageRegion                      *string `json:"cloud_storage_region,omitempty"`
-	CloudStorageSegmentMaxUploadIntervalSec *int    `json:"cloud_storage_segment_max_upload_interval_sec,omitempty"`
-	CloudStorageSegmentUploadTimeoutMs      *int    `json:"cloud_storage_segment_upload_timeout_ms,omitempty"`
-	CloudStorageTrustFile                   *string `json:"cloud_storage_trust_file,omitempty"`
-	CloudStorageUploadCtrlDCoeff            *int    `json:"cloud_storage_upload_ctrl_d_coeff,omitempty"`
-	CloudStorageUploadCtrlMaxShares         *int    `json:"cloud_storage_upload_ctrl_max_shares,omitempty"`
-	CloudStorageUploadCtrlMinShares         *int    `json:"cloud_storage_upload_ctrl_min_shares,omitempty"`
-	CloudStorageUploadCtrlPCoeff            *int    `json:"cloud_storage_upload_ctrl_p_coeff,omitempty"`
-	CloudStorageUploadCtrlUpdateIntervalMs  *int    `json:"cloud_storage_upload_ctrl_update_interval_ms,omitempty"`
+	// Enable object storage. Must be set to `true` to use Tiered Storage, Remote
+	// Read Replicas, or Cloud Topics.
+	CloudStorageEnabled *bool `json:"cloud_storage_enabled,omitempty"`
+	// Optional API endpoint. The only instance in which you must set this value
+	// is when using a custom domain with your object storage service.
+	CloudStorageAPIEndpoint *string `json:"cloud_storage_api_endpoint,omitempty"`
+	// TLS port override.
+	CloudStorageAPIEndpointPort *int `json:"cloud_storage_api_endpoint_port,omitempty"`
+	// AWS or GCP bucket that should be used to store data.
+	CloudStorageBucket *string `json:"cloud_storage_bucket,omitempty"`
+	// The name of the Azure container to use with Tiered Storage. If `null`, the
+	// property is disabled.
+	CloudStorageAzureContainer *string `json:"cloud_storage_azure_container,omitempty"`
+	// The managed identity ID to use for access to the Azure storage account. To
+	// use Azure managed identities, you must set
+	// `cloud_storage_credentials_source` to `azure_vm_instance_metadata`.
+	CloudStorageAzureManagedIdentityID *string `json:"cloud_storage_azure_managed_identity_id,omitempty"`
+	// The name of the Azure storage account to use with Tiered Storage. If
+	// `null`, the property is disabled.
+	CloudStorageAzureStorageAccount *string `json:"cloud_storage_azure_storage_account,omitempty"`
+	// The account access key to be used for Azure Shared Key authentication with
+	// the Azure storage account configured by
+	// `cloud_storage_azure_storage_account`. If `null`, the property is
+	// disabled.
+	CloudStorageAzureSharedKey *string `json:"cloud_storage_azure_shared_key,omitempty"`
+	// Azure Data Lake Storage v2 endpoint override. Use when hierarchical
+	// namespaces are enabled on your storage account and you have set up a
+	// custom endpoint.
+	CloudStorageAzureADLSEndpoint *string `json:"cloud_storage_azure_adls_endpoint,omitempty"`
+	// Azure Data Lake Storage v2 port override. See also:
+	// `cloud_storage_azure_adls_endpoint`. Use when hierarchical namespaces are
+	// enabled on your storage account and you have set up a custom endpoint.
+	CloudStorageAzureADLSPort *int `json:"cloud_storage_azure_adls_port,omitempty"`
+	// Minimum interval between Tiered Storage cache trims, measured in
+	// milliseconds. This setting dictates the cooldown period after a cache trim
+	// operation before another trim can occur. If a cache fetch operation
+	// requests a trim but the interval since the last trim has not yet passed,
+	// the trim will be postponed until this cooldown expires. Adjusting this
+	// interval helps manage the balance between cache size and retrieval
+	// performance.
+	CloudStorageCacheCheckInterval *int `json:"cloud_storage_cache_check_interval,omitempty"`
+	// Directory for archival cache. Set when the `cloud_storage_enabled` cluster
+	// property is enabled. If not specified, Redpanda uses a default path within
+	// the data directory.
+	CloudStorageCacheDirectory *string `json:"cloud_storage_cache_directory,omitempty"`
+	// Maximum size of the object storage cache, in bytes.
+	CloudStorageCacheSize *string `json:"cloud_storage_cache_size,omitempty"`
+	// The source of credentials used to authenticate to object storage services.
+	// Required for AWS or GCP authentication with IAM roles.
+	CloudStorageCredentialsSource *string `json:"cloud_storage_credentials_source,omitempty"`
+	// Disable TLS for all object storage connections.
+	CloudStorageDisableTLS *bool `json:"cloud_storage_disable_tls,omitempty"`
+	// Default remote read config value for new topics. When set to `true`, new
+	// topics are by default configured to allow reading data directly from
+	// object storage, facilitating access to older data that might have been
+	// offloaded as part of Tiered Storage. With the default set to `false`,
+	// remote reads must be explicitly enabled at the topic level.
+	CloudStorageEnableRemoteRead *bool `json:"cloud_storage_enable_remote_read,omitempty"`
+	// Default remote write value for new topics. When set to `true`, new topics
+	// are by default configured to upload data to object storage. With the
+	// default set to `false`, remote write must be explicitly enabled at the
+	// topic level.
+	CloudStorageEnableRemoteWrite *bool `json:"cloud_storage_enable_remote_write,omitempty"`
+	// Initial backoff time for exponential backoff algorithm (ms).
+	CloudStorageInitialBackoffMs *int `json:"cloud_storage_initial_backoff_ms,omitempty"`
+	// Manifest upload timeout, in milliseconds.
+	CloudStorageManifestUploadTimeoutMs *int `json:"cloud_storage_manifest_upload_timeout_ms,omitempty"`
+	// Defines the maximum duration an HTTPS connection to object storage can
+	// stay idle, in milliseconds, before being terminated. This setting reduces
+	// resource utilization by closing inactive connections. Adjust this property
+	// to balance keeping connections ready for subsequent requests and freeing
+	// resources associated with idle connections.
+	CloudStorageMaxConnectionIdleTimeMs *int `json:"cloud_storage_max_connection_idle_time_ms,omitempty"`
+	// Maximum simultaneous object storage connections per shard, applicable to
+	// upload and download activities.
+	CloudStorageMaxConnections *int `json:"cloud_storage_max_connections,omitempty"`
+	// Cloud provider region that houses the bucket or container used for
+	// storage.
+	CloudStorageRegion *string `json:"cloud_storage_region,omitempty"`
+	// Time that a segment can be kept locally without uploading it to the object
+	// storage, in seconds.
+	CloudStorageSegmentMaxUploadIntervalSec *int `json:"cloud_storage_segment_max_upload_interval_sec,omitempty"`
+	// Log segment upload timeout, in milliseconds.
+	CloudStorageSegmentUploadTimeoutMs *int `json:"cloud_storage_segment_upload_timeout_ms,omitempty"`
+	// Path to certificate that should be used to validate server certificate
+	// during TLS handshake.
+	CloudStorageTrustFile *string `json:"cloud_storage_trust_file,omitempty"`
+	// Derivative coefficient for upload PID controller.
+	CloudStorageUploadCtrlDCoeff *int `json:"cloud_storage_upload_ctrl_d_coeff,omitempty"`
+	// Maximum number of I/O and CPU shares that archival upload can use.
+	CloudStorageUploadCtrlMaxShares *int `json:"cloud_storage_upload_ctrl_max_shares,omitempty"`
+	// Minimum number of I/O and CPU shares that archival upload can use.
+	CloudStorageUploadCtrlMinShares *int `json:"cloud_storage_upload_ctrl_min_shares,omitempty"`
+	// Proportional coefficient for upload PID controller.
+	CloudStorageUploadCtrlPCoeff *int `json:"cloud_storage_upload_ctrl_p_coeff,omitempty"`
+	// The interval (in milliseconds) for updating the controller that manages
+	// the priority of Tiered Storage uploads. This property determines how
+	// frequently the system recalculates and adjusts the work scheduling for
+	// uploads to object storage.
+	CloudStorageUploadCtrlUpdateIntervalMs *int `json:"cloud_storage_upload_ctrl_update_interval_ms,omitempty"`
 }
 
 // StretchLogging defines log level settings for stretch clusters.

--- a/operator/api/redpanda/v1alpha2/stretch_cluster_types.go
+++ b/operator/api/redpanda/v1alpha2/stretch_cluster_types.go
@@ -276,7 +276,9 @@ type StretchTieredConfig struct {
 	// Maximum size of the object storage cache, in bytes.
 	CloudStorageCacheSize *string `json:"cloud_storage_cache_size,omitempty"`
 	// The source of credentials used to authenticate to object storage services.
-	// Required for AWS or GCP authentication with IAM roles.
+	// Required for AWS or GCP authentication with IAM roles. Accepted values:
+	// `config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`,
+	// `azure_aks_oidc_federation`, `azure_vm_instance_metadata`.
 	CloudStorageCredentialsSource *string `json:"cloud_storage_credentials_source,omitempty"`
 	// Disable TLS for all object storage connections.
 	CloudStorageDisableTLS *bool `json:"cloud_storage_disable_tls,omitempty"`

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
@@ -10418,64 +10418,158 @@ spec:
                         description: Configures Tiered Storage properties.
                         properties:
                           cloud_storage_api_endpoint:
+                            description: |-
+                              Optional API endpoint. The only instance in which you must set this value
+                              is when using a custom domain with your object storage service.
                             type: string
                           cloud_storage_api_endpoint_port:
+                            description: TLS port override.
                             type: integer
                           cloud_storage_azure_adls_endpoint:
+                            description: |-
+                              Azure Data Lake Storage v2 endpoint override. Use when hierarchical
+                              namespaces are enabled on your storage account and you have set up a
+                              custom endpoint.
                             type: string
                           cloud_storage_azure_adls_port:
+                            description: |-
+                              Azure Data Lake Storage v2 port override. See also:
+                              `cloud_storage_azure_adls_endpoint`. Use when hierarchical namespaces are
+                              enabled on your storage account and you have set up a custom endpoint.
                             type: integer
                           cloud_storage_azure_container:
+                            description: |-
+                              The name of the Azure container to use with Tiered Storage. If `null`, the
+                              property is disabled.
                             type: string
                           cloud_storage_azure_managed_identity_id:
+                            description: |-
+                              The managed identity ID to use for access to the Azure storage account. To
+                              use Azure managed identities, you must set
+                              `cloud_storage_credentials_source` to `azure_vm_instance_metadata`.
                             type: string
                           cloud_storage_azure_shared_key:
+                            description: |-
+                              The account access key to be used for Azure Shared Key authentication with
+                              the Azure storage account configured by
+                              `cloud_storage_azure_storage_account`. If `null`, the property is
+                              disabled.
                             type: string
                           cloud_storage_azure_storage_account:
+                            description: |-
+                              The name of the Azure storage account to use with Tiered Storage. If
+                              `null`, the property is disabled.
                             type: string
                           cloud_storage_bucket:
+                            description: AWS or GCP bucket that should be used to
+                              store data.
                             type: string
                           cloud_storage_cache_check_interval:
+                            description: |-
+                              Minimum interval between Tiered Storage cache trims, measured in
+                              milliseconds. This setting dictates the cooldown period after a cache trim
+                              operation before another trim can occur. If a cache fetch operation
+                              requests a trim but the interval since the last trim has not yet passed,
+                              the trim will be postponed until this cooldown expires. Adjusting this
+                              interval helps manage the balance between cache size and retrieval
+                              performance.
                             type: integer
                           cloud_storage_cache_directory:
+                            description: |-
+                              Directory for archival cache. Set when the `cloud_storage_enabled` cluster
+                              property is enabled. If not specified, Redpanda uses a default path within
+                              the data directory.
                             type: string
                           cloud_storage_cache_size:
+                            description: Maximum size of the object storage cache,
+                              in bytes.
                             type: string
                           cloud_storage_credentials_source:
+                            description: |-
+                              The source of credentials used to authenticate to object storage services.
+                              Required for AWS or GCP authentication with IAM roles.
                             type: string
                           cloud_storage_disable_tls:
+                            description: Disable TLS for all object storage connections.
                             type: boolean
                           cloud_storage_enable_remote_read:
+                            description: |-
+                              Default remote read config value for new topics. When set to `true`, new
+                              topics are by default configured to allow reading data directly from
+                              object storage, facilitating access to older data that might have been
+                              offloaded as part of Tiered Storage. With the default set to `false`,
+                              remote reads must be explicitly enabled at the topic level.
                             type: boolean
                           cloud_storage_enable_remote_write:
+                            description: |-
+                              Default remote write value for new topics. When set to `true`, new topics
+                              are by default configured to upload data to object storage. With the
+                              default set to `false`, remote write must be explicitly enabled at the
+                              topic level.
                             type: boolean
                           cloud_storage_enabled:
+                            description: |-
+                              Enable object storage. Must be set to `true` to use Tiered Storage, Remote
+                              Read Replicas, or Cloud Topics.
                             type: boolean
                           cloud_storage_initial_backoff_ms:
+                            description: Initial backoff time for exponential backoff
+                              algorithm (ms).
                             type: integer
                           cloud_storage_manifest_upload_timeout_ms:
+                            description: Manifest upload timeout, in milliseconds.
                             type: integer
                           cloud_storage_max_connection_idle_time_ms:
+                            description: |-
+                              Defines the maximum duration an HTTPS connection to object storage can
+                              stay idle, in milliseconds, before being terminated. This setting reduces
+                              resource utilization by closing inactive connections. Adjust this property
+                              to balance keeping connections ready for subsequent requests and freeing
+                              resources associated with idle connections.
                             type: integer
                           cloud_storage_max_connections:
+                            description: |-
+                              Maximum simultaneous object storage connections per shard, applicable to
+                              upload and download activities.
                             type: integer
                           cloud_storage_region:
+                            description: |-
+                              Cloud provider region that houses the bucket or container used for
+                              storage.
                             type: string
                           cloud_storage_segment_max_upload_interval_sec:
+                            description: |-
+                              Time that a segment can be kept locally without uploading it to the object
+                              storage, in seconds.
                             type: integer
                           cloud_storage_segment_upload_timeout_ms:
+                            description: Log segment upload timeout, in milliseconds.
                             type: integer
                           cloud_storage_trust_file:
+                            description: |-
+                              Path to certificate that should be used to validate server certificate
+                              during TLS handshake.
                             type: string
                           cloud_storage_upload_ctrl_d_coeff:
+                            description: Derivative coefficient for upload PID controller.
                             type: integer
                           cloud_storage_upload_ctrl_max_shares:
+                            description: Maximum number of I/O and CPU shares that
+                              archival upload can use.
                             type: integer
                           cloud_storage_upload_ctrl_min_shares:
+                            description: Minimum number of I/O and CPU shares that
+                              archival upload can use.
                             type: integer
                           cloud_storage_upload_ctrl_p_coeff:
+                            description: Proportional coefficient for upload PID controller.
                             type: integer
                           cloud_storage_upload_ctrl_update_interval_ms:
+                            description: |-
+                              The interval (in milliseconds) for updating the controller that manages
+                              the priority of Tiered Storage uploads. This property determines how
+                              frequently the system recalculates and adjusts the work scheduling for
+                              uploads to object storage.
                             type: integer
                         type: object
                       credentialsSecretRef:

--- a/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_redpandabrokerpools.yaml
@@ -10487,7 +10487,9 @@ spec:
                           cloud_storage_credentials_source:
                             description: |-
                               The source of credentials used to authenticate to object storage services.
-                              Required for AWS or GCP authentication with IAM roles.
+                              Required for AWS or GCP authentication with IAM roles. Accepted values:
+                              `config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`,
+                              `azure_aks_oidc_federation`, `azure_vm_instance_metadata`.
                             type: string
                           cloud_storage_disable_tls:
                             description: Disable TLS for all object storage connections.

--- a/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
@@ -594,64 +594,158 @@ spec:
                         description: Configures Tiered Storage properties.
                         properties:
                           cloud_storage_api_endpoint:
+                            description: |-
+                              Optional API endpoint. The only instance in which you must set this value
+                              is when using a custom domain with your object storage service.
                             type: string
                           cloud_storage_api_endpoint_port:
+                            description: TLS port override.
                             type: integer
                           cloud_storage_azure_adls_endpoint:
+                            description: |-
+                              Azure Data Lake Storage v2 endpoint override. Use when hierarchical
+                              namespaces are enabled on your storage account and you have set up a
+                              custom endpoint.
                             type: string
                           cloud_storage_azure_adls_port:
+                            description: |-
+                              Azure Data Lake Storage v2 port override. See also:
+                              `cloud_storage_azure_adls_endpoint`. Use when hierarchical namespaces are
+                              enabled on your storage account and you have set up a custom endpoint.
                             type: integer
                           cloud_storage_azure_container:
+                            description: |-
+                              The name of the Azure container to use with Tiered Storage. If `null`, the
+                              property is disabled.
                             type: string
                           cloud_storage_azure_managed_identity_id:
+                            description: |-
+                              The managed identity ID to use for access to the Azure storage account. To
+                              use Azure managed identities, you must set
+                              `cloud_storage_credentials_source` to `azure_vm_instance_metadata`.
                             type: string
                           cloud_storage_azure_shared_key:
+                            description: |-
+                              The account access key to be used for Azure Shared Key authentication with
+                              the Azure storage account configured by
+                              `cloud_storage_azure_storage_account`. If `null`, the property is
+                              disabled.
                             type: string
                           cloud_storage_azure_storage_account:
+                            description: |-
+                              The name of the Azure storage account to use with Tiered Storage. If
+                              `null`, the property is disabled.
                             type: string
                           cloud_storage_bucket:
+                            description: AWS or GCP bucket that should be used to
+                              store data.
                             type: string
                           cloud_storage_cache_check_interval:
+                            description: |-
+                              Minimum interval between Tiered Storage cache trims, measured in
+                              milliseconds. This setting dictates the cooldown period after a cache trim
+                              operation before another trim can occur. If a cache fetch operation
+                              requests a trim but the interval since the last trim has not yet passed,
+                              the trim will be postponed until this cooldown expires. Adjusting this
+                              interval helps manage the balance between cache size and retrieval
+                              performance.
                             type: integer
                           cloud_storage_cache_directory:
+                            description: |-
+                              Directory for archival cache. Set when the `cloud_storage_enabled` cluster
+                              property is enabled. If not specified, Redpanda uses a default path within
+                              the data directory.
                             type: string
                           cloud_storage_cache_size:
+                            description: Maximum size of the object storage cache,
+                              in bytes.
                             type: string
                           cloud_storage_credentials_source:
+                            description: |-
+                              The source of credentials used to authenticate to object storage services.
+                              Required for AWS or GCP authentication with IAM roles.
                             type: string
                           cloud_storage_disable_tls:
+                            description: Disable TLS for all object storage connections.
                             type: boolean
                           cloud_storage_enable_remote_read:
+                            description: |-
+                              Default remote read config value for new topics. When set to `true`, new
+                              topics are by default configured to allow reading data directly from
+                              object storage, facilitating access to older data that might have been
+                              offloaded as part of Tiered Storage. With the default set to `false`,
+                              remote reads must be explicitly enabled at the topic level.
                             type: boolean
                           cloud_storage_enable_remote_write:
+                            description: |-
+                              Default remote write value for new topics. When set to `true`, new topics
+                              are by default configured to upload data to object storage. With the
+                              default set to `false`, remote write must be explicitly enabled at the
+                              topic level.
                             type: boolean
                           cloud_storage_enabled:
+                            description: |-
+                              Enable object storage. Must be set to `true` to use Tiered Storage, Remote
+                              Read Replicas, or Cloud Topics.
                             type: boolean
                           cloud_storage_initial_backoff_ms:
+                            description: Initial backoff time for exponential backoff
+                              algorithm (ms).
                             type: integer
                           cloud_storage_manifest_upload_timeout_ms:
+                            description: Manifest upload timeout, in milliseconds.
                             type: integer
                           cloud_storage_max_connection_idle_time_ms:
+                            description: |-
+                              Defines the maximum duration an HTTPS connection to object storage can
+                              stay idle, in milliseconds, before being terminated. This setting reduces
+                              resource utilization by closing inactive connections. Adjust this property
+                              to balance keeping connections ready for subsequent requests and freeing
+                              resources associated with idle connections.
                             type: integer
                           cloud_storage_max_connections:
+                            description: |-
+                              Maximum simultaneous object storage connections per shard, applicable to
+                              upload and download activities.
                             type: integer
                           cloud_storage_region:
+                            description: |-
+                              Cloud provider region that houses the bucket or container used for
+                              storage.
                             type: string
                           cloud_storage_segment_max_upload_interval_sec:
+                            description: |-
+                              Time that a segment can be kept locally without uploading it to the object
+                              storage, in seconds.
                             type: integer
                           cloud_storage_segment_upload_timeout_ms:
+                            description: Log segment upload timeout, in milliseconds.
                             type: integer
                           cloud_storage_trust_file:
+                            description: |-
+                              Path to certificate that should be used to validate server certificate
+                              during TLS handshake.
                             type: string
                           cloud_storage_upload_ctrl_d_coeff:
+                            description: Derivative coefficient for upload PID controller.
                             type: integer
                           cloud_storage_upload_ctrl_max_shares:
+                            description: Maximum number of I/O and CPU shares that
+                              archival upload can use.
                             type: integer
                           cloud_storage_upload_ctrl_min_shares:
+                            description: Minimum number of I/O and CPU shares that
+                              archival upload can use.
                             type: integer
                           cloud_storage_upload_ctrl_p_coeff:
+                            description: Proportional coefficient for upload PID controller.
                             type: integer
                           cloud_storage_upload_ctrl_update_interval_ms:
+                            description: |-
+                              The interval (in milliseconds) for updating the controller that manages
+                              the priority of Tiered Storage uploads. This property determines how
+                              frequently the system recalculates and adjusts the work scheduling for
+                              uploads to object storage.
                             type: integer
                         type: object
                       credentialsSecretRef:

--- a/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
+++ b/operator/config/crd/bases/cluster.redpanda.com_stretchclusters.yaml
@@ -663,7 +663,9 @@ spec:
                           cloud_storage_credentials_source:
                             description: |-
                               The source of credentials used to authenticate to object storage services.
-                              Required for AWS or GCP authentication with IAM roles.
+                              Required for AWS or GCP authentication with IAM roles. Accepted values:
+                              `config_file`, `aws_instance_metadata`, `sts`, `gcp_instance_metadata`,
+                              `azure_aks_oidc_federation`, `azure_vm_instance_metadata`.
                             type: string
                           cloud_storage_disable_tls:
                             description: Disable TLS for all object storage connections.


### PR DESCRIPTION
Tracked by [DOC-2455](https://redpandadata.atlassian.net/browse/DOC-2455) for the Console CRD half.

Draft: the chart-values half and the Tiered Storage CRD fields are done and reviewable. The Console CRD half is still to come, see **Remaining** below.

## Why

Two reference pages are generated from this repo, and both ship rows with an empty description:

| surface | generator | blank on `main` |
|---|---|---|
| Helm reference | helm-docs | **86** values |
| CRD reference | crd-ref-docs / controller-gen | **173** fields, plus 19 that inherit their Go type's comment |

Counts come from running the generators, not from eyeballing: helm-docs 1.14.2 per chart, and the committed `operator/config/crd/bases/*.yaml`.

## This commit: chart values, 86 to 3

Every description was checked against how the value is actually consumed, in the gotohelm templates or `values.go`, rather than guessed from the key name. A few examples:

- `connectors.secretManager.region` sets `config.providers.secretsManager.param.aws.region`
- `container.javaGCLogEnabled` becomes the `CONNECT_GC_LOG_ENABLED` environment variable
- `post_install_job.enabled` gates the Job that runs `sync-cluster-config`
- `statefulset.budget.maxUnavailable` is consumed by `_poddisruptionbudget.go.tpl`

**Array elements and probe timings are fixed on the parent, not per element.** helm-docs renders no row for a key covered by a documented ancestor, so one `# --` on `storage.volume` removes `storage.volume[0].emptyDir.medium` and its siblings rather than documenting scaffolding values one at a time. Same for `deployment.topologySpreadConstraints`, `deployment.securityContext`, and connectors' `readinessProbe`, which was simply missing the marker its sibling `livenessProbe` already had.

## Three values left blank on purpose

Nothing in the repository consumes these, so a description would document behaviour that does not exist:

| chart | value | why |
|---|---|---|
| connectors | `deployment.budget.maxUnavailable` | declared in `values.go` and the schema, but this chart renders no PodDisruptionBudget (the redpanda chart's identically named value *is* consumed, and is documented here) |
| console | `tests.enabled` | declared in `values.go`, but the chart has no `helm.sh/hook: test` template |
| redpanda | `tests.enabled` | same |

Each should be wired up or removed. Someone who knows the intent should decide which, and I did not want to paper over it with prose.

## Verification

- `doc-tools lint-strings --surface helm` reports **3** undocumented keys on this branch against **86** on `main`, with error and warning counts unchanged, so nothing regressed.
- Re-running helm-docs confirms exactly 3 blank rows remain, one per chart, matching the table above.
- READMEs regenerated with the repo's own command from `taskfiles/charts.yml`: `helm-docs --chart-to-generate charts/connectors,charts/console/chart,operator/chart,charts/redpanda/chart`.

## Reviewed against the docs team's embedded-reference-strings standard

Every string added here went through that bar, which turned up nine findings in my own wording, all fixed in the third commit:

- **Interactions named.** The systematic gap. A value that only takes effect when a sibling is enabled now says so, verified against the templates: `replicaCount` is read only when `autoscaling.enabled` is false (`_console.deployment.tpl` gates it), and the same applies across `autoscaling.*`, `ingress.*`, `monitoring.*`, `secretManager.*`, `pvcUnbinder.unbindAfter`, `brokerDecommissioner.*`, the `sideCars.controllers` addresses and `fsValidator.expectedFS`.
- **Legal values in prose**, since the prose is what readers see: `service.type` lists its three values and notes that `nodePort` only applies to `NodePort`; `restartPolicy` states that Kubernetes requires `Always`; `cloud_storage_credentials_source` lists its six accepted values, which the property reference had and my extraction had dropped.
- **Restatement replaced with effect.** `strategy`, `securityContext`, `tolerations`, `affinity` and `topologySpreadConstraints` were near-restatements of their own keys, and now carry the same Kubernetes documentation links the connectors and redpanda charts already use.
- **Cross-row references removed**, because a reference table row has to stand alone: "the volumes above", "that endpoint" and "that secret name prefix" all now name what they mean.
- **Source-only references removed**: `resources` pointed at "the commented example below", which does not exist on the rendered page.

Pre-existing and left alone so as not to bury the diff: 26 chart descriptions across the three charts end without a terminal period, and four dead markers in the redpanda chart use the indented `#   -- ` form that helm-docs does not recognise.

## Remaining

The Console CRD half, DOC-2455. `StretchTieredConfig`'s 30 fields are done in this PR; 143 remain. Concentrated in a few structs, and much of it can reuse the wording landed here because `RedpandaClusterSpec` and `ConsoleSpec` mirror the chart values, which is worth doing for consistency between the two references:

| file | blank fields |
|---|---|
| `console_types.go` | 69 |
| `redpanda_clusterspec_types.go` | 44 |
| everything else | 30 |

Plus 19 fields with no comment of their own that publish their Go type's comment instead, so the CRD reference says things like "KafkaSASLOAuthBearer is the config struct for the SASL OAuthBearer mechanism" under the key `oauth`.

The checks that produced these counts are in redpanda-data/docs-extensions-and-macros PR 300. Companion fix for two values published under the wrong key: #1832.


[DOC-2455]: https://redpandadata.atlassian.net/browse/DOC-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ