### PR TITLE
CLAUDE.md: update style guides and compress instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,83 @@ This is a Go monorepo using `go.work` with multiple modules:
 - `gen/` — Code generation tools (partial, schema, pipeline)
 - `harpoon/` — BDD test framework for acceptance tests
 
+## Code Style & File Organization
+
+**Order declarations most-relevant-first.** Entry points and exported API first, then the helpers they call, in call order. A helper above its caller makes the reader hold an unexplained function in their head. Same rule inside tests (`TestXxx` before its helpers).
+
+```go
+// BAD                        // GOOD
+func helper() { ... }         func Exported() { helper() }
+func Exported() { helper() }  func helper() { ... }
+```
+
+A type leads its own declarations: type, constructors, then methods.
+
+```go
+type Foo struct { ... }
+
+func NewFoo() Foo { ... }
+
+func (f *Foo) Do() { ... }
+```
+
+Rote method sets are the exception. When several types satisfy the same interface with one-line bodies, declare the types together and group the implementations, rather than interleaving type/method pairs.
+
+```go
+type Foo struct { ... }
+type Bar struct { ... }
+type Baz struct { ... }
+
+func (Foo) ImplementsQuux() {}
+func (Bar) ImplementsQuux() {}
+func (Baz) ImplementsQuux() {}
+```
+
+Keep pure reordering of existing files in its own commit so it doesn't hide behavioral changes.
+
+**Tests go in `<file>_test.go`.** Tests for `foo.go` go in `foo_test.go` — **do not proliferate test files.** No `foo_edge_cases_test.go`, `foo_regression_test.go`, or per-scenario files; append to the existing one. A long test file beats five with overlapping names. If a test file gets unwieldy, split the *source* file along a real seam and let the test file follow.
+
+**Prefer table-driven tests** over many bespoke `TestXxx` funcs covering the same function. New cases should be a row in the table, not a new function. Reach for a standalone test only when the setup genuinely doesn't fit the table's shape.
+
+**Declare zero values with `var`.** `var x string`, not `x := ""`. `var xs []T`, not `xs := []T{}` — the nil slice is the intended value: it appends, ranges, and `len`s identically, and marshals to `null` rather than `[]`.
+
+**Keep variable scopes tight.** Declare at first use, not at the top of the function. A binding that sits unused through 20 lines of unrelated work is 20 lines the reader has to keep it alive for.
+
+```go
+// BAD                          // GOOD
+x := arg + "-value"             other := work()
+other := work()                 x := arg + "-value"
+return x + other                return x + other
+```
+
+**Don't reuse `err`.** Declare it with the value it belongs to; don't pre-declare a result and assign into it just to share an `err`.
+
+```go
+// BAD                          // GOOD
+var x string                    x, err := failableFunc()
+x, err = failableFunc()
+```
+
+**Write comments for experts.** Assume the reader knows Go and this codebase. Comment the *why*: invariants, constraints, and why the obvious approach doesn't work. Everything else is superfluous — comments cost reading time on every future read and rot silently, so an unearned line is worse than no line.
+
+Do not write:
+- Restatements of the code — `// increment the counter` above `count++`.
+- Diff or conversation archaeology — `// changed to fix the flake`, `// as discussed`, `// we used to call Foo here`. Version control holds this; the reader doesn't need it.
+- Godoc that just re-spells the identifier — `// Broker is a broker.`
+- Commented-out code. Delete it.
+
+```go
+// BAD - narrates the change; tells a future editor nothing.
+// Bumped to 30s from 10s to fix CI flakes.
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+// GOOD - names the constraint that chose the number, so it can be rechecked.
+// Brokers can take ~20s to report ready after a config change.
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+```
+
+The one piece of history worth keeping is a link: for an upstream bug or API quirk, cite the issue rather than describing the symptom.
+
 ## Reconciliation: Idempotency & Quiescence
 
 **Read this before changing controller watch triggers or requeue/rate-limit intervals.**
@@ -72,224 +149,64 @@ missed a real input. `rm -rf .task` forces a full local rebuild.
 
 ## Golden Test Files
 
-Multiple test suites use golden file comparison. To regenerate expected output instead of asserting, pass `-update-golden`:
+Regenerate goldens with `-update-golden`: `go test ./path/to/... -update-golden`. The legacy `-update` flag in `pkg/testutil` is a no-op — chart template tests (`TestTemplate`) go through `common-go/goldenfile`, which registers only `-update-golden`, so `-update` silently regenerates nothing.
 
-```bash
-nix develop -c go test ./path/to/... -update-golden
-```
-
-This includes chart template tests (`TestTemplate`) — their goldens go through `github.com/redpanda-data/common-go/goldenfile`, which registers only `-update-golden`. A legacy `-update` flag still exists in `pkg/testutil` but nothing consumes it: running with `-update` silently regenerates nothing.
-
-### Lifecycle golden tests
-
-Tests in `operator/internal/lifecycle/` use env vars for image values:
-- `TEST_REDPANDA_REPO` — e.g. `redpandadata/redpanda-unstable`
-- `TEST_REDPANDA_VERSION` — e.g. `v26.1.1-rc1`
-
-Golden files must be generated with these env vars set to match CI output.
+Goldens under `operator/internal/lifecycle/` bake in image values from `TEST_REDPANDA_REPO` (e.g. `redpandadata/redpanda-unstable`) and `TEST_REDPANDA_VERSION` (e.g. `v26.1.1-rc1`); both must be set to match CI output.
 
 ## Kubernetes Version Testing
 
-### Architecture
-
-- **k3d-based tests** (integration, acceptance): Use `K3S_IMAGE` env var, default in `pkg/k3d/k3d.go`
-- **Kind-based tests** (kuttl): Use `kindest/node` images in `operator/kind*.yaml`, constrained by kuttl's embedded Kind library version
-- **envtest-based tests** (unit): Use `KUBEBUILDER_ASSETS` from `setup-envtest`, configured in `flake.nix`
+How each suite picks its K8s version:
+- **k3d** (integration, acceptance) — `K3S_IMAGE` env var, default in `pkg/k3d/k3d.go`
+- **Kind** (kuttl) — `kindest/node` images in `operator/kind*.yaml`, capped by kuttl's embedded Kind library
+- **envtest** (unit) — `KUBEBUILDER_ASSETS` from `setup-envtest`, set in `flake.nix`
 
 ### How to Bump Kubernetes Versions
 
-When bumping the supported Kubernetes version range, update ALL of the following:
+These are pinned independently; a missed one surfaces as an unrelated-looking test failure. Update **all** of them:
 
-#### 1. k3d default image (`pkg/k3d/k3d.go`)
-```go
-DefaultK3sImage = `rancher/k3s:v1.XX.Y-k3s1`
-```
-Docker Hub tag format uses `-` not `+`: `rancher/k3s:v1.32.13-k3s1`
+| What | Where |
+|---|---|
+| k3d default image | `pkg/k3d/k3d.go` `DefaultK3sImage`. Docker Hub tags use `-`, not `+`: `rancher/k3s:v1.32.13-k3s1` |
+| k3d nightly default | `flake.nix` devshell `K3S_IMAGE` — the max supported version. The Buildkite nightly schedule overrides it per-run |
+| Kind node images | `operator/kind.yaml`, `kind-for-v2.yaml`, `kind-for-cloud.yaml`. **Must include the `@sha256:` digest** from the matching [Kind release](https://github.com/kubernetes-sigs/kind/releases) |
+| kuttl | `ci/kuttl.nix` — version plus sha256 for both `aarch64-darwin` and `x86_64-linux`. Kuttl embeds a Kind library that caps the usable `kindest/node` version (v0.19.0 → Kind v0.24.0, max K8s 1.31.x; v0.25.0 → Kind v0.31.0, max K8s 1.35.x). Also bump the kuttl entry in `pkg/lint/testdata/tool-versions.txtar` |
+| envtest | `flake.nix`: `{ name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.XX.x)"; }` |
+| Kube component images | `Taskfile.yml` `DEFAULT_TEST_KUBE_VERSION`, plus hardcoded `registry.k8s.io/kube-{apiserver,controller-manager}` refs in the three test files below |
+| vcluster | `pkg/testutil/testutil.go` `VClusterVersion`, `Taskfile.yml` `DEFAULT_TEST_VCLUSTER_VERSION`, and `ghcr.io/loft-sh/vcluster-pro` refs in the three test files below |
+| vcluster distro image | `ghcr.io/loft-sh/kubernetes` tag in **three** places that must match: `pkg/vcluster/vcluster.go` `DefaultValues`, `Taskfile.yml` pre-pull list, `acceptance/main_test.go` `WithImportedImages`. Must be supported by the vcluster chart version above |
+| cert-manager (inside vclusters, for webhook TLS) | `pkg/testutil/testutil.go` `CertManagerVersion`, `Taskfile.yml` `DEFAULT_SECOND_TEST_CERTMANAGER_VERSION`, `quay.io/jetstack/cert-manager-*` refs in the three test files below |
+| Acceptance upgrade baselines | `--version vXX.Y.Z` in `acceptance/features/operator-upgrades.feature`, `console-upgrades.feature`, and `upgrade-regressions.feature` (whose intermediate step uses the local `../operator/chart`), plus `DefaultRedpandaRepo`/`DefaultRedpandaTag` in `acceptance/steps/defaults.go` |
 
-#### 2. Kind node images (`operator/kind*.yaml`)
-Three files: `kind.yaml`, `kind-for-v2.yaml`, `kind-for-cloud.yaml`.
-**Must include `@sha256:` digest** from the matching Kind release.
-Check https://github.com/kubernetes-sigs/kind/releases for image tags.
-
-#### 3. Kuttl version (`ci/kuttl.nix`)
-Kuttl embeds a specific Kind library version. The embedded Kind must support the `kindest/node` image version used in step 2.
-- kuttl v0.19.0 → Kind v0.24.0 (max K8s 1.31.x)
-- kuttl v0.25.0 → Kind v0.31.0 (max K8s 1.35.x)
-
-Update version and sha256 hashes for both `aarch64-darwin` and `x86_64-linux` binaries.
-
-#### 4. Kube component images in Taskfile (`Taskfile.yml`)
-```yaml
-DEFAULT_TEST_KUBE_VERSION: v1.XX.Y
-```
-This controls `kube-controller-manager` and `kube-apiserver` image pulls.
-
-#### 5. Hardcoded kube component images in integration tests
-Search for `registry.k8s.io/kube-controller-manager:` and `registry.k8s.io/kube-apiserver:` in:
-- `operator/internal/controller/redpanda/redpanda_controller_test.go`
-- `operator/internal/probes/broker_test.go`
-- `operator/pkg/client/factory_test.go`
-
-#### 6. Tool version golden file (`pkg/lint/testdata/tool-versions.txtar`)
-If kuttl version changed, update the kuttl version entry.
-
-#### 7. Nightly K3S_IMAGE default (`flake.nix`)
-Update the `K3S_IMAGE` default in `flake.nix` devshell env to the maximum supported K8s version. Nightly builds and local `nix develop` sessions will use this. The Buildkite nightly schedule should set `K3S_IMAGE` via the schedule env to override the per-PR default.
-
-#### 8. envtest version (`flake.nix`)
-```nix
-{ name = "KUBEBUILDER_ASSETS"; eval = "$(setup-envtest use -p path 1.XX.x)"; }
-```
-
-#### 9. vcluster version (`pkg/testutil/testutil.go` + `Taskfile.yml`)
-vcluster is used by acceptance and integration tests to create isolated K8s environments. The vcluster version must support the host K8s version.
-- `pkg/testutil/testutil.go`: `VClusterVersion` constant
-- `Taskfile.yml`: `DEFAULT_TEST_VCLUSTER_VERSION`
-- Integration test files: `ghcr.io/loft-sh/vcluster-pro:<version>` image refs in `factory_test.go`, `redpanda_controller_test.go`, `broker_test.go`
-
-Known compatibility: v0.28.0 fails on K8s 1.32+ (vcluster pod never initializes). Use v0.31.2+ for K8s 1.32.
-
-#### 9b. vcluster distro image tag
-The K8s distro image used inside vclusters (`ghcr.io/loft-sh/kubernetes:<tag>`) is set in **three** places — all must match:
-- `pkg/vcluster/vcluster.go`: `DefaultValues` distro tag
-- `Taskfile.yml`: pre-pull image list
-- `acceptance/main_test.go`: `WithImportedImages` list (hardcoded literal)
-
-The distro version must be supported by the vcluster chart version from step 9.
-
-#### 10. cert-manager version in vcluster (`pkg/testutil/testutil.go` + `Taskfile.yml`)
-cert-manager is deployed inside vclusters for webhook TLS certificates. The version must support the K8s version running inside the vcluster.
-- `pkg/testutil/testutil.go`: `CertManagerVersion` constant
-- `Taskfile.yml`: `DEFAULT_SECOND_TEST_CERTMANAGER_VERSION`
-- Integration test files: `quay.io/jetstack/cert-manager-*:<version>` image refs
-
-Known compatibility: v1.8.0 only supports K8s 1.19-1.24. Use v1.17.2+ for K8s 1.32.
-
-#### 11. Acceptance upgrade test versions (`acceptance/features/*.feature` + `acceptance/steps/defaults.go`)
-Upgrade tests install an old operator version, create a cluster, then upgrade to the current dev build. Update:
-- `acceptance/features/operator-upgrades.feature`: `--version v25.X.Y` in helm install
-- `acceptance/features/upgrade-regressions.feature`: `--version v25.X.Y` in helm install (the intermediate upgrade step should use the local dev chart `"../operator/chart"`)
-- `acceptance/features/console-upgrades.feature`: `--version v25.X.Y` in helm install
-- `acceptance/steps/defaults.go`: `DefaultRedpandaRepo` and `DefaultRedpandaTag` for the Redpanda image used in clusters
+The three test files carrying hardcoded image refs: `operator/internal/controller/redpanda/redpanda_controller_test.go`, `operator/internal/probes/broker_test.go`, `operator/pkg/client/factory_test.go`.
 
 ## Proto Conflict
 
-The operator module has a known protobuf namespace conflict between `buf.build/gen/go/grpc-ecosystem/grpc-gateway` and `github.com/grpc-ecosystem/grpc-gateway/v2`. This causes a panic at test runtime.
-
-CI suppresses this via `flake.nix`:
-```nix
-{ name = "GOLANG_PROTOBUF_REGISTRATION_CONFLICT"; eval = "ignore"; }
-```
-
-When running tests locally, use the nix devshell which sets this automatically:
-```bash
-nix develop -c go test ./operator/...
-```
+The operator module has a protobuf namespace conflict between `buf.build/gen/go/grpc-ecosystem/grpc-gateway` and `github.com/grpc-ecosystem/grpc-gateway/v2` that panics at test runtime. `flake.nix` suppresses it with `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore`, so run tests through the devshell.
 
 ## Cutting a Release
 
-This repository is a monorepo with multiple independently releasable projects. Releases are managed via [Changie](https://github.com/miniscruff/changie) for changelog generation and git tags for versioning. See [CONTRIBUTING.md](./CONTRIBUTING.md#cutting-a-release) for the full process.
+[CONTRIBUTING.md](./CONTRIBUTING.md#cutting-a-release) is authoritative for the mechanics — `changie batch`/`merge`, tagging, pushing, the release workflow, helm-charts sync, and `NEXT_VERSION`. Work on a branch off the target release branch (e.g. `release/v25.1.x`). Changie project keys, which double as tag prefixes (`<key>/vX.Y.Z`): `operator`, `charts/redpanda`, `charts/console`, `charts/connectors`, `gotohelm`.
 
-### Project Keys
+Changie's replacements handle `operator/chart/Chart.yaml` (`version`, `appVersion`, image tag). What they do **not** handle, and you must bump by hand:
+- `charts/redpanda/Chart.yaml` `version` — the `charts/redpanda` project has no changie replacements at all.
+- `charts/redpanda/values.yaml` `sideCars.image.tag` — must match the operator version being released.
+- Version badges in `operator/chart/README.md` and `charts/redpanda/README.md`.
+- Chart goldens. The `operator` project's `helm.sh/chart` replacement regex expects a `v` prefix the real value lacks, so that label never updates on its own:
+  ```bash
+  go test ./operator/chart ./charts/redpanda/... -run TestTemplate -update-golden
+  ```
 
-Each releasable project has a changie key used in commands:
-- `operator` — Redpanda Operator (tagged as `operator/vX.Y.Z`)
-- `charts/redpanda` — Redpanda Helm Chart (tagged as `charts/redpanda/vX.Y.Z`)
-- `charts/console` — Console Helm Chart
-- `charts/connectors` — Connectors Helm Chart
-- `gotohelm` — GoToHelm
-
-### Steps
-
-1. **Create a working branch** off the target release branch (e.g. `release/v25.1.x`).
-
-2. **Mint versions** with `changie batch` for each project being released:
-   ```bash
-   nix develop -c changie batch -j <project> <version>
-   ```
-   For pre-releases, add `-k` to keep unreleased entries for the final release.
-
-3. **Review generated changelog entries** in `.changes/<project>/<version>.md`. Fix formatting or language as needed.
-
-4. **Run `changie merge`** to regenerate all `CHANGELOG.md` files and apply version replacements:
-   ```bash
-   nix develop -c changie merge
-   ```
-
-5. **Bump all version references.** The changie replacements in `.changie.yaml` auto-update some files but not all. A release typically requires bumping these version categories:
-
-   - **Operator helm chart versions** (`operator/chart/Chart.yaml`): `version`, `appVersion`, and image tag. Changie auto-updates these for the `operator` project.
-   - **Redpanda helm chart version** (`charts/redpanda/Chart.yaml`): `version` field. Has **no** changie replacements — must be bumped manually.
-   - **Sidecar image tag** (`charts/redpanda/values.yaml`): The `sideCars.image.tag` must match the operator version being released.
-   - **README.md badges**: Both `operator/chart/README.md` and `charts/redpanda/README.md` contain version badges regenerated by `task generate` in CI. Update these manually to match the new versions.
-
-   Note on changie replacement gaps:
-   - The `operator` project's `helm.sh/chart` label regex expects a `v` prefix but the actual value has none — golden files need regenerating via tests (step 6).
-   - The `charts/redpanda` project has no changie replacements at all.
-
-6. **Update golden test files** to reflect version changes:
-   ```bash
-   # Operator chart golden files
-   nix develop -c go test github.com/redpanda-data/redpanda-operator/operator/chart -run TestTemplate -update-golden
-
-   # Redpanda chart golden files
-   nix develop -c go test github.com/redpanda-data/redpanda-operator/charts/redpanda/... -run TestTemplate -update-golden
-   ```
-   Note: The flag is `-update-golden` (the legacy `-update` flag is a no-op for chart template tests).
-
-7. **Run unit tests and lint** to verify:
-   ```bash
-   nix develop -c task test:unit
-   nix develop -c task lint
-   ```
-
-8. **Commit** with one commit per project using the message format `<project>: cut release <version>`, then open a PR targeting the release branch.
-
-### Checklist of Files to Verify
-
-For an **operator** release (e.g. `v25.1.5`):
-- [ ] `.changes/operator/v25.1.5.md` — new changelog entry
-- [ ] `.changes/unreleased/operator-*` — consumed entries removed
-- [ ] `operator/CHANGELOG.md` — updated
-- [ ] `operator/chart/Chart.yaml` — `version`, `appVersion`, image tag updated
-- [ ] `operator/chart/README.md` — version badge updated
-- [ ] `operator/chart/testdata/template-cases.golden.txtar` — regenerated
-
-For a **charts/redpanda** release (e.g. `v25.1.4`):
-- [ ] `.changes/charts/redpanda/v25.1.4.md` — new changelog entry
-- [ ] `.changes/unreleased/charts-redpanda-*` — consumed entries removed
-- [ ] `charts/redpanda/CHANGELOG.md` — updated
-- [ ] `charts/redpanda/Chart.yaml` — `version` bumped manually
-- [ ] `charts/redpanda/values.yaml` — `sideCars.image.tag` bumped to match operator version
-- [ ] `charts/redpanda/README.md` — version badge updated
-- [ ] `charts/redpanda/testdata/template-cases.golden.txtar` — regenerated
+`task test:unit` and `task lint` report anything still missed. Commit once per project as `<project>: cut release <version>`.
 
 ## Common Commands
 
-All commands should be run inside the nix devshell to ensure correct tool versions and environment variables. Prefix commands with `nix develop -c` or enter the shell with `nix develop`.
+Run everything inside the nix devshell — `nix develop`, or prefix with `nix develop -c`. It pins tool versions and sets `KUBEBUILDER_ASSETS` and `GOLANG_PROTOBUF_REGISTRATION_CONFLICT`.
 
 ```bash
-# Enter nix devshell (recommended for interactive work)
-nix develop
-
-# Or prefix individual commands
-nix develop -c go build ./operator/...
-
-# Build all
-nix develop -c bash -c 'go build ./operator/... && go build ./charts/console/... && go build ./charts/redpanda/...'
-
-# Run unit tests (envtest is configured by the devshell)
-nix develop -c task test:unit
-
-# Run chart template tests
-nix develop -c bash -c 'helm dep build charts/redpanda/chart && go test ./charts/redpanda/... -run TestTemplate'
-
-# Regenerate ALL generated files (preferred — matches CI)
-nix develop -c task generate
-
-# Run golangci-lint (v2 format)
-nix develop -c task lint
-
-# Update golden files
-nix develop -c go test ./path/to/... -update-golden
+task test:unit                     # unit tests (envtest configured by the devshell)
+task lint                          # golangci-lint, helm lint --strict, actionlint
+task generate                      # regenerate ALL generated files (preferred - matches CI)
+task k8s:generate                  # CRDs and RBAC only
+go test ./path/... -update-golden  # refresh golden files
+helm dep build charts/redpanda/chart && go test ./charts/redpanda/... -run TestTemplate
 ```


### PR DESCRIPTION
This commit updates CLAUDE.md with instructions that I personally have had it correct in my own work and in PRs of other. This primarily revolves around code organization, small stylistic nits, and an attempt to reduce the verbosity of comments.

Additionally as context space is precious I've compressed the existing instructions to a minimally functional version.

The latter compression was performed by claude. I can drop if its undesirable.