### PR TITLE
operator: watch lifecycle-rendered resources in the StretchCluster controller

### DIFF
--- a/.changes/unreleased/operator-Added-20260911-120000.yaml
+++ b/.changes/unreleased/operator-Added-20260911-120000.yaml
@@ -1,0 +1,4 @@
+project: operator
+kind: Added
+body: 'The StretchCluster controller now watches the resources rendered by the lifecycle package (StatefulSets, Services, ConfigMaps, Secrets, certificates, ...) across every configured member cluster, so drift in an owned resource triggers reconciliation immediately instead of waiting for the periodic requeue'
+time: 2026-09-11T12:00:00.000000000+02:00

--- a/operator/internal/controller/redpanda/multicluster_controller.go
+++ b/operator/internal/controller/redpanda/multicluster_controller.go
@@ -2075,47 +2075,63 @@ func SetupMulticlusterController(ctx context.Context, mgr multicluster.Manager, 
 	if factory == nil {
 		return errors.New("SetupMulticlusterController requires a non-nil client factory")
 	}
-	return mcbuilder.ControllerManagedBy(mgr).WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
+	lifecycleClient := lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(redpandaImage, sidecarImage, cloudSecrets)).WithBrokerPodNodeUnavailableToleration(brokerPodNodeUnavailableToleration)
+
+	builder := mcbuilder.ControllerManagedBy(mgr).WithOptions(ctrlcontroller.TypedOptions[mcreconcile.Request]{
 		// NB: This is gross, but currently the multicluster runtime doesn't hand this global option off to the controller
 		// registration properly, so we can't boot multiple controllers in test without doing this.
 		// Consider an upstream fix.
 		SkipNameValidation: ptr.To(true),
-	}).For(
-		&redpandav1alpha2.StretchCluster{},
+	})
+
+	// Watch the StretchCluster itself plus every resource the lifecycle
+	// renderers create (StatefulSets, Services, ConfigMaps, Secrets, ...), so
+	// drift in an owned resource triggers reconciliation instead of waiting
+	// for the periodic requeue. Watches are keyed by the union of registered
+	// and configured cluster names: setup runs before the provider registers
+	// any raft peer, so GetClusterNames() alone would leave every peer's
+	// resources unwatched.
+	watchClusters := unionClusterNames(mgr.GetClusterNames(), mgr.GetConfiguredClusterNames())
+	if err := lifecycleClient.WatchResources(builder, &redpandav1alpha2.StretchCluster{}, watchClusters,
 		mcbuilder.WithEngageWithLocalCluster(true),
-		mcbuilder.WithEngageWithProviderClusters(true)).
-		Watches(&redpandav1alpha2.RedpandaBrokerPool{}, func(clusterName string, _ cluster.Cluster) mchandler.EventHandler {
-			return mchandler.TypedEnqueueRequestsFromMapFuncWithClusterPreservation(func(ctx context.Context, object client.Object) []mcreconcile.Request {
-				l := log.FromContext(ctx).WithName("MulticlusterReconciler.RedpandaBrokerPoolWatch").V(log.TraceLevel)
-				np, ok := object.(*redpandav1alpha2.RedpandaBrokerPool)
-				if !ok {
-					return nil
-				}
-				if !np.Spec.ClusterRef.IsStretchCluster() {
-					return nil
-				}
-				l.V(log.TraceLevel).Info("RedpandaBrokerPool event received", "brokerPool", client.ObjectKeyFromObject(np).String(), "clusterRef", np.Spec.ClusterRef.Name)
-				return []mcreconcile.Request{{
-					Request: reconcile.Request{
-						NamespacedName: types.NamespacedName{
-							Namespace: np.Namespace,
-							Name:      np.Spec.ClusterRef.Name,
-						},
+		mcbuilder.WithEngageWithProviderClusters(true),
+	); err != nil {
+		return err
+	}
+
+	builder.Watches(&redpandav1alpha2.RedpandaBrokerPool{}, func(clusterName string, _ cluster.Cluster) mchandler.EventHandler {
+		return mchandler.TypedEnqueueRequestsFromMapFuncWithClusterPreservation(func(ctx context.Context, object client.Object) []mcreconcile.Request {
+			l := log.FromContext(ctx).WithName("MulticlusterReconciler.RedpandaBrokerPoolWatch").V(log.TraceLevel)
+			np, ok := object.(*redpandav1alpha2.RedpandaBrokerPool)
+			if !ok {
+				return nil
+			}
+			if !np.Spec.ClusterRef.IsStretchCluster() {
+				return nil
+			}
+			l.V(log.TraceLevel).Info("RedpandaBrokerPool event received", "brokerPool", client.ObjectKeyFromObject(np).String(), "clusterRef", np.Spec.ClusterRef.Name)
+			return []mcreconcile.Request{{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: np.Namespace,
+						Name:      np.Spec.ClusterRef.Name,
 					},
-					ClusterName: clusterName,
-				}}
-			})
-		}).
-		Complete(
-			observability.Wrap[mcreconcile.Request](&MulticlusterReconciler{
-				Manager:                        mgr,
-				LifecycleClient:                lifecycle.NewMulticlusterResourceClient(mgr, lifecycle.StretchClusterResourceManagers(redpandaImage, sidecarImage, cloudSecrets)).WithBrokerPodNodeUnavailableToleration(brokerPodNodeUnavailableToleration),
-				ClientFactory:                  factory,
-				ReconcileTimeout:               reconcileTimeout,
-				PostRestartCaughtUpPercent:     postRestartCaughtUpPercent,
-				WaitForSchemaRegistrySync:      waitForSchemaRegistrySync,
-				MaintenanceModeClearThreshold:  clearMaintenanceModeAfter,
-				StaleDiskWipeNotReadyThreshold: staleDiskWipeNotReadyThreshold,
-			}, "StretchCluster", periodicRequeue),
-		)
+				},
+				ClusterName: clusterName,
+			}}
+		})
+	})
+
+	return builder.Complete(
+		observability.Wrap[mcreconcile.Request](&MulticlusterReconciler{
+			Manager:                        mgr,
+			LifecycleClient:                lifecycleClient,
+			ClientFactory:                  factory,
+			ReconcileTimeout:               reconcileTimeout,
+			PostRestartCaughtUpPercent:     postRestartCaughtUpPercent,
+			WaitForSchemaRegistrySync:      waitForSchemaRegistrySync,
+			MaintenanceModeClearThreshold:  clearMaintenanceModeAfter,
+			StaleDiskWipeNotReadyThreshold: staleDiskWipeNotReadyThreshold,
+		}, "StretchCluster", periodicRequeue),
+	)
 }

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -244,6 +244,110 @@ func (s *MulticlusterControllerSuite) TestSpecConsistencyConditionSetOnDrift() {
 	}, 1*time.Minute, 1*time.Second, "SpecSynced condition never went back to True after fixing drift")
 }
 
+// TestOwnedResourceDeletionTriggersResync verifies that the controller watches
+// the resources rendered by the lifecycle package: deleting an owned resource
+// triggers a watch-driven reconcile that recreates it well before the next
+// periodic requeue.
+//
+// The StretchCluster deliberately has no BrokerPools: with a pool the
+// controller fast-polls while pods are unready, which would recreate the
+// resource with or without a watch. With zero pools the controller quiesces
+// to the 3 minute periodic requeue, so a sub-minute recreation can only be
+// watch-driven. Inline SASL users are used because the rendered users Secret
+// is the one simple resource emitted without any pools.
+func (s *MulticlusterControllerSuite) TestOwnedResourceDeletionTriggersResync() {
+	t, ctx, cancel, ns := s.setup()
+	defer cancel()
+
+	// scQuiesceWindow is how long the StretchCluster's resourceVersion must
+	// stay unchanged on every cluster before the controller is considered
+	// settled. stretchPeriodicRequeue mirrors the controller's unexported
+	// periodicRequeue — the reconcile cadence of a settled StretchCluster.
+	// recreateBound is the deadline for watch-driven recreation; it must stay
+	// well below stretchPeriodicRequeue-scQuiesceWindow, the earliest a
+	// periodic pass could recreate the Secret without any watch (the last
+	// pass may have run up to scQuiesceWindow before the delete).
+	const (
+		scQuiesceWindow        = 15 * time.Second
+		stretchPeriodicRequeue = 3 * time.Minute
+		recreateBound          = 45 * time.Second
+	)
+
+	const scName = "watch-resync"
+	usersSecretName := scName + "-users"
+	nn := types.NamespacedName{Name: scName, Namespace: ns.Name}
+
+	s.mc.ApplyAllInNamespace(t, ctx, ns.Name, &redpandav1alpha2.StretchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: scName},
+		Spec: redpandav1alpha2.StretchClusterSpec{
+			Auth: &redpandav1alpha2.Auth{
+				SASL: &redpandav1alpha2.SASL{
+					Enabled:   ptr.To(true),
+					SecretRef: ptr.To(usersSecretName),
+					Users: []redpandav1alpha2.UsersItems{{
+						Name:     ptr.To("admin"),
+						Password: ptr.To("changeme"),
+					}},
+				},
+			},
+		},
+	})
+
+	// Wait until every cluster has the rendered users Secret — i.e. the
+	// reconciler completed at least one resource sync pass everywhere.
+	secretKey := client.ObjectKey{Namespace: ns.Name, Name: usersSecretName}
+	for i, env := range s.mc.Envs {
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var secret corev1.Secret
+			if err := cl.Get(ctx, secretKey, &secret); err != nil {
+				t.Logf("[TestOwnedResourceDeletionTriggersResync] waiting for users secret in cluster %d: %v", i, err)
+				return false
+			}
+			return true
+		}, 2*time.Minute, 2*time.Second, "rendered users Secret never appeared in cluster %d", i)
+	}
+
+	// Wait for the controller to quiesce: creation-time passes write status
+	// (finalizer, conditions, bootstrap-user bookkeeping) to every cluster,
+	// and each write re-triggers a reconcile whose SyncAll would recreate the
+	// Secret and mask a missing watch. A pass resets its periodic requeue to
+	// 3 minutes out, so once the StretchCluster's resourceVersion has been
+	// stable everywhere for a while, the only thing that can recreate the
+	// Secret within the assertion window below is the owned-resource watch.
+	for i, env := range s.mc.Envs {
+		var lastRV string
+		var stableSince time.Time
+		cl := env.Client()
+		require.Eventually(t, func() bool {
+			var live redpandav1alpha2.StretchCluster
+			if err := cl.Get(ctx, nn, &live); err != nil {
+				return false
+			}
+			if live.ResourceVersion != lastRV {
+				lastRV = live.ResourceVersion
+				stableSince = time.Now()
+				return false
+			}
+			return time.Since(stableSince) > scQuiesceWindow
+		}, 2*time.Minute, 1*time.Second, "StretchCluster on cluster %d never quiesced", i)
+	}
+
+	var secret corev1.Secret
+	require.NoError(t, s.mc.Envs[1].Client().Get(ctx, secretKey, &secret))
+	deletedUID := secret.UID
+	deletedAt := time.Now()
+	require.NoError(t, s.mc.Envs[1].Client().Delete(ctx, &secret))
+
+	require.Eventually(t, func() bool {
+		var recreated corev1.Secret
+		if err := s.mc.Envs[1].Client().Get(ctx, secretKey, &recreated); err != nil {
+			return false
+		}
+		return recreated.UID != deletedUID && time.Since(deletedAt) < stretchPeriodicRequeue-scQuiesceWindow
+	}, recreateBound, 1*time.Second, "users Secret was never recreated after deletion; owned-resource watch not firing")
+}
+
 // TestIssuerRef verifies that when a user provides their own CA and Issuers
 // (Option 1), the operator:
 //   - Does NOT generate or distribute root-certificate secrets for certs with IssuerRef

--- a/operator/internal/controller/redpanda/multicluster_controller_test.go
+++ b/operator/internal/controller/redpanda/multicluster_controller_test.go
@@ -244,33 +244,19 @@ func (s *MulticlusterControllerSuite) TestSpecConsistencyConditionSetOnDrift() {
 	}, 1*time.Minute, 1*time.Second, "SpecSynced condition never went back to True after fixing drift")
 }
 
-// TestOwnedResourceDeletionTriggersResync verifies that the controller watches
-// the resources rendered by the lifecycle package: deleting an owned resource
-// triggers a watch-driven reconcile that recreates it well before the next
-// periodic requeue.
-//
-// The StretchCluster deliberately has no BrokerPools: with a pool the
-// controller fast-polls while pods are unready, which would recreate the
-// resource with or without a watch. With zero pools the controller quiesces
-// to the 3 minute periodic requeue, so a sub-minute recreation can only be
-// watch-driven. Inline SASL users are used because the rendered users Secret
-// is the one simple resource emitted without any pools.
 func (s *MulticlusterControllerSuite) TestOwnedResourceDeletionTriggersResync() {
 	t, ctx, cancel, ns := s.setup()
 	defer cancel()
 
 	// scQuiesceWindow is how long the StretchCluster's resourceVersion must
 	// stay unchanged on every cluster before the controller is considered
-	// settled. stretchPeriodicRequeue mirrors the controller's unexported
-	// periodicRequeue — the reconcile cadence of a settled StretchCluster.
-	// recreateBound is the deadline for watch-driven recreation; it must stay
-	// well below stretchPeriodicRequeue-scQuiesceWindow, the earliest a
+	// settled. recreateBound is the deadline for watch-driven recreation; it
+	// must stay well below periodicRequeue-scQuiesceWindow, the earliest a
 	// periodic pass could recreate the Secret without any watch (the last
 	// pass may have run up to scQuiesceWindow before the delete).
 	const (
-		scQuiesceWindow        = 15 * time.Second
-		stretchPeriodicRequeue = 3 * time.Minute
-		recreateBound          = 45 * time.Second
+		scQuiesceWindow = 15 * time.Second
+		recreateBound   = 45 * time.Second
 	)
 
 	const scName = "watch-resync"
@@ -336,7 +322,6 @@ func (s *MulticlusterControllerSuite) TestOwnedResourceDeletionTriggersResync() 
 	var secret corev1.Secret
 	require.NoError(t, s.mc.Envs[1].Client().Get(ctx, secretKey, &secret))
 	deletedUID := secret.UID
-	deletedAt := time.Now()
 	require.NoError(t, s.mc.Envs[1].Client().Delete(ctx, &secret))
 
 	require.Eventually(t, func() bool {
@@ -344,7 +329,7 @@ func (s *MulticlusterControllerSuite) TestOwnedResourceDeletionTriggersResync() 
 		if err := s.mc.Envs[1].Client().Get(ctx, secretKey, &recreated); err != nil {
 			return false
 		}
-		return recreated.UID != deletedUID && time.Since(deletedAt) < stretchPeriodicRequeue-scQuiesceWindow
+		return recreated.UID != deletedUID
 	}, recreateBound, 1*time.Second, "users Secret was never recreated after deletion; owned-resource watch not firing")
 }
 

--- a/operator/internal/lifecycle/client.go
+++ b/operator/internal/lifecycle/client.go
@@ -725,7 +725,9 @@ func wrapLoggingHandler[T client.Object](_ T, h handler.TypedEventHandler[T, mcr
 }
 
 // WatchResources configures resource watching for the given cluster, including StatefulSets and other resources.
-func (r *ResourceClient[T, U]) WatchResources(builder Builder, cluster client.Object, clusterNames []string) error {
+// forOpts is applied to the For registration of the cluster object itself; multicluster
+// controllers use it to engage both the local and every provider cluster.
+func (r *ResourceClient[T, U]) WatchResources(builder Builder, cluster client.Object, clusterNames []string, forOpts ...mcbuilder.ForOption) error {
 	// NB: we use localcluster here because the RESTMapper and scheme should be identical across all clusters
 	ctl, err := r.ctl(context.Background(), mcmanager.LocalCluster)
 	if err != nil {
@@ -733,7 +735,7 @@ func (r *ResourceClient[T, U]) WatchResources(builder Builder, cluster client.Ob
 	}
 
 	// set that this is for the cluster
-	builder.For(cluster)
+	builder.For(cluster, forOpts...)
 
 	owns := func(obj client.Object) {
 		if r.traceLogging {
@@ -750,6 +752,13 @@ func (r *ResourceClient[T, U]) WatchResources(builder Builder, cluster client.Ob
 	owns(&appsv1.StatefulSet{})
 
 	for _, resourceType := range r.simpleResourceRenderer.WatchedResourceTypes() {
+		// StatefulSets are the node-pool type and were already registered via
+		// owns above; renderers that list them in WatchedResourceTypes would
+		// otherwise produce a duplicate watch.
+		if _, ok := resourceType.(*appsv1.StatefulSet); ok {
+			continue
+		}
+
 		gvk, err := kube.GVKFor(ctl.Scheme(), resourceType)
 		if err != nil {
 			return err

--- a/operator/internal/lifecycle/client_test.go
+++ b/operator/internal/lifecycle/client_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/redpanda-data/redpanda-operator/pkg/multicluster"
@@ -449,6 +450,9 @@ func TestClientWatchResources(t *testing.T) {
 	for name, tt := range map[string]struct {
 		watchedResources []string
 		ownedResources   []string
+		clusterNames     []string
+		forOpts          []mcbuilder.ForOption
+		traceLogging     bool
 		testParams       clientTest
 	}{
 		"base": {
@@ -476,12 +480,53 @@ func TestClientWatchResources(t *testing.T) {
 				},
 			},
 		},
+		// StatefulSets are the node-pool type and are always watched via the
+		// dedicated owns registration; a renderer that also lists them in
+		// WatchedResourceTypes must not produce a second watch.
+		"statefulset-in-watched-types-not-duplicated": {
+			ownedResources: []string{"*v1.StatefulSet"},
+			testParams: clientTest{
+				watchedResources: []client.Object{
+					&appsv1.StatefulSet{},
+				},
+			},
+		},
+		// The multicluster path (traceLogging on, as both production
+		// constructors set) registers one watch per cluster name for every
+		// resource type, so events on peer clusters enqueue reconciles too.
+		"multicluster-per-cluster-watches": {
+			traceLogging: true,
+			clusterNames: []string{mcmanager.LocalCluster, "peer-a"},
+			watchedResources: []string{
+				"*v1.StatefulSet", "*v1.StatefulSet",
+				"*v1.Secret", "*v1.Secret",
+				"*v1.PersistentVolume", "*v1.PersistentVolume",
+			},
+			forOpts: []mcbuilder.ForOption{
+				mcbuilder.WithEngageWithLocalCluster(true),
+				mcbuilder.WithEngageWithProviderClusters(true),
+			},
+			testParams: clientTest{
+				watchedResources: []client.Object{
+					&appsv1.StatefulSet{},
+					&corev1.Secret{},
+					&corev1.PersistentVolume{},
+				},
+			},
+		},
 	} {
 		tt.testParams.Run(parentCtx, t, name, func(t *testing.T, instances *clientTestInstances, cluster *MockCluster) {
 			builder := NewMockBuilder(instances.manager)
+			instances.resourceClient.traceLogging = tt.traceLogging
 
-			require.NoError(t, instances.resourceClient.WatchResources(builder, &MockCluster{}, []string{mcmanager.LocalCluster}))
+			clusterNames := tt.clusterNames
+			if clusterNames == nil {
+				clusterNames = []string{mcmanager.LocalCluster}
+			}
+
+			require.NoError(t, instances.resourceClient.WatchResources(builder, &MockCluster{}, clusterNames, tt.forOpts...))
 			require.Equal(t, "*lifecycle.MockCluster", builder.Base())
+			require.Len(t, builder.ForOptions(), len(tt.forOpts))
 
 			require.ElementsMatch(t, tt.ownedResources, builder.Owned())
 			require.ElementsMatch(t, tt.watchedResources, builder.Watched())

--- a/operator/internal/lifecycle/interfaces_test.go
+++ b/operator/internal/lifecycle/interfaces_test.go
@@ -51,6 +51,7 @@ func init() {
 type MockBuilder struct {
 	*mcbuilder.Builder
 	base    string
+	forOpts []mcbuilder.ForOption
 	watches []string
 	owns    []string
 }
@@ -65,6 +66,10 @@ func (b *MockBuilder) Base() string {
 	return b.base
 }
 
+func (b *MockBuilder) ForOptions() []mcbuilder.ForOption {
+	return b.forOpts
+}
+
 func (b *MockBuilder) Owned() []string {
 	return b.owns
 }
@@ -75,6 +80,7 @@ func (b *MockBuilder) Watched() []string {
 
 func (b *MockBuilder) For(object client.Object, opts ...mcbuilder.ForOption) *mcbuilder.Builder {
 	b.base = fmt.Sprintf("%T", object)
+	b.forOpts = opts
 	return b.Builder.For(object, opts...)
 }
 


### PR DESCRIPTION
## What

`SetupMulticlusterController` now registers its watches through `lifecycle.ResourceClient.WatchResources`, mirroring `RedpandaReconciler.SetupWithManager`: the StretchCluster `For`-watch plus per-cluster watches on every resource type the stretch renderers create (StatefulSets via owner enqueue, Services, ConfigMaps, Secrets, Certificates, Issuers, EndpointSlices, ServiceExports/Imports, PDBs, RBAC objects, ...). Drift in an owned resource now triggers reconciliation immediately instead of waiting for the 3 minute periodic requeue.

## Notable decisions

- **Watches are keyed by `unionClusterNames(GetClusterNames(), GetConfiguredClusterNames())`**, not `GetClusterNames()` alone: setup runs before the raft provider registers any peer, so the registered set is just the local sentinel at that point and every peer's resources would go unwatched — the same configured-vs-registered window as K8S-891.
- **`WatchResources` gains variadic `mcbuilder.ForOption`s** (source-compatible with the existing Redpanda-controller call site) so the stretch controller keeps engaging both the local and provider clusters on its `For` registration.
- **`WatchResources` skips `StatefulSet` in the `WatchedResourceTypes` loop**: the dedicated `owns` registration already covers it. This also removes a pre-existing duplicate StatefulSet watch in the v2 Redpanda controller (both `redpanda.Types()` and `multicluster.Types()` list StatefulSet).

## Testing

- `TestClientWatchResources` (lifecycle, envtest) extended with: For-options forwarding, per-cluster watch registration on the traceLogging path (the production path for both constructors), and the StatefulSet no-duplication case. The dedupe case was watched to fail first (StatefulSet registered 4x instead of 2x).
- New gated integration test `TestMulticlusterController/TestOwnedResourceDeletionTriggersResync` (3-cluster k3d env): a zero-pool StretchCluster with inline SASL users — the one rendered resource that exists while the controller is fully quiesced (with a pool, the 10s not-ready fast poll would recreate resources with or without a watch). After the StretchCluster's resourceVersion is stable everywhere, the test deletes the rendered users Secret on one member and requires watch-driven recreation within a bound that a periodic pass cannot reach. **Red/green verified**: fails on the previous wiring with "owned-resource watch not firing", passes with this change (recreation in ~1–2s); the quiescence wait also passing with the new watches active confirms no reconcile hot-loop was introduced.
- `golangci-lint run` clean on both packages; `task generate` produces no drift (RBAC watch verbs already covered by existing markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)