### PR TITLE
operator: don't enable Console Kafka impersonation without a login

### DIFF
--- a/.changes/unreleased/operator-Fixed-20260909-091000.yaml
+++ b/.changes/unreleased/operator-Fixed-20260909-091000.yaml
@@ -1,0 +1,5 @@
+project: operator
+kind: Fixed
+body: |-
+    The Console configuration rendered for a Redpanda resource no longer contains `kafka.sasl.enabled: true` and `kafka.sasl.impersonateUser: true` unless the legacy `console.console` block configured a login. Console 3.9 refuses to start with impersonation enabled while its own authentication is disabled, so clusters without SASL had a crash-looping Console.
+time: 2026-09-09T09:10:00.000000-07:00

--- a/charts/console/migrate_nogotohelm.go
+++ b/charts/console/migrate_nogotohelm.go
@@ -71,8 +71,12 @@ type mapping struct {
 }
 
 // mappings is a slice of destination path to JQ query that together migrate a
-// Console v2 config to a Console v3 config. Its behavior is exactly the same
-// as the converter in our public docs (Thanks Jake!)
+// Console v2 config to a Console v3 config. Its behavior matches the converter
+// in our public docs (Thanks Jake!) except that the kafka.sasl defaults are
+// gated on a login being configured: the docs converter always emits them, but
+// Console refuses to start with impersonateUser set while its own
+// authentication is disabled, so an unconditional default crash-loops Console
+// on clusters without SASL.
 // https://github.com/redpanda-data/docs-ui/blob/d55545f392e0a9aaa0dbd193606a2b629d779699/console-config-migrator/main.go#L25
 // Due to module dependency conflicts and the quasi closed source nature of
 // console typing the configurations was deemed a non-option. JQ was elected as
@@ -93,8 +97,11 @@ var mappings = compileMappings([]mappingSpec{
 	{"schemaRegistry", `.kafka.schemaRegistry | del(.username, .password, .bearerToken)`},
 
 	// Kafka
-	{"kafka.sasl.enabled", "true"},
-	{"kafka.sasl.impersonateUser", "true"},
+	// Unlike the docs converter, the SASL defaults are only emitted when v2
+	// configured a login: Console refuses to start with impersonateUser set
+	// while its own authentication is disabled.
+	{"kafka.sasl.enabled", ".login | select(.) | true"},
+	{"kafka.sasl.impersonateUser", ".login | select(.) | true"},
 	{"kafka", `.kafka | del(.schemaRegistry, .protobuf, .cbor, .messagePack)`},
 
 	// Serde

--- a/charts/console/migrate_nogotohelm.go
+++ b/charts/console/migrate_nogotohelm.go
@@ -73,10 +73,7 @@ type mapping struct {
 // mappings is a slice of destination path to JQ query that together migrate a
 // Console v2 config to a Console v3 config. Its behavior matches the converter
 // in our public docs (Thanks Jake!) except that the kafka.sasl defaults are
-// gated on a login being configured: the docs converter always emits them, but
-// Console refuses to start with impersonateUser set while its own
-// authentication is disabled, so an unconditional default crash-loops Console
-// on clusters without SASL.
+// gated on a configured login.
 // https://github.com/redpanda-data/docs-ui/blob/d55545f392e0a9aaa0dbd193606a2b629d779699/console-config-migrator/main.go#L25
 // Due to module dependency conflicts and the quasi closed source nature of
 // console typing the configurations was deemed a non-option. JQ was elected as

--- a/charts/console/testdata/migrate-cases.golden.txtar
+++ b/charts/console/testdata/migrate-cases.golden.txtar
@@ -70,9 +70,6 @@ output:
   kafka:
     brokers:
     - localhost:9092
-    sasl:
-      enabled: true
-      impersonateUser: true
   schemaRegistry:
     authentication:
       basic:
@@ -89,9 +86,6 @@ output:
   kafka:
     brokers:
     - localhost:9092
-    sasl:
-      enabled: true
-      impersonateUser: true
   schemaRegistry:
     authentication:
       bearerToken: token123
@@ -106,9 +100,6 @@ output:
   kafka:
     brokers:
     - localhost:9092
-    sasl:
-      enabled: true
-      impersonateUser: true
   serde:
     cbor:
       enabled: true
@@ -120,10 +111,6 @@ warnings: null
 
 -- 09-connect-to-kafka-connect --
 output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
   kafkaConnect:
     clusters:
     - name: local
@@ -133,10 +120,6 @@ warnings: null
 
 -- 10-console-max-payload --
 output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
   serde:
     maxDeserializationPayloadSize: 1048576
 warnings: null
@@ -151,10 +134,6 @@ output:
         name: alice
       - loginType: oidc
         name: bob
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
 warnings: null
 
 -- 12-rolebindings-with-groups --
@@ -165,19 +144,11 @@ output:
       users:
       - loginType: basic
         name: alice
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
 warnings:
 - Removed group subject from role binding 'viewer'. Groups are not supported in v3.
 
 -- 13-redpanda-adminapi-with-creds --
 output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
   redpanda:
     adminApi:
       authentication:
@@ -192,10 +163,6 @@ warnings: null
 
 -- 14-redpanda-adminapi-no-creds --
 output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
   redpanda:
     adminApi:
       authentication:
@@ -257,18 +224,10 @@ warnings: null
 output:
   authentication:
     jwtSigningKey: existing-key
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
 warnings: null
 
 -- 17-remaining-fields --
 output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
   logger:
     level: info
   server:
@@ -332,11 +291,7 @@ warnings:
   in Redpanda instead.
 
 -- 22-empty-config --
-output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
+output: {}
 warnings: null
 
 -- 23-kafka-with-tls --
@@ -344,9 +299,6 @@ output:
   kafka:
     brokers:
     - localhost:9093
-    sasl:
-      enabled: true
-      impersonateUser: true
     tls:
       caFilepath: /etc/certs/ca.crt
       enabled: true
@@ -354,10 +306,6 @@ warnings: null
 
 -- 24-redpanda-with-extra-fields --
 output:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
   redpanda:
     adminApi:
       authentication:
@@ -393,4 +341,13 @@ warnings:
   in Redpanda instead.
 - Removed 'directory' from 'keycloak'. OIDC groups are not supported in v3. Create
   Roles in Redpanda instead.
+
+-- 26-kafka-without-login --
+output:
+  kafka:
+    brokers:
+    - broker-0:9092
+    sasl:
+      enabled: false
+warnings: null
 

--- a/charts/console/testdata/migrate-cases.txtar
+++ b/charts/console/testdata/migrate-cases.txtar
@@ -226,3 +226,11 @@ login:
     enabled: true
     realm: "keycloak realm"
     directory: "keycloak directory"
+-- 26-kafka-without-login --
+# No login stanza: Console authentication stays disabled, so the migration must
+# not enable SASL impersonation (Console 3.9 refuses to start otherwise).
+kafka:
+  brokers:
+    - broker-0:9092
+  sasl:
+    enabled: false

--- a/operator/api/redpanda/v1alpha2/testdata/console-migration-cases.golden.txtar
+++ b/operator/api/redpanda/v1alpha2/testdata/console-migration-cases.golden.txtar
@@ -1,9 +1,5 @@
 -- 00-empty --
-config:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
+config: {}
 secret: {}
 
 -- 01-disabled --
@@ -40,11 +36,7 @@ config:
 secret: {}
 
 -- 04-enterprise-and-license-ref --
-config:
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
+config: {}
 licenseSecretRef:
   key: license
   name: license
@@ -56,10 +48,6 @@ config:
     roleBindings:
     - roleName: admin
       users: []
-  kafka:
-    sasl:
-      enabled: true
-      impersonateUser: true
 secret: {}
 warnings:
 - Removed group subject from role binding 'admin'. Groups are not supported in v3.


### PR DESCRIPTION
When the operator renders a Console for a Redpanda cluster with SASL disabled, the migrated config contained `kafka.sasl.enabled: true` and `kafka.sasl.impersonateUser: true`, and Console 3.9 refuses to start:

```
config validation failed: user impersonation for Kafka API is not allowed when authentication is disabled
```

`ConfigFromV2` injected those SASL defaults unconditionally (matching our public docs converter). They only make sense when Console itself has a login configured, since impersonation acts on the logged-in user. The migration now gates the SASL defaults on a login being present, so a login-less cluster no longer gets an impersonation config it can't start with. Configs that do define a login are unchanged. Added a migration case and regenerated the console/operator goldens (the operator's empty and login-less cases now render `config: {}` / no SASL).

Found while testing #1843 on EKS with ArgoCD: a Redpanda CR with SASL disabled left its Console pod in CrashLoopBackOff with the error above, while the redpanda Helm chart's own Console (which never runs this migration) came up fine.
